### PR TITLE
fix: prevent 'closed pipe' errors with thread-safe segment writer

### DIFF
--- a/internal/usenet/segment_test.go
+++ b/internal/usenet/segment_test.go
@@ -1,0 +1,275 @@
+package usenet
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/acomagu/bufpipe"
+)
+
+// TestSegmentWriter_WriteAfterClose verifies that writes after close return io.ErrClosedPipe
+func TestSegmentWriter_WriteAfterClose(t *testing.T) {
+	t.Parallel()
+
+	// Create a segment with a pipe
+	reader, writer := bufpipe.New(nil)
+	seg := &segment{
+		Id:     "test-segment",
+		reader: reader,
+		writer: writer,
+	}
+
+	// Get writer reference
+	w := seg.Writer()
+
+	// Close the segment
+	if err := seg.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	// Attempt to write after close
+	_, err := w.Write([]byte("test data"))
+	if err == nil {
+		t.Fatal("Expected error when writing after close, got nil")
+	}
+
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Errorf("Expected io.ErrClosedPipe, got: %v", err)
+	}
+}
+
+// TestSegmentWriter_ConcurrentWriteAndClose tests race condition between write and close
+func TestSegmentWriter_ConcurrentWriteAndClose(t *testing.T) {
+	t.Parallel()
+
+	// Run this test multiple times to increase chance of catching race
+	for i := 0; i < 10; i++ {
+		reader, writer := bufpipe.New(nil)
+		seg := &segment{
+			Id:     "test-segment",
+			reader: reader,
+			writer: writer,
+		}
+
+		w := seg.Writer()
+		var wg sync.WaitGroup
+		writeErr := make(chan error, 1)
+
+		// Start goroutine that writes slowly
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			data := make([]byte, 1024)
+			for j := 0; j < 100; j++ {
+				_, err := w.Write(data)
+				if err != nil {
+					writeErr <- err
+					return
+				}
+				time.Sleep(time.Microsecond) // Small delay to increase race likelihood
+			}
+		}()
+
+		// Close segment from main goroutine during write
+		time.Sleep(time.Millisecond)
+		if err := seg.Close(); err != nil {
+			t.Errorf("Close() failed: %v", err)
+		}
+
+		wg.Wait()
+		close(writeErr)
+
+		// The writer should either succeed or get io.ErrClosedPipe
+		// The important thing is no panic occurred
+		if err := <-writeErr; err != nil && !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("Expected nil or io.ErrClosedPipe, got: %v", err)
+		}
+	}
+}
+
+// TestSegmentClose_Idempotent verifies that calling Close() multiple times is safe
+func TestSegmentClose_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := bufpipe.New(nil)
+	seg := &segment{
+		Id:     "test-segment",
+		reader: reader,
+		writer: writer,
+	}
+
+	// Close multiple times
+	for i := 0; i < 5; i++ {
+		if err := seg.Close(); err != nil {
+			t.Errorf("Close() call %d failed: %v", i+1, err)
+		}
+	}
+
+	// Verify closed flag is set
+	seg.mx.Lock()
+	if !seg.closed {
+		t.Error("Expected segment to be marked as closed")
+	}
+	seg.mx.Unlock()
+}
+
+// TestSafeWriter_ReturnsErrorWhenClosed verifies Writer() returns safe writer even after close
+func TestSafeWriter_ReturnsErrorWhenClosed(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := bufpipe.New(nil)
+	seg := &segment{
+		Id:     "test-segment",
+		reader: reader,
+		writer: writer,
+	}
+
+	// Close first
+	if err := seg.Close(); err != nil {
+		t.Fatalf("Close() failed: %v", err)
+	}
+
+	// Get writer after close
+	w := seg.Writer()
+	if w == nil {
+		t.Fatal("Writer() returned nil")
+	}
+
+	// Attempt to write - should get clean error
+	_, err := w.Write([]byte("test data"))
+	if err == nil {
+		t.Fatal("Expected error when writing to closed segment, got nil")
+	}
+
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Errorf("Expected io.ErrClosedPipe, got: %v", err)
+	}
+}
+
+// TestSegmentWriter_ConcurrentWrites tests multiple concurrent writers with close
+func TestSegmentWriter_ConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := bufpipe.New(nil)
+	seg := &segment{
+		Id:     "test-segment",
+		reader: reader,
+		writer: writer,
+	}
+
+	w := seg.Writer()
+	var wg sync.WaitGroup
+	numWriters := 10
+	errChan := make(chan error, numWriters)
+
+	// Start multiple concurrent writers
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			data := make([]byte, 100)
+			for j := 0; j < 50; j++ {
+				_, err := w.Write(data)
+				if err != nil {
+					errChan <- err
+					return
+				}
+				time.Sleep(time.Microsecond)
+			}
+		}(i)
+	}
+
+	// Close segment during concurrent writes
+	time.Sleep(5 * time.Millisecond)
+	if err := seg.Close(); err != nil {
+		t.Errorf("Close() failed: %v", err)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// All errors should be io.ErrClosedPipe
+	for err := range errChan {
+		if !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("Expected io.ErrClosedPipe, got: %v", err)
+		}
+	}
+}
+
+// TestSegmentWriter_NilWriter verifies handling of nil writer
+func TestSegmentWriter_NilWriter(t *testing.T) {
+	t.Parallel()
+
+	seg := &segment{
+		Id:     "test-segment",
+		writer: nil, // Nil writer
+	}
+
+	w := seg.Writer()
+	_, err := w.Write([]byte("test"))
+	if err == nil {
+		t.Fatal("Expected error when writing to nil writer, got nil")
+	}
+
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Errorf("Expected io.ErrClosedPipe for nil writer, got: %v", err)
+	}
+}
+
+// TestSegmentClose_NilSegment verifies Close() handles nil segment safely
+func TestSegmentClose_NilSegment(t *testing.T) {
+	t.Parallel()
+
+	var seg *segment
+	if err := seg.Close(); err != nil {
+		t.Errorf("Close() on nil segment should return nil, got: %v", err)
+	}
+}
+
+// TestSegmentWriter_RaceDetection is designed to be run with -race flag
+func TestSegmentWriter_RaceDetection(t *testing.T) {
+	t.Parallel()
+
+	// This test is specifically designed to catch data races
+	// Run with: go test -race -run TestSegmentWriter_RaceDetection
+	for iteration := 0; iteration < 20; iteration++ {
+		reader, writer := bufpipe.New(nil)
+		seg := &segment{
+			Id:     "test-segment",
+			reader: reader,
+			writer: writer,
+		}
+
+		w := seg.Writer()
+		var wg sync.WaitGroup
+
+		// Multiple goroutines accessing Writer() and Close() concurrently
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = seg.Writer()
+			}()
+		}
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, _ = w.Write([]byte("test"))
+			}()
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Microsecond)
+			_ = seg.Close()
+		}()
+
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the `"bufpipe: read/write on closed pipe"` error that occurs when background download goroutines attempt to write to segment pipes that have been closed due to reader cancellation or context cancellation.

