### PR TITLE
refactor(importer): decompose service into focused sub-packages

### DIFF
--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -1,0 +1,146 @@
+package importer
+
+import (
+	"context"
+
+	"github.com/javi11/altmount/internal/database"
+)
+
+// QueueManager manages the import queue worker lifecycle
+type QueueManager interface {
+	// Start begins processing queue items with the configured number of workers
+	Start(ctx context.Context) error
+	// Stop gracefully stops all workers and waits for completion
+	Stop(ctx context.Context) error
+	// Pause temporarily stops processing new items (workers remain active)
+	Pause()
+	// Resume continues processing after a pause
+	Resume()
+	// IsPaused returns whether the queue is currently paused
+	IsPaused() bool
+	// IsRunning returns whether the queue manager is active
+	IsRunning() bool
+	// GetWorkerCount returns the current number of workers
+	GetWorkerCount() int
+	// UpdateWorkerCount changes the number of active workers
+	UpdateWorkerCount(count int) error
+	// CancelProcessing cancels processing of a specific item
+	CancelProcessing(itemID int64) error
+	// ProcessItemInBackground starts processing a specific item in the background
+	ProcessItemInBackground(ctx context.Context, itemID int64)
+}
+
+// DirectoryScanner provides manual directory scanning functionality
+type DirectoryScanner interface {
+	// StartManualScan begins scanning a directory for NZB files
+	StartManualScan(scanPath string) error
+	// GetScanStatus returns the current scan status
+	GetScanStatus() ScanInfo
+	// CancelScan cancels an in-progress scan
+	CancelScan() error
+}
+
+// NzbDavImporter handles bulk import from NzbDav databases
+type NzbDavImporter interface {
+	// StartNzbdavImport begins importing from an NzbDav database
+	StartNzbdavImport(dbPath string, rootFolder string, cleanupFile bool) error
+	// GetImportStatus returns the current import status
+	GetImportStatus() ImportInfo
+	// CancelImport cancels an in-progress import
+	CancelImport() error
+}
+
+// QueueOperations provides queue manipulation operations
+type QueueOperations interface {
+	// AddToQueue adds an item to the import queue
+	AddToQueue(ctx context.Context, filePath string, relativePath *string, category *string, priority *database.QueuePriority) (*database.ImportQueueItem, error)
+	// GetQueueStats returns queue statistics
+	GetQueueStats(ctx context.Context) (*database.QueueStats, error)
+	// GetStats returns comprehensive service statistics
+	GetStats(ctx context.Context) (*ServiceStats, error)
+}
+
+// SymlinkCreator handles symlink creation for imported files
+type SymlinkCreator interface {
+	// CreateSymlinks creates symlinks for an imported item
+	CreateSymlinks(item *database.ImportQueueItem, resultingPath string) error
+}
+
+// StrmGenerator handles STRM file generation
+type StrmGenerator interface {
+	// CreateStrmFiles creates STRM files for an imported item
+	CreateStrmFiles(item *database.ImportQueueItem, resultingPath string) error
+}
+
+// VFSNotifier handles rclone VFS cache notifications
+type VFSNotifier interface {
+	// NotifyVFS notifies rclone VFS about file changes
+	NotifyVFS(ctx context.Context, resultingPath string, async bool)
+	// RefreshMountPathIfNeeded refreshes the mount path cache if required
+	RefreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64)
+}
+
+// HealthScheduler handles health check scheduling for imported files
+type HealthScheduler interface {
+	// ScheduleHealthCheck schedules a health check for an imported file
+	ScheduleHealthCheck(ctx context.Context, filePath string, sourceNzb string, priority database.HealthPriority) error
+}
+
+// ARRNotifier handles notifications to ARR applications (Sonarr/Radarr)
+type ARRNotifier interface {
+	// NotifyARR notifies ARR applications about imported content
+	NotifyARR(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error
+}
+
+// SABnzbdFallback handles fallback to external SABnzbd for failed imports
+type SABnzbdFallback interface {
+	// AttemptFallback tries to send a failed import to external SABnzbd
+	AttemptFallback(ctx context.Context, item *database.ImportQueueItem) error
+}
+
+// IDMetadataLinker handles NzbDav ID metadata linking
+type IDMetadataLinker interface {
+	// HandleIDMetadataLinks creates ID-based metadata links
+	HandleIDMetadataLinks(item *database.ImportQueueItem, resultingPath string)
+}
+
+// PostProcessor coordinates all post-import processing steps
+type PostProcessor interface {
+	SymlinkCreator
+	StrmGenerator
+	VFSNotifier
+	HealthScheduler
+	ARRNotifier
+	SABnzbdFallback
+	IDMetadataLinker
+
+	// HandleSuccess performs all post-processing for successful imports
+	HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error
+	// HandleFailure performs all cleanup for failed imports
+	HandleFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error)
+}
+
+// ImportService is the main interface combining all importer capabilities
+type ImportService interface {
+	QueueManager
+	DirectoryScanner
+	NzbDavImporter
+	QueueOperations
+
+	// Database returns the underlying database connection
+	Database() *database.DB
+	// Close releases all resources
+	Close() error
+	// SetRcloneClient sets the rclone client for VFS notifications
+	SetRcloneClient(client interface{})
+	// SetArrsService sets the ARRs service for notifications
+	SetArrsService(service interface{})
+	// RegisterConfigChangeHandler registers a handler for configuration changes
+	RegisterConfigChangeHandler(configManager interface{})
+}
+
+// FileSizeCalculator calculates file sizes for different file types
+type FileSizeCalculator interface {
+	// CalculateFileSizeOnly calculates the size of a file without full processing
+	CalculateFileSizeOnly(filePath string) (int64, error)
+}

--- a/internal/importer/postprocessor/arr_notifier.go
+++ b/internal/importer/postprocessor/arr_notifier.go
@@ -1,0 +1,65 @@
+package postprocessor
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/javi11/altmount/internal/database"
+)
+
+// NotifyARR notifies ARR applications about imported content
+func (c *Coordinator) NotifyARR(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	if c.arrsService == nil || item.Category == nil {
+		return nil
+	}
+
+	cfg := c.configGetter()
+
+	// Try to trigger scan on the specific instance that manages this file
+	fullMountPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(resultingPath, "/"))
+
+	if err := c.arrsService.TriggerScanForFile(ctx, fullMountPath); err != nil {
+		// Fallback: broadcast to all instances of the type
+		c.log.DebugContext(ctx, "Could not find specific ARR instance for file, broadcasting scan",
+			"path", fullMountPath, "error", err)
+
+		return c.broadcastToARRType(ctx, item)
+	}
+
+	return nil
+}
+
+// broadcastToARRType broadcasts scan to all instances of the determined ARR type
+func (c *Coordinator) broadcastToARRType(ctx context.Context, item *database.ImportQueueItem) error {
+	categoryName := *item.Category
+	category := strings.ToLower(categoryName)
+	arrType := ""
+
+	cfg := c.configGetter()
+
+	// Try to find an explicit mapping in SABnzbd categories
+	for _, cat := range cfg.SABnzbd.Categories {
+		if strings.EqualFold(cat.Name, categoryName) && cat.Type != "" {
+			arrType = strings.ToLower(cat.Type)
+			break
+		}
+	}
+
+	// Fallback to heuristic if no explicit type is mapped
+	if arrType == "" {
+		if category == "tv" || strings.Contains(category, "tv") || strings.Contains(category, "show") || category == "sonarr" {
+			arrType = "sonarr"
+		} else if category == "movies" || strings.Contains(category, "movie") || category == "radarr" {
+			arrType = "radarr"
+		}
+	}
+
+	if arrType != "" {
+		c.arrsService.TriggerDownloadScan(ctx, arrType)
+		return nil
+	}
+
+	return fmt.Errorf("could not determine ARR type for category: %s", categoryName)
+}

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -1,0 +1,137 @@
+// Package postprocessor handles all post-import processing steps including
+// symlink creation, STRM file generation, VFS notifications, health check
+// scheduling, and ARR notifications.
+package postprocessor
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/javi11/altmount/internal/arrs"
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	"github.com/javi11/altmount/pkg/rclonecli"
+)
+
+// Coordinator orchestrates all post-import processing steps
+type Coordinator struct {
+	configGetter    config.ConfigGetter
+	metadataService *metadata.MetadataService
+	rcloneClient    rclonecli.RcloneRcClient
+	healthRepo      *database.HealthRepository
+	arrsService     *arrs.Service
+	userRepo        *database.UserRepository
+	log             *slog.Logger
+}
+
+// Config holds configuration for the Coordinator
+type Config struct {
+	ConfigGetter    config.ConfigGetter
+	MetadataService *metadata.MetadataService
+	RcloneClient    rclonecli.RcloneRcClient
+	HealthRepo      *database.HealthRepository
+	ArrsService     *arrs.Service
+	UserRepo        *database.UserRepository
+}
+
+// NewCoordinator creates a new post-processor coordinator
+func NewCoordinator(cfg Config) *Coordinator {
+	return &Coordinator{
+		configGetter:    cfg.ConfigGetter,
+		metadataService: cfg.MetadataService,
+		rcloneClient:    cfg.RcloneClient,
+		healthRepo:      cfg.HealthRepo,
+		arrsService:     cfg.ArrsService,
+		userRepo:        cfg.UserRepo,
+		log:             slog.Default().With("component", "postprocessor"),
+	}
+}
+
+// SetRcloneClient updates the rclone client (called when config changes)
+func (c *Coordinator) SetRcloneClient(client rclonecli.RcloneRcClient) {
+	c.rcloneClient = client
+}
+
+// SetArrsService updates the ARRs service (called after initialization)
+func (c *Coordinator) SetArrsService(service *arrs.Service) {
+	c.arrsService = service
+}
+
+// ProcessingResult holds the result of post-processing operations
+type ProcessingResult struct {
+	SymlinksCreated bool
+	StrmCreated     bool
+	VFSNotified     bool
+	HealthScheduled bool
+	ARRNotified     bool
+	Errors          []error
+}
+
+// HandleSuccess performs all post-processing for successful imports
+func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) (*ProcessingResult, error) {
+	result := &ProcessingResult{}
+
+	// 1. Notify VFS (blocking to ensure visibility)
+	c.NotifyVFS(ctx, resultingPath, false)
+	result.VFSNotified = true
+
+	// 2. Create symlinks if configured
+	if err := c.CreateSymlinks(ctx, item, resultingPath); err != nil {
+		c.log.WarnContext(ctx, "Failed to create symlinks",
+			"queue_id", item.ID,
+			"path", resultingPath,
+			"error", err)
+		result.Errors = append(result.Errors, err)
+	} else {
+		result.SymlinksCreated = true
+	}
+
+	// 3. Create ID metadata links
+	c.HandleIDMetadataLinks(ctx, item, resultingPath)
+
+	// 4. Create STRM files if configured
+	if err := c.CreateStrmFiles(ctx, item, resultingPath); err != nil {
+		c.log.WarnContext(ctx, "Failed to create STRM files",
+			"queue_id", item.ID,
+			"path", resultingPath,
+			"error", err)
+		result.Errors = append(result.Errors, err)
+	} else {
+		result.StrmCreated = true
+	}
+
+	// 5. Schedule health check
+	if err := c.ScheduleHealthCheck(ctx, resultingPath); err != nil {
+		c.log.WarnContext(ctx, "Failed to schedule health check",
+			"path", resultingPath,
+			"error", err)
+		result.Errors = append(result.Errors, err)
+	} else {
+		result.HealthScheduled = true
+	}
+
+	// 6. Notify ARR applications
+	if err := c.NotifyARR(ctx, item, resultingPath); err != nil {
+		c.log.DebugContext(ctx, "ARR notification not sent",
+			"path", resultingPath,
+			"error", err)
+		// Don't add to errors - ARR notification is optional
+	} else {
+		result.ARRNotified = true
+	}
+
+	return result, nil
+}
+
+// HandleFailure performs cleanup and fallback for failed imports
+func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) error {
+	cfg := c.configGetter()
+
+	// Attempt SABnzbd fallback if configured
+	if cfg.SABnzbd.FallbackHost != "" && cfg.SABnzbd.FallbackAPIKey != "" {
+		return c.AttemptFallback(ctx, item)
+	}
+
+	return nil
+}

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -1,0 +1,70 @@
+package postprocessor
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/javi11/altmount/internal/database"
+)
+
+// ScheduleHealthCheck schedules a health check for an imported file
+func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, resultingPath string) error {
+	if c.healthRepo == nil {
+		return nil // Health checks not configured
+	}
+
+	// Read metadata to get SourceNzbPath needed for health check
+	fileMeta, err := c.metadataService.ReadFileMetadata(resultingPath)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to read metadata for health check scheduling",
+			"path", resultingPath,
+			"error", err)
+		return err
+	}
+
+	if fileMeta == nil {
+		return nil
+	}
+
+	// Add/Update health record with high priority
+	err = c.healthRepo.AddFileToHealthCheck(ctx, resultingPath, 2, &fileMeta.SourceNzbPath, database.HealthPriorityNext)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to schedule immediate health check for imported file",
+			"path", resultingPath,
+			"error", err)
+		return err
+	}
+
+	slog.InfoContext(ctx, "Scheduled immediate health check for imported file", "path", resultingPath)
+
+	// Resolve pending repairs in the directory if configured
+	c.resolvePendingRepairs(ctx, resultingPath)
+
+	return nil
+}
+
+// resolvePendingRepairs resolves pending repairs in the same directory
+func (c *Coordinator) resolvePendingRepairs(ctx context.Context, resultingPath string) {
+	cfg := c.configGetter()
+	resolveRepairs := true
+	if cfg.Health.ResolveRepairOnImport != nil {
+		resolveRepairs = *cfg.Health.ResolveRepairOnImport
+	}
+
+	if !resolveRepairs {
+		return
+	}
+
+	parentDir := filepath.Dir(resultingPath)
+	if parentDir == "." || parentDir == "/" {
+		return
+	}
+
+	count, err := c.healthRepo.ResolvePendingRepairsInDirectory(ctx, parentDir)
+	if err == nil && count > 0 {
+		slog.InfoContext(ctx, "Resolved pending repairs in directory due to new import",
+			"directory", parentDir,
+			"resolved_count", count)
+	}
+}

