### PR TITLE
fix(importer): implement replace strategy for persistent NZB storage

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -642,6 +642,14 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 	newFilename := sanitizeFilename(filename)
 	newPath := filepath.Join(nzbDir, newFilename)
 
+	// Replace strategy: remove existing file if it exists
+	if _, err := os.Stat(newPath); err == nil {
+		s.log.DebugContext(ctx, "Replacing existing persistent NZB", "path", newPath)
+		if err := os.Remove(newPath); err != nil {
+			return fmt.Errorf("failed to remove existing NZB for replace: %w", err)
+		}
+	}
+
 	s.log.DebugContext(ctx, "Moving NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath)
 
 	// Move or Copy


### PR DESCRIPTION
## Summary
- Adds explicit replace strategy when saving NZBs to persistent storage (`.nzbs/` directory)
- Before moving/copying an NZB, checks if destination file exists and removes it first
- Ensures consistent behavior across operating systems (previously `os.Rename` behavior varied)

## Test plan
- [x] Verify builds pass
- [x] Add an NZB to queue, verify it's saved to `.nzbs/`
- [ ] Re-add the same NZB, verify it replaces the existing file without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)