### PR TITLE
fix(health,importer): skip rclone VFS notifications for FUSE/none mounts

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -211,6 +211,15 @@ func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
 		return // No rclone client configured
 	}
 
+	// Only notify for rclone-based mounts; FUSE and none don't use rclone VFS
+	cfg := hc.configGetter()
+	switch cfg.MountType {
+	case config.MountTypeRClone, config.MountTypeRCloneExternal:
+		// continue
+	default:
+		return
+	}
+
 	// Only notify on significant status changes (healthy <-> corrupted)
 	switch event.Type {
 	case EventTypeFileHealthy, EventTypeFileCorrupted:
@@ -229,7 +238,6 @@ func (hc *HealthChecker) notifyRcloneVFS(filePath string, event HealthEvent) {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
-		cfg := hc.configGetter()
 		vfsName := cfg.RClone.VFSName
 		if vfsName == "" {
 			vfsName = config.MountProvider

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -17,6 +17,14 @@ func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async
 		return
 	}
 
+	// Only notify for rclone-based mounts; FUSE and none don't use rclone VFS
+	switch c.configGetter().MountType {
+	case config.MountTypeRClone, config.MountTypeRCloneExternal:
+		// continue
+	default:
+		return
+	}
+
 	refreshFunc := func(path string) {
 		refreshCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()
@@ -71,6 +79,14 @@ func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async
 // RefreshMountPathIfNeeded refreshes the mount path cache if required
 func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64) {
 	if c.rcloneClient == nil {
+		return
+	}
+
+	// Only notify for rclone-based mounts; FUSE and none don't use rclone VFS
+	switch c.configGetter().MountType {
+	case config.MountTypeRClone, config.MountTypeRCloneExternal:
+		// continue
+	default:
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Add mount type guard in `notifyRcloneVFS` (`internal/health/checker.go`) to return early when `mount_type` is not `rclone` or `rclone_external`
- Add the same guard in `NotifyVFS` and `RefreshMountPathIfNeeded` (`internal/importer/postprocessor/vfs_notifier.go`)
- Hoist `cfg := hc.configGetter()` call in `notifyRcloneVFS` to avoid a redundant second call inside the goroutine

## Problem

When using `mount_type: fuse`, the app still attempted to notify rclone VFS after health checks, producing repeated errors:

```
Failed to notify rclone VFS about file status change
file=complete/sonarr/... event=file_healthy err="provider altmount not mounted"
```

The rclone client was non-nil from a prior configuration (or initial wiring) but no rclone provider was registered, causing every RC call to fail.

## Test plan

- [ ] Start with `mount_type: fuse` — no "Failed to notify rclone VFS" errors in logs
- [ ] Start with `mount_type: rclone` — VFS refresh calls still happen (no regression)
- [ ] Start with `mount_type: rclone_external` — VFS refresh calls still happen
- [ ] Switch from rclone → fuse via config reload — notifications stop without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)