### PR TITLE
fix(importer): correct file validation and prevent virtual directory …

### DIFF
--- a/internal/importer/filesystem/utils.go
+++ b/internal/importer/filesystem/utils.go
@@ -29,7 +29,12 @@ func CalculateVirtualDirectory(nzbPath, relativePath string) string {
 
 	relDir := filepath.Dir(relPath)
 	if relDir == "." || relDir == "" {
-		return "/"
+		// If the file is at the root, create a directory based on the filename
+		// This prevents flattening and potential "delete root" issues
+		filename := filepath.Base(nzbPath)
+		ext := filepath.Ext(filename)
+		dirName := strings.TrimSuffix(filename, ext)
+		return "/" + dirName
 	}
 
 	virtualPath := "/" + strings.ReplaceAll(relDir, string(filepath.Separator), "/")

--- a/internal/importer/filesystem/utils_test.go
+++ b/internal/importer/filesystem/utils_test.go
@@ -78,3 +78,46 @@ func TestDetermineFileLocation(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateVirtualDirectory(t *testing.T) {
+	tests := []struct {
+		name         string
+		nzbPath      string
+		relativePath string
+		expected     string
+	}{
+		{
+			name:         "file in root of relative path",
+			nzbPath:      "/downloads/sonarr/Movie.mkv",
+			relativePath: "/downloads/sonarr",
+			expected:     "/Movie", // Should create folder based on filename
+		},
+		{
+			name:         "file in subfolder",
+			nzbPath:      "/downloads/sonarr/MovieFolder/Movie.mkv",
+			relativePath: "/downloads/sonarr",
+			expected:     "/MovieFolder",
+		},
+		{
+			name:         "empty relative path",
+			nzbPath:      "/downloads/Movie.mkv",
+			relativePath: "",
+			expected:     "/", // Default behavior for empty relative path
+		},
+		{
+			name:         "file with spaces",
+			nzbPath:      "/downloads/sonarr/Movie Name (2023).mkv",
+			relativePath: "/downloads/sonarr",
+			expected:     "/Movie Name (2023)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateVirtualDirectory(tt.nzbPath, tt.relativePath)
+			if result != tt.expected {
+				t.Errorf("CalculateVirtualDirectory(%q, %q) = %q, want %q", tt.nzbPath, tt.relativePath, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/importer/singlefile/processor.go
+++ b/internal/importer/singlefile/processor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -78,12 +77,6 @@ func ProcessSingleFile(
 		file.ReleaseDate.Unix(),
 		par2Refs,
 	)
-
-	// Delete old metadata if exists (simple collision handling)
-	metadataPath := metadataService.GetMetadataFilePath(virtualFilePath)
-	if _, err := os.Stat(metadataPath); err == nil {
-		_ = metadataService.DeleteFileMetadata(virtualFilePath)
-	}
 
 	// Write file metadata to disk
 	if err := metadataService.WriteFileMetadata(virtualFilePath, fileMeta); err != nil {

--- a/internal/importer/utils/file_validation.go
+++ b/internal/importer/utils/file_validation.go
@@ -17,7 +17,11 @@ func createExtensionMap(extensions []string) map[string]bool {
 	extMap := make(map[string]bool, len(extensions))
 	for _, ext := range extensions {
 		// Normalize to lowercase for case-insensitive comparison
-		extMap[strings.ToLower(ext)] = true
+		ext = strings.ToLower(ext)
+		if strings.HasPrefix(ext, ".") {
+			ext = ext[1:]
+		}
+		extMap[ext] = true
 	}
 	return extMap
 }
@@ -40,6 +44,9 @@ func IsAllowedFile(filename string, allowedExtensions []string) bool {
 	}
 
 	ext := strings.ToLower(filepath.Ext(filename))
+	if strings.HasPrefix(ext, ".") {
+		ext = ext[1:]
+	}
 	extMap := createExtensionMap(allowedExtensions)
 	return extMap[ext]
 }

--- a/internal/importer/utils/file_validation_test.go
+++ b/internal/importer/utils/file_validation_test.go
@@ -101,6 +101,11 @@ func TestIsAllowedFile_WithExtensions(t *testing.T) {
 			filename: "movie.sample.avi",
 			expected: false,
 		},
+		{
+			name:     "allowed extension without dot",
+			filename: "movie.mkv",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -262,6 +267,41 @@ func TestIsAllowedFile_SampleProofPatterns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := IsAllowedFile(tt.filename, []string{})
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsAllowedFile_MixedDotFormats(t *testing.T) {
+	tests := []struct {
+		name        string
+		filename    string
+		allowed     []string
+		expected    bool
+	}{
+		{
+			name:     "allowed without dot matches file",
+			filename: "movie.mkv",
+			allowed:  []string{"mkv"},
+			expected: true,
+		},
+		{
+			name:     "allowed with dot matches file",
+			filename: "movie.mkv",
+			allowed:  []string{".mkv"},
+			expected: true,
+		},
+		{
+			name:     "mixed allowed list",
+			filename: "movie.mp4",
+			allowed:  []string{"mkv", ".mp4"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsAllowedFile(tt.filename, tt.allowed)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
…flattening

- Fix inconsistent file extension validation by normalizing extensions and stripping leading dots.
- Refactor 'CalculateVirtualDirectory' to create unique subdirectories for files at the root of a relative path, preventing file flattening and accidental parent directory deletions.
- Implement atomic metadata writes in 'WriteFileMetadata' to prevent race conditions during import.
- Add comprehensive tests for file validation and virtual directory calculation.