### PR TITLE
fix: ensure reliable mount startup and shutdown

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
@@ -194,7 +195,28 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// This ensures the WebDAV server is ready to accept connections
 	go func() {
 		// Wait for HTTP server to be fully ready
-		time.Sleep(2 * time.Second)
+		serverURL := fmt.Sprintf("http://localhost:%d/live", cfg.WebDAV.Port)
+		client := &http.Client{Timeout: 500 * time.Millisecond}
+
+		ready := false
+		for i := 0; i < 20; i++ { // Wait up to 10 seconds
+			time.Sleep(500 * time.Millisecond)
+			resp, err := client.Get(serverURL)
+			if err == nil {
+				resp.Body.Close()
+				if resp.StatusCode == 200 {
+					ready = true
+					break
+				}
+			}
+		}
+
+		if !ready {
+			logger.WarnContext(ctx, "Timeout waiting for server to be ready, proceeding with mount attempt")
+		} else {
+			// Give it one more second to settle
+			time.Sleep(1 * time.Second)
+		}
 
 		if err := startMountService(ctx, cfg, mountService, logger); err != nil {
 			logger.WarnContext(ctx, "Mount service failed to start", "err", err)
@@ -231,12 +253,10 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	// Stop RClone mount service if running
-	if cfg.RClone.MountEnabled != nil && *cfg.RClone.MountEnabled {
-		if err := mountService.Stop(ctx); err != nil {
-			logger.ErrorContext(ctx, "Failed to stop mount service", "error", err)
-		} else {
-			logger.InfoContext(ctx, "RClone mount service stopped")
-		}
+	if err := mountService.Stop(ctx); err != nil {
+		logger.ErrorContext(ctx, "Failed to stop mount service", "error", err)
+	} else {
+		logger.InfoContext(ctx, "RClone mount service stopped")
 	}
 
 	// Shutdown custom server with timeout


### PR DESCRIPTION
This PR addresses reliability issues with the rclone mount service startup and shutdown.

### Changes:
- **Shutdown:** Modified `cmd/altmount/cmd/serve.go` to unconditionally stop the mount service during shutdown. This ensures that if the mount was enabled dynamically (e.g., via API) or if the configuration state was desynchronized, the mount is still properly unmounted, preventing orphaned processes.
- **Startup:** Replaced the fixed 2-second sleep with a robust polling mechanism that checks the `/live` endpoint. This ensures the mount service only attempts to start after the WebDAV server is fully responsive, preventing race conditions on slower systems.

These changes improve the overall stability of the application's lifecycle management.