### PR TITLE
fix(importer): do not mark items as fallback if not configured

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -75,4 +75,10 @@ var (
 		message: "import contains no video files",
 		cause:   nil,
 	}
+
+	// ErrFallbackNotConfigured indicates that SABnzbd fallback is not enabled or configured.
+	ErrFallbackNotConfigured = &NonRetryableError{
+		message: "SABnzbd fallback not configured",
+		cause:   nil,
+	}
 )

--- a/internal/importer/errors.go
+++ b/internal/importer/errors.go
@@ -24,4 +24,7 @@ var (
 
 	// ErrNoVideoFiles indicates that an import contains no video files.
 	ErrNoVideoFiles = sharedErrors.ErrNoVideoFiles
+
+	// ErrFallbackNotConfigured indicates that SABnzbd fallback is not enabled or configured.
+	ErrFallbackNotConfigured = sharedErrors.ErrFallbackNotConfigured
 )

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -117,7 +117,7 @@ type PostProcessor interface {
 	// HandleSuccess performs all post-processing for successful imports
 	HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error
 	// HandleFailure performs all cleanup for failed imports
-	HandleFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error)
+	HandleFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) error
 }
 
 // ImportService is the main interface combining all importer capabilities

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/errors"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/pkg/rclonecli"
 )
@@ -133,5 +134,5 @@ func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQu
 		return c.AttemptFallback(ctx, item)
 	}
 
-	return nil
+	return errors.ErrFallbackNotConfigured
 }

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -732,6 +732,15 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 				"file", item.NzbPath,
 				"fallback_host", s.configGetter().SABnzbd.FallbackHost)
 		}
+	} else if IsNonRetryable(err) && strings.Contains(err.Error(), "SABnzbd fallback not configured") {
+		s.log.DebugContext(ctx, "SABnzbd fallback skipped (not configured)",
+			"queue_id", item.ID,
+			"file", item.NzbPath)
+	} else {
+		s.log.ErrorContext(ctx, "Fallback handling failed",
+			"queue_id", item.ID,
+			"file", item.NzbPath,
+			"error", err)
 	}
 }
 


### PR DESCRIPTION
Previously, the importer service would incorrectly transition failed items to the 'fallback' status even if no fallback was configured (e.g., empty host).

This PR:
1. Fixes the logic to only transition to 'fallback' if it was actually attempted and succeeded.
2. Moves common error constants to  to prevent import cycles.
3. Adds logging to clarify when fallback is skipped due to configuration.