### PR TITLE
fix(health/arrs): improve health check scheduling and arrs integration

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -445,8 +445,6 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	libraryDir := ""
 	if cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "" {
 		libraryDir = *cfg.Health.LibraryDir
-	} else {
-		return fmt.Errorf("Health.LibraryDir is not configured")
 	}
 
 	slog.DebugContext(ctx, "Triggering Sonarr rescan/re-download by path",

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -155,7 +155,6 @@ type Service struct {
 	paused  bool
 	ctx     context.Context
 	cancel  context.CancelFunc
-	wg      sync.WaitGroup
 
 	// Cancellation tracking for processing items
 	cancelFuncs map[int64]context.CancelFunc


### PR DESCRIPTION
### Summary
This PR introduces improvements to the health check scheduling system and fixes a configuration requirement for Sonarr integration.

### Changes

#### Health Check System
- **Periodic Re-checks for Healthy Files:** Modified `GetUnhealthyFiles` query to include files marked as `healthy` if their `scheduled_check_at` time has passed. This enables the intended tiered scheduling strategy (aggressive -> daily -> normal) to function effectively, ensuring long-term validation of file retention.
- **Repair Retry Delay:** Added a 1-hour backoff delay (`scheduled_check_at = datetime('now', '+1 hour')`) when updating status to `repair_triggered`. This prevents rapid retry loops when repairs fail.

#### Arrs Integration
- **Optional Library Directory:** Updated `triggerSonarrRescanByPath` to treat `Health.LibraryDir` as optional. Previously, missing this configuration would cause the repair process to error out. It now gracefully handles the missing config by falling back to other path resolution methods.

#### Code Cleanup
- **Linter Fixes:** Removed an unused `sync.WaitGroup` field in `internal/importer/service.go`.