### PR TITLE
fix(health): prevent scan error on NULL scheduled_check_at in health DB

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -846,12 +846,16 @@ func (r *HealthRepository) GetAllHealthCheckRecords(ctx context.Context) ([]Auto
 			path             string
 			libraryPath      *string
 			releaseDate      *time.Time
-			scheduledCheckAt time.Time
+			scheduledCheckAtNT sql.NullTime
 			sourceNzbPath    *string
 		)
 
-		if err := rows.Scan(&path, &libraryPath, &releaseDate, &scheduledCheckAt, &sourceNzbPath); err != nil {
+		if err := rows.Scan(&path, &libraryPath, &releaseDate, &scheduledCheckAtNT, &sourceNzbPath); err != nil {
 			return nil, fmt.Errorf("failed to scan file path: %w", err)
+		}
+		var scheduledCheckAt time.Time
+		if scheduledCheckAtNT.Valid {
+			scheduledCheckAt = scheduledCheckAtNT.Time
 		}
 		records = append(records, AutomaticHealthCheckRecord{
 			FilePath:         path,


### PR DESCRIPTION
### Description

- **Problem**: Library sync errored when reading health records with NULL `scheduled_check_at`.
  - Error: `sql: Scan error on column index 3, name "scheduled_check_at": unsupported Scan, storing driver.Value type <nil> into type *time.Time`
  - Commonly affected corrupted files that did not have a scheduled check time.

- **Root cause**: `GetAllHealthCheckRecords` scanned `scheduled_check_at` into `time.Time`, which fails on NULL.

- **Fix**: Scan `scheduled_check_at` as `sql.NullTime` and map to zero time when NULL. External types/behavior unchanged.

- **Impact**:
  - Library sync and metadata-only sync no longer fail on NULL schedule times.
  - “Due for check” queries remain unchanged (they already filter for non-NULL times).

- **Risk**: Low. Read-only change localized to the query method.

- **Files touched**:
  - `internal/database/health_repository.go`

- **Testing**:
  - Built and ran on my server; library sync completes without errors.
  - Verified corrupted items with NULL `scheduled_check_at` no longer trigger the scan error.
  - Lint passes.