### PR TITLE
feat(fuse): add metadata cache to reduce filesystem lookups

### DIFF
--- a/frontend/src/components/config/FuseConfig.tsx
+++ b/frontend/src/components/config/FuseConfig.tsx
@@ -21,6 +21,14 @@ export function FuseConfig() {
 		max_download_workers: 15,
 		max_cache_size_mb: 128,
 		max_read_ahead_mb: 128,
+		// Metadata cache defaults
+		metadata_cache_enabled: false,
+		stat_cache_size: 10000,
+		dir_cache_size: 1000,
+		negative_cache_size: 5000,
+		stat_cache_ttl_seconds: 30,
+		dir_cache_ttl_seconds: 60,
+		negative_cache_ttl_seconds: 10,
 	});
 
 	const [isLoading, setIsLoading] = useState(false);
@@ -334,6 +342,158 @@ export function FuseConfig() {
 								<p className="label">Read-ahead cache size per file</p>
 							</fieldset>
 						</div>
+					</div>
+
+					{/* Metadata Cache Settings */}
+					<div className="space-y-4">
+						<h4 className="font-medium text-base">Metadata Cache Settings</h4>
+
+						<fieldset className="fieldset">
+							<legend className="fieldset-legend">Enable Metadata Cache</legend>
+							<label className="label cursor-pointer">
+								<span className="label-text">Cache file and directory metadata</span>
+								<input
+									type="checkbox"
+									className="checkbox"
+									checked={formData.metadata_cache_enabled ?? false}
+									onChange={(e) =>
+										setFormData({ ...formData, metadata_cache_enabled: e.target.checked })
+									}
+									disabled={isRunning}
+								/>
+							</label>
+							<p className="label">
+								Reduces filesystem lookups by caching file attributes and directory listings
+							</p>
+						</fieldset>
+
+						{formData.metadata_cache_enabled && (
+							<>
+								<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Stat Cache Size</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.stat_cache_size ?? 10000}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														stat_cache_size: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">entries</span>
+										</div>
+										<p className="label">Max cached file metadata entries</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Dir Cache Size</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.dir_cache_size ?? 1000}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														dir_cache_size: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">entries</span>
+										</div>
+										<p className="label">Max cached directory listings</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Negative Cache Size</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.negative_cache_size ?? 5000}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														negative_cache_size: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">entries</span>
+										</div>
+										<p className="label">Max cached "not found" results</p>
+									</fieldset>
+								</div>
+
+								<div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Stat Cache TTL</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.stat_cache_ttl_seconds ?? 30}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														stat_cache_ttl_seconds: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">sec</span>
+										</div>
+										<p className="label">File metadata cache lifetime</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Dir Cache TTL</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.dir_cache_ttl_seconds ?? 60}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														dir_cache_ttl_seconds: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">sec</span>
+										</div>
+										<p className="label">Directory listing cache lifetime</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Negative Cache TTL</legend>
+										<div className="join">
+											<input
+												type="number"
+												className="input join-item w-full"
+												value={formData.negative_cache_ttl_seconds ?? 10}
+												onChange={(e) =>
+													setFormData({
+														...formData,
+														negative_cache_ttl_seconds: Number.parseInt(e.target.value, 10) || 0,
+													})
+												}
+												disabled={isRunning}
+											/>
+											<span className="btn no-animation join-item">sec</span>
+										</div>
+										<p className="label">"Not found" cache lifetime</p>
+									</fieldset>
+								</div>
+							</>
+						)}
 					</div>
 
 					{/* Advanced Options */}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -176,6 +176,14 @@ export interface FuseConfig {
 	max_download_workers: number;
 	max_cache_size_mb: number;
 	max_read_ahead_mb: number;
+	// Metadata cache settings
+	metadata_cache_enabled?: boolean;
+	stat_cache_size?: number;
+	dir_cache_size?: number;
+	negative_cache_size?: number;
+	stat_cache_ttl_seconds?: number;
+	dir_cache_ttl_seconds?: number;
+	negative_cache_ttl_seconds?: number;
 }
 
 // Import strategy type

