### PR TITLE
feat: dashboard and navigation improvements

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -27,11 +27,6 @@ const navigation = [
 		icon: List,
 	},
 	{
-		name: "Import",
-		href: "/import",
-		icon: Upload,
-	},
-	{
 		name: "Health",
 		href: "/health",
 		icon: Heart,
@@ -40,6 +35,11 @@ const navigation = [
 		name: "Files",
 		href: "/files",
 		icon: Folder,
+	},
+	{
+		name: "Import",
+		href: "/import",
+		icon: Upload,
 	},
 	{
 		name: "Configuration",

--- a/frontend/src/components/system/PoolMetricsCard.tsx
+++ b/frontend/src/components/system/PoolMetricsCard.tsx
@@ -79,7 +79,7 @@ export function PoolMetricsCard({ className }: PoolMetricsCardProps) {
 						{/* Max Download Speed - Only show if > 0 */}
 						{poolMetrics.max_download_speed_bytes_per_sec > 0 && (
 							<div className="flex items-center justify-between text-sm">
-								<span className="text-base-content/70">Top Speed</span>
+								<span className="text-base-content/70">Top Pool Speed</span>
 								<span className="font-medium text-success">
 									{formatSpeed(poolMetrics.max_download_speed_bytes_per_sec)}
 								</span>

--- a/frontend/src/components/system/ProviderCard.tsx
+++ b/frontend/src/components/system/ProviderCard.tsx
@@ -1,3 +1,4 @@
+import { formatDistanceToNowStrict } from "date-fns";
 import { AlertTriangle, CheckCircle, Network, XCircle } from "lucide-react";
 import type { ProviderStatus } from "../../types/api";
 
@@ -64,7 +65,9 @@ export function ProviderCard({ provider, className }: ProviderCardProps) {
 					<div className="min-w-0 flex-1">
 						<h3 className="card-title truncate font-medium text-base">{provider.host}</h3>
 						{provider.username && (
-							<p className="truncate text-base-content/60 text-sm">@{provider.username}</p>
+							<p className="cursor-pointer truncate text-base-content/60 text-sm blur-sm transition-all hover:blur-none">
+								@{provider.username}
+							</p>
 						)}
 					</div>
 					<div className={`badge ${stateBadge.color} gap-1`}>
@@ -87,6 +90,25 @@ export function ProviderCard({ provider, className }: ProviderCardProps) {
 						max={provider.max_connections}
 					/>
 				</div>
+
+				{/* Speed Test Info */}
+				{provider.last_speed_test_mbps > 0 && (
+					<div className="mt-2 flex items-center justify-between text-xs">
+						<span className="text-base-content/60">Last Speed Test:</span>
+						<div className="text-right">
+							<span className="font-medium text-success">
+								{provider.last_speed_test_mbps.toFixed(2)} MB/s
+							</span>
+							{provider.last_speed_test_time && (
+								<div className="text-base-content/50">
+									{formatDistanceToNowStrict(new Date(provider.last_speed_test_time), {
+										addSuffix: true,
+									})}
+								</div>
+							)}
+						</div>
+					</div>
+				)}
 
 				{/* Failure reason - only show if present */}
 				{provider.failure_reason && provider.failure_reason !== "" && (

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
@@ -99,7 +99,6 @@ export function ProviderHealth() {
 									<th>Provider Host</th>
 									<th>State</th>
 									<th>Connections</th>
-									<th>Errors (% of Total)</th>
 									<th>Last Activity</th>
 									<th>Failure Reason</th>
 								</tr>
@@ -140,21 +139,6 @@ export function ProviderHealth() {
 												<span className="font-mono text-sm">
 													{provider.used_connections}/{provider.max_connections}
 												</span>
-											</div>
-										</td>
-										<td>
-											<div className="flex flex-col">
-												<span
-													className={`font-mono ${provider.error_count > 0 ? "font-bold text-error" : "text-success"}`}
-												>
-													{provider.error_count.toLocaleString()}
-												</span>
-												{data.total_errors > 0 && provider.error_count > 0 && (
-													<span className="text-base-content/50 text-xs">
-														{((provider.error_count / data.total_errors) * 100).toFixed(1)}% of
-														total
-													</span>
-												)}
 											</div>
 										</td>
 										<td className="text-base-content/70 text-sm">

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -303,6 +303,8 @@ export interface ProviderStatus {
 	last_connection_attempt: string;
 	last_successful_connect: string;
 	failure_reason: string;
+	last_speed_test_mbps: number;
+	last_speed_test_time?: string;
 }
 
 export interface PoolMetrics {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -662,6 +662,8 @@ type ProviderStatusResponse struct {
 	LastConnectionAttempt time.Time `json:"last_connection_attempt"`
 	LastSuccessfulConnect time.Time `json:"last_successful_connect"`
 	FailureReason         string    `json:"failure_reason"`
+	LastSpeedTestMbps     float64   `json:"last_speed_test_mbps"`
+	LastSpeedTestTime     *time.Time `json:"last_speed_test_time,omitempty"`
 }
 
 // PoolMetricsResponse represents NNTP pool metrics in API responses


### PR DESCRIPTION
This PR introduces several UI and backend improvements:

- **Navigation:** Reordered 'Import' item to appear before 'Configuration' in the sidebar.
- **Dashboard:** 
    - Blurred provider usernames for privacy (reveals on hover).
    - Renamed 'Top Speed' to 'Top Pool Speed' in pool metrics card.
    - Added 'Last Speed Test' information to provider cards.
- **Provider Health:** Removed the redundant 'Errors (% of Total)' column from the provider table.
- **Backend:** Implemented logic in  to populate  and  for providers, with a fallback lookup mechanism.