### PR TITLE
perf(fuse): optimize Linux mount options inspired by rclone

### DIFF
--- a/internal/fuse/vfs/file.go
+++ b/internal/fuse/vfs/file.go
@@ -18,7 +18,7 @@ var noopFetchGroup singleflight.Group
 
 var fetchBufPool = sync.Pool{
 	New: func() any {
-		buf := make([]byte, 256*1024) // 256KB default
+		buf := make([]byte, 1024*1024) // 1MB — fewer pool ops per chunk fetch
 		return &buf
 	},
 }


### PR DESCRIPTION
## Summary

- **DisableReadDirPlus**: Prevents kernel READDIRPLUS which does per-entry stat calls on directory listings, making `ls` faster for directories with many files
- **DirectMount**: Calls `mount(2)` syscall directly instead of going through `fusermount` helper binary on Linux (auto-falls back if it fails)
- **MaxBackground 64**: Increases concurrent async I/O requests from kernel default of 12, keeping more I/O in flight for prefetch pipelines
- **Default MaxReadAhead 128KB**: Sets a sensible default when unconfigured (matches rclone)
- **1MB fetch buffer pool**: Reduces allocation churn during chunk fetches (was 256KB, now matches rclone's buffer size)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/fuse/...` passes
- [ ] Test FUSE mount on Linux environment to verify speed improvements
- [ ] Verify DirectMount falls back gracefully in unprivileged containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)