### PR TITLE
perf(usenet): lazy on-demand segment loading

### DIFF
--- a/internal/usenet/range_test.go
+++ b/internal/usenet/range_test.go
@@ -281,3 +281,329 @@ func TestGetSegmentsInRangeFromIndex_LargeSkip(t *testing.T) {
 		t.Fatalf("length mismatch got %d want 1000", collectedLen(rg))
 	}
 }
+
+// collectedLenLazy reads all segments lazily via GetSegment() and sums their byte ranges.
+func collectedLenLazy(r *segmentRange) int64 {
+	var total int64
+	for i := range r.segments {
+		s, err := r.GetSegment(i)
+		if err != nil || s == nil {
+			continue
+		}
+		total += (s.End - s.Start + 1)
+	}
+	return total
+}
+
+func TestNewLazySegmentRange_FullCoverage(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}}}
+
+	rg := NewLazySegmentRange(context.Background(), 0, 19, loader, 0, 0, 1, 10)
+
+	if rg.Len() != 2 {
+		t.Fatalf("expected 2 segments, got %d", rg.Len())
+	}
+	if !rg.HasSegments() {
+		t.Fatal("expected HasSegments to be true")
+	}
+
+	s0, err := rg.GetSegment(0)
+	if err != nil {
+		t.Fatalf("GetSegment(0) error: %v", err)
+	}
+	if s0.Id != "s1" || s0.Start != 0 || s0.End != 9 {
+		t.Fatalf("unexpected segment 0: id=%s start=%d end=%d", s0.Id, s0.Start, s0.End)
+	}
+
+	s1, err := rg.GetSegment(1)
+	if err != nil {
+		t.Fatalf("GetSegment(1) error: %v", err)
+	}
+	if s1.Id != "s2" || s1.Start != 0 || s1.End != 9 {
+		t.Fatalf("unexpected segment 1: id=%s start=%d end=%d", s1.Id, s1.Start, s1.End)
+	}
+
+	if collectedLenLazy(rg) != 20 {
+		t.Fatalf("length mismatch got %d want 20", collectedLenLazy(rg))
+	}
+}
+
+func TestNewLazySegmentRange_PartialFirstAndLast(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+		{Id: "s3", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}, {}}}
+
+	// Request bytes 5..24 (length 20), spans all 3 segments.
+	// startSegIdx=0 (filePos=0), endSegIdx=2 (filePos=20)
+	rg := NewLazySegmentRange(context.Background(), 5, 24, loader, 0, 0, 2, 20)
+
+	if rg.Len() != 3 {
+		t.Fatalf("expected 3 segments, got %d", rg.Len())
+	}
+
+	s0, _ := rg.GetSegment(0)
+	if s0.Start != 5 || s0.End != 9 {
+		t.Fatalf("unexpected first segment trimmed bounds: %d-%d", s0.Start, s0.End)
+	}
+
+	s1, _ := rg.GetSegment(1)
+	if s1.Start != 0 || s1.End != 9 {
+		t.Fatalf("unexpected middle segment bounds: %d-%d", s1.Start, s1.End)
+	}
+
+	s2, _ := rg.GetSegment(2)
+	if s2.Start != 0 || s2.End != 4 {
+		t.Fatalf("unexpected last segment trimmed bounds: %d-%d", s2.Start, s2.End)
+	}
+
+	if collectedLenLazy(rg) != 20 {
+		t.Fatalf("length mismatch got %d want 20", collectedLenLazy(rg))
+	}
+}
+
+func TestNewLazySegmentRange_SingleSegmentTrimmed(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 99, Size: 100},
+	}, groups: [][]string{{}}}
+
+	// Request bytes 10..49 from a single segment (startSeg == endSeg).
+	rg := NewLazySegmentRange(context.Background(), 10, 49, loader, 0, 0, 0, 0)
+
+	if rg.Len() != 1 {
+		t.Fatalf("expected 1 segment, got %d", rg.Len())
+	}
+
+	s0, _ := rg.GetSegment(0)
+	if s0.Start != 10 || s0.End != 49 {
+		t.Fatalf("unexpected bounds: %d-%d", s0.Start, s0.End)
+	}
+
+	if collectedLenLazy(rg) != 40 {
+		t.Fatalf("length mismatch got %d want 40", collectedLenLazy(rg))
+	}
+}
+
+func TestNewLazySegmentRange_InternalStartOffset(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 2, End: 9, Size: 10}, // usable 8 bytes -> file 0..7
+		{Id: "s2", Start: 1, End: 8, Size: 9},  // usable 8 bytes -> file 8..15
+	}, groups: [][]string{{}, {}}}
+
+	// Request bytes 3..12 (length 10).
+	// startSegIdx=0, startFilePos=0, endSegIdx=1, endFilePos=8
+	rg := NewLazySegmentRange(context.Background(), 3, 12, loader, 0, 0, 1, 8)
+
+	if rg.Len() != 2 {
+		t.Fatalf("expected 2 segments, got %d", rg.Len())
+	}
+
+	s0, _ := rg.GetSegment(0)
+	// file offset 3 -> 3 into first segment's usable (base 0) -> physical 2+3=5
+	if s0.Start != 5 || s0.End != 9 {
+		t.Fatalf("unexpected first segment bounds: %d-%d", s0.Start, s0.End)
+	}
+
+	s1, _ := rg.GetSegment(1)
+	// file offset 12 -> last segment covers file 8..15, need 8..12 -> physical 1..5
+	if s1.Start != 1 || s1.End != 5 {
+		t.Fatalf("unexpected second segment bounds: %d-%d", s1.Start, s1.End)
+	}
+
+	if collectedLenLazy(rg) != 10 {
+		t.Fatalf("length mismatch got %d want 10", collectedLenLazy(rg))
+	}
+}
+
+func TestNewLazySegmentRange_EquivalentToEager(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+		{Id: "s3", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}, {}}}
+
+	eager := GetSegmentsInRangeFromIndex(context.Background(), 5, 24, loader, 0, 0)
+	lazy := NewLazySegmentRange(context.Background(), 5, 24, loader, 0, 0, 2, 20)
+
+	if eager.Len() != lazy.Len() {
+		t.Fatalf("segment count mismatch: eager=%d lazy=%d", eager.Len(), lazy.Len())
+	}
+
+	for i := 0; i < eager.Len(); i++ {
+		e := eager.segments[i]
+		l, err := lazy.GetSegment(i)
+		if err != nil {
+			t.Fatalf("lazy GetSegment(%d) error: %v", i, err)
+		}
+		if e.Id != l.Id || e.Start != l.Start || e.End != l.End || e.SegmentSize != l.SegmentSize {
+			t.Fatalf("segment %d mismatch: eager{%s %d-%d size=%d} lazy{%s %d-%d size=%d}",
+				i, e.Id, e.Start, e.End, e.SegmentSize, l.Id, l.Start, l.End, l.SegmentSize)
+		}
+	}
+}
+
+func TestNewLazySegmentRange_InvalidInputs(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}}}
+
+	// Negative start
+	rg := NewLazySegmentRange(context.Background(), -1, 9, loader, 0, 0, 0, 0)
+	if rg.HasSegments() {
+		t.Fatal("expected no segments for negative start")
+	}
+
+	// end < start
+	rg = NewLazySegmentRange(context.Background(), 10, 5, loader, 0, 0, 0, 0)
+	if rg.HasSegments() {
+		t.Fatal("expected no segments for end < start")
+	}
+
+	// endSegIdx < startSegIdx
+	rg = NewLazySegmentRange(context.Background(), 0, 9, loader, 5, 0, 3, 0)
+	if rg.HasSegments() {
+		t.Fatal("expected no segments for endSegIdx < startSegIdx")
+	}
+}
+
+func TestNewLazySegmentRange_GetAndNext(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+		{Id: "s3", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}, {}}}
+
+	rg := NewLazySegmentRange(context.Background(), 0, 29, loader, 0, 0, 2, 20)
+
+	// Get() should return first segment via lazy creation
+	s, err := rg.Get()
+	if err != nil || s.Id != "s1" {
+		t.Fatalf("Get() expected s1, got %v err=%v", s, err)
+	}
+
+	// Next() should advance and return second segment
+	s, err = rg.Next()
+	if err != nil || s.Id != "s2" {
+		t.Fatalf("Next() expected s2, got %v err=%v", s, err)
+	}
+
+	// Next() again should return third segment
+	s, err = rg.Next()
+	if err != nil || s.Id != "s3" {
+		t.Fatalf("Next() expected s3, got %v err=%v", s, err)
+	}
+
+	// Next() past end should return error
+	_, err = rg.Next()
+	if err == nil {
+		t.Fatal("expected error after last segment")
+	}
+}
+
+func TestNewLazySegmentRange_LargeSegmentCount(t *testing.T) {
+	const numSegments = 100_000
+	const segmentSize = 750
+	segments := make([]Segment, numSegments)
+	groups := make([][]string, numSegments)
+	for i := range segments {
+		segments[i] = Segment{Id: "seg", Start: 0, End: segmentSize - 1, Size: segmentSize}
+		groups[i] = []string{}
+	}
+	loader := &mockLoader{segments: segments, groups: groups}
+
+	totalSize := int64(numSegments * segmentSize)
+	lastSegFilePos := int64((numSegments - 1) * segmentSize)
+
+	rg := NewLazySegmentRange(context.Background(), 0, totalSize-1, loader, 0, 0, numSegments-1, lastSegFilePos)
+
+	if rg.Len() != numSegments {
+		t.Fatalf("expected %d segments, got %d", numSegments, rg.Len())
+	}
+
+	// Verify first and last segments are correct
+	first, _ := rg.GetSegment(0)
+	if first.Start != 0 || first.End != segmentSize-1 {
+		t.Fatalf("unexpected first segment: %d-%d", first.Start, first.End)
+	}
+	last, _ := rg.GetSegment(numSegments - 1)
+	if last.Start != 0 || last.End != segmentSize-1 {
+		t.Fatalf("unexpected last segment: %d-%d", last.Start, last.End)
+	}
+
+	// Verify a middle segment
+	mid, _ := rg.GetSegment(50000)
+	if mid.Start != 0 || mid.End != segmentSize-1 {
+		t.Fatalf("unexpected middle segment: %d-%d", mid.Start, mid.End)
+	}
+}
+
+func TestBuildSegmentRange_ChoosesLazyWhenIndexAvailable(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}}}
+
+	// Provide valid endSegIdx (>= 0) -> should use lazy path
+	rg := BuildSegmentRange(context.Background(), 0, 19, loader, 0, 0, 1, 10)
+	if rg.Len() != 2 {
+		t.Fatalf("expected 2 segments, got %d", rg.Len())
+	}
+	// Verify lazy: loader field should be set
+	if rg.loader == nil {
+		t.Fatal("expected lazy range (loader != nil)")
+	}
+}
+
+func TestBuildSegmentRange_FallsBackToEager(t *testing.T) {
+	loader := &mockLoader{segments: []Segment{
+		{Id: "s1", Start: 0, End: 9, Size: 10},
+		{Id: "s2", Start: 0, End: 9, Size: 10},
+	}, groups: [][]string{{}, {}}}
+
+	// Provide endSegIdx = -1 -> should fall back to eager
+	rg := BuildSegmentRange(context.Background(), 0, 19, loader, 0, 0, -1, 0)
+	if rg.Len() != 2 {
+		t.Fatalf("expected 2 segments, got %d", rg.Len())
+	}
+	// Verify eager: loader field should be nil
+	if rg.loader != nil {
+		t.Fatal("expected eager range (loader == nil)")
+	}
+}
+
+func TestNewLazySegmentRange_SkipToMiddle(t *testing.T) {
+	const numSegments = 10
+	segments := make([]Segment, numSegments)
+	groups := make([][]string, numSegments)
+	for i := range segments {
+		segments[i] = Segment{Id: string(rune('a' + i)), Start: 0, End: 9, Size: 10}
+		groups[i] = []string{}
+	}
+	loader := &mockLoader{segments: segments, groups: groups}
+
+	// Request bytes 55-64 starting from segment 5 (file offset 50).
+	// startSegIdx=5, startFilePos=50, endSegIdx=6, endFilePos=60
+	rg := NewLazySegmentRange(context.Background(), 55, 64, loader, 5, 50, 6, 60)
+
+	if rg.Len() != 2 {
+		t.Fatalf("expected 2 segments, got %d", rg.Len())
+	}
+
+	s0, _ := rg.GetSegment(0)
+	if s0.Id != "f" || s0.Start != 5 || s0.End != 9 {
+		t.Fatalf("unexpected first segment: id=%s start=%d end=%d", s0.Id, s0.Start, s0.End)
+	}
+
+	s1, _ := rg.GetSegment(1)
+	if s1.Id != "g" || s1.Start != 0 || s1.End != 4 {
+		t.Fatalf("unexpected second segment: id=%s start=%d end=%d", s1.Id, s1.Start, s1.End)
+	}
+
+	if collectedLenLazy(rg) != 10 {
+		t.Fatalf("length mismatch got %d want 10", collectedLenLazy(rg))
+	}
+}


### PR DESCRIPTION
## Summary

- **Defer `buildSegmentIndex`**: Moved the O(n) segment offset index build from `OpenFile` to `createUsenetReader`, protected by `sync.Once`. Files that are only stat'd or listed never pay the index cost.
- **Lazy `segmentRange`**: `segmentRange` now supports a `SegmentLoader` + index metadata and creates `*segment` objects on demand (`createSegmentLocked`) instead of eagerly iterating all segments upfront via `GetSegmentsInRangeFromIndex`.
- **Direct `NewLazySegmentRange`**: `createUsenetReader` now calls `NewLazySegmentRange` directly (O(1) init) instead of routing through `BuildSegmentRange`, since the segment index is always available at read time.

## Performance Impact

| Stage | Before | After |
|-------|--------|-------|
| `OpenFile` | O(n) index build over all segments | O(1) |
| First read | O(1) (index pre-built) | O(n) index build + O(log n) lookup |
| Subsequent reads | O(log n) binary search | O(log n) binary search |
| `segmentRange` init | O(N) eager segment creation | O(1) slot allocation |
| Per-segment object creation | Upfront | On demand as downloader advances |

Files only accessed via stat/readdir/metadata operations pay zero segment processing cost.