### PR TITLE
feat(metadata): add automatic metadata backup system

### DIFF
--- a/frontend/src/components/config/MetadataConfigSection.tsx
+++ b/frontend/src/components/config/MetadataConfigSection.tsx
@@ -1,7 +1,7 @@
 import { Download, Save } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useBatchExportNZB } from "../../hooks/useConfig";
-import type { ConfigResponse, MetadataConfig } from "../../types/config";
+import type { ConfigResponse, MetadataBackupConfig, MetadataConfig } from "../../types/config";
 
 interface MetadataConfigSectionProps {
 	config: ConfigResponse;
@@ -38,6 +38,18 @@ export function MetadataConfigSection({
 		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.metadata));
 	};
 
+	const handleBackupChange = (field: keyof MetadataBackupConfig, value: string | number | boolean) => {
+		const newData = {
+			...formData,
+			backup: {
+				...formData.backup,
+				[field]: value,
+			},
+		};
+		setFormData(newData);
+		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.metadata));
+	};
+
 	const handleSave = async () => {
 		if (onUpdate && hasChanges) {
 			await onUpdate("metadata", formData);
@@ -61,6 +73,68 @@ export function MetadataConfigSection({
 						required
 					/>
 					<p className="label">Directory path where file metadata will be stored (required)</p>
+				</fieldset>
+
+				<fieldset className="fieldset">
+					<legend className="fieldset-legend">Backup Options</legend>
+					<label className="label cursor-pointer">
+						<span className="label-text">Enable Automatic Backups</span>
+						<input
+							type="checkbox"
+							className="checkbox"
+							checked={formData.backup?.enabled ?? false}
+							disabled={isReadOnly}
+							onChange={(e) => handleBackupChange("enabled", e.target.checked)}
+						/>
+					</label>
+					<p className="label">
+						When enabled, all .meta files will be periodically mirrored to the backup directory
+					</p>
+
+					<div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+						<div className="form-control">
+							<label className="label">
+								<span className="label-text">Backup Interval (Hours)</span>
+							</label>
+							<input
+								type="number"
+								className="input"
+								value={formData.backup?.interval_hours ?? 24}
+								disabled={isReadOnly || !formData.backup?.enabled}
+								onChange={(e) => handleBackupChange("interval_hours", Number.parseInt(e.target.value))}
+								min="1"
+							/>
+						</div>
+
+						<div className="form-control">
+							<label className="label">
+								<span className="label-text">Keep Backups</span>
+							</label>
+							<input
+								type="number"
+								className="input"
+								value={formData.backup?.keep_backups ?? 10}
+								disabled={isReadOnly || !formData.backup?.enabled}
+								onChange={(e) => handleBackupChange("keep_backups", Number.parseInt(e.target.value))}
+								min="1"
+							/>
+						</div>
+					</div>
+
+					<div className="form-control mt-4">
+						<label className="label">
+							<span className="label-text">Backup Path</span>
+						</label>
+						<input
+							type="text"
+							className="input"
+							value={formData.backup?.path ?? ""}
+							disabled={isReadOnly || !formData.backup?.enabled}
+							onChange={(e) => handleBackupChange("path", e.target.value)}
+							placeholder="/path/to/backups"
+						/>
+						<p className="label">Absolute path where metadata mirrors will be stored</p>
+					</div>
 				</fieldset>
 
 				<fieldset className="fieldset">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -49,6 +49,14 @@ export interface MetadataConfig {
 	delete_source_nzb_on_removal?: boolean;
 	delete_failed_nzb?: boolean;
 	delete_completed_nzb?: boolean;
+	backup: MetadataBackupConfig;
+}
+
+export interface MetadataBackupConfig {
+	enabled: boolean;
+	interval_hours: number;
+	keep_backups: number;
+	path: string;
 }
 
 // Streaming configuration
@@ -281,6 +289,7 @@ export interface DatabaseUpdateRequest {
 export interface MetadataUpdateRequest {
 	root_path?: string;
 	delete_source_nzb_on_removal?: boolean;
+	backup?: MetadataBackupConfig;
 }
 
 // Streaming update request
@@ -453,6 +462,7 @@ export interface ImportFormData {
 export interface MetadataFormData {
 	root_path: string;
 	delete_source_nzb_on_removal?: boolean;
+	backup: MetadataBackupConfig;
 }
 
 export interface StreamingFormData {

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -85,3 +85,19 @@ func (c *Config) GetReadTimeoutSeconds() int {
 func (c *Config) GetReadTimeout() time.Duration {
 	return time.Duration(c.GetReadTimeoutSeconds()) * time.Second
 }
+
+// GetMetadataBackupInterval returns the metadata backup interval with a default fallback.
+func (c *Config) GetMetadataBackupInterval() time.Duration {
+	if c.Metadata.Backup.IntervalHours <= 0 {
+		return 24 * time.Hour // Default: 24 hours
+	}
+	return time.Duration(c.Metadata.Backup.IntervalHours) * time.Hour
+}
+
+// GetMetadataBackupKeep returns the number of metadata backups to keep with a default fallback.
+func (c *Config) GetMetadataBackupKeep() int {
+	if c.Metadata.Backup.KeepBackups <= 0 {
+		return 10 // Default: 10 backups
+	}
+	return c.Metadata.Backup.KeepBackups
+}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -79,10 +79,19 @@ type DatabaseConfig struct {
 
 // MetadataConfig represents metadata filesystem configuration
 type MetadataConfig struct {
-	RootPath                 string `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
-	DeleteSourceNzbOnRemoval *bool  `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
-	DeleteFailedNzb          *bool  `yaml:"delete_failed_nzb" mapstructure:"delete_failed_nzb" json:"delete_failed_nzb,omitempty"`
-	DeleteCompletedNzb       *bool  `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
+	RootPath                 string               `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
+	DeleteSourceNzbOnRemoval *bool                `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
+	DeleteFailedNzb          *bool                `yaml:"delete_failed_nzb" mapstructure:"delete_failed_nzb" json:"delete_failed_nzb,omitempty"`
+	DeleteCompletedNzb       *bool                `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
+	Backup                   MetadataBackupConfig `yaml:"backup" mapstructure:"backup" json:"backup"`
+}
+
+// MetadataBackupConfig represents metadata backup configuration
+type MetadataBackupConfig struct {
+	Enabled       *bool  `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	IntervalHours int    `yaml:"interval_hours" mapstructure:"interval_hours" json:"interval_hours"`
+	KeepBackups   int    `yaml:"keep_backups" mapstructure:"keep_backups" json:"keep_backups"`
+	Path          string `yaml:"path" mapstructure:"path" json:"path"`
 }
 
 // StreamingConfig represents streaming and chunking configuration
@@ -408,6 +417,22 @@ func (c *Config) Validate() error {
 	// Validate metadata configuration (now required)
 	if c.Metadata.RootPath == "" {
 		return fmt.Errorf("metadata root_path cannot be empty")
+	}
+
+	// Validate metadata backup configuration
+	if c.Metadata.Backup.Enabled != nil && *c.Metadata.Backup.Enabled {
+		if c.Metadata.Backup.IntervalHours <= 0 {
+			return fmt.Errorf("metadata backup interval_hours must be greater than 0")
+		}
+		if c.Metadata.Backup.KeepBackups <= 0 {
+			return fmt.Errorf("metadata backup keep_backups must be greater than 0")
+		}
+		if c.Metadata.Backup.Path == "" {
+			return fmt.Errorf("metadata backup path cannot be empty")
+		}
+		if !filepath.IsAbs(c.Metadata.Backup.Path) {
+			return fmt.Errorf("metadata backup path must be an absolute path")
+		}
 	}
 
 	// Validate streaming configuration
@@ -868,9 +893,10 @@ func DefaultConfig(configDir ...string) *Config {
 	skipHealthCheck := true
 	watchIntervalSeconds := 10 // Default watch interval
 	cleanupAutomaticImportFailure := false
+	metadataBackupEnabled := false
 
 	// Set paths based on whether we're running in Docker or have a specific config directory
-	var dbPath, metadataPath, logPath, rclonePath, cachePath string
+	var dbPath, metadataPath, logPath, rclonePath, cachePath, backupPath string
 
 	// If a config directory is provided, use it
 	if len(configDir) > 0 && configDir[0] != "" {
@@ -879,18 +905,21 @@ func DefaultConfig(configDir ...string) *Config {
 		logPath = filepath.Join(configDir[0], "altmount.log")
 		rclonePath = configDir[0]
 		cachePath = filepath.Join(configDir[0], "cache")
+		backupPath = filepath.Join(configDir[0], "backups")
 	} else if isRunningInDocker() {
 		dbPath = "/config/altmount.db"
 		metadataPath = "/metadata"
 		logPath = "/config/altmount.log"
 		rclonePath = "/config"
 		cachePath = "/config/cache"
+		backupPath = "/config/backups"
 	} else {
 		dbPath = "./altmount.db"
 		metadataPath = "./metadata"
 		logPath = "./altmount.log"
 		rclonePath = "."
 		cachePath = "./cache"
+		backupPath = "./backups"
 	}
 
 	return &Config{
@@ -911,6 +940,12 @@ func DefaultConfig(configDir ...string) *Config {
 		Metadata: MetadataConfig{
 			RootPath:                 metadataPath,
 			DeleteSourceNzbOnRemoval: &deleteSourceNzbOnRemoval,
+			Backup: MetadataBackupConfig{
+				Enabled:       &metadataBackupEnabled,
+				IntervalHours: 24,
+				KeepBackups:   10,
+				Path:          backupPath,
+			},
 		},
 		Streaming: StreamingConfig{
 			MaxDownloadWorkers: 15, // Default: 15 download workers

--- a/internal/metadata/backup_worker.go
+++ b/internal/metadata/backup_worker.go
@@ -1,0 +1,211 @@
+package metadata
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+type BackupWorker struct {
+	configGetter config.ConfigGetter
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
+	workerWg     sync.WaitGroup
+	workerMu     sync.Mutex
+	workerRunning bool
+}
+
+func NewBackupWorker(configGetter config.ConfigGetter) *BackupWorker {
+	return &BackupWorker{
+		configGetter: configGetter,
+	}
+}
+
+func (w *BackupWorker) Start(ctx context.Context) error {
+	w.workerMu.Lock()
+	defer w.workerMu.Unlock()
+
+	if w.workerRunning {
+		return nil
+	}
+
+	cfg := w.configGetter()
+	if cfg.Metadata.Backup.Enabled == nil || !*cfg.Metadata.Backup.Enabled {
+		return nil
+	}
+
+	w.workerCtx, w.workerCancel = context.WithCancel(ctx)
+	w.workerRunning = true
+
+	w.workerWg.Add(1)
+	go w.runWorker()
+
+	slog.InfoContext(ctx, "Metadata backup worker started",
+		"interval_hours", cfg.Metadata.Backup.IntervalHours,
+		"keep_backups", cfg.Metadata.Backup.KeepBackups,
+		"path", cfg.Metadata.Backup.Path)
+	return nil
+}
+
+func (w *BackupWorker) Stop(ctx context.Context) {
+	w.workerMu.Lock()
+	defer w.workerMu.Unlock()
+
+	if !w.workerRunning {
+		return
+	}
+
+	w.workerCancel()
+	w.workerWg.Wait()
+	w.workerRunning = false
+	slog.InfoContext(ctx, "Metadata backup worker stopped")
+}
+
+func (w *BackupWorker) runWorker() {
+	defer w.workerWg.Done()
+
+	ticker := time.NewTicker(w.configGetter().GetMetadataBackupInterval())
+	defer ticker.Stop()
+
+	// Initial backup after a short delay
+	select {
+	case <-time.After(1 * time.Minute):
+		w.performBackup()
+	case <-w.workerCtx.Done():
+		return
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			w.performBackup()
+		case <-w.workerCtx.Done():
+			return
+		}
+	}
+}
+
+func (w *BackupWorker) performBackup() {
+	cfg := w.configGetter()
+	backupRoot := cfg.Metadata.Backup.Path
+	metadataDir := cfg.Metadata.RootPath
+
+	timestamp := time.Now().Format("20060102-150405")
+	backupDir := filepath.Join(backupRoot, timestamp)
+
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		slog.Error("Failed to create backup directory", "error", err, "path", backupDir)
+		return
+	}
+
+	slog.Info("Starting metadata backup (copy)", "destination", backupDir)
+
+	count := 0
+	err := filepath.Walk(metadataDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(info.Name(), ".meta") {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(metadataDir, path)
+		if err != nil {
+			return err
+		}
+
+		destPath := filepath.Join(backupDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return err
+		}
+
+		if err := w.copyFile(path, destPath); err != nil {
+			return err
+		}
+		count++
+		return nil
+	})
+
+	if err != nil {
+		slog.Error("Failed to complete metadata backup", "error", err)
+		// Cleanup failed partial backup
+		os.RemoveAll(backupDir)
+		return
+	}
+
+	slog.Info("Metadata backup completed successfully", "files_copied", count)
+
+	w.cleanupOldBackups(backupRoot, cfg.GetMetadataBackupKeep())
+}
+
+func (w *BackupWorker) copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
+}
+
+func (w *BackupWorker) cleanupOldBackups(backupRoot string, keep int) {
+	files, err := os.ReadDir(backupRoot)
+	if err != nil {
+		slog.Error("Failed to read backup directory for cleanup", "error", err)
+		return
+	}
+
+	type backupEntry struct {
+		name    string
+		modTime time.Time
+	}
+
+	var backups []backupEntry
+	for _, f := range files {
+		if f.IsDir() {
+			info, err := f.Info()
+			if err == nil {
+				backups = append(backups, backupEntry{
+					name:    f.Name(),
+					modTime: info.ModTime(),
+				})
+			}
+		}
+	}
+
+	if len(backups) <= keep {
+		return
+	}
+
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].modTime.After(backups[j].modTime)
+	})
+
+	for i := keep; i < len(backups); i++ {
+		path := filepath.Join(backupRoot, backups[i].name)
+		slog.Info("Deleting old backup directory", "path", path)
+		if err := os.RemoveAll(path); err != nil {
+			slog.Error("Failed to delete old backup directory", "error", err, "path", path)
+		}
+	}
+}

--- a/internal/metadata/backup_worker_test.go
+++ b/internal/metadata/backup_worker_test.go
@@ -1,0 +1,81 @@
+package metadata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackupWorker_performBackup(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "metadata-test-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	metadataDir := filepath.Join(tempDir, "metadata")
+	backupRoot := filepath.Join(tempDir, "backups")
+	err = os.MkdirAll(metadataDir, 0755)
+	assert.NoError(t, err)
+
+	// Create some dummy .meta files in subdirectories
+	err = os.MkdirAll(filepath.Join(metadataDir, "movies"), 0755)
+	assert.NoError(t, err)
+
+	metaFiles := []string{
+		filepath.Join("movies", "test1.meta"),
+		"test2.meta",
+		"test3.txt",
+	}
+	for _, f := range metaFiles {
+		err = os.WriteFile(filepath.Join(metadataDir, f), []byte("content"), 0644)
+		assert.NoError(t, err)
+	}
+
+	enabled := true
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			RootPath: metadataDir,
+			Backup: config.MetadataBackupConfig{
+				Enabled:       &enabled,
+				IntervalHours: 24,
+				KeepBackups:   2,
+				Path:          backupRoot,
+			},
+		},
+	}
+
+	configGetter := func() *config.Config {
+		return cfg
+	}
+
+	worker := NewBackupWorker(configGetter)
+
+	// Run backup
+	worker.performBackup()
+
+	// Check if backup directory exists
+	dirs, err := os.ReadDir(backupRoot)
+	assert.NoError(t, err)
+	assert.Len(t, dirs, 1)
+	assert.True(t, dirs[0].IsDir())
+
+	backupDir := filepath.Join(backupRoot, dirs[0].Name())
+	
+	// Verify copied files and structure
+	assert.FileExists(t, filepath.Join(backupDir, "movies", "test1.meta"))
+	assert.FileExists(t, filepath.Join(backupDir, "test2.meta"))
+	assert.NoFileExists(t, filepath.Join(backupDir, "test3.txt"))
+
+	// Test cleanup: create more backups
+	time.Sleep(1 * time.Second)
+	worker.performBackup()
+	time.Sleep(1 * time.Second)
+	worker.performBackup()
+
+	dirs, err = os.ReadDir(backupRoot)
+	assert.NoError(t, err)
+	assert.Len(t, dirs, 2) // Should keep only 2 latest folders
+}


### PR DESCRIPTION
## Description
This PR implements an automatic metadata backup system for AltMount. It periodically mirrors `.meta` files from the metadata root to a specified backup directory, preserving the original directory structure.

### Key Features
- **Automatic Mirroring:** Periodically copies all `.meta` files to a timestamped folder in the backup directory.
- **Configurable Retention:** Automatically prunes old backup sets to keep only a user-defined number of historical snapshots (default: 10).
- **UI Integration:** Full configuration support added to the Metadata settings page in the web UI.

### Configuration Options
```yaml
metadata:
  backup:
    enabled: true
    interval_hours: 24
    keep_backups: 10
    path: /config/backups
```