## Problem

Race condition in `internal/usenet/segment.go`:
1. Download goroutine calls `cp.Body()` which writes to segment writer
2. Meanwhile, `Close()` is called (from reader close or context cancellation)
3. `segment.Close()` closes the writer pipe
4. In-flight `Body()` write operation fails with "closed pipe" panic

## Solution

Implemented thread-safe writer wrapper:
- Added `closed` flag to track segment state
- Created `safeWriter` that checks closed status before writes
- Returns `io.ErrClosedPipe` instead of causing panic
- Made `Close()` idempotent to handle multiple calls safely

## Changes

### Modified Files
- `internal/usenet/segment.go` - Thread-safe writer implementation

### New Files
- `internal/usenet/segment_test.go` - Comprehensive test coverage (8 tests)

## Testing

✅ All 16 tests pass (8 new + 8 existing)
✅ No race conditions detected with `-race` flag
✅ Existing functionality preserved

### Test Coverage
- Write after close behavior
- Concurrent write and close race conditions  
- Idempotent close operations
- Multiple concurrent writers with close
- Nil writer/segment edge cases
- Race detector validation (20 iterations)

## Impact

- No more "closed pipe" panics during downloads
- Graceful error handling when segments close during download
- Downloads can be safely cancelled without crashes
- Error is handled by existing retry logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)