### PR TITLE
doc: add rshared flag to docker volume documentaion

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ services:
       - COOKIE_DOMAIN=localhost # Must match the domain/IP where web interface is accessed
     volumes:
       - ./config:/config
-      - /mnt:/mnt
+      - /mnt:/mnt:rshared
       - /metadata:/metadata # This is optional you can still use /mnt
     ports:
       - "8080:8080"


### PR DESCRIPTION
This PR adds the missing rshared flag to the Docker Compose example in the README.md file.
The absence of this flag could lead to incorrect mount behavior or limited functionality when running the container.