### PR TITLE
fix: improve sample detection to handle underscore patterns

### DIFF
--- a/internal/importer/utils/file_validation.go
+++ b/internal/importer/utils/file_validation.go
@@ -8,9 +8,11 @@ import (
 	"github.com/javi11/altmount/internal/importer/parser"
 )
 
-// sampleProofPattern matches filenames that are likely just sample or proof files
-// It matches "sample" or "proof" as a standalone word.
-var sampleProofPattern = regexp.MustCompile(`(?i)\b(sample|proof)\b`)
+// sampleProofPattern matches filenames containing "sample" or "proof" as a standalone word.
+// Uses leading non-alphanumeric boundary (including underscore) and trailing word boundary.
+// Examples matched: "movie.sample.mkv", "_sample.mkv", "movie_sample.mkv"
+// Examples not matched: "samplemovie.mkv", "Free.Samples.mkv" (plural)
+var sampleProofPattern = regexp.MustCompile(`(?i)(^|[^a-zA-Z0-9])(sample|proof)\b`)
 
 // isSampleOrProof checks if a filename looks like a sample or proof file
 func isSampleOrProof(filename string, size int64) bool {

--- a/internal/importer/utils/file_validation_test.go
+++ b/internal/importer/utils/file_validation_test.go
@@ -315,6 +315,41 @@ func TestIsAllowedFile_SampleProofPatterns(t *testing.T) {
 			filename: "regular_movie.mkv",
 			expected: true,
 		},
+		{
+			name:     "underscore prefix sample is rejected",
+			filename: "_sample.mkv",
+			expected: false,
+		},
+		{
+			name:     "underscore separator sample is rejected",
+			filename: "movie_sample.mkv",
+			expected: false,
+		},
+		{
+			name:     "underscore prefix proof is rejected",
+			filename: "_proof.mkv",
+			expected: false,
+		},
+		{
+			name:     "underscore separator proof is rejected",
+			filename: "movie_proof.mkv",
+			expected: false,
+		},
+		{
+			name:     "sample followed by underscore is allowed",
+			filename: "sample_test.mkv",
+			expected: true,
+		},
+		{
+			name:     "sample in directory path is rejected",
+			filename: "sample/movie.mkv",
+			expected: false,
+		},
+		{
+			name:     "sample with space prefix is rejected",
+			filename: "movie sample.mkv",
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fixed sample detection regex to properly detect files with underscore separators like `_sample.mkv` and `movie_sample.mkv`
- Updated regex from `\b(sample|proof)\b` to `(^|[^a-zA-Z0-9])(sample|proof)\b`
- Added comprehensive test cases for underscore patterns

## Test plan

- [x] All existing tests pass
- [x] New test cases cover underscore prefix (`_sample.mkv`)
- [x] New test cases cover underscore separator (`movie_sample.mkv`)
- [x] Verified no false positives on plurals like `Free.Samples.mkv`
- [x] Verified `sample_test.mkv` is still allowed (sample as prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)