### PR TITLE
fix(ui): require save button for provider reorder and extend cache size range

### DIFF
--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -192,7 +192,7 @@ export function StreamingConfigSection({
 						<input
 							type="range"
 							min="1"
-							max="200"
+							max="1000"
 							value={cacheData.max_size_gb}
 							step="1"
 							className="range range-primary range-sm w-full [&::-webkit-slider-runnable-track]:rounded-full"
@@ -203,10 +203,10 @@ export function StreamingConfigSection({
 						/>
 						<div className="flex justify-between px-2 font-black text-base-content/50 text-xs">
 							<span>1</span>
-							<span>50</span>
-							<span>100</span>
-							<span>150</span>
-							<span>200</span>
+							<span>250</span>
+							<span>500</span>
+							<span>750</span>
+							<span>1000</span>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- **Provider reorder now requires Save**: Drag-and-drop sorting previously auto-saved to the backend immediately. It now updates local state only and shows the "Unsaved Changes" banner, requiring the user to click Save Changes — consistent with toggling enabled/disabled or editing other provider fields.
- **Fix index bug**: `handleDrop` was looking up indices in `config.providers` but splicing from `formData`, which could produce wrong results after multiple reorders without saving. Now uses `formData` indices consistently.
- **Remove reordering overlay**: The "Reordering…" loading overlay and disabled-drag guards are no longer needed since the save is deferred.
- **Extend cache size slider**: Max `max_size_gb` increased from 200 → 1000 GB with updated tick marks (250 / 500 / 750 / 1000).

## Test plan

- [ ] Drag providers to reorder — "Unsaved Changes" banner appears, no API call fired
- [ ] Click Save Changes — order is persisted correctly
- [ ] Toggle provider enabled/disabled — still shows unsaved changes and saves on button click
- [ ] Discard changes by navigating away and back — order reverts to saved state
- [ ] Cache size slider goes up to 1000 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)