### PR TITLE
fix(api): improve SABnzbd category compatibility for Sonarr/Radarr

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -472,10 +472,7 @@ func (s *Server) handleSABnzbdQueue(c *fiber.Ctx) error {
 	}
 
 	// Get category filter from query parameter
-	categoryFilter := c.Query("category", "")
-	if categoryFilter == "" {
-		categoryFilter = c.Query("cat", "")
-	}
+	categoryFilter := s.normalizeCategoryFilter(c)
 
 	// Get pagination parameters
 	start := 0
@@ -606,7 +603,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	}
 
 	// Get category filter from query parameter
-	categoryFilter := c.Query("category", "")
+	categoryFilter := s.normalizeCategoryFilter(c)
 
 	// Get pagination parameters
 	start := 0
@@ -1001,6 +998,21 @@ func (s *Server) ensureCategoryDirectories(category string) error {
 	}
 
 	return nil
+}
+
+// normalizeCategoryFilter extracts and normalizes the category filter from query parameters
+func (s *Server) normalizeCategoryFilter(c *fiber.Ctx) string {
+	category := c.Query("category", "")
+	if category == "" {
+		category = c.Query("cat", "")
+	}
+
+	lower := strings.ToLower(category)
+	if lower == "all" || lower == "*" || lower == "default" {
+		return ""
+	}
+
+	return category
 }
 
 // calculateItemBasePath calculates the base path for an item based on the import strategy configuration

--- a/internal/api/sabnzbd_types.go
+++ b/internal/api/sabnzbd_types.go
@@ -50,6 +50,7 @@ type SABnzbdQueueSlot struct {
 	Priority   string `json:"priority"`
 	Filename   string `json:"filename"`
 	Cat        string `json:"cat"`
+	Category   string `json:"category"`
 	Percentage string `json:"percentage"`
 	Status     string `json:"status"`
 	Timeleft   string `json:"timeleft"`
@@ -79,6 +80,7 @@ type SABnzbdHistorySlot struct {
 	NzoID        string   `json:"nzo_id"`
 	Name         string   `json:"name"`
 	Category     string   `json:"category"`
+	Cat          string   `json:"cat"`
 	PP           string   `json:"pp"`
 	Script       string   `json:"script"`
 	Report       string   `json:"report"`
@@ -382,6 +384,7 @@ func ToSABnzbdQueueSlot(item *database.ImportQueueItem, index int, progressBroad
 		Priority:   priority,
 		Filename:   jobName,
 		Cat:        category,
+		Category:   category,
 		Percentage: fmt.Sprintf("%d", progressPercentage),
 		Status:     status,
 		Timeleft:   timeLeft,
@@ -514,6 +517,8 @@ func ToSABnzbdHistorySlot(item *database.ImportQueueItem, index int, basePath st
 		Name: jobName,
 
 		Category: category,
+
+		Cat: category,
 
 		PP: "3",
 


### PR DESCRIPTION
## Description
This PR addresses several compatibility issues with Sonarr and Radarr when interacting with AltMount's SABnzbd-compatible API.

### Key Fixes
1.  **Response Field Consistency:** Added `category` field to queue responses and `cat` field to history responses. Sonarr/Radarr can sometimes be inconsistent in which field they expect, so providing both ensures compatibility.
2.  **Filter Normalization:** Added a helper to correctly handle both `cat` and `category` query parameters for filtering.
3.  **'All Categories' Handling:** Common values like `all`, `*`, or `default` are now correctly normalized to 'no filter', preventing empty results when Sonarr/Radarr polls for all items.