### PR TITLE
Fix docs for Windows rclone commands

### DIFF
--- a/docs/docs/1. intro.md
+++ b/docs/docs/1. intro.md
@@ -166,19 +166,19 @@ AltMount includes a built-in rclone mount feature for the WebDAV interface:
 >
 > # Then create the config:
 > rclone config create altmount webdav `
->   url http://localhost:8080 `
+>   url http://localhost:8080/webdav `
 >   vendor other `
 >   user your-username `
 >   pass $obscuredPass
 >
 > # Step 2: Mount AltMount with VFS cache
-> rclone mount altmount: X: ^
->   --vfs-cache-mode full ^
->   --vfs-cache-max-size 50G ^
->   --vfs-cache-max-age 504h ^
->   --vfs-read-chunk-size 32M ^
->   --vfs-read-ahead 128M ^
->   --dir-cache-time 10m ^
+> rclone mount altmount: X: `
+>   --vfs-cache-mode full `
+>   --vfs-cache-max-size 50G `
+>   --vfs-cache-max-age 504h `
+>   --vfs-read-chunk-size 32M `
+>   --vfs-read-ahead 128M `
+>   --dir-cache-time 10m `
 >   --cache-dir %LOCALAPPDATA%\rclone\cache
 > ```
 >


### PR DESCRIPTION
Updated the docs to reflect some of the things I needed to do in order to get this working on a Windows setup; I assume that the paths and commands were probably changed and but not reflected in the docs.