### PR TITLE
feat(rclone): implement RClone connection testing functionality in API and frontend

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -404,6 +404,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 		// Set health worker reference in API server
 		apiServer.SetHealthWorker(healthWorker)
+		// Set rclone client reference in API server
+		if rcloneClient != nil {
+			apiServer.SetRcloneClient(rcloneClient)
+		}
 
 		// Start health worker with the main context
 		if err := healthWorker.Start(ctx); err != nil {

--- a/frontend/src/components/config/WebDAVConfigSection.tsx
+++ b/frontend/src/components/config/WebDAVConfigSection.tsx
@@ -78,48 +78,33 @@ export function WebDAVConfigSection({
 					placeholder="/mnt/altmount"
 				/>
 				<p className="label">
-					Absolute path where WebDAV is mounted. Required when ARRs is enabled.
-					This path will be stripped from file paths when communicating with Radarr/Sonarr.
+					Absolute path where WebDAV is mounted. Required when ARRs is enabled. This path will be
+					stripped from file paths when communicating with Radarr/Sonarr.
 				</p>
 
 				{/* Rclone Mount Instructions */}
-				<div className="mt-4 p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
-					<h4 className="font-medium text-sm mb-2">How to create the mount using rclone:</h4>
-					<div className="text-sm text-gray-600 dark:text-gray-400 space-y-2">
+				<div className="mt-4 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
+					<h4 className="mb-2 font-medium text-sm">How to create the mount using rclone:</h4>
+					<div className="space-y-2 text-gray-600 text-sm dark:text-gray-400">
 						<p>1. Install rclone if not already installed</p>
 						<p>2. Create the mount directory:</p>
-						<code className="block bg-gray-100 dark:bg-gray-700 p-2 rounded text-xs font-mono">
+						<code className="block rounded bg-gray-100 p-2 font-mono text-xs dark:bg-gray-700">
 							sudo mkdir -p {formData.mount_path || "/mnt/altmount"}
 						</code>
 						<p>3. Mount the WebDAV server:</p>
-						<code className="block bg-gray-100 dark:bg-gray-700 p-2 rounded text-xs font-mono whitespace-pre-wrap">
+						<code className="block whitespace-pre-wrap rounded bg-gray-100 p-2 font-mono text-xs dark:bg-gray-700">
 							rclone mount webdav: {formData.mount_path || "/mnt/altmount"} \
-							--webdav-url=http://localhost:{formData.port || "8080"}/webdav \
-							--webdav-user={formData.user || "username"} \
-							--webdav-pass={formData.password || "password"} \
-							--async-read=true \
-							--allow-non-empty \
-							--allow-other \
-							--rc \
-							--rc-no-auth \
-							--rc-addr=0.0.0.0:5573 \
-							--vfs-read-ahead=128M \
-							--vfs-read-chunk-size=32M \
-							--vfs-read-chunk-size-limit=2G \
-							--vfs-cache-mode=full \
-							--vfs-cache-max-age=504h \
-							--vfs-cache-max-size=50G \
-							--vfs-cache-poll-interval=30s \
-							--buffer-size=32M \
-							--dir-cache-time=10m \
-							--timeout=10m \
-							--umask=002 \
-							--syslog \
-							--daemon
+							--webdav-url=http://localhost:{formData.port || "8080"}/webdav \ --webdav-user=
+							{formData.user || "username"} \ --webdav-pass={formData.password || "password"} \
+							--async-read=true \ --allow-non-empty \ --allow-other \ --rc \ --rc-no-auth \
+							--rc-addr=0.0.0.0:5573 \ --vfs-read-ahead=128M \ --vfs-read-chunk-size=32M \
+							--vfs-read-chunk-size-limit=2G \ --vfs-cache-mode=full \ --vfs-cache-max-age=504h \
+							--vfs-cache-max-size=50G \ --vfs-cache-poll-interval=30s \ --buffer-size=32M \
+							--dir-cache-time=10m \ --timeout=10m \ --umask=002 \ --syslog \ --daemon
 						</code>
-						<p className="text-xs text-gray-500 dark:text-gray-500">
-							Note: Replace the placeholder values with your actual WebDAV configuration.
-							The <code>--allow-other</code> flag requires additional system configuration.
+						<p className="text-gray-500 text-xs dark:text-gray-500">
+							Note: Replace the placeholder values with your actual WebDAV configuration. The{" "}
+							<code>--allow-other</code> flag requires additional system configuration.
 						</p>
 					</div>
 				</div>

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -518,10 +518,10 @@ export function ConfigurationPage() {
 									"arrs",
 									"health",
 								].includes(activeSection) && (
-										<ComingSoonSection
-											sectionName={CONFIG_SECTIONS[activeSection]?.title || activeSection}
-										/>
-									)}
+									<ComingSoonSection
+										sectionName={CONFIG_SECTIONS[activeSection]?.title || activeSection}
+									/>
+								)}
 							</div>
 						</div>
 					</div>

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/javi11/altmount/internal/importer"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/pkg/rclonecli"
 )
 
 // Config represents API server configuration