--- a/internal/importer/postprocessor/id_linker.go
+++ b/internal/importer/postprocessor/id_linker.go
@@ -1,0 +1,108 @@
+package postprocessor
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/javi11/altmount/internal/database"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+// HandleIDMetadataLinks creates ID-based metadata links for nzbdav compatibility
+func (c *Coordinator) HandleIDMetadataLinks(ctx context.Context, item *database.ImportQueueItem, resultingPath string) {
+	// 1. Check if the queue item itself has a release-level ID in its metadata
+	if item.Metadata != nil && *item.Metadata != "" {
+		var meta struct {
+			NzbdavID string `json:"nzbdav_id"`
+		}
+		if err := json.Unmarshal([]byte(*item.Metadata), &meta); err == nil && meta.NzbdavID != "" {
+			if err := c.createIDMetadataLink(meta.NzbdavID, resultingPath); err != nil {
+				c.log.Warn("Failed to create release ID metadata link", "id", meta.NzbdavID, "error", err)
+			}
+		}
+	}
+
+	// 2. Check individual files for IDs
+	cfg := c.configGetter()
+	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
+
+	_ = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".meta") {
+			return nil
+		}
+
+		// Read the metadata file to find the ID
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+
+		// Parse the protobuf metadata to get the ID
+		meta := &metapb.FileMetadata{}
+		if err := proto.Unmarshal(data, meta); err != nil {
+			return nil
+		}
+
+		// Check sidecar ID file if not in proto (compatibility mode)
+		if meta.NzbdavId == "" {
+			if idData, err := os.ReadFile(path + ".id"); err == nil {
+				meta.NzbdavId = string(idData)
+			}
+		}
+
+		if meta.NzbdavId != "" {
+			// Calculate the virtual path from the metadata file path
+			relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
+			if err != nil {
+				return nil
+			}
+			// Remove .meta extension
+			virtualPath := strings.TrimSuffix(relPath, ".meta")
+
+			if err := c.createIDMetadataLink(meta.NzbdavId, virtualPath); err != nil {
+				c.log.Warn("Failed to create file ID metadata link", "id", meta.NzbdavId, "error", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// createIDMetadataLink creates a symlink from an ID-based sharded path to the metadata file
+func (c *Coordinator) createIDMetadataLink(nzbdavID, resultingPath string) error {
+	cfg := c.configGetter()
+	metadataRoot := cfg.Metadata.RootPath
+
+	// Calculate sharded path
+	// 04db0bde-7ad0-46a3-a2f4-9ef8efd0d7d7 -> .ids/0/4/d/b/0/04db0bde-7ad0-46a3-a2f4-9ef8efd0d7d7.meta
+	id := strings.ToLower(nzbdavID)
+	if len(id) < 5 {
+		return nil // Invalid ID for sharding
+	}
+
+	shardPath := filepath.Join(".ids", string(id[0]), string(id[1]), string(id[2]), string(id[3]), string(id[4]))
+	fullShardDir := filepath.Join(metadataRoot, shardPath)
+
+	if err := os.MkdirAll(fullShardDir, 0755); err != nil {
+		return err
+	}
+
+	targetMetaPath := c.metadataService.GetMetadataFilePath(resultingPath)
+	linkPath := filepath.Join(fullShardDir, id+".meta")
+
+	// Remove if exists
+	os.Remove(linkPath)
+
+	// Create relative symlink if possible
+	relTarget, err := filepath.Rel(fullShardDir, targetMetaPath)
+	if err != nil {
+		return os.Symlink(targetMetaPath, linkPath)
+	}
+
+	return os.Symlink(relTarget, linkPath)
+}

--- a/internal/importer/postprocessor/sabnzbd_fallback.go
+++ b/internal/importer/postprocessor/sabnzbd_fallback.go
@@ -1,0 +1,65 @@
+package postprocessor
+
+import (
+	"context"
+	"os"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/sabnzbd"
+)
+
+// AttemptFallback tries to send a failed import to external SABnzbd
+func (c *Coordinator) AttemptFallback(ctx context.Context, item *database.ImportQueueItem) error {
+	cfg := c.configGetter()
+
+	// Check if the NZB file still exists
+	if _, err := os.Stat(item.NzbPath); err != nil {
+		c.log.WarnContext(ctx, "SABnzbd fallback not attempted - NZB file not found",
+			"queue_id", item.ID,
+			"file", item.NzbPath,
+			"error", err)
+		return err
+	}
+
+	c.log.InfoContext(ctx, "Attempting to send failed import to external SABnzbd",
+		"queue_id", item.ID,
+		"file", item.NzbPath,
+		"fallback_host", cfg.SABnzbd.FallbackHost)
+
+	// Convert priority to SABnzbd format
+	priority := convertPriorityToSABnzbd(item.Priority)
+
+	// Create client and send
+	client := sabnzbd.NewSABnzbdClient()
+	nzoID, err := client.SendNZBFile(
+		ctx,
+		cfg.SABnzbd.FallbackHost,
+		cfg.SABnzbd.FallbackAPIKey,
+		item.NzbPath,
+		item.Category,
+		&priority,
+	)
+	if err != nil {
+		return err
+	}
+
+	c.log.InfoContext(ctx, "Successfully sent failed import to external SABnzbd",
+		"queue_id", item.ID,
+		"file", item.NzbPath,
+		"fallback_host", cfg.SABnzbd.FallbackHost,
+		"sabnzbd_nzo_id", nzoID)
+
+	return nil
+}
+
+// convertPriorityToSABnzbd converts AltMount queue priority to SABnzbd priority format
+func convertPriorityToSABnzbd(priority database.QueuePriority) string {
+	switch priority {
+	case database.QueuePriorityHigh:
+		return "2" // High
+	case database.QueuePriorityLow:
+		return "0" // Low
+	default:
+		return "1" // Normal
+	}
+}

--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -1,0 +1,165 @@
+package postprocessor
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// CreateStrmFiles creates STRM files for an imported file or directory
+func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	cfg := c.configGetter()
+
+	// Check if STRM is enabled
+	if cfg.Import.ImportStrategy != config.ImportStrategySTRM {
+		return nil // Skip if not enabled
+	}
+
+	if cfg.Import.ImportDir == nil || *cfg.Import.ImportDir == "" {
+		return fmt.Errorf("STRM directory not configured")
+	}
+
+	// Check the metadata directory to determine if this is a file or directory
+	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
+	fileInfo, err := os.Stat(metadataPath)
+
+	// If stat fails, check if it's a .meta file (single file case)
+	if err != nil {
+		metaFile := metadataPath + ".meta"
+		if _, metaErr := os.Stat(metaFile); metaErr == nil {
+			return c.createSingleStrmFile(ctx, resultingPath, cfg.WebDAV.Port)
+		}
+		return fmt.Errorf("failed to stat metadata path: %w", err)
+	}
+
+	if !fileInfo.IsDir() {
+		return c.createSingleStrmFile(ctx, resultingPath, cfg.WebDAV.Port)
+	}
+
+	// Directory - walk through and create STRM files for all files
+	var strmErrors []error
+	strmCount := 0
+
+	err = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			c.log.WarnContext(ctx, "Error accessing metadata path during STRM creation",
+				"path", path,
+				"error", err)
+			return nil
+		}
+
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".meta") {
+			return nil
+		}
+
+		// Calculate relative path from the root metadata directory
+		relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
+		if err != nil {
+			c.log.ErrorContext(ctx, "Failed to calculate relative path",
+				"path", path,
+				"base", cfg.Metadata.RootPath,
+				"error", err)
+			return nil
+		}
+
+		// Remove .meta extension
+		relPath = strings.TrimSuffix(relPath, ".meta")
+
+		if err := c.createSingleStrmFile(ctx, relPath, cfg.WebDAV.Port); err != nil {
+			c.log.ErrorContext(ctx, "Failed to create STRM file",
+				"path", relPath,
+				"error", err)
+			strmErrors = append(strmErrors, err)
+			return nil
+		}
+
+		strmCount++
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	if len(strmErrors) > 0 {
+		c.log.WarnContext(ctx, "Some STRM files failed to create",
+			"queue_id", item.ID,
+			"total_errors", len(strmErrors),
+			"successful", strmCount)
+	}
+
+	return nil
+}
+
+// createSingleStrmFile creates a STRM file for a single file with authentication
+func (c *Coordinator) createSingleStrmFile(ctx context.Context, virtualPath string, port int) error {
+	cfg := c.configGetter()
+
+	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(virtualPath))
+
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return fmt.Errorf("failed to create STRM directory: %w", err)
+	}
+
+	// Keep original filename and add .strm extension
+	filename := filepath.Base(virtualPath) + ".strm"
+	strmPath := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(virtualPath), filename)
+
+	// Get first admin user's API key for authentication
+	if c.userRepo == nil {
+		return fmt.Errorf("user repository not available for STRM generation")
+	}
+
+	users, err := c.userRepo.GetAllUsers(ctx)
+	if err != nil || len(users) == 0 {
+		return fmt.Errorf("no users with API keys found for STRM generation: %w", err)
+	}
+
+	// Find first admin user with an API key
+	var adminAPIKey string
+	for _, user := range users {
+		if user.IsAdmin && user.APIKey != nil && *user.APIKey != "" {
+			adminAPIKey = *user.APIKey
+			break
+		}
+	}
+
+	if adminAPIKey == "" {
+		return fmt.Errorf("no admin user with API key found for STRM generation")
+	}
+
+	// Hash the API key with SHA256
+	hashedKey := hashAPIKey(adminAPIKey)
+
+	// Generate streaming URL with download_key
+	encodedPath := strings.ReplaceAll(virtualPath, " ", "%20")
+	streamURL := fmt.Sprintf("http://localhost:%d/api/files/stream?path=%s&download_key=%s",
+		port, encodedPath, hashedKey)
+
+	// Check if STRM file already exists with the same content
+	if existingContent, err := os.ReadFile(strmPath); err == nil {
+		if string(existingContent) == streamURL {
+			return nil // File exists with correct content
+		}
+	}
+
+	if err := os.WriteFile(strmPath, []byte(streamURL), 0644); err != nil {
+		return fmt.Errorf("failed to write STRM file: %w", err)
+	}
+
+	return nil
+}
+
+// hashAPIKey generates a SHA256 hash of the API key for secure comparison
+func hashAPIKey(apiKey string) string {
+	hash := sha256.Sum256([]byte(apiKey))
+	return hex.EncodeToString(hash[:])
+}

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -1,0 +1,131 @@
+package postprocessor
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// CreateSymlinks creates symlinks for an imported item based on the import strategy
+func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	cfg := c.configGetter()
+
+	// Check if symlinks are enabled
+	if cfg.Import.ImportStrategy != config.ImportStrategySYMLINK {
+		return nil // Skip if not enabled
+	}
+
+	if cfg.Import.ImportDir == nil || *cfg.Import.ImportDir == "" {
+		return fmt.Errorf("symlink directory not configured")
+	}
+
+	// Get the actual metadata/mount path (where the content actually lives)
+	actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(resultingPath, "/"))
+
+	// Check the metadata directory to determine if this is a file or directory
+	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
+	fileInfo, err := os.Stat(metadataPath)
+
+	// If stat fails, check if it's a .meta file (single file case)
+	if err != nil {
+		metaFile := metadataPath + ".meta"
+		if _, metaErr := os.Stat(metaFile); metaErr == nil {
+			return c.createSingleSymlink(actualPath, resultingPath)
+		}
+		return fmt.Errorf("failed to stat metadata path: %w", err)
+	}
+
+	if !fileInfo.IsDir() {
+		return c.createSingleSymlink(actualPath, resultingPath)
+	}
+
+	// Directory - walk through and create symlinks for all files
+	var symlinkErrors []error
+	symlinkCount := 0
+
+	err = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			c.log.WarnContext(ctx, "Error accessing metadata path during symlink creation",
+				"path", path,
+				"error", err)
+			return nil // Continue walking
+		}
+
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".meta") {
+			return nil
+		}
+
+		// Calculate relative path from the root metadata directory
+		relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
+		if err != nil {
+			c.log.ErrorContext(ctx, "Failed to calculate relative path",
+				"path", path,
+				"base", cfg.Metadata.RootPath,
+				"error", err)
+			return nil
+		}
+
+		// Remove .meta extension
+		relPath = strings.TrimSuffix(relPath, ".meta")
+
+		// Build the actual file path in the mount
+		actualFilePath := filepath.Join(cfg.MountPath, strings.TrimPrefix(relPath, "/"))
+		fileResultingPath := relPath
+
+		if err := c.createSingleSymlink(actualFilePath, fileResultingPath); err != nil {
+			c.log.ErrorContext(ctx, "Failed to create symlink",
+				"path", actualFilePath,
+				"error", err)
+			symlinkErrors = append(symlinkErrors, err)
+			return nil
+		}
+
+		symlinkCount++
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	if len(symlinkErrors) > 0 {
+		c.log.WarnContext(ctx, "Some symlinks failed to create",
+			"queue_id", item.ID,
+			"total_errors", len(symlinkErrors),
+			"successful", symlinkCount)
+	}
+
+	return nil
+}
+
+// createSingleSymlink creates a symlink for a single file
+func (c *Coordinator) createSingleSymlink(actualPath, resultingPath string) error {
+	cfg := c.configGetter()
+
+	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(strings.TrimPrefix(resultingPath, "/")))
+
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return fmt.Errorf("failed to create symlink category directory: %w", err)
+	}
+
+	symlinkPath := filepath.Join(*cfg.Import.ImportDir, strings.TrimPrefix(resultingPath, "/"))
+
+	// Remove existing symlink if present
+	if _, err := os.Lstat(symlinkPath); err == nil {
+		if err := os.Remove(symlinkPath); err != nil {
+			return fmt.Errorf("failed to remove existing symlink: %w", err)
+		}
+	}
+
+	if err := os.Symlink(actualPath, symlinkPath); err != nil {
+		return fmt.Errorf("failed to create symlink: %w", err)
+	}
+
+	return nil
+}

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -1,0 +1,96 @@
+package postprocessor
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// NotifyVFS notifies rclone VFS about file changes
+func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async bool) {
+	if c.rcloneClient == nil {
+		return
+	}
+
+	refreshFunc := func(path string) {
+		refreshCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		cfg := c.configGetter()
+		vfsName := cfg.RClone.VFSName
+		if vfsName == "" {
+			vfsName = config.MountProvider
+		}
+
+		// Normalize paths for rclone (no leading slash)
+		normalizeForRclone := func(p string) string {
+			p = strings.TrimPrefix(p, "/")
+			if p == "" {
+				return "."
+			}
+			return p
+		}
+
+		dirsToRefresh := []string{normalizeForRclone(path)}
+		parentDir := filepath.Dir(path)
+		if parentDir != "." && parentDir != "/" {
+			dirsToRefresh = append(dirsToRefresh, normalizeForRclone(parentDir))
+
+			// Also refresh grandparent if parent might be new
+			grandParent := filepath.Dir(parentDir)
+			if grandParent != "." && grandParent != "/" {
+				dirsToRefresh = append(dirsToRefresh, normalizeForRclone(grandParent))
+			}
+		}
+
+		slog.DebugContext(refreshCtx, "Notifying rclone VFS refresh", "dirs", dirsToRefresh, "vfs", vfsName)
+
+		err := c.rcloneClient.RefreshDir(refreshCtx, vfsName, dirsToRefresh)
+		if err != nil {
+			slog.WarnContext(refreshCtx, "Failed to notify rclone VFS refresh",
+				"dirs", dirsToRefresh,
+				"error", err)
+		} else {
+			slog.InfoContext(refreshCtx, "Successfully notified rclone VFS refresh",
+				"dirs", dirsToRefresh)
+		}
+	}
+
+	if async {
+		go refreshFunc(resultingPath)
+	} else {
+		refreshFunc(resultingPath)
+	}
+}
+
+// RefreshMountPathIfNeeded refreshes the mount path cache if required
+func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64) {
+	if c.rcloneClient == nil {
+		return
+	}
+
+	cfg := c.configGetter()
+	mountPath := filepath.Join(cfg.MountPath, filepath.Dir(strings.TrimPrefix(resultingPath, "/")))
+
+	if _, err := os.Stat(mountPath); err != nil {
+		if os.IsNotExist(err) {
+			vfsName := cfg.RClone.VFSName
+			if vfsName == "" {
+				vfsName = config.MountProvider
+			}
+
+			// Refresh the root path if the mount path is not found
+			if err := c.rcloneClient.RefreshDir(ctx, vfsName, []string{"/"}); err != nil {
+				c.log.ErrorContext(ctx, "Failed to refresh mount path",
+					"queue_id", itemID,
+					"path", mountPath,
+					"error", err)
+			}
+		}
+	}
+}

