### PR TITLE
fix(importer): ignore persistent .nzbs path in virtual directory calculation

### DIFF
--- a/internal/importer/filesystem/utils.go
+++ b/internal/importer/filesystem/utils.go
@@ -34,6 +34,22 @@ func CalculateVirtualDirectory(nzbPath, relativePath string) string {
 		return "/"
 	}
 
+	// Ignore .nzbs folder if present (persistent storage)
+	if strings.Contains(relDir, ".nzbs") {
+		parts := strings.Split(relDir, string(filepath.Separator))
+		filtered := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p != ".nzbs" {
+				filtered = append(filtered, p)
+			}
+		}
+		relDir = filepath.Join(filtered...)
+	}
+
+	if relDir == "." || relDir == "" {
+		return "/"
+	}
+
 	virtualPath := "/" + strings.ReplaceAll(relDir, string(filepath.Separator), "/")
 	return filepath.Clean(virtualPath)
 }

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -215,6 +215,12 @@ func TestCalculateVirtualDirectory(t *testing.T) {
 			relativePath: "/downloads/sonarr",
 			expected:     "/",
 		},
+		{
+			name:         "file in persistent .nzbs directory",
+			nzbPath:      "/config/.nzbs/MovieFolder/Movie.nzb",
+			relativePath: "/config",
+			expected:     "/MovieFolder",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -558,27 +558,6 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 	// Calculate initial virtual directory from physical/relative path
 	virtualDir := filesystem.CalculateVirtualDirectory(item.NzbPath, *basePath)
 
-	// Fix for issue where files moved to persistent .nzbs directory end up with exposed .nzbs path in virtual directory
-	// This happens when RelativePath is "/" (e.g. from NZBDav or root watch) and NzbPath is inside .nzbs
-	nzbFolder := s.GetNzbFolder()
-	// Check if NzbPath is inside the persistent NZB folder
-	if strings.HasPrefix(item.NzbPath, nzbFolder) {
-		// If virtualDir contains the .nzbs folder name, it means CalculateVirtualDirectory 
-		// included it because the file is physically there.
-		// We want to hide this implementation detail.
-		if strings.Contains(virtualDir, filepath.Base(nzbFolder)) {
-			if *basePath == "" {
-				virtualDir = "/"
-			} else {
-				virtualDir = *basePath
-				if !strings.HasPrefix(virtualDir, "/") {
-					virtualDir = "/" + virtualDir
-				}
-				virtualDir = filepath.ToSlash(virtualDir)
-			}
-		}
-	}
-
 	// If category is specified, resolve to configured directory path
 	if item.Category != nil && *item.Category != "" {
 		categoryPath := s.buildCategoryPath(*item.Category)


### PR DESCRIPTION
This PR fixes an issue where the internal persistent storage directory '.nzbs' was being exposed in the virtual mount path when NZB files were moved to persistent storage.

### Changes:
- **Core Logic**: Modified 'CalculateVirtualDirectory' in 'internal/importer/filesystem/utils.go' to filter out '.nzbs' segments from the path calculation.
- **Cleanup**: Removed the redundant (and slightly buggy) manual fix in 'internal/importer/service.go' as it's now handled natively by the filesystem utility.
- **Tests**: Added a new test case to 'internal/importer/processor_test.go' to ensure '.nzbs' is correctly ignored and prevent future regressions.

Verified with 'go test ./internal/importer/...' and all tests passed.