### PR TITLE
fix: allow undefined value in handleInputChange function

### DIFF
--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -24,7 +24,7 @@ export function HealthConfigSection({
 		setHasChanges(false);
 	}, [config.health]);
 
-	const handleInputChange = (field: keyof HealthConfig, value: string | boolean | number) => {
+	const handleInputChange = (field: keyof HealthConfig, value: string | boolean | number | undefined) => {
 		const newData = { ...formData, [field]: value };
 		setFormData(newData);
 		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.health));


### PR DESCRIPTION
suggested interface for `HealthConfig`:

```tsx
export interface HealthConfig {
  enabled: boolean
  auto_repair_enabled: boolean
  library_dir?: string                  // optional
  max_concurrent_jobs?: number          // optional
  max_retries?: number                  // optional
  check_interval_seconds?: number       // optional
  check_all_segments?: boolean          // optional
}
```
Fields marked with a question mark (`?`) are optional and may be `undefined`.
Booleans such as `enabled` and `auto_repair_enabled` are mandatory, as they always exist.
Optional numbers have a fallback in JSX (`|| 0` or a defined minimum).
