### PR TITLE
Fix: ARR repair paths to prefer symlink import dir when available over mount fallback

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 )
 
@@ -410,6 +411,12 @@ func (s *Server) handleRepairHealth(c *fiber.Ctx) error {
 
 	// Determine final path for ARR rescan
 	pathForRescan := libraryPath
+	if pathForRescan == "" && cfg.Import.ImportStrategy == config.ImportStrategySYMLINK && cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
+		pathForRescan = filepath.Join(*cfg.Import.ImportDir, item.FilePath)
+		slog.InfoContext(ctx, "Using symlink import path for manual repair",
+			"file_path", item.FilePath,
+			"symlink_path", pathForRescan)
+	}
 	if pathForRescan == "" {
 		// Fallback to mount path if no library path found
 		pathForRescan = filepath.Join(cfg.MountPath, item.FilePath)

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -751,6 +751,11 @@ func (hw *HealthWorker) triggerFileRepair(ctx context.Context, filePath string, 
 	pathForRescan := ""
 	if healthRecord.LibraryPath != nil && *healthRecord.LibraryPath != "" {
 		pathForRescan = *healthRecord.LibraryPath
+	} else if cfg := hw.configGetter(); cfg.Import.ImportStrategy == config.ImportStrategySYMLINK && cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
+		pathForRescan = filepath.Join(*cfg.Import.ImportDir, filePath)
+		slog.InfoContext(ctx, "Using symlink import path for repair trigger",
+			"file_path", filePath,
+			"symlink_path", pathForRescan)
 	} else {
 		// Fallback to mount path if no library path found
 		// This is common for ImportStrategyNone or if metadata scan failed before determining library path


### PR DESCRIPTION
Fix: ARR repair paths to prefer symlink import dir when available over mount fallback
- Prefer import_dir symlink path for ARR rescans when using SYMLINK strategy
- Fall back to mount_path only when no library/symlink path is available
- Align health worker and manual repair flows so ARR sees the correct library path