@@ -44,6 +45,7 @@ type Server struct {
 	importerService *importer.Service
 	poolManager     pool.Manager
 	arrsService     *arrs.Service
+	rcloneClient    rclonecli.RcloneRcClient
 	logger          *slog.Logger
 	startTime       time.Time
 }
@@ -87,6 +89,11 @@ func NewServer(
 // SetHealthWorker sets the health worker reference for the server
 func (s *Server) SetHealthWorker(healthWorker *health.HealthWorker) {
 	s.healthWorker = healthWorker
+}
+
+// SetRcloneClient sets the rclone client reference for the server
+func (s *Server) SetRcloneClient(rcloneClient rclonecli.RcloneRcClient) {
+	s.rcloneClient = rcloneClient
 }
 
 // SetupFiberRoutes configures API routes directly on the Fiber app
@@ -160,6 +167,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Patch("/config/:section", s.handlePatchConfigSection)
 	api.Post("/config/reload", s.handleReloadConfig)
 	api.Post("/config/validate", s.handleValidateConfig)
+	api.Post("/config/rclone/test", s.handleTestRCloneConnection)
 
 	// Provider management endpoints
 	api.Post("/providers/test", s.handleTestProvider)


### PR DESCRIPTION
This pull request adds support for testing the RClone RC connection directly from the frontend configuration UI, allowing users to verify their RClone settings before saving. It introduces a new backend API endpoint to test the connection and updates the frontend to provide a "Test Connection" button with real-time feedback. Additionally, minor UI improvements are made to the WebDAV configuration section for clarity.

**RClone Connection Testing Feature**

* Added a new backend API endpoint `POST /api/config/rclone/test` that validates RClone RC connection parameters by attempting to refresh the cache on the root directory. The endpoint returns detailed success or error feedback. [[1]](diffhunk://#diff-afc50c8394ab92ac22c7d02fec6c06a0eef71dc2740c9e43b28498443c3bbb10R876-R949) [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R170)
* Updated the API server to hold a reference to the RClone client and provide a setter method, enabling flexible client configuration for testing. [[1]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R48) [[2]](diffhunk://#diff-9dd4887dac4839dd701fb4778bd390ccc23ef2c858e9ad530ad790c2a834d093R94-R98) [[3]](diffhunk://#diff-25e192f39c05036f5438419680acd3e23dadefa91c8d40d7ea21170e5b8bb512R407-R410)
* Enhanced the frontend `RCloneConfigSection` component to include a "Test Connection" button, display connection status, and show informative alerts based on the test result. [[1]](diffhunk://#diff-9135028eee40b8bf7cebb448280731bf8712020b9d1bea1a21a81bcb1c54e2feL1-R1) [[2]](diffhunk://#diff-9135028eee40b8bf7cebb448280731bf8712020b9d1bea1a21a81bcb1c54e2feR26-R30) [[3]](diffhunk://#diff-9135028eee40b8bf7cebb448280731bf8712020b9d1bea1a21a81bcb1c54e2feR81-R128) [[4]](diffhunk://#diff-9135028eee40b8bf7cebb448280731bf8712020b9d1bea1a21a81bcb1c54e2feL161-R240)

**WebDAV Configuration UI Improvements**

* Improved formatting and readability of the WebDAV mount instructions, making the example commands and notes easier to follow.