### PR TITLE
feat(nzblnk): add NZBLNK link resolver with NZBKing and NZBIndex support

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
 	SABnzbdAddResponse,
 	ScanStatusResponse,
 	SystemBrowseResponse,
+	UploadNZBLnkResponse,
 	User,
 	UserAdminUpdateRequest,
 } from "../types/api";
@@ -762,6 +763,23 @@ export class APIClient {
 			body: formData,
 			// Don't set Content-Type header - let browser set it with boundary for multipart/form-data
 			headers: {},
+		});
+	}
+
+	async uploadNZBLnks(
+		links: string[],
+		category?: string,
+		priority?: number,
+		relativePath?: string,
+	): Promise<UploadNZBLnkResponse> {
+		return this.request<UploadNZBLnkResponse>("/queue/upload-nzblnk", {
+			method: "POST",
+			body: JSON.stringify({
+				links,
+				category: category || undefined,
+				priority: priority ?? undefined,
+				relative_path: relativePath || undefined,
+			}),
 		});
 	}
 

--- a/frontend/src/components/queue/DragDropUpload.tsx
+++ b/frontend/src/components/queue/DragDropUpload.tsx
@@ -1,6 +1,7 @@
-import { AlertCircle, CheckCircle2, FileIcon, Upload, X } from "lucide-react";
+import { AlertCircle, CheckCircle2, Download, FileIcon, Link, Upload, X } from "lucide-react";
 import { useCallback, useState } from "react";
