### PR TITLE
fix(health): ensure playback failures trigger immediate repair

### DIFF
--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1072,9 +1072,10 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	ctx, cancel := context.WithTimeout(mvf.ctx, 5*time.Second)
 	defer cancel()
 
-	// Any file with missing segments or corruption is marked as corrupted
+	// Any file with missing segments or corruption is marked as corrupted in metadata
+	// but set to pending in DB to trigger the repair cycle immediately
 	metadataStatus := metapb.FileStatus_FILE_STATUS_CORRUPTED
-	dbStatus := database.HealthStatusCorrupted
+	dbStatus := database.HealthStatusPending
 
 	// Update metadata status (blocking with timeout)
 	if err := mvf.metadataService.UpdateFileStatus(mvf.name, metadataStatus); err != nil {


### PR DESCRIPTION
When a file fails during playback due to missing Usenet articles, it currently enters a 'corrupted' dead-end state because the health worker excludes corrupted files from checks.

This PR modifies the behavior to:
1. Mark playback failures as **pending** instead of corrupted in the DB.
2. Set **High Priority** (HealthPriorityNext) to ensure immediate processing.
3. Max out retry count to force an immediate **repair_triggered** transition on the next health check cycle.
4. Includes regression tests in health_repository_test.go.