### PR TITLE
ci: lower-case GHCR image name for forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
           name: frontend-build
           path: frontend/dist/
 
+
       # Extract version info
       - name: Extract version info
         id: version
@@ -316,6 +317,11 @@ jobs:
           name: frontend-build
           path: frontend/dist/
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -332,7 +338,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=ref,event=tag,suffix=-amd64-temp
             type=semver,pattern={{version}},suffix=-amd64-temp
@@ -373,6 +379,11 @@ jobs:
           name: frontend-build
           path: frontend/dist/
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -389,7 +400,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=ref,event=tag,suffix=-arm64-temp
             type=semver,pattern={{version}},suffix=-arm64-temp
@@ -425,6 +436,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Normalize image name to lowercase for GHCR (required)
+      - name: Normalize image name
+        run: |
+          echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       # docker login
       - name: Docker login
         uses: docker/login-action@v3
@@ -448,64 +464,64 @@ jobs:
       - name: Create multi-platform manifest
         run: |
           # Use temporary tagged images instead of digests
-          AMD64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}-amd64-temp"
-          ARM64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}-arm64-temp"
+          AMD64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-amd64-temp"
+          ARM64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-arm64-temp"
           
           echo "AMD64 Image: $AMD64_IMAGE"
           echo "ARM64 Image: $ARM64_IMAGE"
 
           # Create and push version-specific manifest (v1.2.3)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}
 
           # Create and push semver version manifest (1.2.3)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}
 
           # Create and push major version manifest (v1)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}
 
           # Create and push major version manifest (1)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}
 
           # Create and push major.minor version manifest (v1.2)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
 
           # Create and push major.minor version manifest (1.2)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
 
           # Create and push latest manifest (multi-arch)
           docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest \
             $AMD64_IMAGE \
             $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest
 
       # Clean up temporary tags
       - name: Clean up temporary tags
         run: |
           # Delete temporary platform-specific tags
-          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}-amd64-temp || true
-          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}-arm64-temp || true
+          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-amd64-temp || true
+          docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-arm64-temp || true


### PR DESCRIPTION
Lowercases the image repository path for GHCR to ensure publishes work when the owner/repo contains uppercase characters (common in forks). Keeps the maintainer’s new release approach intact.

**Changes**:
- Add “Normalize image name” step to set `IMAGE_NAME_LC` in:
  - `build-image-amd64`
  - `build-image-arm64`
  - `create-manifest`
- Use `${{ env.IMAGE_NAME_LC }}` for:
  - `docker/metadata-action` `images:` input
  - All `docker manifest create/push/rm` image references
- Preserve temp tags (`-amd64-temp`, `-arm64-temp`) and `provenance: false`/`sbom: false`.

**Why**: GHCR requires lowercase repository names. Without this, forks with uppercase owners fail with errors like “invalid reference format: repository name must be lowercase”.

**Impact**: Only affects image publishing on tag pushes. No changes to binaries, artifacts, or tag scheme (`vX.Y.Z`, `X.Y.Z`, `vX`, `X`, `vX.Y`, `X.Y`, `latest`).

**Validation**: Verified all image references in the release workflow now use `${{ env.IMAGE_NAME_LC }}` where applicable. The arch builds use metadata-action tags derived from the lowercase image path; manifest creation/push also uses the lowercase path.

**Notes**: Supersedes #1 