### PR TITLE
ci: publish multi‑arch manifests with buildx imagetools and lowercase image name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,6 +421,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Ensure Buildx (required for imagetools)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       # docker login
       - name: Docker login
         uses: docker/login-action@v3
@@ -440,54 +444,34 @@ jobs:
           echo "major=$MAJOR" >> $GITHUB_OUTPUT
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
 
-      # Create and push multi-platform manifests
+      # Create and push multi-platform manifests using buildx imagetools
       - name: Create multi-platform manifest
         run: |
-          # Create and push version-specific manifest (v1.2.3)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}
+          R="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
 
-          # Create and push semver version manifest (1.2.3)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          # vX.Y.Z and X.Y.Z
+          docker buildx imagetools create \
+            -t "$R:v${{ steps.version.outputs.version }}" \
+            -t "$R:${{ steps.version.outputs.version }}" \
+            "$R:${{ steps.version.outputs.version }}-amd64" \
+            "$R:${{ steps.version.outputs.version }}-arm64"
 
-          # Create and push major version manifest (v1)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}
+          # vX and X
+          docker buildx imagetools create \
+            -t "$R:v${{ steps.version.outputs.major }}" \
+            -t "$R:${{ steps.version.outputs.major }}" \
+            "$R:${{ steps.version.outputs.version }}-amd64" \
+            "$R:${{ steps.version.outputs.version }}-arm64"
 
-          # Create and push major version manifest (1)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+          # vX.Y and X.Y
+          docker buildx imagetools create \
+            -t "$R:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}" \
+            -t "$R:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}" \
+            "$R:${{ steps.version.outputs.version }}-amd64" \
+            "$R:${{ steps.version.outputs.version }}-arm64"
 
-          # Create and push major.minor version manifest (v1.2)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-
-          # Create and push major.minor version manifest (1.2)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-
-          # Create and push latest manifest (multi-arch)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest-arm64
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          # latest
+          docker buildx imagetools create \
+            -t "$R:latest" \
+            "$R:latest-amd64" \
+            "$R:latest-arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,6 +307,11 @@ jobs:
           name: frontend-build
           path: frontend/dist/
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -323,7 +328,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=ref,event=tag,suffix=-amd64
             type=semver,pattern={{version}},suffix=-amd64
@@ -368,6 +373,11 @@ jobs:
           name: frontend-build
           path: frontend/dist/
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -384,7 +394,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=ref,event=tag,suffix=-arm64
             type=semver,pattern={{version}},suffix=-arm64
@@ -425,6 +435,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       # docker login
       - name: Docker login
         uses: docker/login-action@v3
@@ -447,7 +462,7 @@ jobs:
       # Create and push multi-platform manifests using buildx imagetools
       - name: Create multi-platform manifest
         run: |
-          R="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          R="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}"
 
           # vX.Y.Z and X.Y.Z
           docker buildx imagetools create \


### PR DESCRIPTION
## Summary

- Replace docker manifest create/push with docker buildx imagetools create to assemble multi‑arch manifests from per‑arch tags.
- Normalize image name to lowercase for GHCR compliance (fork owners often have mixed‑case usernames).
- Keep existing tag scheme: vX.Y.Z, X.Y.Z, vX, X, vX.Y, X.Y, latest.

### Why

- Previous workflow failed at manifest creation because buildx pushes per‑arch tags (e.g., :…‑amd64) as OCI manifest lists; docker manifest create cannot nest lists (“… is a manifest list”).
- GHCR requires lowercase image references; mixed‑case org/repo names cause “repository name must be lowercase”.

## What changed

- Create manifests with docker buildx imagetools create:
  - Sources: ghcr.io/:-amd64 and -arm64.
  - Targets: vX.Y.Z and X.Y.Z; vX and X; vX.Y and X.Y; latest.
- Add Buildx setup to the create‑manifest job.
- Normalize `IMAGE_NAME` to lowercase at runtime and use it for:
    - docker/metadata‑action images
    - imagetools target/source references

## Notes

- No change to image content; only how multi‑arch manifests are created and tagged.
- Still supports pushing single‑arch tags (…‑amd64, …‑arm64).
- Uses default `GITHUB_TOKEN` to authenticate to GHCR; requires “Workflow permissions: Read and write”.

## Validation

- Tested in fork with tags `v0.0.1‑test1` and `v0.0.1‑test2`:
    - amd64 and arm64 images built and pushed
    - imagetools successfully created multi‑arch manifests for all tag variants
    - Lowercasing fix resolved GHCR “repository name must be lowercase” error

## Checklist

- [x] Builds: pass in CI on PR (unit tests + lint).
- [x] Release workflow: verified in fork on tag push.
- [x] Backward compatible: yes (tag scheme preserved; no runtime behavior change).