### PR TITLE
fix(importer): fix context cancellation propagation to prevent stuck imports

### DIFF
--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -769,7 +769,7 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 
 	// For manually uploaded files, pass CompleteDir as the base path (not the temp upload directory)
 	// The category will be appended to this by processNzbItem in the service
-	item, err := s.importerService.AddToQueue(tempFile, basePath, categoryPtr, &priority)
+	item, err := s.importerService.AddToQueue(c.Context(), tempFile, basePath, categoryPtr, &priority)
 	if err != nil {
 		// Clean up temp file on error
 		os.Remove(tempFile)
@@ -1103,7 +1103,7 @@ func (s *Server) handleAddTestQueueItem(c *fiber.Ctx) error {
 		}
 	}
 
-	item, err := s.importerService.AddToQueue(tempPath, basePath, &category, &priority)
+	item, err := s.importerService.AddToQueue(c.Context(), tempPath, basePath, &category, &priority)
 	if err != nil {
 		os.Remove(tempPath)
 		return c.Status(500).JSON(fiber.Map{

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -326,7 +326,7 @@ func (s *Server) handleSABnzbdAddFile(c *fiber.Ctx) error {
 	// Add the file to the processing queue using centralized method
 	completeDir := s.configManager.GetConfig().SABnzbd.CompleteDir
 	priority := s.parseSABnzbdPriority(c.FormValue("priority"))
-	item, err := s.importerService.AddToQueue(tempFile, &completeDir, &validatedCategory, &priority)
+	item, err := s.importerService.AddToQueue(c.Context(), tempFile, &completeDir, &validatedCategory, &priority)
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to add to queue")
 	}
@@ -424,7 +424,7 @@ func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 	// Add the file to the processing queue using centralized method
 	completeDir := s.configManager.GetConfig().SABnzbd.CompleteDir
 	priority := s.parseSABnzbdPriority(c.Query("priority"))
-	item, err := s.importerService.AddToQueue(tempFile, &completeDir, &validatedCategory, &priority)
+	item, err := s.importerService.AddToQueue(c.Context(), tempFile, &completeDir, &validatedCategory, &priority)
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to add to queue")
 	}

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -157,6 +157,13 @@ func (sz *sevenZipProcessor) AnalyzeSevenZipContentFromNzb(ctx context.Context, 
 	// Create Afero adapter for the Usenet filesystem
 	aferoFS := filesystem.NewAferoAdapter(ufs)
 
+	// Check context before expensive archive open operation
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Open 7zip archive using OpenReaderWithPassword if password provided
 	var reader *sevenzip.ReadCloser
 	if password != "" {
@@ -186,6 +193,13 @@ func (sz *sevenZipProcessor) AnalyzeSevenZipContentFromNzb(ctx context.Context, 
 	sz.log.DebugContext(ctx, "Successfully analyzed 7zip archive",
 		"main_file", mainSevenZipFile,
 		"files_found", len(fileInfos))
+
+	// Check context before conversion phase
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
 
 	// Convert sevenzip FileInfo results to Content
 	// Note: AES credentials are extracted per-file, not per-archive


### PR DESCRIPTION
## Summary
- Fix double-unlock panic bug in `Stop()` method that caused crashes on service shutdown
- Add `ctx.Done()` checks in `UsenetFile.Read()` with timeout for reader creation to prevent network hangs
- Add context checks before expensive operations in RAR and 7zip archive processors
- Add context parameter to `AddToQueue()` and update all API handler callers
- Add context parameter to `createNzbFileAndPrepareItem()` and `isFileAlreadyInQueue()`
- Replace `context.Background()` with proper service context in logging calls
- Fix `notifyRcloneVFS` to derive timeout from parent context for proper cancellation propagation

## Test plan
- [x] Run `go build ./...` to verify compilation
- [x] Run `go test ./internal/importer/...` to verify existing tests pass
- [x] Manual test: Start an import, cancel mid-process, verify clean cancellation
- [ ] Manual test: Stop the service, verify no panic from double-unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)