### PR TITLE
fix(importer): strip virtual path prefix & feat(ci): timestamped dev tags

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -90,10 +90,6 @@ jobs:
         id: normalize
         run: echo "image_name=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
-      - name: Get timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +'%m.%d.%Y.%I-%M%p')" >> $GITHUB_OUTPUT
-
       - name: Build and push AMD64 image
         uses: docker/build-push-action@v6
         with:
@@ -141,10 +137,6 @@ jobs:
         id: normalize
         run: echo "image_name=$(echo ${{ env.IMAGE_NAME }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
-      - name: Get timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +'%m.%d.%Y.%I-%M%p')" >> $GITHUB_OUTPUT
-
       - name: Build and push ARM64 image
         uses: docker/build-push-action@v6
         with:
@@ -182,7 +174,7 @@ jobs:
 
       - name: Get timestamp
         id: timestamp
-        run: echo "timestamp=$(date +'%m.%d.%Y.%I-%M%p')" >> $GITHUB_OUTPUT
+        run: echo "timestamp=$(TZ='America/New_York' date +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
 
       - name: Create and push manifest
         run: |

--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -27,6 +27,20 @@ func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.Import
 		return fmt.Errorf("STRM directory not configured")
 	}
 
+	// Strip SABnzbd CompleteDir prefix from resultingPath if present
+	if cfg.SABnzbd.CompleteDir != "" {
+		completeDir := filepath.ToSlash(cfg.SABnzbd.CompleteDir)
+		if !strings.HasPrefix(completeDir, "/") {
+			completeDir = "/" + completeDir
+		}
+		if strings.HasPrefix(resultingPath, completeDir) {
+			resultingPath = strings.TrimPrefix(resultingPath, completeDir)
+			if !strings.HasPrefix(resultingPath, "/") {
+				resultingPath = "/" + resultingPath
+			}
+		}
+	}
+
 	// Check the metadata directory to determine if this is a file or directory
 	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(resultingPath, "/"))
 	fileInfo, err := os.Stat(metadataPath)

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -25,6 +25,21 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 		return fmt.Errorf("symlink directory not configured")
 	}
 
+	// Strip SABnzbd CompleteDir prefix from resultingPath if present
+	// This prevents creating nested "complete" folders in the symlink directory
+	if cfg.SABnzbd.CompleteDir != "" {
+		completeDir := filepath.ToSlash(cfg.SABnzbd.CompleteDir)
+		if !strings.HasPrefix(completeDir, "/") {
+			completeDir = "/" + completeDir
+		}
+		if strings.HasPrefix(resultingPath, completeDir) {
+			resultingPath = strings.TrimPrefix(resultingPath, completeDir)
+			if !strings.HasPrefix(resultingPath, "/") {
+				resultingPath = "/" + resultingPath
+			}
+		}
+	}
+
 	// Get the actual metadata/mount path (where the content actually lives)
 	actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(resultingPath, "/"))
 


### PR DESCRIPTION
This PR includes two improvements:

1. **fix(importer): strip virtual complete_dir prefix from physical symlink/strm paths**
   - Corrects the target path for symlinks and STRM files by removing the SABnzbd `complete_dir` prefix if it's present in the virtual path. This prevents creating redundant "complete" subfolders in the final library structure.

2. **feat(ci): add timestamp to dev image tags**
   - Updates the Docker dev image workflow to include a timestamp (`YYYYMMDD-HHmm` in Eastern Time) in the tags, making it easier to identify and track specific dev builds.