### PR TITLE
fix-for-alpha-5

### DIFF
--- a/internal/webdav/error_handler.go
+++ b/internal/webdav/error_handler.go
@@ -124,12 +124,13 @@ func (f *errorHandlingFile) Read(p []byte) (int, error) {
 		}
 
 		if errors.As(err, &corruptedErr) {
-			// Corrupted file - log and return 503
+			// Corrupted file - log and return 404 Not Found so clients like rclone
+			// do not keep retrying access to the remote backend.
 			slog.ErrorContext(f.ctx, "File corrupted",
 				"total_expected", corruptedErr.TotalExpected,
 				"error", corruptedErr.UnderlyingErr)
 			return n, &HTTPError{
-				StatusCode: http.StatusServiceUnavailable,
+				StatusCode: http.StatusNotFound,
 				Message:    "File unavailable due to missing articles",
 				Err:        err,
 			}


### PR DESCRIPTION
**Fix loop for corrupt files:**
```
time=2025-10-18T20:47:01.204-03:00 level=ERROR msg="File corrupted" total_expected=36594 error="failed to authenticate decrypted block - bad password?" file_name="/Season 01/Sweetpea.srt"
time=2025-10-18T20:47:01.223-03:00 level=DEBUG msg="All body retries exhausted" error="All attempts fail:\n#1: error downloading body: BODY <REDACTED@REDACTED.a7a>: copy failed: bufpipe: read/write on closed pipe (drain also failed: [rapidyenc] expected size 36642 but got 1048864: data corruption detected)" segment_idx=0 file_name="/Season 01/Sweetpea.srt" segment_id=REDACTED@REDACTED.a7a
time=2025-10-18T20:47:01.223-03:00 level=DEBUG msg="Error downloading segments:" error="All attempts fail:\n#1: error downloading body: BODY <REDACTED@REDACTED.a7a>: copy failed: bufpipe: read/write on closed pipe (drain also failed: [rapidyenc] expected size 36642 but got 1048864: data corruption detected)" file_name="/Season 01/Sweetpea.srt" segment_id=REDACTED@REDACTED.a7a segment_idx=0
```

Rclone (and other clients) often attempt to open/read a file after a successful stat. If the server responds with a 404 during the stat/lookup, rclone assumes the file doesn't exist and stops repeatedly attempting to open/read.
Previously, the server would accept the stat, and only then, upon attempting to read, would it report a "File corrupted" error, which could lead rclone to attempt multiple open/read attempts. With this change, rclone sees 404s from the start and no longer spams accesses.

Implementation notes:
I changed the service's behavior so that files marked as "corrupted" are treated as "not found" (404) at two important levels:
MetadataRemoteFile.OpenFile — returns not-found when the file is marked as corrupt (unless the client explicitly requests to view corrupted files).
MetadataRemoteFile.Stat — returns not-found when querying metadata for corrupted files, preventing WebDAV from attempting to open/read the file later.


**Fix alt error on killing custom mount:**
```cmd
time=2025-10-18T20:29:25.573-03:00 level=INFO msg="http: superfluous response.WriteHeader call from github.com/javi11/altmount/internal/webdav.NewHandler.func2 (adapter.go:137)"
```
The propfind code (copied/modified from golang.org/x/net/webdav) uses a multistatusWriter which calls [ResponseWriter.WriteHeader(webdav.StatusMulti)](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when it writes the first part of the response. If the caller (adapter.go) then calls WriteHeader again, net/http logs a "superfluous response.WriteHeader" with a stack trace showing the second call site. By tracking whether the writer already wrote a header (or body) and only calling WriteHeader when nothing was written, we avoid the duplicate WriteHeader call.

Implementation notes:
I added trackedWriter with WriteHeader and Write methods that mark wroteHeader when invoked.
The adapter now passes an instance of trackedWriter to [propfind.HandlePropfind](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). After HandlePropfind returns, we only call WriteHeader(status) (and write message) if trackedWriter hasn't already written anything.