### PR TITLE
fix(importer): NZB cleanup behavior and persistence improvements

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -567,10 +567,10 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 		// included it because the file is physically there.
 		// We want to hide this implementation detail.
 		if strings.Contains(virtualDir, filepath.Base(nzbFolder)) {
-			if basePath == "" {
+			if *basePath == "" {
 				virtualDir = "/"
 			} else {
-				virtualDir = basePath
+				virtualDir = *basePath
 				if !strings.HasPrefix(virtualDir, "/") {
 					virtualDir = "/" + virtualDir
 				}


### PR DESCRIPTION
This PR introduces configurable NZB cleanup behavior and improves NZB persistence reliability.

### Changes
- **Configurable Cleanup:** Added `nzb_cleanup_behavior` setting to choose between `delete` (default) or `keep` for both success and failure scenarios.
- **Persistence Fix:** Ensures NZB files are moved to persistent storage (`.nzbs/`) immediately upon queue addition to prevent data loss on container restarts.
- **Failure Handling:** Moves failed NZB files to `.nzbs/failed` instead of deleting them (unless configured to delete), aiding in debugging.
- **Refactor:** Aligned persistence logic in `service.go` with upstream patterns.

### Configuration
New `config.yaml` options:
```yaml
import:
  nzb_cleanup_behavior:
    on_success: 'delete' # Options: delete, keep (default: delete)
    on_failure: 'delete' # Options: delete, keep (default: delete)
```