### PR TITLE
refactor(health): remove dead code and fix Go anti-patterns

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -162,8 +162,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// Register health system config change handler for dynamic enable/disable
 	if healthWorker != nil && librarySyncWorker != nil {
-		healthController := health.NewHealthSystemController(healthWorker, librarySyncWorker, ctx)
-		healthController.RegisterConfigChangeHandler(configManager)
+		healthController := health.NewHealthSystemController(healthWorker, librarySyncWorker)
+		healthController.RegisterConfigChangeHandler(ctx, configManager)
 
 		// Trigger initial metadata date sync if health is enabled
 		if cfg.Health.Enabled != nil && *cfg.Health.Enabled {

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -340,7 +340,6 @@ func startHealthWorker(
 		poolManager,
 		configManager.GetConfigGetter(),
 		rcloneClient,
-		nil, // No event handler for now
 	)
 
 	healthWorker := health.NewHealthWorker(

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -694,7 +694,6 @@ func (s *Server) handleGetHealthWorkerStatus(c *fiber.Ctx) error {
 		TotalFilesCorrupted:    stats.TotalFilesCorrupted,
 		CurrentRunStartTime:    stats.CurrentRunStartTime,
 		CurrentRunFilesChecked: stats.CurrentRunFilesChecked,
-		PendingManualChecks:    stats.PendingManualChecks,
 		LastError:              stats.LastError,
 		ErrorCount:             stats.ErrorCount,
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -394,7 +394,6 @@ type HealthWorkerStatusResponse struct {
 	TotalFilesCorrupted    int64      `json:"total_files_corrupted"`
 	CurrentRunStartTime    *time.Time `json:"current_run_start_time,omitempty"`
 	CurrentRunFilesChecked int        `json:"current_run_files_checked"`
-	PendingManualChecks    int        `json:"pending_manual_checks"`
 	LastError              *string    `json:"last_error,omitempty"`
 	ErrorCount             int64      `json:"error_count"`
 }

--- a/internal/health/controller.go
+++ b/internal/health/controller.go
@@ -14,7 +14,6 @@ import (
 type HealthSystemController struct {
 	healthWorker      *HealthWorker
 	librarySyncWorker *LibrarySyncWorker
-	ctx               context.Context
 	mu                sync.Mutex
 }
 
@@ -22,12 +21,10 @@ type HealthSystemController struct {
 func NewHealthSystemController(
 	healthWorker *HealthWorker,
 	librarySyncWorker *LibrarySyncWorker,
-	ctx context.Context,
 ) *HealthSystemController {
 	return &HealthSystemController{
 		healthWorker:      healthWorker,
 		librarySyncWorker: librarySyncWorker,
-		ctx:               ctx,
 	}
 }
 
@@ -87,7 +84,7 @@ func (hsc *HealthSystemController) SyncMetadataDates(ctx context.Context) {
 }
 
 // RegisterConfigChangeHandler registers a callback to handle health system enable/disable changes
-func (hsc *HealthSystemController) RegisterConfigChangeHandler(configManager *config.Manager) {
+func (hsc *HealthSystemController) RegisterConfigChangeHandler(ctx context.Context, configManager *config.Manager) {
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
 		hsc.mu.Lock()
 		defer hsc.mu.Unlock()
@@ -103,43 +100,43 @@ func (hsc *HealthSystemController) RegisterConfigChangeHandler(configManager *co
 
 		if newEnabled {
 			// Health system was disabled, now enabled - start workers
-			slog.InfoContext(hsc.ctx, "Health system enabled via config change, starting workers")
+			slog.InfoContext(ctx, "Health system enabled via config change, starting workers")
 
 			// Start health worker
 			if !hsc.healthWorker.IsRunning() {
-				if err := hsc.healthWorker.Start(hsc.ctx); err != nil {
-					slog.ErrorContext(hsc.ctx, "Failed to start health worker", "error", err)
+				if err := hsc.healthWorker.Start(ctx); err != nil {
+					slog.ErrorContext(ctx, "Failed to start health worker", "error", err)
 					return
 				}
 			}
 
 			// Start library sync worker
 			if !hsc.librarySyncWorker.IsRunning() {
-				hsc.librarySyncWorker.StartLibrarySync(hsc.ctx)
+				hsc.librarySyncWorker.StartLibrarySync(ctx)
 			}
 
 			// Run background backfill
-			hsc.SyncMetadataDates(hsc.ctx)
+			hsc.SyncMetadataDates(ctx)
 
-			slog.InfoContext(hsc.ctx, "Health system started successfully")
+			slog.InfoContext(ctx, "Health system started successfully")
 		} else {
 			// Health system was enabled, now disabled - stop workers
-			slog.InfoContext(hsc.ctx, "Health system disabled via config change, stopping workers")
+			slog.InfoContext(ctx, "Health system disabled via config change, stopping workers")
 
 			// Stop library sync worker first
 			if hsc.librarySyncWorker.IsRunning() {
-				hsc.librarySyncWorker.Stop(hsc.ctx)
+				hsc.librarySyncWorker.Stop(ctx)
 			}
 
 			// Stop health worker
 			if hsc.healthWorker.IsRunning() {
-				if err := hsc.healthWorker.Stop(hsc.ctx); err != nil {
-					slog.ErrorContext(hsc.ctx, "Failed to stop health worker", "error", err)
+				if err := hsc.healthWorker.Stop(ctx); err != nil {
+					slog.ErrorContext(ctx, "Failed to stop health worker", "error", err)
 					return
 				}
 			}
 
-			slog.InfoContext(hsc.ctx, "Health system stopped successfully")
+			slog.InfoContext(ctx, "Health system stopped successfully")
 		}
 	})
 }

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -39,7 +39,6 @@ type WorkerStats struct {
 	TotalFilesCorrupted    int64        `json:"total_files_corrupted"`
 	CurrentRunStartTime    *time.Time   `json:"current_run_start_time,omitempty"`
 	CurrentRunFilesChecked int          `json:"current_run_files_checked"`
-	PendingManualChecks    int          `json:"pending_manual_checks"`
 	LastError              *string      `json:"last_error,omitempty"`
 	ErrorCount             int64        `json:"error_count"`
 }
@@ -180,10 +179,7 @@ func (hw *HealthWorker) GetStats() WorkerStats {
 	hw.statsMu.RLock()
 	defer hw.statsMu.RUnlock()
 
-	stats := hw.stats
-	stats.PendingManualChecks = 0 // No manual queue anymore
-
-	return stats
+	return hw.stats
 }
 
 // CancelHealthCheck cancels an active health check for the specified file


### PR DESCRIPTION
## Summary

- Remove unused `HealthConfig` struct and `EventHandler` type from checker.go
- Remove `PendingManualChecks` field from `WorkerStats` (no longer used after manual queue removal)
- Rename `config.go` to `controller.go` to accurately reflect its contents (`HealthSystemController`)
- Fix Go anti-pattern: pass context as parameter instead of storing in struct
- Extract `processMetadataForSync` helper to reduce code duplication in `SyncLibrary` and `syncMetadataOnly`
- Extract `updateSymlinkForMountChange` helper for symlink updates in `getAllLibraryFiles` and `getAllImportDirFiles`
- Fix `UsedFiles` comment to match struct name
- Inline thin config getter wrapper functions for clarity

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/health/...` passes
- [x] Verify health worker functionality works correctly
- [x] Verify library sync operations complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)