### PR TITLE
fix(fuse): handle context cancellation as debug logs, not errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -763,12 +763,14 @@ function App() {
 
 ### Before Committing
 
-1. **Run type checking**: `bun run check` (TypeScript validation, linting, formatting, and code quality)
-2. **Test build**: `bun run build` (TypeScript compilation + Vite build)
-3. **Review changes**: Ensure code follows these standards
+1. **Run full build**: `make` (Build both backend and frontend, run all checks)
+2. **Run type checking**: `bun run check` (TypeScript validation, linting, formatting, and code quality)
+3. **Test build**: `bun run build` (TypeScript compilation + Vite build)
+4. **Review changes**: Ensure code follows these standards
 
 **Command Reference:**
 
+- `make` - Full project build (Go backend + frontend, all validations) - **REQUIRED before commit**
 - `bun run check` - Comprehensive validation (TypeScript + linting + formatting)
 - `bun run lint` - Linting-only checks when needed
 - `bun run build` - Production build validation


### PR DESCRIPTION
## Summary

Fixes incorrect error logging when users stop playback or close files in the FUSE layer. Context cancellation is expected behavior and should not pollute logs with ERROR messages.

## Changes

### FUSE Layer Fixes (`internal/fuse/`)

- **`handle.go`**: Fixed context cancellation handling in VFS and fallback Read operations
- **`file.go`**: Fixed context cancellation handling in VFS and fallback Open operations

**What changed:**
- Context cancellation now logged at Debug level instead of Error level
- Returns `syscall.EINTR` (interrupted) instead of `syscall.EIO` (I/O error)
- Added `errors` import to both files for proper error checking

**Pattern followed:**
- Matches existing pattern in `internal/webdav/adapter.go`, `internal/health/library_sync.go`, `internal/importer/parser/parser.go`
- Uses `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)`

### Documentation Update

- **`CLAUDE.md`**: Added requirement to run `make` before committing to ensure full project build succeeds

## Before

```
level=ERROR msg="VFS Read failed" ... error="context canceled"
```

## After

```
level=DEBUG msg="VFS Read canceled" path=... offset=...
```

## Testing

- ✅ `go build ./internal/fuse/...` - Compiles successfully
- ✅ `go vet ./internal/fuse/...` - No issues
- ✅ All 4 error handling locations updated consistently
- ✅ Follows established codebase patterns

## Impact

- Cleaner logs without false ERROR messages during normal operations
- Proper syscall error codes returned to FUSE layer
- Actual I/O errors still logged as ERROR with full context

🤖 Generated with [Claude Code](https://claude.com/claude-code)