### PR TITLE
fix(importer): use relative paths in directory watcher

### DIFF
--- a/internal/importer/scanner/watcher.go
+++ b/internal/importer/scanner/watcher.go
@@ -184,7 +184,6 @@ func (w *Watcher) processNzb(ctx context.Context, watchRoot, filePath string) er
 			relativePath = &relPath
 		}
 	}
-	}
 
 	// Add to queue
 	priority := database.QueuePriorityNormal


### PR DESCRIPTION
Cleaned up version of the relative path fix for the directory watcher.