### PR TITLE
refactor: simplify usenet writer, cleanup code style, and update dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.52.9
 	github.com/google/uuid v1.6.0
 	github.com/hanwen/go-fuse/v2 v2.9.0
-	github.com/javi11/nntppool/v2 v2.3.0
+	github.com/javi11/nntppool/v2 v2.3.2
 	github.com/javi11/nxg v0.1.0
 	github.com/javi11/nzbparser v0.5.4
 	github.com/javi11/rardecode/v2 v2.1.2-0.20251031153435-d6d75db6d6ca
@@ -177,7 +177,7 @@ require (
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/mgechev/revive v1.11.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mnightingale/rapidyenc v0.0.0-20250628164132-aaf36ba945ef // indirect
+	github.com/mnightingale/rapidyenc v0.0.0-20251128204712-7aafef1eaf1c // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
 	github.com/moricho/tparallel v0.3.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/javi11/nntp-server-mock v0.0.1 h1:05KbUlFSnzk82CG/sHWLp9s6Vg8exL3wvdAetX8Bwhc=
 github.com/javi11/nntp-server-mock v0.0.1/go.mod h1:+QBpPor0q44ttab8kWo08+/t5C26IHhUpBTC1lZqujA=
-github.com/javi11/nntppool/v2 v2.3.0 h1:6Jb5/8HHq741Tn1DxiyZ21Wsi401s3WTGa5cp73Qjo8=
-github.com/javi11/nntppool/v2 v2.3.0/go.mod h1:941UHsGeGtbZrHxmOZBS1hUPf9jITbojuRJlvUbMR/4=
+github.com/javi11/nntppool/v2 v2.3.2 h1:fhORrGnjFJIxP6Rl6lz/KPyT0aE3xYgzv3xP4tK3TCs=
+github.com/javi11/nntppool/v2 v2.3.2/go.mod h1:MiVgxT+c+qj7vGT3IdOQ3ZeKBEalIfA4Ab+3stBKesA=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
 github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=
@@ -445,8 +445,8 @@ github.com/mgechev/revive v1.11.0 h1:b/gLLpBE427o+Xmd8G58gSA+KtBwxWinH/A565Awh0w
 github.com/mgechev/revive v1.11.0/go.mod h1:tI0oLF/2uj+InHCBLrrqfTKfjtFTBCFFfG05auyzgdw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mnightingale/rapidyenc v0.0.0-20250628164132-aaf36ba945ef h1:LFK5FupkzCnQqAYEhvy3JMQwCMC6gXDJQe2+jeJyGAM=
-github.com/mnightingale/rapidyenc v0.0.0-20250628164132-aaf36ba945ef/go.mod h1:OwCiJ/ffT27hY2V+WIU4Q6JgCFzGxP89/6UR/WZtJ+E=
+github.com/mnightingale/rapidyenc v0.0.0-20251128204712-7aafef1eaf1c h1:UFEKx2AsNb8Tx80rlOwUCCz4lDxSsZ1tjq2+QDBNOUA=
+github.com/mnightingale/rapidyenc v0.0.0-20251128204712-7aafef1eaf1c/go.mod h1:7KM6S+qWTq1757nqywpgj5SxykojksJepW+a28MEDdk=
 github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
 github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=

--- a/internal/api/sabnzbd_types.go
+++ b/internal/api/sabnzbd_types.go
@@ -472,110 +472,104 @@ func ToSABnzbdHistorySlot(item *database.ImportQueueItem, index int, basePath st
 		category = *item.Category
 	}
 
-		// Get file size if available
+	// Get file size if available
 
-		var sizeBytes int64
+	var sizeBytes int64
 
-		if item.FileSize != nil {
+	if item.FileSize != nil {
 
-			sizeBytes = *item.FileSize
+		sizeBytes = *item.FileSize
 
-		}
+	}
 
-	
+	downloaded := int64(0)
 
-		downloaded := int64(0)
+	actionLine := ""
 
-		actionLine := ""
+	switch item.Status {
+	case database.QueueStatusCompleted:
 
-		if item.Status == database.QueueStatusCompleted {
+		downloaded = sizeBytes
 
-			downloaded = sizeBytes
+		actionLine = "Finished"
 
-			actionLine = "Finished"
+	case database.QueueStatusFailed:
 
-		} else if item.Status == database.QueueStatusFailed {
+		actionLine = "Failed"
 
-			actionLine = "Failed"
+		if item.ErrorMessage != nil {
 
-			if item.ErrorMessage != nil {
-
-				actionLine = fmt.Sprintf("Failed: %s", *item.ErrorMessage)
-
-			}
-
-		}
-
-	
-
-		return SABnzbdHistorySlot{
-
-			Index:        index,
-
-			NzoID:        fmt.Sprintf("%d", item.ID),
-
-			Name:         jobName,
-
-			Category:     category,
-
-			PP:           "3",
-
-			Script:       "",
-
-			Report:       "",
-
-			URL:          "",
-
-			Status:       status,
-
-			NzbName:      nzbFilename,
-
-			Download:     jobName,
-
-			Storage:      finalPath,
-
-			Path:         finalPath,
-
-			Postproc:     "",
-
-			Downloaded:   downloaded,
-
-			Completetime: completetime,
-
-			NzbAvg:       "",
-
-			Script_log:   "",
-
-			DuplicateKey: jobName,
-
-			Script_line:  "",
-
-			Fail_message: failMessage,
-
-			Url_info:     "",
-
-			Bytes:        sizeBytes,
-
-			Meta:         []string{},
-
-			Series:       "",
-
-			Md5sum:       "",
-
-			Password:     "",
-
-			ActionLine:   actionLine,
-
-			Size:         formatHumanSize(sizeBytes),
-
-			Loaded:       true,
-
-			Retry:        item.RetryCount,
-
-			StateLog:     []string{},
+			actionLine = fmt.Sprintf("Failed: %s", *item.ErrorMessage)
 
 		}
 
 	}
 
-	
+	return SABnzbdHistorySlot{
+
+		Index: index,
+
+		NzoID: fmt.Sprintf("%d", item.ID),
+
+		Name: jobName,
+
+		Category: category,
+
+		PP: "3",
+
+		Script: "",
+
+		Report: "",
+
+		URL: "",
+
+		Status: status,
+
+		NzbName: nzbFilename,
+
+		Download: jobName,
+
+		Storage: finalPath,
+
+		Path: finalPath,
+
+		Postproc: "",
+
+		Downloaded: downloaded,
+
+		Completetime: completetime,
+
+		NzbAvg: "",
+
+		Script_log: "",
+
+		DuplicateKey: jobName,
+
+		Script_line: "",
+
+		Fail_message: failMessage,
+
+		Url_info: "",
+
+		Bytes: sizeBytes,
+
+		Meta: []string{},
+
+		Series: "",
+
+		Md5sum: "",
+
+		Password: "",
+
+		ActionLine: actionLine,
+
+		Size: formatHumanSize(sizeBytes),
+
+		Loaded: true,
+
+		Retry: item.RetryCount,
+
+		StateLog: []string{},
+	}
+
+}

--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -261,9 +261,10 @@ func (m *Manager) categoryUsedByOtherInstance(arrType, category string) bool {
 	var instances []config.ArrsInstanceConfig
 	cfg := m.configManager.GetConfig()
 
-	if arrType == "radarr" {
+	switch arrType {
+	case "radarr":
 		instances = cfg.Arrs.RadarrInstances
-	} else if arrType == "sonarr" {
+	case "sonarr":
 		instances = cfg.Arrs.SonarrInstances
 	}
 

--- a/internal/importer/validation/segments.go
+++ b/internal/importer/validation/segments.go
@@ -84,9 +84,10 @@ func ValidateSegmentsForFile(
 
 	// For encrypted files, convert decrypted size to encrypted size for comparison
 	expectedSize := fileSize
-	if encryption == metapb.Encryption_RCLONE {
+	switch encryption {
+	case metapb.Encryption_RCLONE:
 		expectedSize = rclone.EncryptedSize(fileSize)
-	} else if encryption == metapb.Encryption_AES {
+	case metapb.Encryption_AES:
 		// AES-CBC pads to 16-byte block boundary
 		const aesBlockSize = 16
 		if fileSize%aesBlockSize != 0 {


### PR DESCRIPTION
## Summary

- Simplify usenet_reader.go by removing unnecessary type assertions for safeWriter which already implements Close() and CloseWithError()
- Fix formatting issues in sabnzbd_types.go (indentation, trailing newline)
- Convert if-else chains to switch statements in instances/manager.go and validation/segments.go for cleaner code
- Update nntppool/v2 from v2.3.0 to v2.3.2
- Update rapidyenc dependency

## Test plan

- [ ] Run existing unit tests for usenet package
- [ ] Verify SABnzbd API compatibility
- [ ] Test import queue functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)