### PR TITLE
Fix health status not updating from checking to healthy

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1001,7 +1001,7 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	defer stmtCorrupted.Close()
 
 	for _, update := range updates {
-		filePath := strings.TrimPrefix(update.FilePath, "/")
+		filePath := update.FilePath
 		switch update.Status {
 		case HealthStatusHealthy:
 			_, err = stmtHealthy.ExecContext(ctx, update.ScheduledCheckAt, filePath)


### PR DESCRIPTION
## Summary

- Fix `UpdateHealthStatusBulk` stripping the leading `/` from file paths before executing updates
- Paths in the database include the leading `/`, so the WHERE clause was matching 0 rows
- This caused files to get stuck in `checking` status indefinitely

## Test plan

- [x] Deployed and tested on personal instance
- [x] Health check scanner correctly transitions files from pending → healthy
- [x] Verified no files stuck in `checking` status (was 0 after fix deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)