### PR TITLE
feat: Add symlink regeneration option for unlinked files

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "frontend",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -365,6 +365,20 @@ export class APIClient {
 		});
 	}
 
+	async regenerateSymlinks() {
+		return this.request<{
+			message: string;
+			files_processed: number;
+			symlinks_created: number;
+			errors: string[];
+			error_count: number;
+			warning?: string;
+			completed_at: string;
+		}>("/health/regenerate-symlinks", {
+			method: "POST",
+		});
+	}
+
 	async cleanupHealth(params?: HealthCleanupRequest) {
 		return this.request<HealthCleanupResponse>("/health/cleanup", {
 			method: "DELETE",

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -200,6 +200,18 @@ export const useResetAllHealthChecks = () => {
 	});
 };
 
+export const useRegenerateSymlinks = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: () => apiClient.regenerateSymlinks(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["health"] });
+			queryClient.invalidateQueries({ queryKey: ["health", "stats"] });
+		},
+	});
+};
+
 export const useDeleteHealthItem = () => {
 	const queryClient = useQueryClient();
 

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -11,6 +11,7 @@ import {
 	useDirectHealthCheck,
 	useHealth,
 	useHealthStats,
+	useRegenerateSymlinks,
 	useRepairBulkHealthItems,
 	useRepairHealthItem,
 	useResetAllHealthChecks,
@@ -77,6 +78,7 @@ export function HealthPage() {
 	const repairBulkItems = useRepairBulkHealthItems();
 	const cleanupHealth = useCleanupHealth();
 	const resetAllHealth = useResetAllHealthChecks();
+	const regenerateSymlinks = useRegenerateSymlinks();
 	const directHealthCheck = useDirectHealthCheck();
 	const cancelHealthCheck = useCancelHealthCheck();
 	const repairHealthItem = useRepairHealthItem();
@@ -169,6 +171,36 @@ export function HealthPage() {
 				showToast({
 					title: "Reset Failed",
 					message: "Failed to reset all health checks",
+					type: "error",
+				});
+			}
+		}
+	};
+
+	const handleRegenerateSymlinks = async () => {
+		const confirmed = await confirmAction(
+			"Regenerate Symlinks",
+			"This will regenerate symlinks for all files without library path. This operation is only available when import strategy is set to SYMLINK. Are you sure you want to continue?",
+			{
+				type: "info",
+				confirmText: "Regenerate",
+				confirmButtonClass: "btn-primary",
+			},
+		);
+
+		if (confirmed) {
+			try {
+				const result = await regenerateSymlinks.mutateAsync();
+				showToast({
+					title: "Symlinks Regenerated",
+					message: result.message,
+					type: result.error_count > 0 ? "warning" : "success",
+				});
+			} catch (error) {
+				console.error("Failed to regenerate symlinks:", error);
+				showToast({
+					title: "Regeneration Failed",
+					message: error instanceof Error ? error.message : "Failed to regenerate symlinks",
 					type: "error",
 				});
 			}
@@ -554,11 +586,13 @@ export function HealthPage() {
 				userInteracting={userInteracting}
 				isLoading={isLoading}
 				isCleanupPending={cleanupHealth.isPending}
+				isRegenerateSymlinksPending={regenerateSymlinks.isPending}
 				onToggleAutoRefresh={toggleAutoRefresh}
 				onRefreshIntervalChange={handleRefreshIntervalChange}
 				onRefresh={() => refetch()}
 				onResetAll={handleResetAll}
 				onCleanup={handleCleanup}
+				onRegenerateSymlinks={handleRegenerateSymlinks}
 				onUserInteractionStart={handleUserInteractionStart}
 				onUserInteractionEnd={handleUserInteractionEnd}
 			/>

--- a/frontend/src/pages/HealthPage/components/HealthPageHeader.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthPageHeader.tsx
@@ -1,4 +1,4 @@
-import { Pause, Play, RefreshCw, Trash2 } from "lucide-react";
+import { Link, Pause, Play, RefreshCw, Trash2 } from "lucide-react";
 
 interface HealthPageHeaderProps {
 	autoRefreshEnabled: boolean;
@@ -7,11 +7,13 @@ interface HealthPageHeaderProps {
 	userInteracting: boolean;
 	isLoading: boolean;
 	isCleanupPending: boolean;
+	isRegenerateSymlinksPending: boolean;
 	onToggleAutoRefresh: () => void;
 	onRefreshIntervalChange: (interval: number) => void;
 	onRefresh: () => void;
 	onResetAll: () => void;
 	onCleanup: () => void;
+	onRegenerateSymlinks: () => void;
 	onUserInteractionStart: () => void;
 	onUserInteractionEnd: () => void;
 }
@@ -23,11 +25,13 @@ export function HealthPageHeader({
 	userInteracting,
 	isLoading,
 	isCleanupPending,
+	isRegenerateSymlinksPending,
 	onToggleAutoRefresh,
 	onRefreshIntervalChange,
 	onRefresh,
 	onResetAll,
 	onCleanup,
+	onRegenerateSymlinks,
 	onUserInteractionStart,
 	onUserInteractionEnd,
 }: HealthPageHeaderProps) {
@@ -81,6 +85,15 @@ export function HealthPageHeader({
 				<button type="button" className="btn btn-outline" onClick={onResetAll}>
 					<RefreshCw className="h-4 w-4" />
 					Reset All Checks
+				</button>
+				<button
+					type="button"
+					className="btn btn-primary"
+					onClick={onRegenerateSymlinks}
+					disabled={isRegenerateSymlinksPending}
+				>
+					<Link className="h-4 w-4" />
+					Regenerate Symlinks
 				</button>
 				<button
 					type="button"

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -192,6 +192,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Get("/health/stats", s.handleGetHealthStats)
 	api.Delete("/health/cleanup", s.handleCleanupHealth)
 	api.Post("/health/reset-all", s.handleResetAllHealthChecks)
+	api.Post("/health/regenerate-symlinks", s.handleRegenerateSymlinks)
 	api.Post("/health/check", s.handleAddHealthCheck)
 	api.Get("/health/worker/status", s.handleGetHealthWorkerStatus)
 	api.Post("/health/:id/repair", s.handleRepairHealth)


### PR DESCRIPTION
- Add backend API endpoint POST /api/health/regenerate-symlinks
- Add database repository methods to find and update files without library path
- Add frontend button and handler for regenerating symlinks
- Regenerate symlinks for all health records where library_path is NULL
- Update library_path in database after successful symlink creation
- Add confirmation modal and success/error toasts
- Only available when import strategy is set to SYMLINK