### PR TITLE
feat(usenet): improve error propagation in UsenetReader

### DIFF
--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -150,11 +150,6 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	// Create iterator for memory-efficient archive traversal
 	aggregatedFiles, err := rardecode.ListArchiveInfo(mainRarFile, opts...)
 	if err != nil {
-		// Log the strict failure and fallback to a more lenient analysis
-		rh.log.WarnContext(ctx, "Failed to analyze RAR archive strictly, falling back to lenient analysis",
-			"error", err,
-			"main_file", mainRarFile)
-
 		// Check if error indicates incomplete RAR archive with missing volume segments
 		return nil, errors.NewNonRetryableError("failed to create archive iterator", err)
 	}

--- a/internal/usenet/segment_test.go
+++ b/internal/usenet/segment_test.go
@@ -271,3 +271,202 @@ func TestSegmentWriter_RaceDetection(t *testing.T) {
 		wg.Wait()
 	}
 }
+
+// TestSegment_CloseWithError_StoresError verifies that CloseWithError stores the error
+func TestSegment_CloseWithError_StoresError(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := io.Pipe()
+	seg := &segment{
+		Id:     "test-segment",
+		Start:  0,
+		End:    100,
+		reader: reader,
+		writer: writer,
+	}
+
+	testErr := errors.New("article not found in providers")
+
+	// Get writer and close with error
+	sw := seg.Writer()
+	safeW, ok := sw.(interface{ CloseWithError(error) error })
+	if !ok {
+		t.Fatal("Writer does not implement CloseWithError")
+	}
+
+	err := safeW.CloseWithError(testErr)
+	if err != nil {
+		t.Fatalf("CloseWithError failed: %v", err)
+	}
+
+	// Check that error is stored
+	storedErr := seg.GetDownloadError()
+	if storedErr == nil {
+		t.Fatal("Expected download error to be stored, got nil")
+	}
+	if !errors.Is(storedErr, testErr) {
+		t.Errorf("Expected error %v, got %v", testErr, storedErr)
+	}
+}
+
+// TestSegment_GetReader_PropagatesStoredError verifies that stored errors are returned on Read
+func TestSegment_GetReader_PropagatesStoredError(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := io.Pipe()
+	seg := &segment{
+		Id:          "test-segment",
+		Start:       0,
+		End:         100,
+		SegmentSize: 100,
+		reader:      reader,
+		writer:      writer,
+	}
+
+	testErr := errors.New("article not found in providers")
+
+	// Close with error before reading
+	sw := seg.Writer()
+	safeW, ok := sw.(interface{ CloseWithError(error) error })
+	if !ok {
+		t.Fatal("Writer does not implement CloseWithError")
+	}
+	_ = safeW.CloseWithError(testErr)
+
+	// GetReader should work
+	r := seg.GetReader()
+	if r == nil {
+		t.Fatal("GetReader returned nil")
+	}
+
+	// Read should return the stored error
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+	if err == nil {
+		t.Fatal("Expected error on read, got nil")
+	}
+	if !errors.Is(err, testErr) {
+		t.Errorf("Expected error %v, got %v", testErr, err)
+	}
+}
+
+// TestSegment_SetDownloadError_FirstWriteWins verifies first-write-wins semantics
+func TestSegment_SetDownloadError_FirstWriteWins(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := io.Pipe()
+	seg := &segment{
+		Id:     "test-segment",
+		reader: reader,
+		writer: writer,
+	}
+	defer seg.Close()
+
+	firstErr := errors.New("first error")
+	secondErr := errors.New("second error")
+
+	// Set first error
+	seg.SetDownloadError(firstErr)
+
+	// Try to set second error
+	seg.SetDownloadError(secondErr)
+
+	// Should still have first error
+	storedErr := seg.GetDownloadError()
+	if !errors.Is(storedErr, firstErr) {
+		t.Errorf("Expected first error to be preserved, got %v", storedErr)
+	}
+}
+
+// TestSegment_GetDownloadError_NilSegment verifies nil segment handling
+func TestSegment_GetDownloadError_NilSegment(t *testing.T) {
+	t.Parallel()
+
+	var seg *segment
+	if seg.GetDownloadError() != nil {
+		t.Error("Expected nil error for nil segment")
+	}
+}
+
+// TestSegment_SetDownloadError_NilSegment verifies nil segment handling
+func TestSegment_SetDownloadError_NilSegment(t *testing.T) {
+	t.Parallel()
+
+	var seg *segment
+	// Should not panic
+	seg.SetDownloadError(errors.New("test error"))
+}
+
+// TestSegment_ErrorAwareReader_PropagatesErrorBeforeRead verifies error check before read
+func TestSegment_ErrorAwareReader_PropagatesErrorBeforeRead(t *testing.T) {
+	t.Parallel()
+
+	reader, writer := io.Pipe()
+	seg := &segment{
+		Id:          "test-segment",
+		Start:       0,
+		End:         100,
+		SegmentSize: 100,
+		reader:      reader,
+		writer:      writer,
+	}
+
+	// Set error before calling GetReader
+	testErr := errors.New("download failed")
+	seg.SetDownloadError(testErr)
+
+	// GetReader and attempt to read
+	r := seg.GetReader()
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+
+	if !errors.Is(err, testErr) {
+		t.Errorf("Expected error %v, got %v", testErr, err)
+	}
+}
+
+// TestSegment_ErrorPropagation_ConcurrentAccess tests thread safety of error propagation
+func TestSegment_ErrorPropagation_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	for iteration := 0; iteration < 10; iteration++ {
+		reader, writer := io.Pipe()
+		seg := &segment{
+			Id:          "test-segment",
+			Start:       0,
+			End:         100,
+			SegmentSize: 100,
+			reader:      reader,
+			writer:      writer,
+		}
+
+		testErr := errors.New("concurrent error")
+		var wg sync.WaitGroup
+
+		// Multiple goroutines setting and getting error
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				seg.SetDownloadError(testErr)
+			}()
+		}
+
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = seg.GetDownloadError()
+			}()
+		}
+
+		wg.Wait()
+
+		// Error should be set
+		if seg.GetDownloadError() == nil {
+			t.Error("Expected error to be set after concurrent access")
+		}
+
+		_ = seg.Close()
+	}
+}


### PR DESCRIPTION
## Summary

- Adds explicit error storage in segment struct to reliably propagate download errors (e.g., article not found) to the reader
- Creates `errorAwareReader` wrapper that checks for stored errors before/after each read
- Captures errors from `GetReader()` skip logic that were previously discarded
- Includes comprehensive tests for error propagation scenarios with race detection

## Test plan

- [x] All existing usenet package tests pass
- [x] New error propagation tests pass with race detector enabled
- [x] `TestSegment_CloseWithError_StoresError` - verifies error storage
- [x] `TestSegment_GetReader_PropagatesStoredError` - verifies error propagation on read
- [x] `TestSegment_ErrorPropagation_ConcurrentAccess` - verifies thread safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)