### PR TITLE
fix: resolve memory leak in UsenetReader by replacing bufpipe with io.Pipe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ tool (
 
 require (
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
-	github.com/acomagu/bufpipe v1.0.4
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/gabriel-vasile/mimetype v1.4.9
 	github.com/go-pkgz/auth/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd h1:nzE1YQBdx1bq9
 github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd/go.mod h1:C8yoIfvESpM3GD07OCHU7fqI7lhwyZ2Td1rbNbTAhnc=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1 h1:vckeWVESWp6Qog7UZSARNqfu/cZqvki8zsuj3piCMx4=
 github.com/OpenPeeDeeP/depguard/v2 v2.2.1/go.mod h1:q4DKzC4UcVaAvcfd41CZh0PWpGgzrVxUYBlgKNGquUo=
-github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
-github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
@@ -428,7 +426,6 @@ github.com/maratori/testpackage v1.1.1 h1:S58XVV5AD7HADMmD0fNnziNHqKvSdDuEKdPD1r
 github.com/maratori/testpackage v1.1.1/go.mod h1:s4gRK/ym6AMrqpOa/kEbQTV4Q4jb7WeLZzVhVVVOQMc=
 github.com/matoous/godox v1.1.0 h1:W5mqwbyWrwZv6OQ5Z1a/DHGMOvXYCBP3+Ht7KMoJhq4=
 github.com/matoous/godox v1.1.0/go.mod h1:jgE/3fUXiTurkdHOLT5WEkThTSuE7yxHv5iWPa80afs=
-github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=

--- a/internal/usenet/range.go
+++ b/internal/usenet/range.go
@@ -1,7 +1,7 @@
 package usenet
 
 import (
-	"github.com/acomagu/bufpipe"
+	"io"
 )
 
 type SegmentLoader interface {
@@ -84,7 +84,7 @@ func GetSegmentsInRange(start, end int64, ml SegmentLoader) *segmentRange {
 			continue
 		}
 
-		r, w := bufpipe.New(nil)
+		r, w := io.Pipe()
 		seg := &segment{
 			Id:          src.Id,
 			Start:       readStart,

--- a/internal/usenet/segment.go
+++ b/internal/usenet/segment.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"io"
 	"sync"
-
-	"github.com/acomagu/bufpipe"
 )
 
 type Segment struct {
@@ -95,8 +93,8 @@ type segment struct {
 	End           int64
 	SegmentSize   int64
 	groups        []string
-	reader        *bufpipe.PipeReader
-	writer        *bufpipe.PipeWriter
+	reader        *io.PipeReader
+	writer        *io.PipeWriter
 	once          sync.Once
 	limitedReader io.Reader // Cached limited reader to prevent multiple LimitReader wraps
 	mx            sync.Mutex

--- a/internal/usenet/segment_test.go
+++ b/internal/usenet/segment_test.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/acomagu/bufpipe"
 )
 
 // TestSegmentWriter_WriteAfterClose verifies that writes after close return io.ErrClosedPipe
@@ -15,7 +13,7 @@ func TestSegmentWriter_WriteAfterClose(t *testing.T) {
 	t.Parallel()
 
 	// Create a segment with a pipe
-	reader, writer := bufpipe.New(nil)
+	reader, writer := io.Pipe()
 	seg := &segment{
 		Id:     "test-segment",
 		reader: reader,
@@ -47,7 +45,7 @@ func TestSegmentWriter_ConcurrentWriteAndClose(t *testing.T) {
 
 	// Run this test multiple times to increase chance of catching race
 	for i := 0; i < 10; i++ {
-		reader, writer := bufpipe.New(nil)
+		reader, writer := io.Pipe()
 		seg := &segment{
 			Id:     "test-segment",
 			reader: reader,
@@ -94,7 +92,7 @@ func TestSegmentWriter_ConcurrentWriteAndClose(t *testing.T) {
 func TestSegmentClose_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	reader, writer := bufpipe.New(nil)
+	reader, writer := io.Pipe()
 	seg := &segment{
 		Id:     "test-segment",
 		reader: reader,
@@ -120,7 +118,7 @@ func TestSegmentClose_Idempotent(t *testing.T) {
 func TestSafeWriter_ReturnsErrorWhenClosed(t *testing.T) {
 	t.Parallel()
 
-	reader, writer := bufpipe.New(nil)
+	reader, writer := io.Pipe()
 	seg := &segment{
 		Id:     "test-segment",
 		reader: reader,
@@ -153,7 +151,7 @@ func TestSafeWriter_ReturnsErrorWhenClosed(t *testing.T) {
 func TestSegmentWriter_ConcurrentWrites(t *testing.T) {
 	t.Parallel()
 
-	reader, writer := bufpipe.New(nil)
+	reader, writer := io.Pipe()
 	seg := &segment{
 		Id:     "test-segment",
 		reader: reader,
@@ -236,7 +234,7 @@ func TestSegmentWriter_RaceDetection(t *testing.T) {
 	// This test is specifically designed to catch data races
 	// Run with: go test -race -run TestSegmentWriter_RaceDetection
 	for iteration := 0; iteration < 20; iteration++ {
-		reader, writer := bufpipe.New(nil)
+		reader, writer := io.Pipe()
 		seg := &segment{
 			Id:     "test-segment",
 			reader: reader,


### PR DESCRIPTION
## Summary

- Replace unbounded `bufpipe.New(nil)` with Go's standard `io.Pipe()` to fix memory leak
- The bufpipe was causing memory to grow indefinitely as segment data was downloaded ahead of readers
- `io.Pipe()` provides natural backpressure - writers block when readers aren't consuming data
- Remove `github.com/acomagu/bufpipe` dependency from go.mod

## Test plan

- [x] All usenet package tests pass
- [x] Project builds successfully
- [x] Verify stable memory usage via `/debug/pprof/heap` during prolonged file reads
- [x] Confirm memory is reclaimed when readers disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)