### PR TITLE
fix(health): persist library sync result and fix frontend display

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -149,7 +149,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	webdav.RegisterConfigHandlers(ctx, configManager, webdavHandler)
 	api.RegisterLogLevelHandler(ctx, configManager, debugMode)
 
-	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService)
+	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, repos.MainRepo, poolManager, configManager, rcloneRCClient, arrsService)
 	if err != nil {
 		logger.Warn("Health worker initialization failed", "err", err)
 	}

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -325,6 +325,7 @@ func startHealthWorker(
 	ctx context.Context,
 	cfg *config.Config,
 	healthRepo *database.HealthRepository,
+	repo *database.Repository,
 	poolManager pool.Manager,
 	configManager *config.Manager,
 	rcloneClient rclonecli.RcloneRcClient,
@@ -354,6 +355,7 @@ func startHealthWorker(
 	librarySyncWorker := health.NewLibrarySyncWorker(
 		metadataService,
 		healthRepo,
+		repo,
 		configManager.GetConfigGetter(),
 		configManager,
 		rcloneClient,

--- a/frontend/src/pages/HealthPage/components/LibraryScanStatus.tsx
+++ b/frontend/src/pages/HealthPage/components/LibraryScanStatus.tsx
@@ -10,6 +10,9 @@ interface LibrarySyncProgress {
 interface LibrarySyncResult {
 	files_added: number;
 	files_deleted: number;
+	metadata_deleted: number;
+	library_files_deleted: number;
+	library_dirs_deleted: number;
 	duration: number;
 	completed_at: string;
 }
@@ -178,7 +181,16 @@ export function LibraryScanStatus({
 										<strong>Added:</strong> {status.last_sync_result.files_added}
 									</span>
 									<span>
-										<strong>Deleted:</strong> {status.last_sync_result.files_deleted}
+										<strong>Files Deleted:</strong> {status.last_sync_result.files_deleted}
+									</span>
+									<span>
+										<strong>Meta Deleted:</strong> {status.last_sync_result.metadata_deleted}
+									</span>
+									<span>
+										<strong>Lib Deleted:</strong> {status.last_sync_result.library_files_deleted}
+									</span>
+									<span>
+										<strong>Dirs Deleted:</strong> {status.last_sync_result.library_dirs_deleted}
 									</span>
 									<span>
 										<strong>Duration:</strong> {(status.last_sync_result.duration / 1e9).toFixed(2)}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -299,6 +299,7 @@ export interface LibrarySyncProgress {
 export interface LibrarySyncResult {
 	files_added: number;
 	files_deleted: number;
+	metadata_deleted: number;
 	duration: number;
 	completed_at: string;
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -79,7 +79,9 @@ export interface LibrarySyncResult {
 	files_added: number;
 	files_deleted: number;
 	metadata_deleted: number;
-	duration: string;
+	library_files_deleted: number;
+	library_dirs_deleted: number;
+	duration: number;
 	completed_at: string;
 }
 

--- a/internal/database/migrations/010_add_system_state.sql
+++ b/internal/database/migrations/010_add_system_state.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Table for storing persistent system state and worker metadata
+CREATE TABLE IF NOT EXISTS system_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS system_state;

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -890,3 +890,39 @@ func (r *Repository) UpdateQueueItemPriority(ctx context.Context, id int64, prio
 	}
 	return nil
 }
+
+// System State operations
+
+// SetSystemState saves a key-value pair to the system_state table
+func (r *Repository) SetSystemState(ctx context.Context, key string, value string) error {
+	query := `
+		INSERT INTO system_state (key, value, updated_at)
+		VALUES (?, ?, datetime('now'))
+		ON CONFLICT(key) DO UPDATE SET
+		value = excluded.value,
+		updated_at = datetime('now')
+	`
+
+	_, err := r.db.ExecContext(ctx, query, key, value)
+	if err != nil {
+		return fmt.Errorf("failed to set system state: %w", err)
+	}
+
+	return nil
+}
+
+// GetSystemState retrieves a value from the system_state table
+func (r *Repository) GetSystemState(ctx context.Context, key string) (string, error) {
+	query := `SELECT value FROM system_state WHERE key = ?`
+
+	var value string
+	err := r.db.QueryRowContext(ctx, query, key).Scan(&value)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get system state: %w", err)
+	}
+
+	return value, nil
+}


### PR DESCRIPTION
Previously, the last library sync result was stored only in memory, causing it to be lost on restart. This resulted in the 'Next Scan' field showing 'Automatic sync not configured' until a manual scan was triggered. This change adds a system_state table to persist the result. Also fixed frontend type mismatches and added missing deletion stats to the UI.