### PR TITLE
fix(importer): remove ID prefix from NZB filenames and fix formatting

### DIFF
--- a/internal/api/sabnzbd_types.go
+++ b/internal/api/sabnzbd_types.go
@@ -472,110 +472,104 @@ func ToSABnzbdHistorySlot(item *database.ImportQueueItem, index int, basePath st
 		category = *item.Category
 	}
 
-		// Get file size if available
+	// Get file size if available
 
-		var sizeBytes int64
+	var sizeBytes int64
 
-		if item.FileSize != nil {
+	if item.FileSize != nil {
 
-			sizeBytes = *item.FileSize
+		sizeBytes = *item.FileSize
 
-		}
+	}
 
-	
+	downloaded := int64(0)
 
-		downloaded := int64(0)
+	actionLine := ""
 
-		actionLine := ""
+	switch item.Status {
+	case database.QueueStatusCompleted:
 
-		if item.Status == database.QueueStatusCompleted {
+		downloaded = sizeBytes
 
-			downloaded = sizeBytes
+		actionLine = "Finished"
 
-			actionLine = "Finished"
+	case database.QueueStatusFailed:
 
-		} else if item.Status == database.QueueStatusFailed {
+		actionLine = "Failed"
 
-			actionLine = "Failed"
+		if item.ErrorMessage != nil {
 
-			if item.ErrorMessage != nil {
-
-				actionLine = fmt.Sprintf("Failed: %s", *item.ErrorMessage)
-
-			}
-
-		}
-
-	
-
-		return SABnzbdHistorySlot{
-
-			Index:        index,
-
-			NzoID:        fmt.Sprintf("%d", item.ID),
-
-			Name:         jobName,
-
-			Category:     category,
-
-			PP:           "3",
-
-			Script:       "",
-
-			Report:       "",
-
-			URL:          "",
-
-			Status:       status,
-
-			NzbName:      nzbFilename,
-
-			Download:     jobName,
-
-			Storage:      finalPath,
-
-			Path:         finalPath,
-
-			Postproc:     "",
-
-			Downloaded:   downloaded,
-
-			Completetime: completetime,
-
-			NzbAvg:       "",
-
-			Script_log:   "",
-
-			DuplicateKey: jobName,
-
-			Script_line:  "",
-
-			Fail_message: failMessage,
-
-			Url_info:     "",
-
-			Bytes:        sizeBytes,
-
-			Meta:         []string{},
-
-			Series:       "",
-
-			Md5sum:       "",
-
-			Password:     "",
-
-			ActionLine:   actionLine,
-
-			Size:         formatHumanSize(sizeBytes),
-
-			Loaded:       true,
-
-			Retry:        item.RetryCount,
-
-			StateLog:     []string{},
+			actionLine = fmt.Sprintf("Failed: %s", *item.ErrorMessage)
 
 		}
 
 	}
 
-	
+	return SABnzbdHistorySlot{
+
+		Index: index,
+
+		NzoID: fmt.Sprintf("%d", item.ID),
+
+		Name: jobName,
+
+		Category: category,
+
+		PP: "3",
+
+		Script: "",
+
+		Report: "",
+
+		URL: "",
+
+		Status: status,
+
+		NzbName: nzbFilename,
+
+		Download: jobName,
+
+		Storage: finalPath,
+
+		Path: finalPath,
+
+		Postproc: "",
+
+		Downloaded: downloaded,
+
+		Completetime: completetime,
+
+		NzbAvg: "",
+
+		Script_log: "",
+
+		DuplicateKey: jobName,
+
+		Script_line: "",
+
+		Fail_message: failMessage,
+
+		Url_info: "",
+
+		Bytes: sizeBytes,
+
+		Meta: []string{},
+
+		Series: "",
+
+		Md5sum: "",
+
+		Password: "",
+
+		ActionLine: actionLine,
+
+		Size: formatHumanSize(sizeBytes),
+
+		Loaded: true,
+
+		Retry: item.RetryCount,
+
+		StateLog: []string{},
+	}
+
+}

--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -261,9 +261,10 @@ func (m *Manager) categoryUsedByOtherInstance(arrType, category string) bool {
 	var instances []config.ArrsInstanceConfig
 	cfg := m.configManager.GetConfig()
 
-	if arrType == "radarr" {
+	switch arrType {
+	case "radarr":
 		instances = cfg.Arrs.RadarrInstances
-	} else if arrType == "sonarr" {
+	case "sonarr":
 		instances = cfg.Arrs.SonarrInstances
 	}
 

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -637,10 +637,9 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 		return nil
 	}
 
-	// Generate new filename: <id>_<sanitized_filename>
+	// Generate new filename with sanitized name
 	filename := filepath.Base(item.NzbPath)
-	// sanitizeFilename is defined in service.go
-	newFilename := fmt.Sprintf("%d_%s", item.ID, sanitizeFilename(filename))
+	newFilename := sanitizeFilename(filename)
 	newPath := filepath.Join(nzbDir, newFilename)
 
 	s.log.DebugContext(ctx, "Moving NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath)

--- a/internal/importer/validation/segments.go
+++ b/internal/importer/validation/segments.go
@@ -84,9 +84,10 @@ func ValidateSegmentsForFile(
 
 	// For encrypted files, convert decrypted size to encrypted size for comparison
 	expectedSize := fileSize
-	if encryption == metapb.Encryption_RCLONE {
+	switch encryption {
+	case metapb.Encryption_RCLONE:
 		expectedSize = rclone.EncryptedSize(fileSize)
-	} else if encryption == metapb.Encryption_AES {
+	case metapb.Encryption_AES:
 		// AES-CBC pads to 16-byte block boundary
 		const aesBlockSize = 16
 		if fileSize%aesBlockSize != 0 {


### PR DESCRIPTION
## Summary
- Remove queue ID prefix from persistent NZB filenames (e.g., `0_Shrinking.nzb` → `Shrinking.nzb`)
- Fix formatting issues in sabnzbd_types.go
- Replace if-else chains with switch statements in manager.go and segments.go

## Test plan
- [ ] Verify new imports store NZB files without ID prefix
- [ ] Verify existing imports with ID prefix still work (backward compatible via getCleanNzbName)
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)