### PR TITLE
Update manager.go

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -717,9 +717,10 @@ func (c *Config) ToNNTPProviders() []nntppool.UsenetProviderConfig {
 	return providers
 }
 
-// GetActualMountPath returns the actual mount path used by rclone, which includes the provider subdirectory
+// GetActualMountPath returns the actual mount path used by rclone
 func (c *Config) GetActualMountPath(provider string) string {
-	return filepath.Join(c.MountPath, provider)
+    // FIX: Do not join the provider name. Return the MountPath directly.
+	return c.MountPath
 }
 
 // ChangeCallback represents a function called when configuration changes


### PR DESCRIPTION
Explanation of the Fix
Original Code:

Go

func (c *Config) GetActualMountPath(provider string) string {
    return filepath.Join(c.MountPath, provider)
}
Corrected Code:

Go

func (c *Config) GetActualMountPath(provider string) string {
    // FIX: Do not join the provider name. Return the MountPath directly.
    return c.MountPath
}
The original function was taking your mount_path and appending the hardcoded provider name "altmount". The corrected function now simply returns the mount_path directly, which is the behavior you want.