### PR TITLE
fix: add periodic cleanup for stale active streams

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -126,6 +126,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Create stream tracker for monitoring active streams
 	streamTracker := api.NewStreamTracker()
+	streamTracker.StartCleanup(ctx) // Periodic cleanup of stale streams
 
 	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker)
 


### PR DESCRIPTION
## Summary
- Added `StartCleanup(ctx)` method to StreamTracker that runs a background goroutine
- Goroutine periodically (every 5 minutes) removes streams older than 4 hours
- Fixes orphaned stream entries when clients disconnect abruptly

## Test plan
- [ ] Verify streams are tracked normally during playback
- [ ] Verify streams are cleaned up after timeout period
- [ ] Verify cleanup goroutine stops on server shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)