--- a/internal/importer/queue/claimer.go
+++ b/internal/importer/queue/claimer.go
@@ -1,0 +1,107 @@
+// Package queue provides queue management for the NZB import service.
+package queue
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// QueueRepository defines the interface for queue database operations
+type QueueRepository interface {
+	ClaimNextQueueItem(ctx context.Context) (*database.ImportQueueItem, error)
+}
+
+// Claimer handles claiming queue items with retry logic
+type Claimer struct {
+	repo QueueRepository
+	log  *slog.Logger
+}
+
+// NewClaimer creates a new Claimer
+func NewClaimer(repo QueueRepository) *Claimer {
+	return &Claimer{
+		repo: repo,
+		log:  slog.Default().With("component", "queue-claimer"),
+	}
+}
+
+// ClaimWithRetry attempts to claim a queue item with exponential backoff retry logic
+func (c *Claimer) ClaimWithRetry(ctx context.Context, workerID int) (*database.ImportQueueItem, error) {
+	var item *database.ImportQueueItem
+
+	err := retry.Do(
+		func() error {
+			claimedItem, err := c.repo.ClaimNextQueueItem(ctx)
+			if err != nil {
+				return err
+			}
+
+			item = claimedItem
+			return nil
+		},
+		retry.Attempts(3),                // Reduced from 5 - immediate transactions should succeed quickly
+		retry.Delay(50*time.Millisecond), // Increased from 10ms
+		retry.MaxDelay(5*time.Second),    // Increased from 500ms to allow better spreading
+		retry.DelayType(retry.BackOffDelay),
+		retry.RetryIf(IsDatabaseContentionError),
+		retry.OnRetry(func(n uint, err error) {
+			// Add jitter to prevent synchronized retries across workers
+			// Jitter range: 0-1000ms to desynchronize worker retries
+			jitter := time.Duration(rand.Int63n(int64(time.Second)))
+			time.Sleep(jitter)
+
+			// Calculate exponential backoff for logging
+			baseDelay := 50 * time.Millisecond
+			backoffDelay := baseDelay * (1 << n) // Exponential: 50ms, 100ms, 200ms...
+			if backoffDelay > 5*time.Second {
+				backoffDelay = 5 * time.Second
+			}
+
+			// Only log warnings after first retry to reduce noise
+			if n >= 1 {
+				c.log.WarnContext(ctx, "Database contention, retrying claim",
+					"attempt", n+1,
+					"worker_id", workerID,
+					"backoff_ms", backoffDelay.Milliseconds(),
+					"jitter_ms", jitter.Milliseconds(),
+					"error", err)
+			} else {
+				c.log.DebugContext(ctx, "Database contention, retrying claim",
+					"attempt", n+1,
+					"worker_id", workerID,
+					"backoff_ms", backoffDelay.Milliseconds(),
+					"jitter_ms", jitter.Milliseconds(),
+					"error", err)
+			}
+		}),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to claim queue item: %w", err)
+	}
+
+	if item == nil {
+		return nil, nil
+	}
+
+	c.log.DebugContext(ctx, "Next item in processing queue", "queue_id", item.ID, "file", item.NzbPath)
+	return item, nil
+}
+
+// IsDatabaseContentionError checks if an error is a retryable database contention error
+func IsDatabaseContentionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "database is locked") ||
+		strings.Contains(errStr, "database is busy") ||
+		strings.Contains(errStr, "database table is locked")
+}

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -1,0 +1,257 @@
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// ItemProcessor defines the interface for processing queue items
+type ItemProcessor interface {
+	// ProcessItem processes a single queue item and returns the resulting path or an error
+	ProcessItem(ctx context.Context, item *database.ImportQueueItem) (string, error)
+	// HandleSuccess handles successful processing
+	HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error
+	// HandleFailure handles failed processing
+	HandleFailure(ctx context.Context, item *database.ImportQueueItem, err error)
+}
+
+// ManagerConfig holds configuration for the queue manager
+type ManagerConfig struct {
+	Workers      int
+	ConfigGetter config.ConfigGetter
+}
+
+// Manager manages queue workers and processing
+type Manager struct {
+	config       ManagerConfig
+	repository   *database.QueueRepository
+	claimer      *Claimer
+	processor    ItemProcessor
+	configGetter config.ConfigGetter
+	log          *slog.Logger
+
+	// Runtime state
+	mu      sync.RWMutex
+	running bool
+	paused  bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+
+	// Cancellation tracking for processing items
+	cancelFuncs map[int64]context.CancelFunc
+	cancelMu    sync.RWMutex
+}
+
+// NewManager creates a new queue manager
+func NewManager(cfg ManagerConfig, repository *database.QueueRepository, processor ItemProcessor) *Manager {
+	if cfg.Workers == 0 {
+		cfg.Workers = 2
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Manager{
+		config:       cfg,
+		repository:   repository,
+		claimer:      NewClaimer(repository),
+		processor:    processor,
+		configGetter: cfg.ConfigGetter,
+		log:          slog.Default().With("component", "queue-manager"),
+		ctx:          ctx,
+		cancel:       cancel,
+		cancelFuncs:  make(map[int64]context.CancelFunc),
+	}
+}
+
+// Start starts the queue workers
+func (m *Manager) Start(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		return nil
+	}
+
+	// Start worker pool
+	for i := 0; i < m.config.Workers; i++ {
+		m.wg.Add(1)
+		go m.workerLoop(i)
+	}
+
+	m.running = true
+	m.log.InfoContext(ctx, "Queue manager started", "workers", m.config.Workers)
+
+	return nil
+}
+
+// Stop stops the queue workers
+func (m *Manager) Stop(ctx context.Context) error {
+	m.mu.Lock()
+
+	if !m.running {
+		m.mu.Unlock()
+		return nil
+	}
+
+	m.log.InfoContext(ctx, "Stopping queue manager")
+
+	// Cancel all goroutines
+	m.cancel()
+	m.running = false
+	m.mu.Unlock()
+
+	// Wait for all goroutines to finish with timeout
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All goroutines finished
+	case <-time.After(30 * time.Second):
+		m.log.WarnContext(ctx, "Timeout waiting for workers to stop")
+	case <-ctx.Done():
+		m.log.WarnContext(ctx, "Context cancelled while waiting for workers")
+		return ctx.Err()
+	}
+
+	// Re-acquire lock to recreate context for potential restart
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ctx, m.cancel = context.WithCancel(context.Background())
+
+	m.log.InfoContext(ctx, "Queue manager stopped")
+	return nil
+}
+
+// Pause pauses queue processing
+func (m *Manager) Pause() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.paused = true
+	m.log.InfoContext(m.ctx, "Queue manager paused")
+}
+
+// Resume resumes queue processing
+func (m *Manager) Resume() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.paused = false
+	m.log.InfoContext(m.ctx, "Queue manager resumed")
+}
+
+// IsPaused returns whether the manager is paused
+func (m *Manager) IsPaused() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.paused
+}
+
+// IsRunning returns whether the manager is running
+func (m *Manager) IsRunning() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.running
+}
+
+// GetWorkerCount returns the current worker count
+func (m *Manager) GetWorkerCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.config.Workers
+}
+
+// CancelProcessing cancels processing for a specific item
+func (m *Manager) CancelProcessing(itemID int64) error {
+	m.cancelMu.RLock()
+	cancel, exists := m.cancelFuncs[itemID]
+	m.cancelMu.RUnlock()
+
+	if !exists {
+		return nil // Not currently processing
+	}
+
+	m.log.InfoContext(m.ctx, "Cancelling processing for queue item", "item_id", itemID)
+	cancel()
+	return nil
+}
+
+// workerLoop is the main worker loop
+func (m *Manager) workerLoop(workerID int) {
+	defer m.wg.Done()
+
+	log := m.log.With("worker_id", workerID)
+
+	// Get processing interval from configuration
+	processingIntervalSeconds := m.configGetter().Import.QueueProcessingIntervalSeconds
+	processingInterval := time.Duration(processingIntervalSeconds) * time.Second
+
+	ticker := time.NewTicker(processingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// Check if manager is paused
+			if m.IsPaused() {
+				continue
+			}
+			m.processNextItem(m.ctx, workerID)
+		case <-m.ctx.Done():
+			log.Info("Queue worker stopped")
+			return
+		}
+	}
+}
+
+// processNextItem claims and processes the next queue item
+func (m *Manager) processNextItem(ctx context.Context, workerID int) {
+	// Claim next available item
+	item, err := m.claimer.ClaimWithRetry(ctx, workerID)
+	if err != nil {
+		// Only log non-contention errors
+		if !IsDatabaseContentionError(err) {
+			m.log.ErrorContext(ctx, "Failed to claim next queue item", "worker_id", workerID, "error", err)
+		}
+		return
+	}
+
+	if item == nil {
+		return // No work to do
+	}
+
+	m.log.DebugContext(ctx, "Processing claimed queue item", "worker_id", workerID, "queue_id", item.ID, "file", item.NzbPath)
+
+	// Create cancellable context for this item
+	itemCtx, cancel := context.WithCancel(ctx)
+
+	// Register cancel function
+	m.cancelMu.Lock()
+	m.cancelFuncs[item.ID] = cancel
+	m.cancelMu.Unlock()
+
+	// Clean up after processing
+	defer func() {
+		m.cancelMu.Lock()
+		delete(m.cancelFuncs, item.ID)
+		m.cancelMu.Unlock()
+	}()
+
+	// Process the item
+	resultingPath, processingErr := m.processor.ProcessItem(itemCtx, item)
+
+	// Handle results
+	if processingErr != nil {
+		m.processor.HandleFailure(ctx, item, processingErr)
+	} else {
+		m.processor.HandleSuccess(ctx, item, resultingPath)
+	}
+}

--- a/internal/importer/scanner/directory.go
+++ b/internal/importer/scanner/directory.go
@@ -1,0 +1,197 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// QueueAdder defines the interface for adding items to the queue
+type QueueAdder interface {
+	AddToQueue(ctx context.Context, filePath string, relativePath *string) error
+	IsFileInQueue(ctx context.Context, filePath string) bool
+	IsFileProcessed(filePath string, scanRoot string) bool
+}
+
+// DirectoryScanner handles manual directory scanning for NZB/STRM files
+type DirectoryScanner struct {
+	queueAdder QueueAdder
+	log        *slog.Logger
+
+	// State management
+	mu         sync.RWMutex
+	info       ScanInfo
+	cancelFunc context.CancelFunc
+}
+
+// NewDirectoryScanner creates a new directory scanner
+func NewDirectoryScanner(queueAdder QueueAdder) *DirectoryScanner {
+	return &DirectoryScanner{
+		queueAdder: queueAdder,
+		log:        slog.Default().With("component", "directory-scanner"),
+		info:       ScanInfo{Status: ScanStatusIdle},
+	}
+}
+
+// Start starts a manual scan of the specified directory
+func (d *DirectoryScanner) Start(scanPath string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Check if already scanning
+	if d.info.Status != ScanStatusIdle {
+		return fmt.Errorf("scan already in progress, current status: %s", d.info.Status)
+	}
+
+	// Validate path
+	if scanPath == "" {
+		return fmt.Errorf("scan path cannot be empty")
+	}
+
+	// Check if path exists
+	if _, err := filepath.Abs(scanPath); err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Create scan context
+	scanCtx, scanCancel := context.WithCancel(context.Background())
+	d.cancelFunc = scanCancel
+
+	// Initialize scan info
+	now := time.Now()
+	d.info = ScanInfo{
+		Status:      ScanStatusScanning,
+		Path:        scanPath,
+		StartTime:   &now,
+		FilesFound:  0,
+		FilesAdded:  0,
+		CurrentFile: "",
+		LastError:   nil,
+	}
+
+	// Start scanning in goroutine
+	go d.performScan(scanCtx, scanPath)
+
+	d.log.InfoContext(context.Background(), "Manual scan started", "path", scanPath)
+	return nil
+}
+
+// GetStatus returns the current scan status
+func (d *DirectoryScanner) GetStatus() ScanInfo {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.info
+}
+
+// Cancel cancels the current scan operation
+func (d *DirectoryScanner) Cancel() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.info.Status == ScanStatusIdle {
+		return fmt.Errorf("no scan is currently running")
+	}
+
+	if d.info.Status == ScanStatusCanceling {
+		return fmt.Errorf("scan is already being canceled")
+	}
+
+	// Update status and cancel context
+	d.info.Status = ScanStatusCanceling
+	if d.cancelFunc != nil {
+		d.cancelFunc()
+	}
+
+	d.log.InfoContext(context.Background(), "Manual scan cancellation requested", "path", d.info.Path)
+	return nil
+}
+
+// performScan performs the actual scanning work
+func (d *DirectoryScanner) performScan(ctx context.Context, scanPath string) {
+	defer func() {
+		d.mu.Lock()
+		d.info.Status = ScanStatusIdle
+		d.info.CurrentFile = ""
+		if d.cancelFunc != nil {
+			d.cancelFunc()
+			d.cancelFunc = nil
+		}
+		d.mu.Unlock()
+	}()
+
+	d.log.DebugContext(ctx, "Scanning directory for NZB files", "dir", scanPath)
+
+	err := filepath.WalkDir(scanPath, func(path string, entry fs.DirEntry, err error) error {
+		// Check for cancellation
+		select {
+		case <-ctx.Done():
+			d.log.InfoContext(ctx, "Scan cancelled", "path", scanPath)
+			return fmt.Errorf("scan cancelled")
+		default:
+		}
+
+		if err != nil {
+			d.log.WarnContext(ctx, "Error accessing path", "path", path, "error", err)
+			d.mu.Lock()
+			errMsg := err.Error()
+			d.info.LastError = &errMsg
+			d.mu.Unlock()
+			return nil // Continue walking
+		}
+
+		// Skip directories
+		if entry.IsDir() {
+			return nil
+		}
+
+		// Update current file being processed
+		d.mu.Lock()
+		d.info.CurrentFile = path
+		d.info.FilesFound++
+		d.mu.Unlock()
+
+		// Check if it's an NZB or STRM file
+		ext := strings.ToLower(path)
+		if !strings.HasSuffix(ext, ".nzb") && !strings.HasSuffix(ext, ".strm") {
+			return nil
+		}
+
+		// Check if already in queue
+		if d.queueAdder.IsFileInQueue(ctx, path) {
+			return nil
+		}
+
+		// Check if already processed (metadata exists)
+		if d.queueAdder.IsFileProcessed(path, scanPath) {
+			d.log.DebugContext(ctx, "Skipping file - already processed", "file", path)
+			return nil
+		}
+
+		// Add to queue
+		if err := d.queueAdder.AddToQueue(ctx, path, &scanPath); err != nil {
+			d.log.ErrorContext(ctx, "Failed to add file to queue during scan", "file", path, "error", err)
+		}
+
+		// Update files added counter
+		d.mu.Lock()
+		d.info.FilesAdded++
+		d.mu.Unlock()
+
+		return nil
+	})
+
+	if err != nil && !strings.Contains(err.Error(), "scan cancelled") {
+		d.log.ErrorContext(ctx, "Failed to scan directory", "dir", scanPath, "error", err)
+		d.mu.Lock()
+		errMsg := err.Error()
+		d.info.LastError = &errMsg
+		d.mu.Unlock()
+	}
+
+	d.log.InfoContext(ctx, "Manual scan completed", "path", scanPath, "files_found", d.info.FilesFound, "files_added", d.info.FilesAdded)
+}

