### PR TITLE
refactor(importer): remove unused code from importer package

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -64,18 +64,6 @@ func IsNonRetryable(err error) bool {
 
 // Sentinel errors for common non-retryable conditions.
 var (
-	// ErrNoRetryable is kept for backward compatibility with existing code.
-	ErrNoRetryable = &NonRetryableError{
-		message: "no retryable errors found",
-		cause:   nil,
-	}
-
-	// ErrNoVideoFiles indicates that an import contains no video files.
-	ErrNoVideoFiles = &NonRetryableError{
-		message: "import contains no video files",
-		cause:   nil,
-	}
-
 	// ErrFallbackNotConfigured indicates that SABnzbd fallback is not enabled or configured.
 	ErrFallbackNotConfigured = &NonRetryableError{
 		message: "SABnzbd fallback not configured",

--- a/internal/importer/archive/common.go
+++ b/internal/importer/archive/common.go
@@ -1,8 +1,6 @@
 package archive
 
-import "strconv"
-
-// parseInt safely converts string to int
+// ParseInt safely converts string to int
 func ParseInt(s string) int {
 	num := 0
 	for _, r := range s {
@@ -13,9 +11,4 @@ func ParseInt(s string) int {
 		}
 	}
 	return num
-}
-
-// FormatInt converts an integer to a string
-func FormatInt(n int) string {
-	return strconv.Itoa(n)
 }

--- a/internal/importer/errors.go
+++ b/internal/importer/errors.go
@@ -19,12 +19,6 @@ var (
 	// IsNonRetryable checks if an error is non-retryable.
 	IsNonRetryable = sharedErrors.IsNonRetryable
 
-	// ErrNoRetryable is kept for backward compatibility with existing code.
-	ErrNoRetryable = sharedErrors.ErrNoRetryable
-
-	// ErrNoVideoFiles indicates that an import contains no video files.
-	ErrNoVideoFiles = sharedErrors.ErrNoVideoFiles
-
 	// ErrFallbackNotConfigured indicates that SABnzbd fallback is not enabled or configured.
 	ErrFallbackNotConfigured = sharedErrors.ErrFallbackNotConfigured
 )

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -20,10 +20,6 @@ type QueueManager interface {
 	IsPaused() bool
 	// IsRunning returns whether the queue manager is active
 	IsRunning() bool
-	// GetWorkerCount returns the current number of workers
-	GetWorkerCount() int
-	// UpdateWorkerCount changes the number of active workers
-	UpdateWorkerCount(count int) error
 	// CancelProcessing cancels processing of a specific item
 	CancelProcessing(itemID int64) error
 	// ProcessItemInBackground starts processing a specific item in the background
@@ -56,8 +52,6 @@ type QueueOperations interface {
 	AddToQueue(ctx context.Context, filePath string, relativePath *string, category *string, priority *database.QueuePriority) (*database.ImportQueueItem, error)
 	// GetQueueStats returns queue statistics
 	GetQueueStats(ctx context.Context) (*database.QueueStats, error)
-	// GetStats returns comprehensive service statistics
-	GetStats(ctx context.Context) (*ServiceStats, error)
 }
 
 // SymlinkCreator handles symlink creation for imported files
@@ -127,8 +121,6 @@ type ImportService interface {
 	NzbDavImporter
 	QueueOperations
 
-	// Database returns the underlying database connection
-	Database() *database.DB
 	// Close releases all resources
 	Close() error
 	// SetRcloneClient sets the rclone client for VFS notifications

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -162,13 +162,6 @@ func (m *Manager) IsRunning() bool {
 	return m.running
 }
 
-// GetWorkerCount returns the current worker count
-func (m *Manager) GetWorkerCount() int {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.config.Workers
-}
-
 // CancelProcessing cancels processing for a specific item
 func (m *Manager) CancelProcessing(itemID int64) error {
 	m.cancelMu.RLock()

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -401,11 +401,6 @@ func (s *Service) SetArrsService(service *arrs.Service) {
 	}
 }
 
-// Database returns the database instance for processing
-func (s *Service) Database() *database.DB {
-	return s.database
-}
-
 // GetQueueStats returns current queue statistics from database
 func (s *Service) GetQueueStats(ctx context.Context) (*database.QueueStats, error) {
 	return s.database.Repository.GetQueueStats(ctx)
@@ -742,61 +737,6 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 			"file", item.NzbPath,
 			"error", err)
 	}
-}
-
-
-// ServiceStats holds statistics about the service
-type ServiceStats struct {
-	IsRunning  bool                 `json:"is_running"`
-	Workers    int                  `json:"workers"`
-	QueueStats *database.QueueStats `json:"queue_stats,omitempty"`
-	ScanInfo   ScanInfo             `json:"scan_info"`
-}
-
-// GetStats returns service statistics
-func (s *Service) GetStats(ctx context.Context) (*ServiceStats, error) {
-	stats := &ServiceStats{
-		IsRunning: s.IsRunning(),
-		Workers:   s.config.Workers,
-		ScanInfo:  s.GetScanStatus(),
-	}
-
-	// Add queue statistics
-	queueStats, err := s.GetQueueStats(ctx)
-	if err != nil {
-		s.log.WarnContext(ctx, "Failed to get queue stats", "error", err)
-	} else {
-		stats.QueueStats = queueStats
-	}
-
-	return stats, nil
-}
-
-// UpdateWorkerCount updates the worker count configuration (requires service restart to take effect)
-// Dynamic worker scaling is not supported - changes only apply on next service restart
-func (s *Service) UpdateWorkerCount(count int) error {
-	if count <= 0 {
-		return fmt.Errorf("worker count must be greater than 0")
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.log.InfoContext(s.ctx, "Queue worker count update requested - restart required to take effect",
-		"current_count", s.config.Workers,
-		"requested_count", count,
-		"running", s.running)
-
-	// Configuration update is handled at the config manager level
-	// Changes only take effect on service restart
-	return nil
-}
-
-// GetWorkerCount returns the current configured worker count
-func (s *Service) GetWorkerCount() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.config.Workers
 }
 
 // CancelProcessing cancels a processing queue item by cancelling its context


### PR DESCRIPTION
## Summary

- Remove unused error constants (`ErrNoRetryable`, `ErrNoVideoFiles`) from both `internal/errors/errors.go` and `internal/importer/errors.go`
- Remove unused service methods: `Database()`, `GetStats()`, `GetWorkerCount()`, `UpdateWorkerCount()` and `ServiceStats` struct
- Remove unused queue manager method: `GetWorkerCount()`
- Remove unused interface methods from `QueueManager`, `QueueOperations`, and `ImportService` interfaces
- Remove unused archive function: `FormatInt()`
- Remove unused file extension functions: `AllExtensions()`, `AllExtensionsWith()`, `AllPossibleExtensions()`, `WhatIsMostLikelyExtension()`, `sniffTextOrNZB()`, `isLikelyUTF8()`
- Remove unused imports: `bufio`, `os`, `mimetype`, `strconv`

## Test plan

- [x] Verified all removed code was unused via comprehensive grep searches
- [x] `go build ./...` passes
- [x] `go test ./internal/importer/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)