--- a/internal/fuse/adapter_test.go
+++ b/internal/fuse/adapter_test.go
@@ -309,7 +309,7 @@ func TestAltMountRoot_Getattr(t *testing.T) {
 	mockFs := new(MockFs)
 	logger := slog.Default()
 
-	root := NewAltMountRoot(mockFs, "/root", logger, 1000, 1000)
+	root := NewAltMountRoot(mockFs, "/root", logger, 1000, 1000, nil)
 	root.isRootDir = false // Force it to check fs.Stat
 
 	// Test Directory Getattr

--- a/internal/fuse/cache/cache.go
+++ b/internal/fuse/cache/cache.go
@@ -1,0 +1,79 @@
+// Package cache provides metadata caching for the FUSE filesystem to reduce
+// queries to the underlying metadata service.
+package cache
+
+import (
+	"os"
+	"time"
+)
+
+// Cache defines the interface for FUSE metadata caching.
+// It provides separate caches for stat results, directory listings,
+// and negative lookups (file not found).
+type Cache interface {
+	// Stat operations
+	GetStat(path string) (os.FileInfo, bool)
+	SetStat(path string, info os.FileInfo)
+
+	// Directory listing operations
+	GetDirEntries(path string) ([]DirEntry, bool)
+	SetDirEntries(path string, entries []DirEntry)
+
+	// Negative cache (file not found)
+	IsNegative(path string) bool
+	SetNegative(path string)
+
+	// Invalidation
+	Invalidate(path string)
+	InvalidatePrefix(prefix string)
+	InvalidateAll()
+
+	// Statistics
+	Stats() CacheStats
+}
+
+// DirEntry represents a directory entry for caching.
+type DirEntry struct {
+	Name  string
+	IsDir bool
+	Mode  os.FileMode
+}
+
+// CacheStats provides cache statistics for monitoring.
+type CacheStats struct {
+	StatCacheSize     int
+	StatCacheHits     uint64
+	StatCacheMisses   uint64
+	DirCacheSize      int
+	DirCacheHits      uint64
+	DirCacheMisses    uint64
+	NegativeCacheSize int
+	NegativeHits      uint64
+	NegativeMisses    uint64
+}
+
+// Config holds configuration for the cache.
+type Config struct {
+	StatCacheSize     int
+	DirCacheSize      int
+	NegativeCacheSize int
+	StatTTL           time.Duration
+	DirTTL            time.Duration
+	NegativeTTL       time.Duration
+}
+
+// DefaultConfig returns a cache configuration with sensible defaults.
+// Memory budget: ~2.2 MB total
+// - Stat cache: ~1.5 MB (10K entries × ~150 bytes)
+// - Dir cache: ~500 KB (1K entries × ~500 bytes avg)
+// - Negative cache: ~200 KB (5K entries × ~40 bytes)
+func DefaultConfig() Config {
+	return Config{
+		StatCacheSize:     10000,
+		DirCacheSize:      1000,
+		NegativeCacheSize: 5000,
+		StatTTL:           30 * time.Second,
+		DirTTL:            60 * time.Second,
+		NegativeTTL:       10 * time.Second,
+	}
+}

--- a/internal/fuse/cache/lru_cache.go
+++ b/internal/fuse/cache/lru_cache.go
@@ -1,0 +1,256 @@
+package cache
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+// LRUCache implements the Cache interface using LRU eviction with TTL expiration.
+type LRUCache struct {
+	statCache     *lru.Cache[string, *statEntry]
+	dirCache      *lru.Cache[string, *dirEntry]
+	negativeCache *lru.Cache[string, *negativeEntry]
+
+	statTTL     time.Duration
+	dirTTL      time.Duration
+	negativeTTL time.Duration
+
+	// Statistics
+	statHits       atomic.Uint64
+	statMisses     atomic.Uint64
+	dirHits        atomic.Uint64
+	dirMisses      atomic.Uint64
+	negativeHits   atomic.Uint64
+	negativeMisses atomic.Uint64
+
+	// Mutex for prefix invalidation operations
+	mu sync.RWMutex
+}
+
+// statEntry holds a cached stat result with expiration time.
+type statEntry struct {
+	info      os.FileInfo
+	expiresAt time.Time
+}
+
+// dirEntry holds cached directory entries with expiration time.
+type dirEntry struct {
+	entries   []DirEntry
+	expiresAt time.Time
+}
+
+// negativeEntry holds a negative lookup result with expiration time.
+type negativeEntry struct {
+	expiresAt time.Time
+}
+
+// NewLRUCache creates a new LRU-based cache with the given configuration.
+func NewLRUCache(cfg Config) (*LRUCache, error) {
+	statCache, err := lru.New[string, *statEntry](cfg.StatCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	dirCache, err := lru.New[string, *dirEntry](cfg.DirCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	negativeCache, err := lru.New[string, *negativeEntry](cfg.NegativeCacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LRUCache{
+		statCache:     statCache,
+		dirCache:      dirCache,
+		negativeCache: negativeCache,
+		statTTL:       cfg.StatTTL,
+		dirTTL:        cfg.DirTTL,
+		negativeTTL:   cfg.NegativeTTL,
+	}, nil
+}
+
+// GetStat retrieves a cached stat result.
+func (c *LRUCache) GetStat(path string) (os.FileInfo, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.statCache.Get(path)
+	if !ok {
+		c.statMisses.Add(1)
+		return nil, false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.expiresAt) {
+		c.statCache.Remove(path)
+		c.statMisses.Add(1)
+		return nil, false
+	}
+
+	c.statHits.Add(1)
+	return entry.info, true
+}
+
+// SetStat caches a stat result.
+func (c *LRUCache) SetStat(path string, info os.FileInfo) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	c.statCache.Add(path, &statEntry{
+		info:      info,
+		expiresAt: time.Now().Add(c.statTTL),
+	})
+
+	// Remove from negative cache since the file now exists
+	c.negativeCache.Remove(path)
+}
+
+// GetDirEntries retrieves cached directory entries.
+func (c *LRUCache) GetDirEntries(path string) ([]DirEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.dirCache.Get(path)
+	if !ok {
+		c.dirMisses.Add(1)
+		return nil, false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.expiresAt) {
+		c.dirCache.Remove(path)
+		c.dirMisses.Add(1)
+		return nil, false
+	}
+
+	c.dirHits.Add(1)
+	// Return a copy to prevent mutation
+	result := make([]DirEntry, len(entry.entries))
+	copy(result, entry.entries)
+	return result, true
+}
+
+// SetDirEntries caches directory entries.
+func (c *LRUCache) SetDirEntries(path string, entries []DirEntry) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Store a copy to prevent external mutation
+	entriesCopy := make([]DirEntry, len(entries))
+	copy(entriesCopy, entries)
+
+	c.dirCache.Add(path, &dirEntry{
+		entries:   entriesCopy,
+		expiresAt: time.Now().Add(c.dirTTL),
+	})
+}
+
+// IsNegative checks if a path is in the negative cache (known to not exist).
+func (c *LRUCache) IsNegative(path string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.negativeCache.Get(path)
+	if !ok {
+		c.negativeMisses.Add(1)
+		return false
+	}
+
+	// Check if expired
+	if time.Now().After(entry.expiresAt) {
+		c.negativeCache.Remove(path)
+		c.negativeMisses.Add(1)
+		return false
+	}
+
+	c.negativeHits.Add(1)
+	return true
+}
+
+// SetNegative marks a path as non-existent.
+func (c *LRUCache) SetNegative(path string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	c.negativeCache.Add(path, &negativeEntry{
+		expiresAt: time.Now().Add(c.negativeTTL),
+	})
+}
+
+// Invalidate removes all cached data for a specific path.
+func (c *LRUCache) Invalidate(path string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.statCache.Remove(path)
+	c.dirCache.Remove(path)
+	c.negativeCache.Remove(path)
+}
+
+// InvalidatePrefix removes all cached data for paths starting with the given prefix.
+func (c *LRUCache) InvalidatePrefix(prefix string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Ensure prefix ends with / for directory matching
+	normalizedPrefix := prefix
+	if !strings.HasSuffix(normalizedPrefix, "/") {
+		normalizedPrefix += "/"
+	}
+
+	// Invalidate stat cache entries with matching prefix
+	for _, key := range c.statCache.Keys() {
+		if strings.HasPrefix(key, normalizedPrefix) || key == prefix {
+			c.statCache.Remove(key)
+		}
+	}
+
+	// Invalidate dir cache entries with matching prefix
+	for _, key := range c.dirCache.Keys() {
+		if strings.HasPrefix(key, normalizedPrefix) || key == prefix {
+			c.dirCache.Remove(key)
+		}
+	}
+
+	// Invalidate negative cache entries with matching prefix
+	for _, key := range c.negativeCache.Keys() {
+		if strings.HasPrefix(key, normalizedPrefix) || key == prefix {
+			c.negativeCache.Remove(key)
+		}
+	}
+}
+
+// InvalidateAll clears all caches.
+func (c *LRUCache) InvalidateAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.statCache.Purge()
+	c.dirCache.Purge()
+	c.negativeCache.Purge()
+}
+
+// Stats returns cache statistics.
+func (c *LRUCache) Stats() CacheStats {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return CacheStats{
+		StatCacheSize:     c.statCache.Len(),
+		StatCacheHits:     c.statHits.Load(),
+		StatCacheMisses:   c.statMisses.Load(),
+		DirCacheSize:      c.dirCache.Len(),
+		DirCacheHits:      c.dirHits.Load(),
+		DirCacheMisses:    c.dirMisses.Load(),
+		NegativeCacheSize: c.negativeCache.Len(),
+		NegativeHits:      c.negativeHits.Load(),
+		NegativeMisses:    c.negativeMisses.Load(),
+	}
+}

--- a/internal/fuse/cache/lru_cache_test.go
+++ b/internal/fuse/cache/lru_cache_test.go
@@ -1,0 +1,392 @@
+package cache
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockFileInfo implements os.FileInfo for testing
+type mockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (m *mockFileInfo) Name() string       { return m.name }
+func (m *mockFileInfo) Size() int64        { return m.size }
+func (m *mockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m *mockFileInfo) ModTime() time.Time { return m.modTime }
+func (m *mockFileInfo) IsDir() bool        { return m.isDir }
+func (m *mockFileInfo) Sys() any           { return nil }
+
+func TestNewLRUCache(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, cache)
+}
+
+func TestStatCache(t *testing.T) {
+	cfg := Config{
+		StatCacheSize:     100,
+		DirCacheSize:      100,
+		NegativeCacheSize: 100,
+		StatTTL:           1 * time.Hour,
+		DirTTL:            1 * time.Hour,
+		NegativeTTL:       1 * time.Hour,
+	}
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Test cache miss
+	info, ok := cache.GetStat("/test/path")
+	assert.False(t, ok)
+	assert.Nil(t, info)
+
+	// Test cache set and get
+	mockInfo := &mockFileInfo{
+		name:    "testfile",
+		size:    1024,
+		mode:    0644,
+		modTime: time.Now(),
+		isDir:   false,
+	}
+	cache.SetStat("/test/path", mockInfo)
+
+	info, ok = cache.GetStat("/test/path")
+	assert.True(t, ok)
+	assert.Equal(t, "testfile", info.Name())
+	assert.Equal(t, int64(1024), info.Size())
+
+	// Check stats
+	stats := cache.Stats()
+	assert.Equal(t, 1, stats.StatCacheSize)
+	assert.Equal(t, uint64(1), stats.StatCacheHits)
+	assert.Equal(t, uint64(1), stats.StatCacheMisses)
+}
+
+func TestStatCacheTTL(t *testing.T) {
+	cfg := Config{
+		StatCacheSize:     100,
+		DirCacheSize:      100,
+		NegativeCacheSize: 100,
+		StatTTL:           50 * time.Millisecond, // Very short TTL for testing
+		DirTTL:            1 * time.Hour,
+		NegativeTTL:       1 * time.Hour,
+	}
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	mockInfo := &mockFileInfo{name: "testfile", size: 100}
+	cache.SetStat("/test/path", mockInfo)
+
+	// Should hit cache
+	info, ok := cache.GetStat("/test/path")
+	assert.True(t, ok)
+	assert.NotNil(t, info)
+
+	// Wait for TTL to expire
+	time.Sleep(100 * time.Millisecond)
+
+	// Should miss after expiration
+	info, ok = cache.GetStat("/test/path")
+	assert.False(t, ok)
+	assert.Nil(t, info)
+}
+
+func TestDirCache(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Test cache miss
+	entries, ok := cache.GetDirEntries("/test/dir")
+	assert.False(t, ok)
+	assert.Nil(t, entries)
+
+	// Test cache set and get
+	dirEntries := []DirEntry{
+		{Name: "file1.txt", IsDir: false, Mode: 0644},
+		{Name: "subdir", IsDir: true, Mode: 0755},
+	}
+	cache.SetDirEntries("/test/dir", dirEntries)
+
+	entries, ok = cache.GetDirEntries("/test/dir")
+	assert.True(t, ok)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "file1.txt", entries[0].Name)
+	assert.Equal(t, "subdir", entries[1].Name)
+	assert.True(t, entries[1].IsDir)
+
+	// Check stats
+	stats := cache.Stats()
+	assert.Equal(t, 1, stats.DirCacheSize)
+	assert.Equal(t, uint64(1), stats.DirCacheHits)
+	assert.Equal(t, uint64(1), stats.DirCacheMisses)
+}
+
+func TestDirCacheImmutability(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	dirEntries := []DirEntry{
+		{Name: "file1.txt", IsDir: false},
+	}
+	cache.SetDirEntries("/test/dir", dirEntries)
+
+	// Modify original slice
+	dirEntries[0].Name = "modified.txt"
+
+	// Cached copy should be unchanged
+	entries, ok := cache.GetDirEntries("/test/dir")
+	assert.True(t, ok)
+	assert.Equal(t, "file1.txt", entries[0].Name)
+
+	// Modify returned slice
+	entries[0].Name = "also_modified.txt"
+
+	// Fetch again - should still be original
+	entries2, ok := cache.GetDirEntries("/test/dir")
+	assert.True(t, ok)
+	assert.Equal(t, "file1.txt", entries2[0].Name)
+}
+
+func TestNegativeCache(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Test cache miss
+	assert.False(t, cache.IsNegative("/test/nonexistent"))
+
+	// Set negative entry
+	cache.SetNegative("/test/nonexistent")
+
+	// Test cache hit
+	assert.True(t, cache.IsNegative("/test/nonexistent"))
+
+	// Check stats
+	stats := cache.Stats()
+	assert.Equal(t, 1, stats.NegativeCacheSize)
+	assert.Equal(t, uint64(1), stats.NegativeHits)
+	assert.Equal(t, uint64(1), stats.NegativeMisses)
+}
+
+func TestNegativeCacheRemovedOnStatSet(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Mark path as negative
+	cache.SetNegative("/test/path")
+	assert.True(t, cache.IsNegative("/test/path"))
+
+	// Now set stat for same path (file now exists)
+	mockInfo := &mockFileInfo{name: "path"}
+	cache.SetStat("/test/path", mockInfo)
+
+	// Should no longer be in negative cache
+	assert.False(t, cache.IsNegative("/test/path"))
+
+	// Should be in stat cache
+	info, ok := cache.GetStat("/test/path")
+	assert.True(t, ok)
+	assert.NotNil(t, info)
+}
+
+func TestInvalidate(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Set all cache types
+	cache.SetStat("/test/path", &mockFileInfo{name: "test"})
+	cache.SetDirEntries("/test/path", []DirEntry{{Name: "entry"}})
+	cache.SetNegative("/test/path")
+
+	// Verify they're set
+	_, ok := cache.GetStat("/test/path")
+	assert.True(t, ok)
+	_, ok = cache.GetDirEntries("/test/path")
+	assert.True(t, ok)
+	assert.True(t, cache.IsNegative("/test/path"))
+
+	// Invalidate
+	cache.Invalidate("/test/path")
+
+	// All should be gone
+	_, ok = cache.GetStat("/test/path")
+	assert.False(t, ok)
+	_, ok = cache.GetDirEntries("/test/path")
+	assert.False(t, ok)
+	assert.False(t, cache.IsNegative("/test/path"))
+}
+
+func TestInvalidatePrefix(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Set entries with various paths
+	cache.SetStat("/movies/action/movie1.mkv", &mockFileInfo{name: "movie1.mkv"})
+	cache.SetStat("/movies/action/movie2.mkv", &mockFileInfo{name: "movie2.mkv"})
+	cache.SetStat("/movies/comedy/movie3.mkv", &mockFileInfo{name: "movie3.mkv"})
+	cache.SetStat("/tv/show1/ep1.mkv", &mockFileInfo{name: "ep1.mkv"})
+	cache.SetDirEntries("/movies/action", []DirEntry{{Name: "movie1.mkv"}})
+
+	// Invalidate /movies/action prefix
+	cache.InvalidatePrefix("/movies/action")
+
+	// Action movies should be gone
+	_, ok := cache.GetStat("/movies/action/movie1.mkv")
+	assert.False(t, ok)
+	_, ok = cache.GetStat("/movies/action/movie2.mkv")
+	assert.False(t, ok)
+	_, ok = cache.GetDirEntries("/movies/action")
+	assert.False(t, ok)
+
+	// Comedy movie should still be there
+	_, ok = cache.GetStat("/movies/comedy/movie3.mkv")
+	assert.True(t, ok)
+
+	// TV show should still be there
+	_, ok = cache.GetStat("/tv/show1/ep1.mkv")
+	assert.True(t, ok)
+}
+
+func TestInvalidatePrefixExact(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Set entry for exact path
+	cache.SetStat("/movies", &mockFileInfo{name: "movies", isDir: true})
+	cache.SetStat("/movies/action", &mockFileInfo{name: "action", isDir: true})
+
+	// Invalidate prefix should also remove exact match
+	cache.InvalidatePrefix("/movies")
+
+	_, ok := cache.GetStat("/movies")
+	assert.False(t, ok)
+	_, ok = cache.GetStat("/movies/action")
+	assert.False(t, ok)
+}
+
+func TestInvalidateAll(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Set various entries
+	cache.SetStat("/path1", &mockFileInfo{name: "test1"})
+	cache.SetStat("/path2", &mockFileInfo{name: "test2"})
+	cache.SetDirEntries("/dir1", []DirEntry{{Name: "entry"}})
+	cache.SetNegative("/missing")
+
+	// Verify they're set
+	stats := cache.Stats()
+	assert.Equal(t, 2, stats.StatCacheSize)
+	assert.Equal(t, 1, stats.DirCacheSize)
+	assert.Equal(t, 1, stats.NegativeCacheSize)
+
+	// Invalidate all
+	cache.InvalidateAll()
+
+	// All should be gone
+	stats = cache.Stats()
+	assert.Equal(t, 0, stats.StatCacheSize)
+	assert.Equal(t, 0, stats.DirCacheSize)
+	assert.Equal(t, 0, stats.NegativeCacheSize)
+}
+
+func TestLRUEviction(t *testing.T) {
+	cfg := Config{
+		StatCacheSize:     2, // Very small for testing
+		DirCacheSize:      100,
+		NegativeCacheSize: 100,
+		StatTTL:           1 * time.Hour,
+		DirTTL:            1 * time.Hour,
+		NegativeTTL:       1 * time.Hour,
+	}
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	// Add 3 items (exceeds capacity of 2)
+	cache.SetStat("/path1", &mockFileInfo{name: "file1"})
+	cache.SetStat("/path2", &mockFileInfo{name: "file2"})
+	cache.SetStat("/path3", &mockFileInfo{name: "file3"})
+
+	// First item should be evicted
+	_, ok := cache.GetStat("/path1")
+	assert.False(t, ok)
+
+	// Recent items should still exist
+	_, ok = cache.GetStat("/path2")
+	assert.True(t, ok)
+	_, ok = cache.GetStat("/path3")
+	assert.True(t, ok)
+}
+
+func TestConcurrency(t *testing.T) {
+	cfg := DefaultConfig()
+	cache, err := NewLRUCache(cfg)
+	require.NoError(t, err)
+
+	done := make(chan bool)
+	iterations := 100
+
+	// Writer goroutine
+	go func() {
+		for i := 0; i < iterations; i++ {
+			cache.SetStat("/test/path", &mockFileInfo{name: "test"})
+			cache.SetDirEntries("/test/dir", []DirEntry{{Name: "entry"}})
+			cache.SetNegative("/test/missing")
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for i := 0; i < iterations; i++ {
+			cache.GetStat("/test/path")
+			cache.GetDirEntries("/test/dir")
+			cache.IsNegative("/test/missing")
+		}
+		done <- true
+	}()
+
+	// Invalidator goroutine
+	go func() {
+		for i := 0; i < iterations; i++ {
+			cache.Invalidate("/test/path")
+			cache.InvalidatePrefix("/test")
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	for i := 0; i < 3; i++ {
+		<-done
+	}
+
+	// Should complete without race conditions or panics
+	_ = cache.Stats()
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, 10000, cfg.StatCacheSize)
+	assert.Equal(t, 1000, cfg.DirCacheSize)
+	assert.Equal(t, 5000, cfg.NegativeCacheSize)
+	assert.Equal(t, 30*time.Second, cfg.StatTTL)
+	assert.Equal(t, 60*time.Second, cfg.DirTTL)
+	assert.Equal(t, 10*time.Second, cfg.NegativeTTL)
+}

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -74,6 +74,12 @@ type VFSNotifier interface {
 	RefreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64)
 }
 
+// FUSECacheNotifier handles FUSE metadata cache invalidation
+type FUSECacheNotifier interface {
+	// InvalidateFUSECache invalidates cache entries for a path and its parent
+	InvalidateFUSECache(path string)
+}
+
 // HealthScheduler handles health check scheduling for imported files
 type HealthScheduler interface {
 	// ScheduleHealthCheck schedules a health check for an imported file
@@ -103,6 +109,7 @@ type PostProcessor interface {
 	SymlinkCreator
 	StrmGenerator
 	VFSNotifier
+	FUSECacheNotifier
 	HealthScheduler
 	ARRNotifier
 	SABnzbdFallback

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	fusecache "github.com/javi11/altmount/internal/fuse/cache"
 	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/postprocessor"
@@ -414,6 +415,20 @@ func (s *Service) SetArrsService(service *arrs.Service) {
 	s.arrsService = service
 	if s.postProcessor != nil {
 		s.postProcessor.SetArrsService(service)
+	}
+}
+
+// SetFuseCache sets or updates the FUSE metadata cache for invalidation
+func (s *Service) SetFuseCache(cache fusecache.Cache) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.postProcessor != nil {
+		s.postProcessor.SetFuseCache(cache)
+	}
+	if cache != nil {
+		s.log.InfoContext(s.ctx, "FUSE metadata cache connected to import service")
+	} else {
+		s.log.InfoContext(s.ctx, "FUSE metadata cache disconnected from import service")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add application-level metadata caching for FUSE mount to reduce filesystem/metadata service queries
- Implement LRU caches with TTL for stat results, directory listings, and negative lookups
- Add cache invalidation integration with import service via FUSECacheNotifier interface
- Add frontend UI for configuring metadata cache settings

## Changes
- **New `internal/fuse/cache/` package**: Cache interface, LRU implementation, and tests
- **Config updates**: Add metadata cache configuration options with sensible defaults
- **FUSE adapter integration**: Cache checks in Getattr, Lookup, Readdir; invalidation on Rename
- **Import service integration**: Cache invalidation after successful imports
- **Frontend UI**: Metadata Cache Settings section in FUSE configuration page

## Test plan
- [x] Unit tests for cache package (`go test ./internal/fuse/cache/...`)
- [x] Existing FUSE adapter tests pass (`go test ./internal/fuse/...`)
- [x] Frontend TypeScript compilation passes (`bun run check`)
- [ ] Manual testing: Enable cache, verify UI controls work, test cache behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)