### PR TITLE
refactor(importer): remove dead code and consolidate archive processing

### DIFF
--- a/internal/importer/archive/common.go
+++ b/internal/importer/archive/common.go
@@ -1,8 +1,6 @@
 package archive
 
-import "strconv"
-
-// parseInt safely converts string to int
+// ParseInt safely converts string to int
 func ParseInt(s string) int {
 	num := 0
 	for _, r := range s {
@@ -13,9 +11,4 @@ func ParseInt(s string) int {
 		}
 	}
 	return num
-}
-
-// FormatInt converts an integer to a string
-func FormatInt(n int) string {
-	return strconv.Itoa(n)
 }


### PR DESCRIPTION
## Summary

- Remove unused `FormatInt()` function from `archive/common.go`
- Remove 6 unused functions from `utils/file_extensions.go` (`AllExtensions`, `AllExtensionsWith`, `AllPossibleExtensions`, `WhatIsMostLikelyExtension`, `sniffTextOrNZB`, `isLikelyUTF8`)
- Remove unused imports (`bufio`, `os`, `github.com/gabriel-vasile/mimetype`)
- Extract common archive processing logic into unified `processArchive()` function
- Fix severe formatting corruption in `processSevenZipArchive()` (mixed tabs/spaces)
- Reduce ~80 lines of duplicate code between RAR and 7zip processing

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./internal/importer/...` passes
- [x] `go test ./internal/importer/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)