### PR TITLE
fix(config): ensure library_sync_interval_minutes: 0 is visible in UI

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -22,7 +22,7 @@ health:
     max_connections_for_health_checks: 5
     max_concurrent_jobs: 1
     segment_sample_percentage: 5
-    library_sync_interval_minutes: 360
+    library_sync_interval_minutes: 0
     library_sync_concurrency: 0
 rclone:
     path: /config

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -183,12 +183,12 @@ type HealthConfig struct {
 	Enabled                       *bool   `yaml:"enabled" mapstructure:"enabled" json:"enabled,omitempty"`
 	LibraryDir                    *string `yaml:"library_dir" mapstructure:"library_dir" json:"library_dir,omitempty"`
 	CleanupOrphanedMetadata       *bool   `yaml:"cleanup_orphaned_metadata" mapstructure:"cleanup_orphaned_metadata" json:"cleanup_orphaned_metadata,omitempty"`
-	CheckIntervalSeconds          int     `yaml:"check_interval_seconds" mapstructure:"check_interval_seconds" json:"check_interval_seconds,omitempty"`
-	MaxConnectionsForHealthChecks int     `yaml:"max_connections_for_health_checks" mapstructure:"max_connections_for_health_checks" json:"max_connections_for_health_checks,omitempty"`
-	MaxConcurrentJobs             int     `yaml:"max_concurrent_jobs" mapstructure:"max_concurrent_jobs" json:"max_concurrent_jobs,omitempty"`
-	SegmentSamplePercentage       int     `yaml:"segment_sample_percentage" mapstructure:"segment_sample_percentage" json:"segment_sample_percentage,omitempty"`
-	LibrarySyncIntervalMinutes    int     `yaml:"library_sync_interval_minutes" mapstructure:"library_sync_interval_minutes" json:"library_sync_interval_minutes,omitempty"`
-	LibrarySyncConcurrency        int     `yaml:"library_sync_concurrency" mapstructure:"library_sync_concurrency" json:"library_sync_concurrency,omitempty"`
+	CheckIntervalSeconds          int     `yaml:"check_interval_seconds" mapstructure:"check_interval_seconds" json:"check_interval_seconds"`
+	MaxConnectionsForHealthChecks int     `yaml:"max_connections_for_health_checks" mapstructure:"max_connections_for_health_checks" json:"max_connections_for_health_checks"`
+	MaxConcurrentJobs             int     `yaml:"max_concurrent_jobs" mapstructure:"max_concurrent_jobs" json:"max_concurrent_jobs"`
+	SegmentSamplePercentage       int     `yaml:"segment_sample_percentage" mapstructure:"segment_sample_percentage" json:"segment_sample_percentage"`
+	LibrarySyncIntervalMinutes    int     `yaml:"library_sync_interval_minutes" mapstructure:"library_sync_interval_minutes" json:"library_sync_interval_minutes"`
+	LibrarySyncConcurrency        int     `yaml:"library_sync_concurrency" mapstructure:"library_sync_concurrency" json:"library_sync_concurrency"`
 	ResolveRepairOnImport         *bool   `yaml:"resolve_repair_on_import" mapstructure:"resolve_repair_on_import" json:"resolve_repair_on_import,omitempty"`
 }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where setting `library_sync_interval_minutes` (and other integer fields in HealthConfig) to `0` would cause them to be omitted from the JSON response due to the `omitempty` tag. This prevented the frontend UI from correctly displaying or handling these fields when disabled (set to 0).

## Changes
- Removed `omitempty` tag from integer fields in `HealthConfig` struct in `internal/config/manager.go`.
- Updated `config/config.yaml` to set `library_sync_interval_minutes` to 0.

## Motivation
To allow users to explicitly disable library sync (by setting it to 0) and have this configuration correctly reflected and editable in the UI.