--- a/internal/importer/scanner/nzbdav.go
+++ b/internal/importer/scanner/nzbdav.go
@@ -1,0 +1,318 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/nzbdav"
+)
+
+// BatchQueueAdder defines the interface for batch queue operations
+type BatchQueueAdder interface {
+	AddBatchToQueue(ctx context.Context, items []*database.ImportQueueItem) error
+}
+
+// NzbDavImporter handles importing from NZBDav databases
+type NzbDavImporter struct {
+	batchAdder BatchQueueAdder
+	log        *slog.Logger
+
+	// State management
+	mu         sync.RWMutex
+	info       ImportInfo
+	cancelFunc context.CancelFunc
+}
+
+// NewNzbDavImporter creates a new NZBDav importer
+func NewNzbDavImporter(batchAdder BatchQueueAdder) *NzbDavImporter {
+	return &NzbDavImporter{
+		batchAdder: batchAdder,
+		log:        slog.Default().With("component", "nzbdav-importer"),
+		info:       ImportInfo{Status: ImportStatusIdle},
+	}
+}
+
+// Start starts an asynchronous import from an NZBDav database
+func (n *NzbDavImporter) Start(dbPath string, rootFolder string, cleanupFile bool) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.info.Status != ImportStatusIdle {
+		return fmt.Errorf("import already in progress")
+	}
+
+	// Create import context
+	importCtx, cancel := context.WithCancel(context.Background())
+	n.cancelFunc = cancel
+
+	// Initialize status
+	n.info = ImportInfo{
+		Status: ImportStatusRunning,
+		Total:  0,
+		Added:  0,
+		Failed: 0,
+	}
+
+	go n.performImport(importCtx, dbPath, rootFolder, cleanupFile)
+
+	return nil
+}
+
+// GetStatus returns the current import status
+func (n *NzbDavImporter) GetStatus() ImportInfo {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.info
+}
+
+// Cancel cancels the current import operation
+func (n *NzbDavImporter) Cancel() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.info.Status == ImportStatusIdle {
+		return fmt.Errorf("no import is currently running")
+	}
+
+	if n.info.Status == ImportStatusCanceling {
+		return fmt.Errorf("import is already being canceled")
+	}
+
+	n.info.Status = ImportStatusCanceling
+	if n.cancelFunc != nil {
+		n.cancelFunc()
+	}
+
+	return nil
+}
+
+// performImport performs the actual import work
+func (n *NzbDavImporter) performImport(ctx context.Context, dbPath string, rootFolder string, cleanupFile bool) {
+	// Parse Database
+	parser := nzbdav.NewParser(dbPath)
+	nzbChan, errChan := parser.Parse()
+
+	defer func() {
+		n.mu.Lock()
+		n.info.Status = ImportStatusIdle
+		n.cancelFunc = nil
+		n.mu.Unlock()
+
+		if cleanupFile {
+			os.Remove(dbPath)
+		}
+
+		// Drain any remaining items from channels to prevent parser goroutine leaks
+		go func() {
+			for range nzbChan {
+			}
+		}()
+		go func() {
+			for range errChan {
+			}
+		}()
+	}()
+
+	// Create temp dir for NZBs
+	nzbTempDir, err := os.MkdirTemp(os.TempDir(), "altmount-nzbdav-imports-")
+	if err != nil {
+		n.log.ErrorContext(ctx, "Failed to create temp directory for NZBs", "error", err)
+		n.mu.Lock()
+		msg := err.Error()
+		n.info.LastError = &msg
+		n.mu.Unlock()
+		return
+	}
+
+	// Create workers
+	numWorkers := 20 // 20 parallel workers for file creation
+	var workerWg sync.WaitGroup
+	batchChan := make(chan *database.ImportQueueItem, 100)
+
+	// Start batch processor
+	var batchWg sync.WaitGroup
+	batchWg.Add(1)
+	go func() {
+		defer batchWg.Done()
+		n.processBatch(ctx, batchChan)
+	}()
+
+	// Start workers
+	for i := 0; i < numWorkers; i++ {
+		workerWg.Add(1)
+		go func() {
+			defer workerWg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case res, ok := <-nzbChan:
+					if !ok {
+						return
+					}
+
+					n.mu.Lock()
+					n.info.Total++
+					n.mu.Unlock()
+
+					item, err := n.createNzbFileAndPrepareItem(ctx, res, rootFolder, nzbTempDir)
+					if err != nil {
+						n.log.ErrorContext(ctx, "Failed to prepare item", "file", res.Name, "error", err)
+						n.mu.Lock()
+						n.info.Failed++
+						n.mu.Unlock()
+						continue
+					}
+
+					select {
+					case batchChan <- item:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// Wait for workers to finish processing nzbChan
+	workerWg.Wait()
+	close(batchChan)
+	batchWg.Wait()
+
+	// Check for parser errors
+	select {
+	case err := <-errChan:
+		if err != nil {
+			n.log.ErrorContext(ctx, "Error during NZBDav parsing", "error", err)
+			n.mu.Lock()
+			msg := err.Error()
+			n.info.LastError = &msg
+			n.mu.Unlock()
+		}
+	default:
+	}
+}
+
+// processBatch batches queue items and adds them to the queue
+func (n *NzbDavImporter) processBatch(ctx context.Context, batchChan <-chan *database.ImportQueueItem) {
+	var batch []*database.ImportQueueItem
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	insertBatch := func() {
+		if len(batch) > 0 {
+			if err := n.batchAdder.AddBatchToQueue(ctx, batch); err != nil {
+				n.log.ErrorContext(ctx, "Failed to add batch to queue", "count", len(batch), "error", err)
+				n.mu.Lock()
+				n.info.Failed += len(batch)
+				n.mu.Unlock()
+			} else {
+				n.mu.Lock()
+				n.info.Added += len(batch)
+				n.mu.Unlock()
+			}
+			batch = nil // Reset batch
+		}
+	}
+
+	for {
+		select {
+		case item, ok := <-batchChan:
+			if !ok {
+				// Channel closed, drain remaining batch
+				insertBatch()
+				return
+			}
+			batch = append(batch, item)
+			if len(batch) >= 100 { // Batch size
+				insertBatch()
+			}
+		case <-ticker.C:
+			insertBatch()
+		case <-ctx.Done():
+			insertBatch()
+			return
+		}
+	}
+}
+
+// createNzbFileAndPrepareItem creates an NZB file and prepares a queue item
+func (n *NzbDavImporter) createNzbFileAndPrepareItem(ctx context.Context, res *nzbdav.ParsedNzb, rootFolder, nzbTempDir string) (*database.ImportQueueItem, error) {
+	// Check context before file operations
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	// Create Temp NZB File
+	// Use ID to ensure uniqueness and avoid collisions with releases having the same name in the temp directory
+	// but don't include it in the filename to avoid it appearing in the final folder/file names
+	nzbSubDir := filepath.Join(nzbTempDir, sanitizeFilename(res.ID))
+	if err := os.MkdirAll(nzbSubDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create temp NZB subdirectory: %w", err)
+	}
+
+	nzbFileName := fmt.Sprintf("%s.nzb", sanitizeFilename(res.Name))
+	nzbPath := filepath.Join(nzbSubDir, nzbFileName)
+
+	outFile, err := os.Create(nzbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp NZB file: %w", err)
+	}
+
+	// Copy content
+	_, err = io.Copy(outFile, res.Content)
+	outFile.Close()
+	if err != nil {
+		os.Remove(nzbPath)
+		return nil, fmt.Errorf("failed to write temp NZB file content: %w", err)
+	}
+
+	// Determine Category and Relative Path
+	targetCategory := "other"
+	lowerCat := strings.ToLower(res.Category)
+	if strings.Contains(lowerCat, "movie") {
+		targetCategory = "movies"
+	} else if strings.Contains(lowerCat, "tv") || strings.Contains(lowerCat, "series") {
+		targetCategory = "tv"
+	}
+
+	if res.RelPath != "" {
+		targetCategory = filepath.Join(targetCategory, res.RelPath)
+	}
+
+	relPath := rootFolder
+	priority := database.QueuePriorityNormal
+
+	// Store original ID in metadata
+	metaJSON := fmt.Sprintf(`{"nzbdav_id": "%s"}`, res.ID)
+
+	// Prepare item struct
+	item := &database.ImportQueueItem{
+		NzbPath:      nzbPath,
+		RelativePath: &relPath,
+		Category:     &targetCategory,
+		Priority:     priority,
+		Status:       database.QueueStatusPending,
+		RetryCount:   0,
+		MaxRetries:   3,
+		CreatedAt:    time.Now(),
+		Metadata:     &metaJSON,
+	}
+
+	return item, nil
+}
+
+// sanitizeFilename replaces invalid characters in filenames
+func sanitizeFilename(name string) string {
+	return strings.ReplaceAll(name, "/", "_")
+}

--- a/internal/importer/scanner/types.go
+++ b/internal/importer/scanner/types.go
@@ -1,0 +1,42 @@
+// Package scanner provides directory scanning and NZBDav import functionality.
+package scanner
+
+import "time"
+
+// ScanStatus represents the current status of a manual scan
+type ScanStatus string
+
+const (
+	ScanStatusIdle      ScanStatus = "idle"
+	ScanStatusScanning  ScanStatus = "scanning"
+	ScanStatusCanceling ScanStatus = "canceling"
+)
+
+// ScanInfo holds information about the current scan operation
+type ScanInfo struct {
+	Status      ScanStatus `json:"status"`
+	Path        string     `json:"path,omitempty"`
+	StartTime   *time.Time `json:"start_time,omitempty"`
+	FilesFound  int        `json:"files_found"`
+	FilesAdded  int        `json:"files_added"`
+	CurrentFile string     `json:"current_file,omitempty"`
+	LastError   *string    `json:"last_error,omitempty"`
+}
+
+// ImportJobStatus represents the status of an NZBDav import job
+type ImportJobStatus string
+
+const (
+	ImportStatusIdle      ImportJobStatus = "idle"
+	ImportStatusRunning   ImportJobStatus = "running"
+	ImportStatusCanceling ImportJobStatus = "canceling"
+)
+
+// ImportInfo holds information about the current NZBDav import operation
+type ImportInfo struct {
+	Status    ImportJobStatus `json:"status"`
+	Total     int             `json:"total"`
+	Added     int             `json:"added"`
+	Failed    int             `json:"failed"`
+	LastError *string         `json:"last_error,omitempty"`
+}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -3,14 +3,9 @@ package importer
 import (
 	"bufio"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
-	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -20,20 +15,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
-	"github.com/javi11/altmount/internal/importer/filesystem"
+	"github.com/javi11/altmount/internal/importer/postprocessor"
+	"github.com/javi11/altmount/internal/importer/queue"
+	"github.com/javi11/altmount/internal/importer/scanner"
 	"github.com/javi11/altmount/internal/metadata"
-	metapb "github.com/javi11/altmount/internal/metadata/proto"
-	"github.com/javi11/altmount/internal/nzbdav"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/sabnzbd"
 	"github.com/javi11/altmount/pkg/rclonecli"
 	"github.com/javi11/nzbparser"
-	"google.golang.org/protobuf/proto"
 )
 
 // ServiceConfig holds configuration for the NZB import service
@@ -41,42 +34,100 @@ type ServiceConfig struct {
 	Workers int // Number of parallel queue workers (default: 2)
 }
 
-// ScanStatus represents the current status of a manual scan
-type ScanStatus string
-
-const (
-	ScanStatusIdle      ScanStatus = "idle"
-	ScanStatusScanning  ScanStatus = "scanning"
-	ScanStatusCanceling ScanStatus = "canceling"
+// Type aliases from scanner package for backward compatibility
+type (
+	ScanStatus      = scanner.ScanStatus
+	ScanInfo        = scanner.ScanInfo
+	ImportJobStatus = scanner.ImportJobStatus
+	ImportInfo      = scanner.ImportInfo
 )
 
-// ScanInfo holds information about the current scan operation
-type ScanInfo struct {
-	Status      ScanStatus `json:"status"`
-	Path        string     `json:"path,omitempty"`
-	StartTime   *time.Time `json:"start_time,omitempty"`
-	FilesFound  int        `json:"files_found"`
-	FilesAdded  int        `json:"files_added"`
-	CurrentFile string     `json:"current_file,omitempty"`
-	LastError   *string    `json:"last_error,omitempty"`
+// Re-export scanner status constants for backward compatibility
+const (
+	ScanStatusIdle      = scanner.ScanStatusIdle
+	ScanStatusScanning  = scanner.ScanStatusScanning
+	ScanStatusCanceling = scanner.ScanStatusCanceling
+	ImportStatusIdle    = scanner.ImportStatusIdle
+	ImportStatusRunning = scanner.ImportStatusRunning
+)
+
+// queueAdapterForScanner adapts database repository for scanner.QueueAdder interface
+type queueAdapterForScanner struct {
+	repo            *database.QueueRepository
+	metadataService *metadata.MetadataService
+	calcFileSize    func(string) (int64, error)
 }
 
-// ImportJobStatus represents the status of an NZBDav import job
-type ImportJobStatus string
+func (a *queueAdapterForScanner) AddToQueue(ctx context.Context, filePath string, relativePath *string) error {
+	// Calculate file size before adding to queue
+	var fileSize *int64
+	if size, err := a.calcFileSize(filePath); err == nil {
+		fileSize = &size
+	}
 
-const (
-	ImportStatusIdle      ImportJobStatus = "idle"
-	ImportStatusRunning   ImportJobStatus = "running"
-	ImportStatusCanceling ImportJobStatus = "canceling"
-)
+	item := &database.ImportQueueItem{
+		NzbPath:      filePath,
+		RelativePath: relativePath,
+		Priority:     database.QueuePriorityNormal,
+		Status:       database.QueueStatusPending,
+		RetryCount:   0,
+		MaxRetries:   3,
+		FileSize:     fileSize,
+		CreatedAt:    time.Now(),
+	}
 
-// ImportInfo holds information about the current NZBDav import operation
-type ImportInfo struct {
-	Status    ImportJobStatus `json:"status"`
-	Total     int             `json:"total"`
-	Added     int             `json:"added"`
-	Failed    int             `json:"failed"`
-	LastError *string         `json:"last_error,omitempty"`
+	return a.repo.AddToQueue(ctx, item)
+}
+
+func (a *queueAdapterForScanner) IsFileInQueue(ctx context.Context, filePath string) bool {
+	inQueue, _ := a.repo.IsFileInQueue(ctx, filePath)
+	return inQueue
+}
+
+func (a *queueAdapterForScanner) IsFileProcessed(filePath string, scanRoot string) bool {
+	return isFileAlreadyProcessed(a.metadataService, filePath, scanRoot)
+}
+
+// batchQueueAdapterForImporter adapts database repository for scanner.BatchQueueAdder interface
+type batchQueueAdapterForImporter struct {
+	repo *database.QueueRepository
+}
+
+func (a *batchQueueAdapterForImporter) AddBatchToQueue(ctx context.Context, items []*database.ImportQueueItem) error {
+	return a.repo.AddBatchToQueue(ctx, items)
+}
+
+// isFileAlreadyProcessed checks if a file has already been processed by checking metadata
+func isFileAlreadyProcessed(metadataService *metadata.MetadataService, filePath string, scanRoot string) bool {
+	// Calculate virtual path
+	virtualPath := filepath.Dir(filePath)
+	if scanRoot != "" {
+		rel, err := filepath.Rel(scanRoot, filePath)
+		if err == nil {
+			virtualPath = filepath.Dir(rel)
+		}
+	}
+
+	// Normalize filename (remove .nzb extension)
+	fileName := filepath.Base(filePath)
+	baseName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+
+	// Check if a directory exists with the release name
+	releaseDir := filepath.Join(virtualPath, baseName)
+	if metadataService.DirectoryExists(releaseDir) {
+		return true
+	}
+
+	// Also check if any file exists that starts with the release name in that directory
+	if files, err := metadataService.ListDirectory(virtualPath); err == nil {
+		for _, f := range files {
+			if strings.HasPrefix(f, baseName) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // Service provides NZB import functionality with manual directory scanning and queue-based processing
@@ -85,6 +136,10 @@ type Service struct {
 	database        *database.DB              // Database for processing queue
 	metadataService *metadata.MetadataService // Metadata service for file processing
 	processor       *Processor
+	postProcessor   *postprocessor.Coordinator    // Post-import processing coordinator
+	queueManager    *queue.Manager                // Queue worker management
+	dirScanner      *scanner.DirectoryScanner     // Manual directory scanning
+	nzbdavImporter  *scanner.NzbDavImporter       // NZBDav database imports
 	rcloneClient    rclonecli.RcloneRcClient      // Optional rclone client for VFS notifications
 	configGetter    config.ConfigGetter           // Config getter for dynamic configuration access
 	sabnzbdClient   *sabnzbd.SABnzbdClient        // SABnzbd client for fallback
@@ -105,16 +160,6 @@ type Service struct {
 	// Cancellation tracking for processing items
 	cancelFuncs map[int64]context.CancelFunc
 	cancelMu    sync.RWMutex
-
-	// Manual scan state
-	scanMu     sync.RWMutex
-	scanInfo   ScanInfo
-	scanCancel context.CancelFunc
-
-	// Import state
-	importMu     sync.RWMutex
-	importInfo   ImportInfo
-	importCancel context.CancelFunc
 }
 
 // NewService creates a new NZB import service with manual scanning and queue processing capabilities
@@ -141,11 +186,21 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	// Create post-processor coordinator
+	postProc := postprocessor.NewCoordinator(postprocessor.Config{
+		ConfigGetter:    configGetter,
+		MetadataService: metadataService,
+		RcloneClient:    rcloneClient,
+		HealthRepo:      healthRepo,
+		UserRepo:        userRepo,
+	})
+
 	service := &Service{
 		config:          config,
 		metadataService: metadataService,
 		database:        database,
 		processor:       processor,
+		postProcessor:   postProc,
 		rcloneClient:    rcloneClient,
 		configGetter:    configGetter,
 		healthRepo:      healthRepo,
@@ -156,10 +211,32 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 		ctx:             ctx,
 		cancel:          cancel,
 		cancelFuncs:     make(map[int64]context.CancelFunc),
-		scanInfo:        ScanInfo{Status: ScanStatusIdle},
-		importInfo:      ImportInfo{Status: ImportStatusIdle},
 		paused:          false,
 	}
+
+	// Create scanner adapter for directory scanning
+	scannerAdapter := &queueAdapterForScanner{
+		repo:            database.Repository,
+		metadataService: metadataService,
+		calcFileSize:    service.CalculateFileSizeOnly,
+	}
+	service.dirScanner = scanner.NewDirectoryScanner(scannerAdapter)
+
+	// Create adapter for NZBDav imports
+	importerAdapter := &batchQueueAdapterForImporter{
+		repo: database.Repository,
+	}
+	service.nzbdavImporter = scanner.NewNzbDavImporter(importerAdapter)
+
+	// Create queue manager (Service implements queue.ItemProcessor interface)
+	service.queueManager = queue.NewManager(
+		queue.ManagerConfig{
+			Workers:      config.Workers,
+			ConfigGetter: configGetter,
+		},
+		database.Repository,
+		service,
+	)
 
 	return service, nil
 }
@@ -186,10 +263,9 @@ func (s *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to reset stale queue items: %w", err)
 	}
 
-	// Start worker pool for processing queue items
-	for i := 0; i < s.config.Workers; i++ {
-		s.wg.Add(1)
-		go s.workerLoop(i)
+	// Delegate worker management to queue manager
+	if err := s.queueManager.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start queue manager: %w", err)
 	}
 
 	s.running = true
@@ -198,27 +274,42 @@ func (s *Service) Start(ctx context.Context) error {
 	return nil
 }
 
+// ProcessItem implements queue.ItemProcessor - processes a single queue item
+func (s *Service) ProcessItem(ctx context.Context, item *database.ImportQueueItem) (string, error) {
+	return s.processNzbItem(ctx, item)
+}
+
+// HandleSuccess implements queue.ItemProcessor - handles successful processing
+func (s *Service) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	return s.handleProcessingSuccess(ctx, item, resultingPath)
+}
+
+// HandleFailure implements queue.ItemProcessor - handles failed processing
+func (s *Service) HandleFailure(ctx context.Context, item *database.ImportQueueItem, err error) {
+	s.handleProcessingFailure(ctx, item, err)
+}
+
 // Pause pauses the queue processing
 func (s *Service) Pause() {
+	s.queueManager.Pause()
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.paused = true
+	s.mu.Unlock()
 	s.log.InfoContext(s.ctx, "Import service paused")
 }
 
 // Resume resumes the queue processing
 func (s *Service) Resume() {
+	s.queueManager.Resume()
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.paused = false
+	s.mu.Unlock()
 	s.log.InfoContext(s.ctx, "Import service resumed")
 }
 
 // IsPaused returns whether the service is paused
 func (s *Service) IsPaused() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.paused
+	return s.queueManager.IsPaused()
 }
 
 func (s *Service) RegisterConfigChangeHandler(configManager *config.Manager) {
@@ -244,28 +335,16 @@ func (s *Service) Stop(ctx context.Context) error {
 	}
 
 	s.log.InfoContext(ctx, "Stopping NZB import service")
-
-	// Cancel all goroutines
-	s.cancel()
 	s.running = false
 	s.mu.Unlock()
 
-	// Wait for all goroutines to finish with timeout
-	done := make(chan struct{})
-	go func() {
-		s.wg.Wait()
-		close(done)
-	}()
-
-	select {
-	case <-done:
-		// All goroutines finished
-	case <-time.After(30 * time.Second):
-		s.log.WarnContext(ctx, "Timeout waiting for workers to stop, some goroutines may still be running")
-	case <-ctx.Done():
-		s.log.WarnContext(ctx, "Context cancelled while waiting for workers to stop")
-		return ctx.Err()
+	// Delegate worker shutdown to queue manager
+	if err := s.queueManager.Stop(ctx); err != nil {
+		s.log.WarnContext(ctx, "Error stopping queue manager", "error", err)
 	}
+
+	// Cancel service context
+	s.cancel()
 
 	// Re-acquire lock to recreate context for potential restart
 	s.mu.Lock()
@@ -280,11 +359,11 @@ func (s *Service) Stop(ctx context.Context) error {
 // Close closes the NZB import service and releases all resources
 func (s *Service) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	running := s.running
+	s.mu.Unlock()
 
-	if s.running {
-		s.cancel()
-		s.wg.Wait()
+	if running {
+		return s.Stop(context.Background())
 	}
 
 	return nil
@@ -302,6 +381,9 @@ func (s *Service) SetRcloneClient(client rclonecli.RcloneRcClient) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rcloneClient = client
+	if s.postProcessor != nil {
+		s.postProcessor.SetRcloneClient(client)
+	}
 	if client != nil {
 		s.log.InfoContext(s.ctx, "RClone client updated for VFS notifications")
 	} else {
@@ -314,6 +396,9 @@ func (s *Service) SetArrsService(service *arrs.Service) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.arrsService = service
+	if s.postProcessor != nil {
+		s.postProcessor.SetArrsService(service)
+	}
 }
 
 // Database returns the database instance for processing
@@ -328,490 +413,37 @@ func (s *Service) GetQueueStats(ctx context.Context) (*database.QueueStats, erro
 
 // StartManualScan starts a manual scan of the specified directory
 func (s *Service) StartManualScan(scanPath string) error {
-	s.scanMu.Lock()
-	defer s.scanMu.Unlock()
-
-	// Check if already scanning
-	if s.scanInfo.Status != ScanStatusIdle {
-		return fmt.Errorf("scan already in progress, current status: %s", s.scanInfo.Status)
-	}
-
-	// Validate path
-	if scanPath == "" {
-		return fmt.Errorf("scan path cannot be empty")
-	}
-
-	// Check if path exists
-	if _, err := filepath.Abs(scanPath); err != nil {
-		return fmt.Errorf("invalid path: %w", err)
-	}
-
-	// Create scan context
-	scanCtx, scanCancel := context.WithCancel(context.Background())
-	s.scanCancel = scanCancel
-
-	// Initialize scan info
-	now := time.Now()
-	s.scanInfo = ScanInfo{
-		Status:      ScanStatusScanning,
-		Path:        scanPath,
-		StartTime:   &now,
-		FilesFound:  0,
-		FilesAdded:  0,
-		CurrentFile: "",
-		LastError:   nil,
-	}
-
-	// Start scanning in goroutine
-	go s.performManualScan(scanCtx, scanPath)
-
-	s.log.InfoContext(s.ctx, "Manual scan started", "path", scanPath)
-	return nil
+	return s.dirScanner.Start(scanPath)
 }
 
 // GetScanStatus returns the current scan status
 func (s *Service) GetScanStatus() ScanInfo {
-	s.scanMu.RLock()
-	defer s.scanMu.RUnlock()
-	return s.scanInfo
+	return s.dirScanner.GetStatus()
 }
 
 // CancelScan cancels the current scan operation
 func (s *Service) CancelScan() error {
-	s.scanMu.Lock()
-	defer s.scanMu.Unlock()
-
-	if s.scanInfo.Status == ScanStatusIdle {
-		return fmt.Errorf("no scan is currently running")
-	}
-
-	if s.scanInfo.Status == ScanStatusCanceling {
-		return fmt.Errorf("scan is already being canceled")
-	}
-
-	// Update status and cancel context
-	s.scanInfo.Status = ScanStatusCanceling
-	if s.scanCancel != nil {
-		s.scanCancel()
-	}
-
-	s.log.InfoContext(s.ctx, "Manual scan cancellation requested", "path", s.scanInfo.Path)
-	return nil
+	return s.dirScanner.Cancel()
 }
 
 // StartNzbdavImport starts an asynchronous import from an NZBDav database
 func (s *Service) StartNzbdavImport(dbPath string, rootFolder string, cleanupFile bool) error {
-	s.importMu.Lock()
-	defer s.importMu.Unlock()
-
-	if s.importInfo.Status != ImportStatusIdle {
-		return fmt.Errorf("import already in progress")
-	}
-
-	// Create import context
-	importCtx, cancel := context.WithCancel(context.Background())
-	s.importCancel = cancel
-
-	// Initialize status
-	s.importInfo = ImportInfo{
-		Status: ImportStatusRunning,
-		Total:  0,
-		Added:  0,
-		Failed: 0,
-	}
-
-	go func() {
-		// 1. Parse Database
-		parser := nzbdav.NewParser(dbPath)
-		nzbChan, errChan := parser.Parse()
-
-		defer func() {
-			s.importMu.Lock()
-			s.importInfo.Status = ImportStatusIdle
-			s.importCancel = nil
-			s.importMu.Unlock()
-
-			if cleanupFile {
-				os.Remove(dbPath)
-			}
-
-			// Drain any remaining items from channels to prevent parser goroutine leaks.
-			// This ensures the parser can complete even if we exit early due to cancellation.
-			go func() {
-				for range nzbChan {
-				}
-			}()
-			go func() {
-				for range errChan {
-				}
-			}()
-		}()
-
-		// Create temp dir for NZBs
-		nzbTempDir, err := os.MkdirTemp(os.TempDir(), "altmount-nzbdav-imports-")
-		if err != nil {
-			s.log.ErrorContext(importCtx, "Failed to create temp directory for NZBs", "error", err)
-			s.importMu.Lock()
-			msg := err.Error()
-			s.importInfo.LastError = &msg
-			s.importMu.Unlock()
-			return
-		}
-
-		// Create workers
-		numWorkers := 20 // 20 parallel workers for file creation
-		var workerWg sync.WaitGroup
-		batchChan := make(chan *database.ImportQueueItem, 100)
-
-		// Start batch processor
-		var batchWg sync.WaitGroup
-		batchWg.Add(1)
-		go func() {
-			defer batchWg.Done()
-			s.processQueueBatch(importCtx, batchChan)
-		}()
-
-		// Start workers
-		for i := 0; i < numWorkers; i++ {
-			workerWg.Add(1)
-			go func() {
-				defer workerWg.Done()
-				for {
-					select {
-					case <-importCtx.Done():
-						return
-					case res, ok := <-nzbChan:
-						if !ok {
-							return
-						}
-
-						s.importMu.Lock()
-						s.importInfo.Total++
-						s.importMu.Unlock()
-
-						item, err := s.createNzbFileAndPrepareItem(importCtx, res, rootFolder, nzbTempDir)
-						if err != nil {
-							s.log.ErrorContext(importCtx, "Failed to prepare item", "file", res.Name, "error", err)
-							s.importMu.Lock()
-							s.importInfo.Failed++
-							s.importMu.Unlock()
-							continue
-						}
-
-						select {
-						case batchChan <- item:
-						case <-importCtx.Done():
-							return
-						}
-					}
-				}
-			}()
-		}
-
-		// Wait for workers to finish processing nzbChan
-		workerWg.Wait()
-		close(batchChan)
-		batchWg.Wait()
-
-		// Check for parser errors
-		select {
-		case err := <-errChan:
-			if err != nil {
-				s.log.ErrorContext(importCtx, "Error during NZBDav parsing", "error", err)
-				s.importMu.Lock()
-				msg := err.Error()
-				s.importInfo.LastError = &msg
-				s.importMu.Unlock()
-			}
-		default:
-		}
-	}()
-
-	return nil
-}
-
-func (s *Service) processQueueBatch(ctx context.Context, batchChan <-chan *database.ImportQueueItem) {
-	var batch []*database.ImportQueueItem
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	insertBatch := func() {
-		if len(batch) > 0 {
-			if err := s.database.Repository.AddBatchToQueue(ctx, batch); err != nil {
-				s.log.ErrorContext(ctx, "Failed to add batch to queue", "count", len(batch), "error", err)
-				s.importMu.Lock()
-				s.importInfo.Failed += len(batch)
-				s.importMu.Unlock()
-			} else {
-				s.importMu.Lock()
-				s.importInfo.Added += len(batch)
-				s.importMu.Unlock()
-			}
-			batch = nil // Reset batch
-		}
-	}
-
-	for {
-		select {
-		case item, ok := <-batchChan:
-			if !ok {
-				// Channel closed, drain remaining batch
-				insertBatch()
-				return
-			}
-			batch = append(batch, item)
-			if len(batch) >= 100 { // Batch size
-				insertBatch()
-			}
-		case <-ticker.C:
-			insertBatch()
-		case <-ctx.Done():
-			insertBatch()
-			return
-		}
-	}
-}
-
-func (s *Service) createNzbFileAndPrepareItem(ctx context.Context, res *nzbdav.ParsedNzb, rootFolder, nzbTempDir string) (*database.ImportQueueItem, error) {
-	// Check context before file operations
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
-
-	// Create Temp NZB File
-	// Use ID to ensure uniqueness and avoid collisions with releases having the same name in the temp directory
-	// but don't include it in the filename to avoid it appearing in the final folder/file names
-	nzbSubDir := filepath.Join(nzbTempDir, sanitizeFilename(res.ID))
-	if err := os.MkdirAll(nzbSubDir, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create temp NZB subdirectory: %w", err)
-	}
-
-	nzbFileName := fmt.Sprintf("%s.nzb", sanitizeFilename(res.Name))
-	nzbPath := filepath.Join(nzbSubDir, nzbFileName)
-
-	outFile, err := os.Create(nzbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp NZB file: %w", err)
-	}
-
-	// Copy content
-	_, err = io.Copy(outFile, res.Content)
-	outFile.Close()
-	if err != nil {
-		os.Remove(nzbPath)
-		return nil, fmt.Errorf("failed to write temp NZB file content: %w", err)
-	}
-
-	// Determine Category and Relative Path
-	targetCategory := "other"
-	lowerCat := strings.ToLower(res.Category)
-	if strings.Contains(lowerCat, "movie") {
-		targetCategory = "movies"
-	} else if strings.Contains(lowerCat, "tv") || strings.Contains(lowerCat, "series") {
-		targetCategory = "tv"
-	}
-
-	if res.RelPath != "" {
-		targetCategory = filepath.Join(targetCategory, res.RelPath)
-	}
-
-	relPath := rootFolder
-	priority := database.QueuePriorityNormal
-
-	// Store original ID in metadata
-	metaJSON := fmt.Sprintf(`{"nzbdav_id": "%s"}`, res.ID)
-
-	// Prepare item struct
-	item := &database.ImportQueueItem{
-		NzbPath:      nzbPath,
-		RelativePath: &relPath,
-		Category:     &targetCategory,
-		Priority:     priority,
-		Status:       database.QueueStatusPending,
-		RetryCount:   0,
-		MaxRetries:   3,
-		CreatedAt:    time.Now(),
-		Metadata:     &metaJSON,
-	}
-
-	// Calculate file size
-	if size, err := s.CalculateFileSizeOnly(nzbPath); err == nil {
-		item.FileSize = &size
-	}
-
-	return item, nil
+	return s.nzbdavImporter.Start(dbPath, rootFolder, cleanupFile)
 }
 
 // GetImportStatus returns the current import status
 func (s *Service) GetImportStatus() ImportInfo {
-	s.importMu.RLock()
-	defer s.importMu.RUnlock()
-	return s.importInfo
+	return s.nzbdavImporter.GetStatus()
 }
 
 // CancelImport cancels the current import operation
 func (s *Service) CancelImport() error {
-	s.importMu.Lock()
-	defer s.importMu.Unlock()
-
-	if s.importInfo.Status == ImportStatusIdle {
-		return fmt.Errorf("no import is currently running")
-	}
-
-	if s.importInfo.Status == ImportStatusCanceling {
-		return fmt.Errorf("import is already being canceled")
-	}
-
-	s.importInfo.Status = ImportStatusCanceling
-	if s.importCancel != nil {
-		s.importCancel()
-	}
-
-	return nil
+	return s.nzbdavImporter.Cancel()
 }
 
+// sanitizeFilename replaces invalid characters in filenames
 func sanitizeFilename(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
-}
-
-// performManualScan performs the actual scanning work in a separate goroutine
-func (s *Service) performManualScan(ctx context.Context, scanPath string) {
-	defer func() {
-		s.scanMu.Lock()
-		s.scanInfo.Status = ScanStatusIdle
-		s.scanInfo.CurrentFile = ""
-		if s.scanCancel != nil {
-			s.scanCancel()
-			s.scanCancel = nil
-		}
-		s.scanMu.Unlock()
-	}()
-
-	s.log.DebugContext(ctx, "Scanning directory for NZB files", "dir", scanPath)
-
-	err := filepath.WalkDir(scanPath, func(path string, d fs.DirEntry, err error) error {
-		// Check for cancellation
-		select {
-		case <-ctx.Done():
-			s.log.InfoContext(ctx, "Scan cancelled", "path", scanPath)
-			return fmt.Errorf("scan cancelled")
-		default:
-		}
-
-		if err != nil {
-			s.log.WarnContext(ctx, "Error accessing path", "path", path, "error", err)
-			s.scanMu.Lock()
-			errMsg := err.Error()
-			s.scanInfo.LastError = &errMsg
-			s.scanMu.Unlock()
-			return nil // Continue walking
-		}
-
-		// Skip directories
-		if d.IsDir() {
-			return nil
-		}
-
-		// Update current file being processed
-		s.scanMu.Lock()
-		s.scanInfo.CurrentFile = path
-		s.scanInfo.FilesFound++
-		s.scanMu.Unlock()
-
-		// Check if it's an NZB or STRM file
-		ext := strings.ToLower(path)
-		if !strings.HasSuffix(ext, ".nzb") && !strings.HasSuffix(ext, ".strm") {
-			return nil
-		}
-
-		// Check if already in queue (simplified check during scanning)
-		if s.isFileAlreadyInQueue(ctx, path) {
-			return nil
-		}
-
-		// Check if already processed (metadata exists)
-		if s.isFileAlreadyProcessed(path, scanPath) {
-			s.log.DebugContext(ctx, "Skipping file - already processed", "file", path)
-			return nil
-		}
-
-		// Add to queue
-		if _, err := s.AddToQueue(ctx, path, &scanPath, nil, nil); err != nil {
-			s.log.ErrorContext(ctx, "Failed to add file to queue during scan", "file", path, "error", err)
-		}
-
-		// Update files added counter
-		s.scanMu.Lock()
-		s.scanInfo.FilesAdded++
-		s.scanMu.Unlock()
-
-		return nil
-	})
-
-	if err != nil && !strings.Contains(err.Error(), "scan cancelled") {
-		s.log.ErrorContext(ctx, "Failed to scan directory", "dir", scanPath, "error", err)
-		s.scanMu.Lock()
-		errMsg := err.Error()
-		s.scanInfo.LastError = &errMsg
-		s.scanMu.Unlock()
-	}
-
-	s.log.InfoContext(ctx, "Manual scan completed", "path", scanPath, "files_found", s.scanInfo.FilesFound, "files_added", s.scanInfo.FilesAdded)
-}
-
-// isFileAlreadyInQueue checks if file is already in queue (simplified scanning)
-func (s *Service) isFileAlreadyInQueue(ctx context.Context, filePath string) bool {
-	// Only check queue database during scanning for performance
-	// The processor will check main database for duplicates when processing
-	inQueue, err := s.database.Repository.IsFileInQueue(ctx, filePath)
-	if err != nil {
-		s.log.WarnContext(ctx, "Failed to check if file in queue", "file", filePath, "error", err)
-		return false // Assume not in queue on error
-	}
-	return inQueue
-}
-
-// isFileAlreadyProcessed checks if a file has already been processed by checking metadata
-func (s *Service) isFileAlreadyProcessed(filePath string, scanRoot string) bool {
-	// Calculate virtual path
-	// Assuming scanRoot maps to root of virtual FS for simplicity in manual scan
-	// or use CalculateVirtualDirectory logic if needed
-	virtualPath := filesystem.CalculateVirtualDirectory(filePath, scanRoot)
-
-	// Check if we have metadata for this path
-	// For single files: virtualPath/filename (minus .nzb)
-	// For multi files: virtualPath/filename (minus .nzb) as directory
-
-	// Normalize filename (remove .nzb extension)
-	fileName := filepath.Base(filePath)
-	baseName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-
-	// Construct potential virtual paths
-	// 1. As a file (single file import flattened or nested)
-	// We need to check if a file exists with the release name
-	// But we don't know the final extension...
-	// However, metadata service stores files with their final names.
-
-	// Better approach: Check if a directory exists with the release name
-	// Most imports create a folder with the release name
-	releaseDir := filepath.Join(virtualPath, baseName)
-	if s.metadataService.DirectoryExists(releaseDir) {
-		return true
-	}
-
-	// Also check if any file exists that starts with the release name in that directory
-	// This covers flattened single files
-	if files, err := s.metadataService.ListDirectory(virtualPath); err == nil {
-		for _, f := range files {
-			if strings.HasPrefix(f, baseName) {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 // AddToQueue adds a new NZB file to the import queue with optional category and priority
@@ -863,178 +495,6 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 	}
 
 	return item, nil
-}
-
-// workerLoop processes queue items
-func (s *Service) workerLoop(workerID int) {
-	defer s.wg.Done()
-
-	log := s.log.With("worker_id", workerID)
-
-	// Get processing interval from configuration
-	processingIntervalSeconds := s.configGetter().Import.QueueProcessingIntervalSeconds
-	processingInterval := time.Duration(processingIntervalSeconds) * time.Second
-
-	ticker := time.NewTicker(processingInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// Check if service is paused
-			if s.IsPaused() {
-				continue
-			}
-			s.processQueueItems(s.ctx, workerID)
-		case <-s.ctx.Done():
-			log.Info("Queue worker stopped")
-			return
-		}
-	}
-}
-
-// isDatabaseContentionError checks if an error is a retryable database contention error
-func isDatabaseContentionError(err error) bool {
-	if err == nil {
-		return false
-	}
-	errStr := err.Error()
-	return strings.Contains(errStr, "database is locked") ||
-		strings.Contains(errStr, "database is busy") ||
-		strings.Contains(errStr, "database table is locked")
-}
-
-// claimItemWithRetry attempts to claim a queue item with exponential backoff retry logic using retry-go
-func (s *Service) claimItemWithRetry(ctx context.Context, workerID int) (*database.ImportQueueItem, error) {
-	var item *database.ImportQueueItem
-
-	err := retry.Do(
-		func() error {
-			claimedItem, err := s.database.Repository.ClaimNextQueueItem(ctx)
-			if err != nil {
-				return err
-			}
-
-			item = claimedItem
-			return nil
-		},
-		retry.Attempts(3),                // Reduced from 5 - immediate transactions should succeed quickly
-		retry.Delay(50*time.Millisecond), // Increased from 10ms
-		retry.MaxDelay(5*time.Second),    // Increased from 500ms to allow better spreading
-		retry.DelayType(retry.BackOffDelay),
-		retry.RetryIf(isDatabaseContentionError),
-		retry.OnRetry(func(n uint, err error) {
-			// Add jitter to prevent synchronized retries across workers
-			// Jitter range: 0-1000ms to desynchronize worker retries
-			jitter := time.Duration(rand.Int63n(int64(time.Second)))
-			time.Sleep(jitter)
-
-			// Calculate exponential backoff for logging
-			baseDelay := 50 * time.Millisecond
-			backoffDelay := baseDelay * (1 << n) // Exponential: 50ms, 100ms, 200ms...
-			if backoffDelay > 5*time.Second {
-				backoffDelay = 5 * time.Second
-			}
-
-			// Only log warnings after first retry to reduce noise
-			if n >= 1 {
-				s.log.WarnContext(ctx, "Database contention, retrying claim",
-					"attempt", n+1,
-					"worker_id", workerID,
-					"backoff_ms", backoffDelay.Milliseconds(),
-					"jitter_ms", jitter.Milliseconds(),
-					"error", err)
-			} else {
-				s.log.DebugContext(ctx, "Database contention, retrying claim",
-					"attempt", n+1,
-					"worker_id", workerID,
-					"backoff_ms", backoffDelay.Milliseconds(),
-					"jitter_ms", jitter.Milliseconds(),
-					"error", err)
-			}
-		}),
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to claim queue item: %w", err)
-	}
-
-	if item == nil {
-		return nil, nil
-	}
-
-	s.log.DebugContext(ctx, "Next item in processing queue", "queue_id", item.ID, "file", item.NzbPath)
-	return item, nil
-}
-
-// processQueueItems gets and processes pending queue items using two-database workflow
-func (s *Service) processQueueItems(ctx context.Context, workerID int) {
-	// Step 1: Atomically claim next available item from queue database with retry logic
-	item, err := s.claimItemWithRetry(ctx, workerID)
-	if err != nil {
-		// Only log non-contention errors
-		if !strings.Contains(err.Error(), "database is locked") && !strings.Contains(err.Error(), "database is busy") {
-			s.log.ErrorContext(ctx, "Failed to claim next queue item", "worker_id", workerID, "error", err)
-		}
-		return
-	}
-
-	if item == nil {
-		return // No work to do
-	}
-
-	s.log.DebugContext(ctx, "Processing claimed queue item", "worker_id", workerID, "queue_id", item.ID, "file", item.NzbPath)
-
-	// Create cancellable context for this item
-	itemCtx, cancel := context.WithCancel(ctx)
-
-	// Register cancel function
-	s.cancelMu.Lock()
-	s.cancelFuncs[item.ID] = cancel
-	s.cancelMu.Unlock()
-
-	// Clean up after processing
-	defer func() {
-		s.cancelMu.Lock()
-		delete(s.cancelFuncs, item.ID)
-		s.cancelMu.Unlock()
-	}()
-
-	// Step 3: Process the NZB file and write to main database using cancellable context
-	resultingPath, processingErr := s.processNzbItem(itemCtx, item)
-
-	// Step 4: Update queue database with results
-	if processingErr != nil {
-		// Handle failure in queue database
-		s.handleProcessingFailure(ctx, item, processingErr)
-	} else {
-		// Handle success (storage path, VFS notification, symlinks, status update)
-		s.handleProcessingSuccess(ctx, item, resultingPath)
-	}
-}
-
-// refreshMountPathIfNeeded checks if the mount path exists and refreshes the root directory if not found
-func (s *Service) refreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64) {
-	if s.rcloneClient == nil {
-		return
-	}
-
-	mountPath := filepath.Join(s.configGetter().MountPath, filepath.Dir(strings.TrimPrefix(resultingPath, "/")))
-	if _, err := os.Stat(mountPath); err != nil {
-		if os.IsNotExist(err) {
-			cfg := s.configGetter()
-			vfsName := cfg.RClone.VFSName
-			if vfsName == "" {
-				vfsName = config.MountProvider
-			}
-
-			// Refresh the root path if the mount path is not found
-			err := s.rcloneClient.RefreshDir(s.ctx, vfsName, []string{"/"})
-			if err != nil {
-				s.log.ErrorContext(ctx, "Failed to refresh mount path", "queue_id", itemID, "path", mountPath, "error", err)
-			}
-		}
-	}
 }
 
 // processNzbItem processes the NZB file for a queue item
@@ -1195,33 +655,24 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 		return err
 	}
 
-	// Refresh mount path if needed
-	s.refreshMountPathIfNeeded(ctx, resultingPath, item.ID)
+	// Refresh mount path if needed before post-processing
+	s.postProcessor.RefreshMountPathIfNeeded(ctx, resultingPath, item.ID)
 
-	// Notify rclone VFS about the new import (blocking, ensures visibility for ARRs)
-	s.notifyRcloneVFS(ctx, resultingPath, false)
-
-	// Create category symlink (non-blocking)
-	if err := s.createSymlinks(item, resultingPath); err != nil {
-		s.log.WarnContext(ctx, "Failed to create symlink",
-			"queue_id", item.ID,
-			"path", resultingPath,
-			"error", err)
-
+	// Delegate all post-processing to the coordinator
+	// This handles: VFS notification, symlinks, ID links, STRM files, health checks, ARR notifications
+	result, err := s.postProcessor.HandleSuccess(ctx, item, resultingPath)
+	if err != nil {
+		s.log.ErrorContext(ctx, "Post-processing failed", "queue_id", item.ID, "error", err)
 		return err
 	}
 
-	// Create ID metadata links if applicable (for nzbdav compatibility)
-	s.handleIdMetadataLinks(item, resultingPath)
-
-	// Create STRM files (non-blocking)
-	if err := s.createStrmFiles(item, resultingPath); err != nil {
-		s.log.WarnContext(ctx, "Failed to create STRM file",
-			"queue_id", item.ID,
-			"path", resultingPath,
-			"error", err)
-
-		return err
+	// Log any non-fatal errors from post-processing
+	if len(result.Errors) > 0 {
+		for _, postErr := range result.Errors {
+			s.log.WarnContext(ctx, "Post-processing warning",
+				"queue_id", item.ID,
+				"error", postErr)
+		}
 	}
 
 	// Mark as completed in queue database
@@ -1233,85 +684,6 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 	// Clear progress tracking
 	if s.broadcaster != nil {
 		s.broadcaster.ClearProgress(int(item.ID))
-	}
-
-	// Trigger ARR download scan if applicable
-	if s.arrsService != nil && item.Category != nil {
-		// Try to trigger scan on the specific instance that manages this file
-		// resultingPath is the virtual path, e.g. "movies/MovieName/Movie.mkv"
-		// This uses the Root Folder check which is fast and accurate
-		fullMountPath := filepath.Join(s.configGetter().MountPath, strings.TrimPrefix(resultingPath, "/"))
-		if err := s.arrsService.TriggerScanForFile(ctx, fullMountPath); err != nil {
-			// Fallback: If we couldn't find a specific owner, broadcast to all instances of the type
-			s.log.DebugContext(ctx, "Could not find specific ARR instance for file, broadcasting scan",
-				"path", fullMountPath, "error", err)
-
-			categoryName := *item.Category
-			category := strings.ToLower(categoryName)
-			arrType := ""
-
-			// Try to find an explicit mapping in SABnzbd categories
-			cfg := s.configGetter()
-			for _, cat := range cfg.SABnzbd.Categories {
-				if strings.EqualFold(cat.Name, categoryName) && cat.Type != "" {
-					arrType = strings.ToLower(cat.Type)
-					break
-				}
-			}
-
-			// Fallback to heuristic if no explicit type is mapped
-			if arrType == "" {
-				if category == "tv" || strings.Contains(category, "tv") || strings.Contains(category, "show") || category == "sonarr" {
-					arrType = "sonarr"
-				} else if category == "movies" || strings.Contains(category, "movie") || category == "radarr" {
-					arrType = "radarr"
-				}
-			}
-
-			if arrType != "" {
-				s.arrsService.TriggerDownloadScan(ctx, arrType)
-			}
-		}
-	}
-
-	// Schedule immediate health check for the new file
-	if s.healthRepo != nil {
-		// Calculate the mount relative path
-		// resultingPath is the virtual path (e.g. "movies/Movie (Year)/Movie.mkv")
-
-		// Read metadata to get SourceNzbPath needed for health check
-		fileMeta, err := s.metadataService.ReadFileMetadata(resultingPath)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to read metadata for health check scheduling", "path", resultingPath, "error", err)
-		} else if fileMeta != nil {
-			// Add/Update health record with high priority to ensure it's processed right away
-			err := s.healthRepo.AddFileToHealthCheck(ctx, resultingPath, 2, &fileMeta.SourceNzbPath, database.HealthPriorityNext)
-			if err != nil {
-				slog.ErrorContext(ctx, "Failed to schedule immediate health check for imported file", "path", resultingPath, "error", err)
-			} else {
-				slog.InfoContext(ctx, "Scheduled immediate health check for imported file", "path", resultingPath)
-			}
-		}
-
-		// Also check for OTHER files in the same directory that were marked for repair.
-		// This handles the case where "Movie.2020.mkv" (corrupted) is replaced by "Movie.REPACK.mkv".
-		// The directory would be "movies/Movie (Year)".
-		cfg := s.configGetter()
-		resolveRepairs := true
-		if cfg.Health.ResolveRepairOnImport != nil {
-			resolveRepairs = *cfg.Health.ResolveRepairOnImport
-		}
-
-		if resolveRepairs {
-			parentDir := filepath.Dir(resultingPath)
-			if parentDir != "." && parentDir != "/" {
-				if count, err := s.healthRepo.ResolvePendingRepairsInDirectory(ctx, parentDir); err == nil && count > 0 {
-					slog.InfoContext(ctx, "Resolved pending repairs in directory due to new import",
-						"directory", parentDir,
-						"resolved_count", count)
-				}
-			}
-		}
 	}
 
 	s.log.InfoContext(ctx, "Successfully processed queue item", "queue_id", item.ID, "file", item.NzbPath)
@@ -1349,72 +721,20 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 		s.broadcaster.ClearProgress(int(item.ID))
 	}
 
-	cfg := s.configGetter()
-	// Attempt SABnzbd fallback if configured
-	if cfg.SABnzbd.FallbackHost != "" && cfg.SABnzbd.FallbackAPIKey != "" {
-		if err := s.attemptSABnzbdFallback(ctx, item); err != nil {
-			s.log.ErrorContext(ctx, "Failed to send to external SABnzbd",
+	// Delegate fallback handling to post-processor
+	if err := s.postProcessor.HandleFailure(ctx, item, processingErr); err == nil {
+		// Fallback succeeded - mark item as fallback instead of failed
+		if err := s.database.Repository.UpdateQueueItemStatus(ctx, item.ID, database.QueueStatusFallback, nil); err != nil {
+			s.log.ErrorContext(ctx, "Failed to mark item as fallback", "queue_id", item.ID, "error", err)
+		} else {
+			s.log.DebugContext(ctx, "Item marked as fallback after successful SABnzbd transfer",
 				"queue_id", item.ID,
 				"file", item.NzbPath,
-				"fallback_host", s.configGetter().SABnzbd.FallbackHost,
-				"error", err)
-
-		} else {
-			// Mark item as fallback instead of removing from queue
-			if err := s.database.Repository.UpdateQueueItemStatus(ctx, item.ID, database.QueueStatusFallback, nil); err != nil {
-				s.log.ErrorContext(ctx, "Failed to mark item as fallback", "queue_id", item.ID, "error", err)
-			} else {
-				s.log.DebugContext(ctx, "Item marked as fallback after successful SABnzbd transfer",
-					"queue_id", item.ID,
-					"file", item.NzbPath,
-					"fallback_host", s.configGetter().SABnzbd.FallbackHost)
-			}
+				"fallback_host", s.configGetter().SABnzbd.FallbackHost)
 		}
 	}
 }
 
-// attemptSABnzbdFallback attempts to send a failed import to an external SABnzbd instance
-func (s *Service) attemptSABnzbdFallback(ctx context.Context, item *database.ImportQueueItem) error {
-	cfg := s.configGetter()
-
-	// Check if the NZB file still exists
-	if _, err := os.Stat(item.NzbPath); err != nil {
-		s.log.WarnContext(ctx, "SABnzbd fallback not attempted - NZB file not found",
-			"queue_id", item.ID,
-			"file", item.NzbPath,
-			"error", err)
-		return err
-	}
-
-	s.log.InfoContext(ctx, "Attempting to send failed import to external SABnzbd",
-		"queue_id", item.ID,
-		"file", item.NzbPath,
-		"fallback_host", cfg.SABnzbd.FallbackHost)
-
-	// Convert priority to SABnzbd format
-	priority := s.convertPriorityToSABnzbd(item.Priority)
-
-	// Send to external SABnzbd
-	nzoID, err := s.sabnzbdClient.SendNZBFile(
-		ctx,
-		cfg.SABnzbd.FallbackHost,
-		cfg.SABnzbd.FallbackAPIKey,
-		item.NzbPath,
-		item.Category,
-		&priority,
-	)
-	if err != nil {
-		return err
-	}
-
-	s.log.InfoContext(ctx, "Successfully sent failed import to external SABnzbd",
-		"queue_id", item.ID,
-		"file", item.NzbPath,
-		"fallback_host", cfg.SABnzbd.FallbackHost,
-		"sabnzbd_nzo_id", nzoID)
-
-	return nil
-}
 
 // ServiceStats holds statistics about the service
 type ServiceStats struct {
@@ -1472,78 +792,9 @@ func (s *Service) GetWorkerCount() int {
 
 // CancelProcessing cancels a processing queue item by cancelling its context
 func (s *Service) CancelProcessing(itemID int64) error {
-	s.cancelMu.RLock()
-	cancel, exists := s.cancelFuncs[itemID]
-	s.cancelMu.RUnlock()
-
-	if !exists {
-		return fmt.Errorf("item %d is not currently processing", itemID)
-	}
-
-	s.log.InfoContext(s.ctx, "Cancelling processing for queue item", "item_id", itemID)
-	cancel()
-	return nil
+	return s.queueManager.CancelProcessing(itemID)
 }
 
-// notifyRcloneVFS notifies rclone VFS about a new import
-func (s *Service) notifyRcloneVFS(ctx context.Context, resultingPath string, async bool) {
-	if s.rcloneClient == nil {
-		return // No rclone client configured or RClone RC is disabled
-	}
-
-	refreshFunc := func(path string) {
-		// Derive timeout context from parent context for proper cancellation propagation
-		// Increased timeout to 60 seconds as vfs/refresh can be slow
-		refreshCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-		defer cancel()
-
-		cfg := s.configGetter()
-		vfsName := cfg.RClone.VFSName
-		if vfsName == "" {
-			vfsName = config.MountProvider
-		}
-
-		// Refresh both the path and its parent to ensure visibility
-		// Ensure paths are relative to the rclone remote root (no leading slash)
-		normalizeForRclone := func(p string) string {
-			p = strings.TrimPrefix(p, "/")
-			if p == "" {
-				return "."
-			}
-			return p
-		}
-
-		dirsToRefresh := []string{normalizeForRclone(path)}
-		parentDir := filepath.Dir(path)
-		if parentDir != "." && parentDir != "/" {
-			dirsToRefresh = append(dirsToRefresh, normalizeForRclone(parentDir))
-
-			// Also refresh grandparent if parent might be new (e.g. /complete/tv)
-			grandParent := filepath.Dir(parentDir)
-			if grandParent != "." && grandParent != "/" {
-				dirsToRefresh = append(dirsToRefresh, normalizeForRclone(grandParent))
-			}
-		}
-
-		slog.DebugContext(refreshCtx, "Notifying rclone VFS refresh", "dirs", dirsToRefresh, "vfs", vfsName)
-
-		err := s.rcloneClient.RefreshDir(refreshCtx, vfsName, dirsToRefresh)
-		if err != nil {
-			slog.WarnContext(refreshCtx, "Failed to notify rclone VFS refresh",
-				"dirs", dirsToRefresh,
-				"error", err)
-		} else {
-			slog.InfoContext(refreshCtx, "Successfully notified rclone VFS refresh",
-				"dirs", dirsToRefresh)
-		}
-	}
-
-	if async {
-		go refreshFunc(resultingPath)
-	} else {
-		refreshFunc(resultingPath)
-	}
-}
 
 // ProcessItemInBackground processes a specific queue item in the background
 func (s *Service) ProcessItemInBackground(ctx context.Context, itemID int64) {
@@ -1674,410 +925,6 @@ func (s *Service) calculateStrmFileSize(r io.Reader) (int64, error) {
 	return 0, NewNonRetryableError("no valid NXG link found in STRM file", nil)
 }
 
-// convertPriorityToSABnzbd converts AltMount queue priority to SABnzbd priority format
-func (s *Service) convertPriorityToSABnzbd(priority database.QueuePriority) string {
-	switch priority {
-	case database.QueuePriorityHigh:
-		return "2" // High
-	case database.QueuePriorityLow:
-		return "0" // Low
-	default:
-		return "1" // Normal
-	}
-}
 
-// createSymlinks creates symlinks for an imported file or directory in the category folder
-func (s *Service) createSymlinks(item *database.ImportQueueItem, resultingPath string) error {
-	cfg := s.configGetter()
 
-	// Check if symlinks are enabled
-	if cfg.Import.ImportStrategy != config.ImportStrategySYMLINK {
-		return nil // Skip if not enabled
-	}
 
-	if cfg.Import.ImportDir == nil || *cfg.Import.ImportDir == "" {
-		return fmt.Errorf("symlink directory not configured")
-	}
-
-	// Get the actual metadata/mount path (where the content actually lives)
-	actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(resultingPath, "/"))
-
-	// Check the metadata directory to determine if this is a file or directory
-	// (Don't use os.Stat on mount path as it might not be immediately available)
-	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
-	fileInfo, err := os.Stat(metadataPath)
-
-	// If stat fails, check if it's a .meta file (single file case)
-	if err != nil {
-		// Try checking for .meta file
-		metaFile := metadataPath + ".meta"
-		if _, metaErr := os.Stat(metaFile); metaErr == nil {
-			// It's a single file
-			return s.createSingleSymlink(actualPath, resultingPath)
-		}
-		return fmt.Errorf("failed to stat metadata path: %w", err)
-	}
-
-	if !fileInfo.IsDir() {
-		// Single file - create one symlink
-		return s.createSingleSymlink(actualPath, resultingPath)
-	}
-
-	// Directory - walk through and create symlinks for all files
-	var symlinkErrors []error
-	symlinkCount := 0
-
-	// Walk the metadata directory to find all files
-	err = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			s.log.WarnContext(context.Background(), "Error accessing metadata path during symlink creation",
-				"path", path,
-				"error", err)
-			return nil // Continue walking
-		}
-
-		// Skip directories, we only create symlinks for files (.meta files)
-		if d.IsDir() {
-			return nil
-		}
-
-		// Only process .meta files
-		if !strings.HasSuffix(d.Name(), ".meta") {
-			return nil
-		}
-
-		// Calculate relative path from the root metadata directory (not metadataPath)
-		relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
-		if err != nil {
-			s.log.ErrorContext(context.Background(), "Failed to calculate relative path",
-				"path", path,
-				"base", cfg.Metadata.RootPath,
-				"error", err)
-			return nil // Continue walking
-		}
-
-		// Remove .meta extension to get the actual filename
-		relPath = strings.TrimSuffix(relPath, ".meta")
-
-		// Build the actual file path in the mount (mount root + virtual path)
-		actualFilePath := filepath.Join(cfg.MountPath, strings.TrimPrefix(relPath, "/"))
-
-		// The relPath already IS the full virtual path from root, so use it directly
-		fileResultingPath := relPath
-
-		// Create symlink for this file using the helper function
-		if err := s.createSingleSymlink(actualFilePath, fileResultingPath); err != nil {
-			s.log.ErrorContext(context.Background(), "Failed to create symlink",
-				"path", actualFilePath,
-				"error", err)
-			symlinkErrors = append(symlinkErrors, err)
-			return nil // Continue walking
-		}
-
-		symlinkCount++
-
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to walk directory: %w", err)
-	}
-
-	if len(symlinkErrors) > 0 {
-		s.log.WarnContext(context.Background(), "Some symlinks failed to create",
-			"queue_id", item.ID,
-			"total_errors", len(symlinkErrors),
-			"successful", symlinkCount)
-		// Don't fail the import, just log the warning
-	}
-
-	return nil
-}
-
-// createSingleSymlink creates a symlink for a single file
-func (s *Service) createSingleSymlink(actualPath, resultingPath string) error {
-	cfg := s.configGetter()
-
-	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(strings.TrimPrefix(resultingPath, "/")))
-
-	// Ensure category directory exists
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return fmt.Errorf("failed to create symlink category directory: %w", err)
-	}
-
-	symlinkPath := filepath.Join(*cfg.Import.ImportDir, strings.TrimPrefix(resultingPath, "/"))
-
-	// Check if symlink already exists
-	if _, err := os.Lstat(symlinkPath); err == nil {
-		// Symlink exists, remove it first
-		if err := os.Remove(symlinkPath); err != nil {
-			return fmt.Errorf("failed to remove existing symlink: %w", err)
-		}
-	}
-
-	// Create the symlink
-	if err := os.Symlink(actualPath, symlinkPath); err != nil {
-		return fmt.Errorf("failed to create symlink: %w", err)
-	}
-
-	return nil
-}
-
-// createStrmFiles creates STRM files for an imported file or directory
-func (s *Service) createStrmFiles(item *database.ImportQueueItem, resultingPath string) error {
-	cfg := s.configGetter()
-
-	// Check if STRM is enabled
-	if cfg.Import.ImportStrategy != config.ImportStrategySTRM {
-		return nil // Skip if not enabled
-	}
-
-	if cfg.Import.ImportDir == nil || *cfg.Import.ImportDir == "" {
-		return fmt.Errorf("STRM directory not configured")
-	}
-
-	// Check the metadata directory to determine if this is a file or directory
-	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
-	fileInfo, err := os.Stat(metadataPath)
-
-	// If stat fails, check if it's a .meta file (single file case)
-	if err != nil {
-		// Try checking for .meta file
-		metaFile := metadataPath + ".meta"
-		if _, metaErr := os.Stat(metaFile); metaErr == nil {
-			// It's a single file
-			return s.createSingleStrmFile(resultingPath, cfg.WebDAV.Port)
-		}
-		return fmt.Errorf("failed to stat metadata path: %w", err)
-	}
-
-	if !fileInfo.IsDir() {
-		// Single file - create one STRM file
-		return s.createSingleStrmFile(resultingPath, cfg.WebDAV.Port)
-	}
-
-	// Directory - walk through and create STRM files for all files
-	var strmErrors []error
-	strmCount := 0
-
-	// Walk the metadata directory to find all files
-	err = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			s.log.WarnContext(context.Background(), "Error accessing metadata path during STRM creation",
-				"path", path,
-				"error", err)
-			return nil // Continue walking
-		}
-
-		// Skip directories, we only create STRM files for files (.meta files)
-		if d.IsDir() {
-			return nil
-		}
-
-		// Only process .meta files
-		if !strings.HasSuffix(d.Name(), ".meta") {
-			return nil
-		}
-
-		// Calculate relative path from the root metadata directory
-		relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
-		if err != nil {
-			s.log.ErrorContext(context.Background(), "Failed to calculate relative path",
-				"path", path,
-				"base", cfg.Metadata.RootPath,
-				"error", err)
-			return nil // Continue walking
-		}
-
-		// Remove .meta extension to get the actual filename
-		relPath = strings.TrimSuffix(relPath, ".meta")
-
-		// Create STRM file for this file
-		if err := s.createSingleStrmFile(relPath, cfg.WebDAV.Port); err != nil {
-			s.log.ErrorContext(context.Background(), "Failed to create STRM file",
-				"path", relPath,
-				"error", err)
-			strmErrors = append(strmErrors, err)
-			return nil // Continue walking
-		}
-
-		strmCount++
-
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to walk directory: %w", err)
-	}
-
-	if len(strmErrors) > 0 {
-		s.log.WarnContext(context.Background(), "Some STRM files failed to create",
-			"queue_id", item.ID,
-			"total_errors", len(strmErrors),
-			"successful", strmCount)
-		// Don't fail the import, just log the warning
-	}
-
-	return nil
-}
-
-// createSingleStrmFile creates a STRM file for a single file with authentication
-func (s *Service) createSingleStrmFile(virtualPath string, port int) error {
-	ctx := context.Background()
-	cfg := s.configGetter()
-
-	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(virtualPath))
-
-	// Ensure directory exists
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
-		return fmt.Errorf("failed to create STRM directory: %w", err)
-	}
-
-	// Keep original filename and add .strm extension
-	filename := filepath.Base(virtualPath)
-	filename = filename + ".strm"
-
-	strmPath := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(virtualPath), filename)
-
-	// Get first admin user's API key for authentication
-	users, err := s.userRepo.GetAllUsers(ctx)
-	if err != nil || len(users) == 0 {
-		return fmt.Errorf("no users with API keys found for STRM generation: %w", err)
-	}
-
-	// Find first admin user with an API key
-	var adminAPIKey string
-	for _, user := range users {
-		if user.IsAdmin && user.APIKey != nil && *user.APIKey != "" {
-			adminAPIKey = *user.APIKey
-			break
-		}
-	}
-
-	if adminAPIKey == "" {
-		return fmt.Errorf("no admin user with API key found for STRM generation")
-	}
-
-	// Hash the API key with SHA256
-	hashedKey := hashAPIKey(adminAPIKey)
-
-	// Generate streaming URL with download_key
-	// URL encode the path to handle special characters
-	encodedPath := strings.ReplaceAll(virtualPath, " ", "%20")
-	streamURL := fmt.Sprintf("http://localhost:%d/api/files/stream?path=%s&download_key=%s",
-		port, encodedPath, hashedKey)
-
-	// Check if STRM file already exists with the same content
-	if existingContent, err := os.ReadFile(strmPath); err == nil {
-		if string(existingContent) == streamURL {
-			// File exists with correct content, skip
-			return nil
-		}
-	}
-
-	// Write the STRM file
-	if err := os.WriteFile(strmPath, []byte(streamURL), 0644); err != nil {
-		return fmt.Errorf("failed to write STRM file: %w", err)
-	}
-
-	return nil
-}
-
-// hashAPIKey generates a SHA256 hash of the API key for secure comparison
-func hashAPIKey(apiKey string) string {
-	hash := sha256.Sum256([]byte(apiKey))
-	return hex.EncodeToString(hash[:])
-}
-
-func (s *Service) handleIdMetadataLinks(item *database.ImportQueueItem, resultingPath string) {
-	// 1. Check if the queue item itself has a release-level ID in its metadata
-	if item.Metadata != nil && *item.Metadata != "" {
-		var meta struct {
-			NzbdavID string `json:"nzbdav_id"`
-		}
-		if err := json.Unmarshal([]byte(*item.Metadata), &meta); err == nil && meta.NzbdavID != "" {
-			if err := s.createIDMetadataLink(meta.NzbdavID, resultingPath); err != nil {
-				s.log.Warn("Failed to create release ID metadata link", "id", meta.NzbdavID, "error", err)
-			}
-		}
-	}
-
-	// 2. Check individual files for IDs
-	cfg := s.configGetter()
-	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
-
-	_ = filepath.WalkDir(metadataPath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".meta") {
-			return nil
-		}
-
-		// Read the metadata file to find the ID
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-
-		// Parse the protobuf metadata to get the ID
-		meta := &metapb.FileMetadata{}
-		if err := proto.Unmarshal(data, meta); err != nil {
-			return nil
-		}
-
-		// Check sidecar ID file if not in proto (compatibility mode)
-		if meta.NzbdavId == "" {
-			if idData, err := os.ReadFile(path + ".id"); err == nil {
-				meta.NzbdavId = string(idData)
-			}
-		}
-
-		if meta.NzbdavId != "" {
-			// Calculate the virtual path from the metadata file path
-			relPath, err := filepath.Rel(cfg.Metadata.RootPath, path)
-			if err != nil {
-				return nil
-			}
-			// Remove .meta extension
-			virtualPath := strings.TrimSuffix(relPath, ".meta")
-
-			if err := s.createIDMetadataLink(meta.NzbdavId, virtualPath); err != nil {
-				s.log.Warn("Failed to create file ID metadata link", "id", meta.NzbdavId, "error", err)
-			}
-		}
-
-		return nil
-	})
-}
-
-func (s *Service) createIDMetadataLink(nzbdavID, resultingPath string) error {
-	cfg := s.configGetter()
-	metadataRoot := cfg.Metadata.RootPath
-
-	// Calculate sharded path
-	// 04db0bde-7ad0-46a3-a2f4-9ef8efd0d7d7 -> .ids/0/4/d/b/0/04db0bde-7ad0-46a3-a2f4-9ef8efd0d7d7.meta
-	id := strings.ToLower(nzbdavID)
-	if len(id) < 5 {
-		return nil // Invalid ID for sharding
-	}
-
-	shardPath := filepath.Join(".ids", string(id[0]), string(id[1]), string(id[2]), string(id[3]), string(id[4]))
-	fullShardDir := filepath.Join(metadataRoot, shardPath)
-
-	if err := os.MkdirAll(fullShardDir, 0755); err != nil {
-		return err
-	}
-
-	targetMetaPath := s.metadataService.GetMetadataFilePath(resultingPath)
-	linkPath := filepath.Join(fullShardDir, id+".meta")
-
-	// Remove if exists
-	os.Remove(linkPath)
-
-	// Create relative symlink if possible, or absolute
-	// Relative is better if metadataRoot moves
-	relTarget, err := filepath.Rel(fullShardDir, targetMetaPath)
-	if err != nil {
-		return os.Symlink(targetMetaPath, linkPath)
-	}
-
-	return os.Symlink(relTarget, linkPath)
-}

--- a/internal/importer/service_test.go
+++ b/internal/importer/service_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/javi11/altmount/internal/importer/queue"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,7 +55,7 @@ func TestIsDatabaseContentionError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := isDatabaseContentionError(tt.err)
+			result := queue.IsDatabaseContentionError(tt.err)
 			assert.Equal(t, tt.expected, result,
 				"isDatabaseContentionError should return %v for error: %v", tt.expected, tt.err)
 		})
@@ -107,7 +108,7 @@ func TestRetryBackoff_ErrorMatching(t *testing.T) {
 	for _, errMsg := range databaseErrors {
 		t.Run("should retry: "+errMsg, func(t *testing.T) {
 			err := errors.New(errMsg)
-			shouldRetry := isDatabaseContentionError(err)
+			shouldRetry := queue.IsDatabaseContentionError(err)
 			assert.True(t, shouldRetry,
 				"Error '%s' should trigger retry", errMsg)
 		})
@@ -116,7 +117,7 @@ func TestRetryBackoff_ErrorMatching(t *testing.T) {
 	for _, errMsg := range nonDatabaseErrors {
 		t.Run("should not retry: "+errMsg, func(t *testing.T) {
 			err := errors.New(errMsg)
-			shouldRetry := isDatabaseContentionError(err)
+			shouldRetry := queue.IsDatabaseContentionError(err)
 			assert.False(t, shouldRetry,
 				"Error '%s' should NOT trigger retry", errMsg)
 		})
@@ -190,7 +191,7 @@ func TestRetryBackoff_SelectiveRetry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := errors.New(tt.errorMessage)
-			result := isDatabaseContentionError(err)
+			result := queue.IsDatabaseContentionError(err)
 
 			assert.Equal(t, tt.shouldRetry, result, tt.description)
 


### PR DESCRIPTION
## Summary

- Extract the 1700+ line importer service into a thin facade delegating to specialized sub-services
- Create `queue/` package for worker pool management with exponential backoff retry (Manager, Claimer)
- Create `scanner/` package for directory scanning and NZBDav imports (DirectoryScanner, NzbDavImporter)
- Create `postprocessor/` package for post-import processing coordination (Coordinator orchestrating symlinks, STRM files, VFS notifications, health scheduling, ARR notifications)
- Reduce service.go from ~1700 to ~930 lines (~45% reduction) while maintaining backward compatibility via type aliases

## Test plan

- [x] Verify build passes: `go build ./...`
- [x] Verify all tests pass: `go test ./internal/importer/...`
- [x] Test manual directory scanning functionality
- [x] Test NZBDav import functionality
- [x] Test queue processing with pause/resume
- [x] Verify post-processing (symlinks, STRM files, VFS notifications) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)