### PR TITLE
refactor(pool): unify NNTP provider creation into single factory

### DIFF
--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,7 +12,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/config"
-	"github.com/javi11/nntppool/v3"
+	"github.com/javi11/altmount/internal/pool"
 )
 
 // ConfigManager interface defines methods for configuration management
@@ -313,28 +312,17 @@ func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(c.Context(), 30*time.Second)
 	defer cancel()
 
-	// Build TLS config if TLS is enabled
-	var tlsConfig *tls.Config
-	if testReq.TLS {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: testReq.InsecureTLS,
-			ServerName:         testReq.Host,
-		}
-	}
-
 	// Create provider to test connectivity
-	address := fmt.Sprintf("%s:%d", testReq.Host, testReq.Port)
-	provider, err := nntppool.NewProvider(ctx, nntppool.ProviderConfig{
-		Address:               address,
-		MaxConnections:        1,
-		InitialConnections:    1, // Force immediate connection to test
-		InflightPerConnection: 1,
-		MaxConnIdleTime:       30 * time.Second,
-		MaxConnLifetime:       30 * time.Second,
-		Auth:                  nntppool.Auth{Username: testReq.Username, Password: testReq.Password},
-		TLSConfig:             tlsConfig,
-		ProxyURL:              testReq.ProxyURL,
-	})
+	provider, err := pool.NewProviderFromTestRequest(
+		ctx,
+		testReq.Host,
+		testReq.Port,
+		testReq.Username,
+		testReq.Password,
+		testReq.TLS,
+		testReq.InsecureTLS,
+		testReq.ProxyURL,
+	)
 	if err != nil {
 		return RespondSuccess(c, TestProviderResponse{
 			Success:      false,

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/nntppool/v3"
 	"github.com/javi11/nzbparser"
 )
@@ -121,25 +121,9 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	}
 
 	// 3. Run Speed Test - Create provider and client
-	var tlsConfig *tls.Config
-	if targetProvider.TLS {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: targetProvider.InsecureTLS,
-			ServerName:         targetProvider.Host,
-		}
-	}
-
-	address := fmt.Sprintf("%s:%d", targetProvider.Host, targetProvider.Port)
-	provider, err := nntppool.NewProvider(c.Context(), nntppool.ProviderConfig{
-		Address:               address,
-		MaxConnections:        targetProvider.MaxConnections,
-		InitialConnections:    0,
-		InflightPerConnection: targetProvider.MaxConnections * 2,
-		MaxConnIdleTime:       60 * time.Second,
-		MaxConnLifetime:       60 * time.Second,
-		Auth:                  nntppool.Auth{Username: targetProvider.Username, Password: targetProvider.Password},
-		TLSConfig:             tlsConfig,
-		ProxyURL:              targetProvider.ProxyURL,
+	provider, err := pool.NewProvider(c.Context(), *targetProvider, pool.ProviderOptions{
+		ConnIdleTime: 60 * time.Second,
+		ConnLifetime: 60 * time.Second,
 	})
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{

--- a/internal/pool/provider_factory.go
+++ b/internal/pool/provider_factory.go
@@ -1,0 +1,92 @@
+package pool
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/nntppool/v3"
+)
+
+// ProviderOptions configures provider creation behavior
+type ProviderOptions struct {
+	// ForceImmediateConnection forces 1 initial connection for connectivity testing
+	ForceImmediateConnection bool
+	// MaxConnections overrides config.MaxConnections (0 = use config value)
+	MaxConnections int
+	// ConnIdleTime overrides the default idle timeout (0 = default 30s)
+	ConnIdleTime time.Duration
+	// ConnLifetime overrides the default lifetime (0 = default 30s)
+	ConnLifetime time.Duration
+}
+
+// NewProvider creates an nntppool.Provider from config with optional options.
+func NewProvider(ctx context.Context, cfg config.ProviderConfig, opts ...ProviderOptions) (*nntppool.Provider, error) {
+	var opt ProviderOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	var tlsConfig *tls.Config
+	if cfg.TLS {
+		tlsConfig = &tls.Config{
+			InsecureSkipVerify: cfg.InsecureTLS,
+			ServerName:         cfg.Host,
+		}
+	}
+
+	maxConns := cfg.MaxConnections
+	if opt.MaxConnections > 0 {
+		maxConns = opt.MaxConnections
+	}
+
+	initialConns := 0
+	inflightPerConn := maxConns * 2
+	if opt.ForceImmediateConnection {
+		initialConns = 1
+		inflightPerConn = 1
+	}
+
+	idleTime := 30 * time.Second
+	if opt.ConnIdleTime > 0 {
+		idleTime = opt.ConnIdleTime
+	}
+
+	lifetime := 30 * time.Second
+	if opt.ConnLifetime > 0 {
+		lifetime = opt.ConnLifetime
+	}
+
+	address := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	return nntppool.NewProvider(ctx, nntppool.ProviderConfig{
+		Address:               address,
+		MaxConnections:        maxConns,
+		InitialConnections:    initialConns,
+		InflightPerConnection: inflightPerConn,
+		MaxConnIdleTime:       idleTime,
+		MaxConnLifetime:       lifetime,
+		Auth:                  nntppool.Auth{Username: cfg.Username, Password: cfg.Password},
+		TLSConfig:             tlsConfig,
+		ProxyURL:              cfg.ProxyURL,
+	})
+}
+
+// NewProviderFromTestRequest creates a provider from API test request fields.
+// Used for testing connectivity with credentials not yet saved to config.
+func NewProviderFromTestRequest(ctx context.Context, host string, port int, username, password string, useTLS, insecureTLS bool, proxyURL string) (*nntppool.Provider, error) {
+	cfg := config.ProviderConfig{
+		Host:           host,
+		Port:           port,
+		Username:       username,
+		Password:       password,
+		TLS:            useTLS,
+		InsecureTLS:    insecureTLS,
+		ProxyURL:       proxyURL,
+		MaxConnections: 1,
+	}
+	return NewProvider(ctx, cfg, ProviderOptions{
+		ForceImmediateConnection: true,
+	})
+}


### PR DESCRIPTION
## Summary

- Consolidate 3 separate locations where NNTP providers were created into a single factory in the `pool` package
- Add `pool.NewProvider()` with optional `ProviderOptions` for customization
- Add `pool.NewProviderFromTestRequest()` convenience function for connectivity testing
- Remove duplicate `createProvider()` from `manager.go`
- Update `config_handlers.go` and `provider_speedtest_handler.go` to use the new factory

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/pool/... ./internal/api/...` passes
- [ ] Manual test: verify provider connectivity test still works
- [ ] Manual test: verify speed test still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)