### PR TITLE
feat(fuse): cross-platform force unmount & mount health validation

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -14,15 +14,15 @@ runs:
   steps:
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.25.1' # Pinned version
-    
+        go-version: '1.26.0' # Pinned version
+
     - name: Get Go cache paths
       shell: bash
       id: go-cache-paths
       run: |
         echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-    
+
     - name: Cache Go modules
       uses: actions/cache@v4
       continue-on-error: true
@@ -30,11 +30,11 @@ runs:
         path: |
           ${{ steps.go-cache-paths.outputs.go-mod }}
           ${{ steps.go-cache-paths.outputs.go-build }}
-        key: go-cache-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}-go1.25.1
+        key: go-cache-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}-go1.26.0
         restore-keys: |
           go-cache-${{ runner.os }}-${{ hashFiles('go.mod', 'go.sum') }}-
           go-cache-${{ runner.os }}-
-    
+
     - name: Go info
       shell: bash
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.1
+          go-version: 1.26.0
 
       # checkout
       - name: Checkout

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/tmp/bun-build-cache,sharing=locked \
     bun run build
 
 # Backend build stage with native arch support (no cross-compilation)
-FROM golang:1.25-alpine AS backend-builder
+FROM golang:1.26-alpine AS backend-builder
 
 # Install build dependencies including sqlite with cache mount
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -13,7 +13,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Backend build stage with Debian for reliable ARM64 QEMU support
-FROM golang:1.25-bookworm AS backend-builder
+FROM golang:1.26-bookworm AS backend-builder
 
 # Install build dependencies including sqlite with cache mount
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/docs/docs/6. Development/setup.md
+++ b/docs/docs/6. Development/setup.md
@@ -6,7 +6,7 @@ This guide will help you set up a development environment for AltMount.
 
 Before you begin, ensure you have the following installed on your system:
 
-- **Go 1.25.1+** - [Download Go](https://golang.org/dl/)
+- **Go 1.26.0+** - [Download Go](https://golang.org/dl/)
 - **Bun** - [Install Bun](https://bun.sh/docs/installation)
 - **Protobuf Compiler** - [Install Protocol Buffers](https://grpc.io/docs/protoc-installation/)
 - **Git** - [Download Git](https://git-scm.com/downloads)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -828,6 +828,13 @@ export class APIClient {
 			body: JSON.stringify({}),
 		});
 	}
+
+	async forceStopFuseMount() {
+		return this.request<{ message: string }>("/fuse/force-stop", {
+			method: "POST",
+			body: JSON.stringify({}),
+		});
+	}
 }
 
 // Export a default instance

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -409,4 +409,6 @@ export interface SystemBrowseResponse {
 export interface FuseStatus {
 	status: "stopped" | "starting" | "running" | "error";
 	path: string;
+	healthy?: boolean;
+	health_error?: string;
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/javi11/altmount
 
-go 1.25.1
+go 1.26.0
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -729,6 +729,16 @@ func (s *Server) startRCServerIfNeeded(ctx context.Context) {
 		return
 	}
 
+	// Only start RC server for rclone-based mount types
+	if s.configManager != nil {
+		cfg := s.configManager.GetConfig()
+		if cfg != nil && cfg.MountType != config.MountTypeRClone && cfg.MountType != config.MountTypeRCloneExternal {
+			slog.DebugContext(ctx, "Skipping RC server start, mount_type is not rclone-based",
+				"mount_type", string(cfg.MountType))
+			return
+		}
+	}
+
 	// Use the mount service to start the RC server (non-blocking for config save)
 	go func() {
 		if err := s.mountService.StartRCServer(ctx); err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -239,6 +239,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	// FUSE endpoints
 	api.Post("/fuse/start", s.handleStartFuseMount)
 	api.Post("/fuse/stop", s.handleStopFuseMount)
+	api.Post("/fuse/force-stop", s.handleForceStopFuseMount)
 	api.Get("/fuse/status", s.handleGetFuseStatus)
 
 	// Provider management endpoints

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -501,8 +501,8 @@ func (c *Config) Validate() error {
 	switch c.MountType {
 	case MountTypeNone, "":
 		c.RClone.MountEnabled = &falseVal
+		c.RClone.RCEnabled = &falseVal
 		c.Fuse.Enabled = &falseVal
-		// Leave RCEnabled as-is (user may want RC without mount)
 	case MountTypeRClone:
 		if c.MountPath == "" {
 			return fmt.Errorf("mount_path cannot be empty when mount type is rclone")
@@ -521,6 +521,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("mount_path must be an absolute path")
 		}
 		c.RClone.MountEnabled = &falseVal
+		c.RClone.RCEnabled = &falseVal
 		c.Fuse.Enabled = &trueVal
 		c.Fuse.MountPath = c.MountPath
 	case MountTypeRCloneExternal:


### PR DESCRIPTION
## Summary

- **Cross-platform ForceUnmount**: Replace Linux-only implementation with macOS (umount -f, diskutil unmount force) and Linux (fusermount -uz, umount -l, fusermount3 -uz) support
- **Mount health validation**: Add `ValidateMount()` that stat-checks the mount with a 5s timeout to detect stuck FUSE connections; status endpoint auto-corrects to "error" when unresponsive
- **Force-stop API endpoint**: `POST /api/fuse/force-stop` bypasses graceful unmount and always resets manager state so users aren't stuck
- **Stop handler state fix**: On unmount failure, resets status to "error" and clears server reference instead of leaving user permanently stuck in "running"
- **Response builder migration**: All FUSE handlers now use unified response builders per project standards
- **Frontend**: Force Unmount button with confirmation dialog, health_error display, proper error state handling
- **Config fixes**: Disable RC server start for non-rclone mount types; disable RCEnabled when mount_type is "none" or "fuse"
- **Go 1.26.0**: Bump Go version across CI, Docker, and docs

## Test plan

- [ ] `go build ./...` passes
- [ ] `cd frontend && bun run check` passes (only pre-existing MetadataConfigSection lint issues)
- [ ] Mount FUSE, verify status shows `healthy: true`
- [ ] Stop via normal unmount, verify status returns to "stopped"
- [ ] Simulate stuck mount, verify status auto-corrects to "error"
- [ ] Verify force-stop endpoint resets state and unmounts
- [ ] Verify force unmount button appears next to Unmount when FUSE is mounted
- [ ] Verify force unmount button is sole action when status is "error"
- [ ] Test on macOS: verify `umount -f` / `diskutil unmount force` commands are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)