### PR TITLE
fix(frontend): resolve TypeScript build errors with missing type definitions

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,10 +11,12 @@ import type {
 	HealthPriority,
 	HealthStats,
 	HealthWorkerStatus,
+	ImportHistoryItem,
 	ImportStatusResponse,
 	LibrarySyncStatus,
 	ManualScanRequest,
 	PoolMetrics,
+	QueueHistoricalStatsResponse,
 	QueueItem,
 	QueueStats,
 	SABnzbdAddResponse,
@@ -752,9 +754,7 @@ export class APIClient {
 		if (limit) searchParams.set("limit", limit.toString());
 
 		const query = searchParams.toString();
-		return this.request<Array<Record<string, unknown>>>(
-			`/import/history${query ? `?${query}` : ""}`,
-		);
+		return this.request<ImportHistoryItem[]>(`/import/history${query ? `?${query}` : ""}`);
 	}
 
 	async cancelScan() {

--- a/frontend/src/components/queue/QueueHistoricalStatsCard.tsx
+++ b/frontend/src/components/queue/QueueHistoricalStatsCard.tsx
@@ -96,7 +96,7 @@ export function QueueHistoricalStatsCard() {
 							</div>
 						</div>
 
-						{history.daily.length > 0 && (
+						{history?.daily && history.daily.length > 0 && (
 							<div className="mt-4 flex h-16 items-end gap-1 overflow-x-auto pb-1">
 								{history.daily.slice(-30).map((day: DailyStat) => {
 									const total = day.completed + day.failed;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -55,6 +55,15 @@ export interface ProgressUpdate {
 	percentage: number;
 }
 
+export interface ImportHistoryItem {
+	id: number;
+	nzb_name: string;
+	file_name: string;
+	category?: string;
+	file_size: number;
+	completed_at: string;
+}
+
 export interface QueueStats {
 	total_queued: number;
 	total_processing: number;


### PR DESCRIPTION
## Summary
- Fixed TypeScript build errors related to missing type definitions
- Added `ImportHistoryItem` interface for properly typing import history data
- Added missing imports for `QueueHistoricalStatsResponse` and `ImportHistoryItem`
- Updated `getImportHistory` method to return properly typed `ImportHistoryItem[]`
- Fixed optional chaining in `QueueHistoricalStatsCard` for `history.daily`

## Changes
- `src/types/api.ts`: Added `ImportHistoryItem` interface with proper field types
- `src/api/client.ts`: Added missing type imports and updated return type for `getImportHistory`
- `src/components/queue/QueueHistoricalStatsCard.tsx`: Fixed optional chaining to handle undefined `history`

## Test plan
- [x] `bun run build` passes successfully
- [x] `bun run check` passes with all type checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)