### PR TITLE
fix: redundant folder creation on import (#113)

### DIFF
--- a/internal/importer/filesystem/utils.go
+++ b/internal/importer/filesystem/utils.go
@@ -29,12 +29,9 @@ func CalculateVirtualDirectory(nzbPath, relativePath string) string {
 
 	relDir := filepath.Dir(relPath)
 	if relDir == "." || relDir == "" {
-		// If the file is at the root, create a directory based on the filename
-		// This prevents flattening and potential "delete root" issues
-		filename := filepath.Base(nzbPath)
-		ext := filepath.Ext(filename)
-		dirName := strings.TrimSuffix(filename, ext)
-		return "/" + dirName
+		// If the file is at the root, return root
+		// The processor will handle creating a folder if needed (e.g. for archives or multi-file NZBs)
+		return "/"
 	}
 
 	virtualPath := "/" + strings.ReplaceAll(relDir, string(filepath.Separator), "/")

--- a/internal/importer/filesystem/utils_test.go
+++ b/internal/importer/filesystem/utils_test.go
@@ -90,7 +90,7 @@ func TestCalculateVirtualDirectory(t *testing.T) {
 			name:         "file in root of relative path",
 			nzbPath:      "/downloads/sonarr/Movie.mkv",
 			relativePath: "/downloads/sonarr",
-			expected:     "/Movie", // Should create folder based on filename
+			expected:     "/",
 		},
 		{
 			name:         "file in subfolder",
@@ -108,7 +108,7 @@ func TestCalculateVirtualDirectory(t *testing.T) {
 			name:         "file with spaces",
 			nzbPath:      "/downloads/sonarr/Movie Name (2023).mkv",
 			relativePath: "/downloads/sonarr",
-			expected:     "/Movie Name (2023)",
+			expected:     "/",
 		},
 	}
 

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -204,9 +204,8 @@ func (proc *Processor) processSingleFile(
 		return "", fmt.Errorf("no regular files to process")
 	}
 
-	// Create NZB folder (always put single files in a folder to handle obfuscation and keep structure clean)
-	nzbFolder, err := filesystem.CreateNzbFolder(virtualDir, filepath.Base(nzbPath), proc.metadataService)
-	if err != nil {
+	// Ensure the virtual directory exists in metadata
+	if err := filesystem.EnsureDirectoryExists(virtualDir, proc.metadataService); err != nil {
 		return "", err
 	}
 
@@ -219,7 +218,7 @@ func (proc *Processor) processSingleFile(
 	// Process the single file
 	result, err := singlefile.ProcessSingleFile(
 		ctx,
-		nzbFolder,
+		virtualDir,
 		regularFiles[0],
 		par2Files,
 		nzbPath,


### PR DESCRIPTION
This PR fixes the issue where redundant folders were created during NZB imports.

Changes:
- Modified `CalculateVirtualDirectory` in `internal/importer/filesystem/utils.go` to return `/` when the file is at the root of the relative path, preventing double nesting.
- Updated `processSingleFile` in `internal/importer/processor.go` to skip `CreateNzbFolder` and place files directly in the virtual directory, resolving the single-file nesting issue.
- Updated tests in `internal/importer/filesystem/utils_test.go` to reflect the correct behavior.

Fixes #113