### PR TITLE
fix: preserve library paths and sync metadata status during file corruption

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1048,7 +1048,7 @@ func (r *HealthRepository) batchInsertAutomaticHealthChecks(ctx context.Context,
 		)
 		VALUES %s
 		ON CONFLICT(file_path) DO UPDATE SET
-			library_path = excluded.library_path,
+			library_path = COALESCE(excluded.library_path, library_path),
 			release_date = excluded.release_date,
 			scheduled_check_at = excluded.scheduled_check_at,
 			status = excluded.status,


### PR DESCRIPTION
Fixes these bugs:
1. Library path comparison now checks both full and relative paths
2. Use COALESCE to prevent NULL from overwriting existing library paths
3. Update metadata file status when registering corrupted files

This ensures:
- Library paths (from Sonarr/Radarr) are never lost during corruption
- Healthy files automatically reappear in WebDAV mount
- Radarr/Sonarr can successfully trigger repairs with correct library paths