-import { useUploadToQueue } from "../../hooks/useApi";
+import { useToast } from "../../contexts/ToastContext";
+import { useUploadNZBLnks, useUploadToQueue } from "../../hooks/useApi";
 import { ErrorAlert } from "../ui/ErrorAlert";
 
 interface UploadedFile {
@@ -12,11 +13,25 @@ interface UploadedFile {
 	category?: string;
 }
 
+interface UploadedLink {
+	link: string;
+	id: string;
+	status: "pending" | "resolving" | "success" | "error";
+	errorMessage?: string;
+	queueId?: string;
+	title?: string;
+}
+
 export function DragDropUpload() {
 	const [isDragOver, setIsDragOver] = useState(false);
 	const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+	const [uploadedLinks, setUploadedLinks] = useState<UploadedLink[]>([]);
 	const [category, setCategory] = useState<string>("");
+	const [linkInput, setLinkInput] = useState<string>("");
+	const [activeTab, setActiveTab] = useState<"files" | "nzblnk">("files");
 	const uploadMutation = useUploadToQueue();
+	const uploadLinksMutation = useUploadNZBLnks();
+	const { showToast } = useToast();
 
 	const validateFile = useCallback((file: File): string | null => {
 		// Check file extension
@@ -30,6 +45,43 @@ export function DragDropUpload() {
 		}
 
 		return null;
+	}, []);
+
+	const validateNZBLink = useCallback((link: string): string | null => {
+		const trimmed = link.trim();
+		if (!trimmed) return null; // Empty lines are skipped
+
+		if (!trimmed.startsWith("nzblnk:?")) {
+			return "Link must start with 'nzblnk:?'";
+		}
+
+		// Check for required parameters
+		if (!trimmed.includes("t=")) {
+			return "Missing required parameter 't' (title)";
+		}
+
+		if (!trimmed.includes("h=")) {
+			return "Missing required parameter 'h' (header)";
+		}
+
+		return null;
+	}, []);
+
+	const parseLinks = useCallback((input: string): string[] => {
+		return input
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	}, []);
+
+	const extractTitleFromLink = useCallback((link: string): string => {
+		try {
+			const queryPart = link.replace("nzblnk:?", "");
+			const params = new URLSearchParams(queryPart);
+			return params.get("t") || "Unknown";
+		} catch {
+			return "Unknown";
+		}
 	}, []);
 
 	const handleFiles = useCallback(
@@ -102,6 +154,119 @@ export function DragDropUpload() {
 		[uploadMutation, validateFile, category],
 	);
 
+	const handleLinkSubmit = useCallback(async () => {
+		const links = parseLinks(linkInput);
+		if (links.length === 0) return;
+
+		// Validate links and create tracking entries
+		const linkEntries: UploadedLink[] = links.map((link) => {
+			const error = validateNZBLink(link);
+			return {
+				link,
+				id: `${link.slice(0, 50)}-${Date.now()}-${Math.random()}`,
+				status: error ? ("error" as const) : ("pending" as const),
+				errorMessage: error || undefined,
+				title: extractTitleFromLink(link),
+			};
+		});
+
+		setUploadedLinks((prev) => [...prev, ...linkEntries]);
+
+		// Filter valid links
+		const validLinks = linkEntries
+			.filter((entry) => entry.status === "pending")
+			.map((entry) => entry.link);
+
+		if (validLinks.length === 0) {
+			return;
+		}
+
+		// Mark valid links as resolving
+		setUploadedLinks((prev) =>
+			prev.map((l) =>
+				validLinks.includes(l.link) && l.status === "pending"
+					? { ...l, status: "resolving" as const }
+					: l,
+			),
+		);
+
+		try {
+			const response = await uploadLinksMutation.mutateAsync({
+				links: validLinks,
+				category: category || undefined,
+			});
+
+			// Update status based on results
+			setUploadedLinks((prev) =>
+				prev.map((l) => {
+					const result = response.results.find((r) => r.link === l.link);
+					if (!result) return l;
+
+					return {
+						...l,
+						status: result.success ? ("success" as const) : ("error" as const),
+						errorMessage: result.error_message,
+						queueId: result.queue_id?.toString(),
+						title: result.title || l.title,
+					};
+				}),
+			);
+
+			// Show toast feedback based on results
+			const successCount = response.success_count ?? 0;
+			const failedCount = response.failed_count ?? 0;
+
+			if (failedCount > 0 && successCount === 0) {
+				showToast({
+					type: "error",
+					title: `Failed to resolve ${failedCount} link${failedCount > 1 ? "s" : ""}`,
+				});
+			} else if (failedCount > 0) {
+				showToast({
+					type: "warning",
+					title: `${successCount} link${successCount > 1 ? "s" : ""} queued, ${failedCount} failed to resolve`,
+				});
+			} else if (successCount > 0) {
+				showToast({
+					type: "success",
+					title: `${successCount} link${successCount > 1 ? "s" : ""} added to queue`,
+				});
+			}
+
+			// Clear input on success
+			if (response.success_count > 0) {
+				setLinkInput("");
+			}
+		} catch (error) {
+			// Mark all as error
+			setUploadedLinks((prev) =>
+				prev.map((l) =>
+					validLinks.includes(l.link) && l.status === "resolving"
+						? {
+								...l,
+								status: "error" as const,
+								errorMessage: error instanceof Error ? error.message : "Resolution failed",
+							}
+						: l,
+				),
+			);
+
+			showToast({
+				type: "error",
+				title: "Failed to process links",
+				message: "Please try again.",
+			});
+		}
+	}, [
+		linkInput,
+		category,
+		uploadLinksMutation,
+		parseLinks,
+		validateNZBLink,
+		extractTitleFromLink,
+		showToast,
+	]);
+
 	const handleDragOver = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -144,9 +309,17 @@ export function DragDropUpload() {
 		setUploadedFiles((prev) => prev.filter((f) => f.id !== fileId));
 	};
 
+	const removeLink = (linkId: string) => {
+		setUploadedLinks((prev) => prev.filter((l) => l.id !== linkId));
+	};
+
 	const clearAllFiles = () => {
 		setUploadedFiles([]);
-		setCategory("");
+	};
+
+	const clearAllLinks = () => {
+		setUploadedLinks([]);
+		setLinkInput("");
 	};
 
 	const getFileStatusIcon = (status: UploadedFile["status"]) => {
@@ -155,6 +328,19 @@ export function DragDropUpload() {
 				return <FileIcon className="h-4 w-4 text-base-content/70" />;
 			case "uploading":
 				return <Upload className="h-4 w-4 animate-pulse text-info" />;
+			case "success":
+				return <CheckCircle2 className="h-4 w-4 text-success" />;
+			case "error":
+				return <AlertCircle className="h-4 w-4 text-error" />;
+		}
+	};
+
+	const getLinkStatusIcon = (status: UploadedLink["status"]) => {
+		switch (status) {
+			case "pending":
+				return <Link className="h-4 w-4 text-base-content/70" />;
+			case "resolving":
+				return <Download className="h-4 w-4 animate-pulse text-info" />;
 			case "success":
 				return <CheckCircle2 className="h-4 w-4 text-success" />;
 			case "error":
@@ -175,6 +361,19 @@ export function DragDropUpload() {
 		}
 	};
 
+	const getLinkStatusText = (status: UploadedLink["status"]) => {
+		switch (status) {
+			case "pending":
+				return "Pending";
+			case "resolving":
+				return "Resolving...";
+			case "success":
+				return "Queued";
+			case "error":
+				return "Failed";
+		}
+	};
+
 	return (
 		<div className="card bg-base-100 shadow-lg">
 			<div className="card-body">
@@ -183,7 +382,29 @@ export function DragDropUpload() {
 					<h2 className="card-title">Upload NZB Files</h2>
 				</div>
 
-				{/* Category Input */}
+				{/* Tab Selector */}
+				<div role="tablist" className="tabs tabs-boxed mb-4">
+					<button
+						type="button"
+						role="tab"
+						className={`tab ${activeTab === "files" ? "tab-active" : ""}`}
+						onClick={() => setActiveTab("files")}
+					>
+						<FileIcon className="mr-2 h-4 w-4" />
+						Files
+					</button>
+					<button
+						type="button"
+						role="tab"
+						className={`tab ${activeTab === "nzblnk" ? "tab-active" : ""}`}
+						onClick={() => setActiveTab("nzblnk")}
+					>
+						<Link className="mr-2 h-4 w-4" />
+						NZBLNK
+					</button>
+				</div>
+
+				{/* Category Input (shared) */}
 				<fieldset className="fieldset mb-4">
 					<legend className="fieldset-legend">Category (optional)</legend>
 					<input
@@ -193,117 +414,219 @@ export function DragDropUpload() {
 						value={category}
 						onChange={(e) => setCategory(e.target.value)}
 					/>
-					<p className="label">Category will be applied to all uploaded files</p>
+					<p className="label">Category will be applied to all uploaded items</p>
 				</fieldset>
 
-				{/* Drag and Drop Zone */}
-				{/* biome-ignore lint/a11y/useSemanticElements: drag-drop zone requires div for proper drag events */}
-				<div
-					className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
-						isDragOver
-							? "border-primary bg-primary/10"
-							: "border-base-300 hover:border-base-content/30"
-					}`}
-					onDragOver={handleDragOver}
-					onDragLeave={handleDragLeave}
-					onDrop={handleDrop}
-					role="button"
-					tabIndex={0}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							// Trigger file input click
-							const input = e.currentTarget.querySelector("input[type=file]") as HTMLInputElement;
-							input?.click();
-						}
-					}}
-				>
-					<Upload
-						className={`mx-auto mb-4 h-12 w-12 ${isDragOver ? "text-primary" : "text-base-content/50"}`}
-					/>
-					<h3 className="mb-2 font-semibold text-lg">
-						{isDragOver ? "Drop your NZB files here" : "Drag and drop NZB files"}
-					</h3>
-					<p className="mb-4 text-base-content/70">or</p>
-					<label className="btn btn-outline">
-						<Upload className="h-4 w-4" />
-						Browse Files
-						<input
-							type="file"
-							multiple
-							accept=".nzb"
-							onChange={handleFileInput}
-							className="hidden"
-						/>
-					</label>
-					<p className="mt-4 text-base-content/50 text-sm">
-						Supports multiple .nzb files up to 100MB each
-					</p>
-				</div>
-
-				{/* File List */}
-				{uploadedFiles.length > 0 && (
-					<div className="mt-6">
-						<div className="mb-4 flex items-center justify-between">
-							<h3 className="font-semibold">Upload Queue ({uploadedFiles.length} files)</h3>
-							<button type="button" className="btn btn-ghost btn-sm" onClick={clearAllFiles}>
-								Clear All
-							</button>
+				{/* Files Tab */}
+				{activeTab === "files" && (
+					<>
+						{/* Drag and Drop Zone */}
+						{/* biome-ignore lint/a11y/useSemanticElements: drag-drop zone requires div for proper drag events */}
+						<div
+							className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors ${
+								isDragOver
+									? "border-primary bg-primary/10"
+									: "border-base-300 hover:border-base-content/30"
+							}`}
+							onDragOver={handleDragOver}
+							onDragLeave={handleDragLeave}
+							onDrop={handleDrop}
+							role="button"
+							tabIndex={0}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									const input = e.currentTarget.querySelector(
+										"input[type=file]",
+									) as HTMLInputElement;
+									input?.click();
+								}
+							}}
+						>
+							<Upload
+								className={`mx-auto mb-4 h-12 w-12 ${isDragOver ? "text-primary" : "text-base-content/50"}`}
+							/>
+							<h3 className="mb-2 font-semibold text-lg">
+								{isDragOver ? "Drop your NZB files here" : "Drag and drop NZB files"}
+							</h3>
+							<p className="mb-4 text-base-content/70">or</p>
+							<label className="btn btn-outline">
+								<Upload className="h-4 w-4" />
+								Browse Files
+								<input
+									type="file"
+									multiple
+									accept=".nzb"
+									onChange={handleFileInput}
+									className="hidden"
+								/>
+							</label>
+							<p className="mt-4 text-base-content/50 text-sm">
+								Supports multiple .nzb files up to 100MB each
+							</p>
 						</div>
 
-						<div className="max-h-60 space-y-2 overflow-y-auto">
-							{uploadedFiles.map((uploadFile) => (
-								<div
-									key={uploadFile.id}
-									className="flex items-center gap-3 rounded-lg bg-base-200 p-3"
-								>
-									{getFileStatusIcon(uploadFile.status)}
-
-									<div className="min-w-0 flex-1">
-										<div className="truncate font-medium">{uploadFile.file.name}</div>
-										<div className="flex items-center gap-2 text-base-content/70 text-sm">
-											<span>{getFileStatusText(uploadFile.status)}</span>
-											<span>•</span>
-											<span>{(uploadFile.file.size / 1024 / 1024).toFixed(1)} MB</span>
-											{uploadFile.category && (
-												<>
-													<span>•</span>
-													<span className="badge badge-outline badge-sm">
-														{uploadFile.category}
-													</span>
-												</>
-											)}
-											{uploadFile.queueId && (
-												<>
-													<span>•</span>
-													<span>Queue ID: {uploadFile.queueId}</span>
-												</>
-											)}
-										</div>
-										{uploadFile.errorMessage && (
-											<div className="mt-1 text-error text-sm">{uploadFile.errorMessage}</div>
-										)}
-									</div>
-
-									<button
-										type="button"
-										className="btn btn-ghost btn-sm"
-										onClick={() => removeFile(uploadFile.id)}
-										disabled={uploadFile.status === "uploading"}
-									>
-										<X className="h-4 w-4" />
+						{/* File List */}
+						{uploadedFiles.length > 0 && (
+							<div className="mt-6">
+								<div className="mb-4 flex items-center justify-between">
+									<h3 className="font-semibold">Upload Queue ({uploadedFiles.length} files)</h3>
+									<button type="button" className="btn btn-ghost btn-sm" onClick={clearAllFiles}>
+										Clear All
 									</button>
 								</div>
-							))}
-						</div>
+
+								<div className="max-h-60 space-y-2 overflow-y-auto">
+									{uploadedFiles.map((uploadFile) => (
+										<div
+											key={uploadFile.id}
+											className="flex items-center gap-3 rounded-lg bg-base-200 p-3"
+										>
+											{getFileStatusIcon(uploadFile.status)}
+
+											<div className="min-w-0 flex-1">
+												<div className="truncate font-medium">{uploadFile.file.name}</div>
+												<div className="flex items-center gap-2 text-base-content/70 text-sm">
+													<span>{getFileStatusText(uploadFile.status)}</span>
+													<span>•</span>
+													<span>{(uploadFile.file.size / 1024 / 1024).toFixed(1)} MB</span>
+													{uploadFile.category && (
+														<>
+															<span>•</span>
+															<span className="badge badge-outline badge-sm">
+																{uploadFile.category}
+															</span>
+														</>
+													)}
+													{uploadFile.queueId && (
+														<>
+															<span>•</span>
+															<span>Queue ID: {uploadFile.queueId}</span>
+														</>
+													)}
+												</div>
+												{uploadFile.errorMessage && (
+													<div className="mt-1 text-error text-sm">{uploadFile.errorMessage}</div>
+												)}
+											</div>
+
+											<button
+												type="button"
+												className="btn btn-ghost btn-sm"
+												onClick={() => removeFile(uploadFile.id)}
+												disabled={uploadFile.status === "uploading"}
+											>
+												<X className="h-4 w-4" />
+											</button>
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+					</>
+				)}
+
+				{/* NZBLNK Tab */}
+				{activeTab === "nzblnk" && (
+					<div className="space-y-4">
+						<fieldset className="fieldset">
+							<legend className="fieldset-legend">NZBLNK Links</legend>
+							<textarea
+								className="textarea h-32 w-full font-mono text-sm"
+								placeholder={
+									"Paste nzblnk:// links, one per line\nnzblnk:?t=Movie+Title&h=header123&g=alt.binaries.movies\nnzblnk:?t=Another+File&h=header456"
+								}
+								value={linkInput}
+								onChange={(e) => setLinkInput(e.target.value)}
+							/>
+							<p className="label">Enter NZBLNK links to resolve and queue (max 20 per request)</p>
+						</fieldset>
+
+						<button
+							type="button"
+							className="btn btn-primary"
+							onClick={handleLinkSubmit}
+							disabled={!linkInput.trim() || uploadLinksMutation.isPending}
+						>
+							{uploadLinksMutation.isPending ? (
+								<>
+									<span className="loading loading-spinner loading-sm" />
+									Resolving...
+								</>
+							) : (
+								<>
+									<Download className="h-4 w-4" />
+									Resolve and Queue
+								</>
+							)}
+						</button>
+
+						{/* Link Results List */}
+						{uploadedLinks.length > 0 && (
+							<div className="mt-6">
+								<div className="mb-4 flex items-center justify-between">
+									<h3 className="font-semibold">NZBLNK Queue ({uploadedLinks.length} links)</h3>
+									<button type="button" className="btn btn-ghost btn-sm" onClick={clearAllLinks}>
+										Clear All
+									</button>
+								</div>
+
+								<div className="max-h-60 space-y-2 overflow-y-auto">
+									{uploadedLinks.map((uploadLink) => (
+										<div
+											key={uploadLink.id}
+											className="flex items-center gap-3 rounded-lg bg-base-200 p-3"
+										>
+											{getLinkStatusIcon(uploadLink.status)}
+
+											<div className="min-w-0 flex-1">
+												<div className="truncate font-medium">{uploadLink.title || "Unknown"}</div>
+												<div className="flex items-center gap-2 text-base-content/70 text-sm">
+													<span>{getLinkStatusText(uploadLink.status)}</span>
+													{uploadLink.queueId && (
+														<>
+															<span>•</span>
+															<span>Queue ID: {uploadLink.queueId}</span>
+														</>
+													)}
+												</div>
+												{uploadLink.errorMessage && (
+													<div className="mt-1 text-error text-sm">{uploadLink.errorMessage}</div>
+												)}
+												<div className="mt-1 truncate text-base-content/50 text-xs">
+													{uploadLink.link}
+												</div>
+											</div>
+
+											<button
+												type="button"
+												className="btn btn-ghost btn-sm"
+												onClick={() => removeLink(uploadLink.id)}
+												disabled={uploadLink.status === "resolving"}
+											>
+												<X className="h-4 w-4" />
+											</button>
+										</div>
+									))}
+								</div>
+							</div>
+						)}
 					</div>
 				)}
 
-				{/* Global upload error */}
-				{uploadMutation.error && (
+				{/* Global upload errors */}
+				{uploadMutation.error && activeTab === "files" && (
 					<div className="mt-4">
 						<ErrorAlert
 							error={uploadMutation.error as Error}
 							onRetry={() => uploadMutation.reset()}
+						/>
+					</div>
+				)}
+				{uploadLinksMutation.error && activeTab === "nzblnk" && (
+					<div className="mt-4">
+						<ErrorAlert
+							error={uploadLinksMutation.error as Error}
+							onRetry={() => uploadLinksMutation.reset()}
 						/>
 					</div>
 				)}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -449,6 +449,29 @@ export const useUploadToQueue = () => {
 	});
 };
 
+export const useUploadNZBLnks = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			links,
+			category,
+			priority,
+			relativePath,
+		}: {
+			links: string[];
+			category?: string;
+			priority?: number;
+			relativePath?: string;
+		}) => apiClient.uploadNZBLnks(links, category, priority, relativePath),
+		onSuccess: () => {
+			// Invalidate queue data to show newly added items
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+			queryClient.invalidateQueries({ queryKey: ["queue", "stats"] });
+		},
+	});
+};
+
 export const useAddTestQueueItem = () => {
 	const queryClient = useQueryClient();
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -58,6 +58,21 @@ export interface QueueStats {
 	last_updated: string;
 }
 
+// NZBLNK upload types
+export interface NZBLnkResult {
+	link: string;
+	success: boolean;
+	queue_id?: number;
+	title?: string;
+	error_message?: string;
+}
+
+export interface UploadNZBLnkResponse {
+	results: NZBLnkResult[];
+	success_count: number;
+	failed_count: number;
+}
+
 // Manual Scan types
 export const ScanStatus = {
 	IDLE: "idle",

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ tool (
 require (
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
 	github.com/avast/retry-go/v4 v4.6.1
-	github.com/gabriel-vasile/mimetype v1.4.9
 	github.com/go-pkgz/auth/v2 v2.0.0
 	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/uuid v1.6.0
@@ -22,6 +21,7 @@ require (
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/rardecode/v2 v2.1.2-0.20251031153435-d6d75db6d6ca
 	github.com/javi11/sevenzip v1.6.2-0.20251026160715-ca961b7f1239
+	github.com/jinzhu/copier v0.4.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/pressly/goose/v3 v3.24.3
@@ -148,7 +148,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jgautheron/goconst v1.8.2 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
-	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/jjti/go-spancheck v0.6.5 // indirect
 	github.com/jstemmer/go-junit-report/v2 v2.1.0 // indirect
 	github.com/julz/importas v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
-github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
-github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/gavv/httpexpect v2.0.0+incompatible h1:1X9kcRshkSKEjNJJxX9Y9mQ5BRfbxU5kORdjhlA1yX8=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/ghostiam/protogetter v0.3.15 h1:1KF5sXel0HE48zh1/vn0Loiw25A9ApyseLzQuif1mLY=

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -176,6 +176,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/queue/bulk/restart", s.handleRestartQueueBulk)
 	api.Post("/queue/bulk/cancel", s.handleCancelQueueBulk)
 	api.Post("/queue/upload", s.handleUploadToQueue)
+	api.Post("/queue/upload-nzblnk", s.handleUploadNZBLnk)
 	api.Post("/queue/test", s.handleAddTestQueueItem)
 	api.Get("/queue/:id", s.handleGetQueue)
 	api.Delete("/queue/:id", s.handleDeleteQueue)

--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -133,14 +133,7 @@ func (w *Worker) safeCleanup() {
 func (w *Worker) CleanupQueue(ctx context.Context) error {
 	cfg := w.configGetter()
 
-	slog.InfoContext(ctx, "Starting ARR queue cleanup")
-
-	// Process all instances via our manager which has them normalized
-	// But we need the config instance to pass to cleanup functions...
-	// Actually `instances.GetConfigInstances()` returns `model.ConfigInstance`.
-	// The original code iterated over `cfg.Arrs.RadarrInstances` directly.
-	// Using `w.instances.GetConfigInstances()` is better as it handles enabled logic (partially)
-	// but `cleanupRadarrQueue` expects `model.ConfigInstance` now.
+	slog.DebugContext(ctx, "Starting ARR queue cleanup")
 
 	instances := w.instances.GetAllInstances()
 
@@ -149,12 +142,13 @@ func (w *Worker) CleanupQueue(ctx context.Context) error {
 			continue
 		}
 
-		if instance.Type == "radarr" {
+		switch instance.Type {
+		case "radarr":
 			if err := w.cleanupRadarrQueue(ctx, instance, cfg); err != nil {
 				slog.WarnContext(ctx, "Failed to cleanup Radarr queue",
 					"instance", instance.Name, "error", err)
 			}
-		} else if instance.Type == "sonarr" {
+		case "sonarr":
 			if err := w.cleanupSonarrQueue(ctx, instance, cfg); err != nil {
 				slog.WarnContext(ctx, "Failed to cleanup Sonarr queue",
 					"instance", instance.Name, "error", err)
@@ -162,7 +156,7 @@ func (w *Worker) CleanupQueue(ctx context.Context) error {
 		}
 	}
 
-	slog.InfoContext(ctx, "ARR queue cleanup completed")
+	slog.DebugContext(ctx, "ARR queue cleanup completed")
 	return nil
 }
 

--- a/internal/nzblnk/indexers.go
+++ b/internal/nzblnk/indexers.go
@@ -1,0 +1,215 @@
+package nzblnk
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	// User-Agent to use for indexer requests (browser-like)
+	userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+	// Maximum response size to prevent memory issues (10MB)
+	maxResponseSize = 10 * 1024 * 1024
+)
+
+// NZBKingIndexer searches nzbking.com for NZB files
+type NZBKingIndexer struct {
+	client *http.Client
+}
+
+// NewNZBKingIndexer creates a new NZBKing indexer
+func NewNZBKingIndexer(client *http.Client) *NZBKingIndexer {
+	return &NZBKingIndexer{client: client}
+}
+
+// Name returns the indexer name
+func (n *NZBKingIndexer) Name() string {
+	return "nzbking"
+}
+
+// Search searches nzbking.com for the given query
+func (n *NZBKingIndexer) Search(ctx context.Context, query string) (*SearchResult, error) {
+	// Build search URL
+	searchURL := fmt.Sprintf("https://www.nzbking.com/?q=%s", url.QueryEscape(query))
+
+	slog.DebugContext(ctx, "NZBKing search", "url", searchURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	slog.DebugContext(ctx, "NZBKing response", "status", resp.StatusCode)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search returned status %d", resp.StatusCode)
+	}
+
+	// Read response with size limit
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Parse HTML to extract first result ID
+	// Look for pattern: href="/details:[hex_id]/"
+	re := regexp.MustCompile(`href="/details:([a-f0-9]+)/"`)
+	matches := re.FindSubmatch(body)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("no results found")
+	}
+
+	id := string(matches[1])
+
+	slog.DebugContext(ctx, "NZBKing found result", "id", id)
+
+	return &SearchResult{
+		ID:    id,
+		Title: query,
+	}, nil
+}
+
+// DownloadNZB downloads the NZB file from nzbking.com
+func (n *NZBKingIndexer) DownloadNZB(ctx context.Context, id string) ([]byte, error) {
+	// Build download URL
+	downloadURL := fmt.Sprintf("https://www.nzbking.com/nzb:%s/", id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	// Read response with size limit
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read NZB: %w", err)
+	}
+
+	return body, nil
+}
+
+// NZBIndexIndexer searches nzbindex.com for NZB files
+type NZBIndexIndexer struct {
+	client *http.Client
+}
+
+// NewNZBIndexIndexer creates a new NZBIndex indexer
+func NewNZBIndexIndexer(client *http.Client) *NZBIndexIndexer {
+	return &NZBIndexIndexer{client: client}
+}
+
+// Name returns the indexer name
+func (n *NZBIndexIndexer) Name() string {
+	return "nzbindex"
+}
+
+// Search searches nzbindex.com for the given query
+func (n *NZBIndexIndexer) Search(ctx context.Context, query string) (*SearchResult, error) {
+	// Build search URL (HTML endpoint)
+	searchURL := fmt.Sprintf("https://nzbindex.com/search?q=%s&minage=&maxage=&minsize=&maxsize=&sort=agedesc&max=25&poster=&groups=", url.QueryEscape(query))
+
+	slog.DebugContext(ctx, "NZBIndex search", "url", searchURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	slog.DebugContext(ctx, "NZBIndex response", "status", resp.StatusCode)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search returned status %d", resp.StatusCode)
+	}
+
+	// Read response with size limit
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Parse HTML to extract first result ID
+	// Look for download link pattern: href="/download/[ID]"
+	re := regexp.MustCompile(`href="/download/(\d+)"`)
+	matches := re.FindSubmatch(body)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("no results found")
+	}
+
+	id := string(matches[1])
+
+	slog.DebugContext(ctx, "NZBIndex found result", "id", id)
+
+	return &SearchResult{
+		ID:    id,
+		Title: query,
+	}, nil
+}
+
+
+// DownloadNZB downloads the NZB file from nzbindex.com
+func (n *NZBIndexIndexer) DownloadNZB(ctx context.Context, id string) ([]byte, error) {
+	// Build download URL
+	downloadURL := fmt.Sprintf("https://nzbindex.com/download/%s", id)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	// Check content type - should be NZB
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "nzb") && !strings.Contains(contentType, "xml") && !strings.Contains(contentType, "octet-stream") {
+		return nil, fmt.Errorf("unexpected content type: %s", contentType)
+	}
+
+	// Read response with size limit
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read NZB: %w", err)
+	}
+
+	return body, nil
+}

--- a/internal/nzblnk/resolver.go
+++ b/internal/nzblnk/resolver.go
@@ -1,0 +1,193 @@
+package nzblnk
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// NZBLinkParams represents parsed nzblnk:// parameters
+type NZBLinkParams struct {
+	Title    string   // t param (required) - content title used for search
+	Header   string   // h param (required) - header pattern for verification
+	Groups   []string // g param (optional, can repeat) - newsgroups
+	Password string   // p param (optional) - archive password
+}
+
+// SearchResult represents a search result from an indexer
+type SearchResult struct {
+	ID       string  // Unique identifier for downloading
+	Title    string  // Title of the NZB
+	Size     int64   // Size in bytes (0 if unknown)
+	Complete float64 // Percentage complete (0-100, 0 if unknown)
+}
+
+// Indexer interface for NZB search engines
+type Indexer interface {
+	Name() string
+	Search(ctx context.Context, title string) (*SearchResult, error)
+	DownloadNZB(ctx context.Context, id string) ([]byte, error)
+}
+
+// Resolver searches indexers to find NZB files for NZBLNK links
+type Resolver struct {
+	httpClient *http.Client
+	indexers   []Indexer
+}
+
+// NewResolver creates a new NZBLNK resolver with default indexers
+func NewResolver() *Resolver {
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+
+	return &Resolver{
+		httpClient: client,
+		indexers: []Indexer{
+			NewNZBKingIndexer(client),
+			NewNZBIndexIndexer(client),
+		},
+	}
+}
+
+// ParseNZBLink parses an nzblnk:// URL and extracts parameters
+func ParseNZBLink(link string) (*NZBLinkParams, error) {
+	// Normalize the link format
+	link = strings.TrimSpace(link)
+
+	// Check for valid scheme
+	if !strings.HasPrefix(link, "nzblnk:?") {
+		return nil, fmt.Errorf("invalid NZBLNK format: must start with 'nzblnk:?'")
+	}
+
+	// Parse the query string part
+	queryPart := strings.TrimPrefix(link, "nzblnk:?")
+	values, err := url.ParseQuery(queryPart)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse NZBLNK parameters: %w", err)
+	}
+
+	// Extract required parameters
+	title := values.Get("t")
+	if title == "" {
+		return nil, fmt.Errorf("missing required parameter 't' (title)")
+	}
+
+	header := values.Get("h")
+	if header == "" {
+		return nil, fmt.Errorf("missing required parameter 'h' (header)")
+	}
+
+	// Extract optional parameters
+	params := &NZBLinkParams{
+		Title:    title,
+		Header:   header,
+		Groups:   values["g"], // Can have multiple 'g' params
+		Password: values.Get("p"),
+	}
+
+	return params, nil
+}
+
+// ResolveResult represents the result of resolving an NZBLNK
+type ResolveResult struct {
+	NZBContent []byte // The downloaded NZB file content
+	Title      string // The title from the link
+	Password   string // Optional password from the link
+	Indexer    string // Which indexer was used
+}
+
+// Resolve attempts to resolve an NZBLNK and download the NZB file
+func (r *Resolver) Resolve(ctx context.Context, link string) (*ResolveResult, error) {
+	// Parse the link
+	params, err := ParseNZBLink(link)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.DebugContext(ctx, "Resolving NZBLNK",
+		"title", params.Title,
+		"header", params.Header,
+		"groups", params.Groups)
+
+	// Try each indexer until one succeeds
+	var lastErr error
+	for _, indexer := range r.indexers {
+		slog.DebugContext(ctx, "Trying indexer",
+			"indexer", indexer.Name(),
+			"header", params.Header)
+
+		// Search for the NZB using the header parameter
+		result, err := indexer.Search(ctx, params.Header)
+		if err != nil {
+			slog.DebugContext(ctx, "Indexer search failed",
+				"indexer", indexer.Name(),
+				"error", err)
+			lastErr = fmt.Errorf("%s: %w", indexer.Name(), err)
+			continue
+		}
+
+		if result == nil {
+			slog.DebugContext(ctx, "Indexer returned no results",
+				"indexer", indexer.Name())
+			lastErr = fmt.Errorf("%s: no results found", indexer.Name())
+			continue
+		}
+
+		slog.DebugContext(ctx, "Indexer found result",
+			"indexer", indexer.Name(),
+			"result_id", result.ID,
+			"result_title", result.Title)
+
+		// Download the NZB
+		nzbContent, err := indexer.DownloadNZB(ctx, result.ID)
+		if err != nil {
+			slog.DebugContext(ctx, "Failed to download NZB",
+				"indexer", indexer.Name(),
+				"error", err)
+			lastErr = fmt.Errorf("%s: failed to download NZB: %w", indexer.Name(), err)
+			continue
+		}
+
+		// Validate NZB content
+		if !isValidNZB(nzbContent) {
+			slog.DebugContext(ctx, "Downloaded content is not valid NZB",
+				"indexer", indexer.Name(),
+				"content_size", len(nzbContent))
+			lastErr = fmt.Errorf("%s: downloaded content is not valid NZB", indexer.Name())
+			continue
+		}
+
+		slog.InfoContext(ctx, "NZBLNK resolved successfully",
+			"indexer", indexer.Name(),
+			"title", params.Title,
+			"nzb_size", len(nzbContent))
+
+		return &ResolveResult{
+			NZBContent: nzbContent,
+			Title:      params.Title,
+			Password:   params.Password,
+			Indexer:    indexer.Name(),
+		}, nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("all indexers failed: %w", lastErr)
+	}
+	return nil, fmt.Errorf("no indexers available")
+}
+
+// isValidNZB performs basic validation on NZB content
+func isValidNZB(content []byte) bool {
+	if len(content) == 0 {
+		return false
+	}
+
+	// Check for XML declaration or nzb root element
+	s := strings.ToLower(string(content[:min(len(content), 500)]))
+	return strings.Contains(s, "<?xml") || strings.Contains(s, "<nzb")
+}


### PR DESCRIPTION
## Summary
- Add support for resolving NZBLNK protocol links (`nzblnk:?t=...&h=...&p=...`) to download NZB files from public indexers
- New NZBLNK tab in upload UI for pasting nzblnk:// links with batch processing (up to 20 links)
- NZBKing and NZBIndex indexer implementations that search by header parameter for precise matching
- Password embedding: `p=` parameter from links is injected into NZB XML metadata for RAR extraction
- Toast notifications provide feedback on resolution success/failure

## Test plan
- [x] Test NZBLNK tab appears in upload dialog
- [x] Test valid nzblnk:// links are parsed and validated
- [x] Test links with password parameter have password embedded in NZB
- [x] Test toast notifications show for success/failure cases
- [x] Test batch processing of multiple links
- [x] Verify NZBKing and NZBIndex search endpoints work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)