### PR TITLE
feat(queue): add sorting functionality to queue items

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -151,6 +151,8 @@ export class APIClient {
 		status?: string;
 		since?: string;
 		search?: string;
+		sort_by?: string;
+		sort_order?: "asc" | "desc";
 	}) {
 		const searchParams = new URLSearchParams();
 		if (params?.limit) searchParams.set("limit", params.limit.toString());
@@ -158,6 +160,8 @@ export class APIClient {
 		if (params?.status) searchParams.set("status", params.status);
 		if (params?.since) searchParams.set("since", params.since);
 		if (params?.search) searchParams.set("search", params.search);
+		if (params?.sort_by) searchParams.set("sort_by", params.sort_by);
+		if (params?.sort_order) searchParams.set("sort_order", params.sort_order);
 
 		const query = searchParams.toString();
 		return this.requestWithMeta<QueueItem[]>(`/queue${query ? `?${query}` : ""}`);

--- a/frontend/src/components/config/MetadataConfigSection.tsx
+++ b/frontend/src/components/config/MetadataConfigSection.tsx
@@ -99,8 +99,8 @@ export function MetadataConfigSection({
 						{batchExport.isPending ? "Exporting..." : "Export All as NZB"}
 					</button>
 					<p className="label">
-						Export all file metadata as NZB files in a single ZIP archive. Archives (RAR/7zip) and encrypted
-						files are automatically excluded.
+						Export all file metadata as NZB files in a single ZIP archive. Archives (RAR/7zip) and
+						encrypted files are automatically excluded.
 					</p>
 				</fieldset>
 			</div>

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -9,6 +9,8 @@ export const useQueue = (params?: {
 	status?: string;
 	since?: string;
 	search?: string;
+	sort_by?: string;
+	sort_order?: "asc" | "desc";
 	refetchInterval?: number;
 }) => {
 	return useQuery({

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -1,5 +1,7 @@
 import {
 	AlertCircle,
+	ChevronDown,
+	ChevronUp,
 	Download,
 	MoreHorizontal,
 	Pause,
@@ -45,6 +47,10 @@ export function QueuePage() {
 	const [userInteracting, setUserInteracting] = useState(false);
 	const [countdown, setCountdown] = useState(0);
 	const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
+	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(
+		"updated_at",
+	);
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
 	const pageSize = 20;
 	const {
@@ -57,6 +63,8 @@ export function QueuePage() {
 		offset: page * pageSize,
 		status: statusFilter || undefined,
 		search: searchTerm || undefined,
+		sort_by: sortBy,
+		sort_order: sortOrder,
 		refetchInterval: autoRefreshEnabled && !userInteracting ? refreshInterval : undefined,
 	});
 
@@ -301,6 +309,21 @@ export function QueuePage() {
 	const clearSelection = useCallback(() => {
 		setSelectedItems(new Set());
 	}, []);
+
+	// Handle sort column change
+	const handleSort = (column: "created_at" | "updated_at" | "status" | "nzb_path") => {
+		if (sortBy === column) {
+			// Toggle sort order if clicking the same column
+			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+		} else {
+			// Set new column and default sort order
+			setSortBy(column);
+			// Default to desc for dates, asc for others
+			setSortOrder(column === "updated_at" || column === "created_at" ? "desc" : "asc");
+		}
+		setPage(0); // Reset to first page
+		clearSelection(); // Clear selections when sorting changes
+	};
 
 	// Helper functions for select all checkbox state
 	const isAllSelected =
@@ -612,13 +635,41 @@ export function QueuePage() {
 											/>
 										</label>
 									</th>
-									<th>NZB File</th>
+									<th>
+										<button
+											type="button"
+											className="flex items-center gap-1 hover:text-primary"
+											onClick={() => handleSort("nzb_path")}
+										>
+											NZB File
+											{sortBy === "nzb_path" &&
+												(sortOrder === "asc" ? (
+													<ChevronUp className="h-4 w-4" />
+												) : (
+													<ChevronDown className="h-4 w-4" />
+												))}
+										</button>
+									</th>
 									<th>Target Path</th>
 									<th>Category</th>
 									<th>File Size</th>
 									<th>Status</th>
 									<th>Retry Count</th>
-									<th>Updated</th>
+									<th>
+										<button
+											type="button"
+											className="flex items-center gap-1 hover:text-primary"
+											onClick={() => handleSort("updated_at")}
+										>
+											Updated
+											{sortBy === "updated_at" &&
+												(sortOrder === "asc" ? (
+													<ChevronUp className="h-4 w-4" />
+												) : (
+													<ChevronDown className="h-4 w-4" />
+												))}
+										</button>
+									</th>
 									<th>Actions</th>
 								</tr>
 							</thead>

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -56,6 +56,26 @@ func (s *Server) handleListQueue(c *fiber.Ctx) error {
 	// Parse search parameter
 	searchFilter := c.Query("search")
 
+	// Parse sort parameters
+	sortBy := c.Query("sort_by", "updated_at")
+	sortOrder := c.Query("sort_order", "desc")
+
+	// Validate sort_by
+	validSortFields := map[string]bool{
+		"created_at": true,
+		"updated_at": true,
+		"status":     true,
+		"nzb_path":   true,
+	}
+	if !validSortFields[sortBy] {
+		sortBy = "updated_at"
+	}
+
+	// Validate sort_order
+	if sortOrder != "asc" && sortOrder != "desc" {
+		sortOrder = "desc"
+	}
+
 	// Parse since filter
 	var sinceFilter *time.Time
 	if since, err := ParseTimeParamFiber(c, "since"); err != nil {
@@ -85,7 +105,7 @@ func (s *Server) handleListQueue(c *fiber.Ctx) error {
 	}
 
 	// Get queue items from repository
-	items, err := s.queueRepo.ListQueueItems(c.Context(),statusFilter, searchFilter, "", pagination.Limit, pagination.Offset)
+	items, err := s.queueRepo.ListQueueItems(c.Context(), statusFilter, searchFilter, "", pagination.Limit, pagination.Offset, sortBy, sortOrder)
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
 			"success": false,

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -356,7 +356,7 @@ func (s *Server) handleSABnzbdQueue(c *fiber.Ctx) error {
 	categoryFilter := c.Query("category", "")
 
 	// Get pending and processing items
-	items, err := s.queueRepo.ListQueueItems(c.Context(), nil, "", categoryFilter, 100, 0)
+	items, err := s.queueRepo.ListQueueItems(c.Context(), nil, "", categoryFilter, 100, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get queue")
 	}
@@ -430,14 +430,14 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 
 	// Get completed items
 	completedStatus := database.QueueStatusCompleted
-	completed, err := s.queueRepo.ListQueueItems(c.Context(), &completedStatus, "", categoryFilter, 50, 0)
+	completed, err := s.queueRepo.ListQueueItems(c.Context(), &completedStatus, "", categoryFilter, 50, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get completed items")
 	}
 
 	// Get failed items
 	failedStatus := database.QueueStatusFailed
-	failed, err := s.queueRepo.ListQueueItems(c.Context(), &failedStatus, "", categoryFilter, 50, 0)
+	failed, err := s.queueRepo.ListQueueItems(c.Context(), &failedStatus, "", categoryFilter, 50, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get failed items")
 	}
@@ -516,7 +516,7 @@ func (s *Server) handleSABnzbdStatus(c *fiber.Ctx) error {
 	// Get queue information
 	var slots []SABnzbdQueueSlot
 	if s.queueRepo != nil {
-		items, err := s.queueRepo.ListQueueItems(c.Context(), nil, "", "", 50, 0)
+		items, err := s.queueRepo.ListQueueItems(c.Context(), nil, "", "", 50, 0, "updated_at", "desc")
 		if err == nil {
 			for i, item := range items {
 				if item.Status == database.QueueStatusPending || item.Status == database.QueueStatusProcessing {


### PR DESCRIPTION
- Introduced `sort_by` and `sort_order` parameters to the API for sorting queue items.
- Updated frontend components to support sorting by various fields (created_at, updated_at, status, nzb_path).
- Enhanced backend logic to handle sorting and validation of parameters.
- Updated relevant database queries to incorporate sorting options.