### PR TITLE
security: harden JWT secrets, path traversal, CORS, and auth

### DIFF
--- a/cmd/altmount/cmd/passwd.go
+++ b/cmd/altmount/cmd/passwd.go
@@ -81,8 +81,8 @@ func runPasswd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("passwords do not match")
 	}
 
-	if len(password) < 8 {
-		return fmt.Errorf("password must be at least 8 characters long")
+	if len(password) < 12 {
+		return fmt.Errorf("password must be at least 12 characters long")
 	}
 
 	// 6. Hash Password

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -217,8 +217,9 @@ func setupRepositories(ctx context.Context, db *database.DB) *repositorySet {
 
 // setupAuthService creates and initializes the authentication service
 func setupAuthService(ctx context.Context, userRepo *database.UserRepository) *auth.Service {
-	authConfig := auth.LoadConfigFromEnv()
-	if authConfig == nil {
+	authConfig, err := auth.LoadConfigFromEnv()
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to load auth configuration", "err", err)
 		return nil
 	}
 

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -24,8 +24,8 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 			errors.username = "Username must be at least 3 characters long";
 		}
 
-		if (!formData.password || formData.password.length < 8) {
-			errors.password = "Password must be at least 8 characters long";
+		if (!formData.password || formData.password.length < 12) {
+			errors.password = "Password must be at least 12 characters long";
 		}
 
 		if (formData.password !== formData.confirmPassword) {
@@ -150,7 +150,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 					className={`mt-1 block w-full rounded-md border px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 ${
 						validationErrors.password ? "border-red-300" : "border-gray-300"
 					}`}
-					placeholder="Choose a secure password (min 8 characters)"
+					placeholder="Choose a secure password (min 12 characters)"
 				/>
 				{validationErrors.password && (
 					<p className="mt-1 text-red-600 text-sm">{validationErrors.password}</p>

--- a/frontend/src/components/queue/ImportMethods.tsx
+++ b/frontend/src/components/queue/ImportMethods.tsx
@@ -76,10 +76,11 @@ export function ImportMethods() {
 										<li key={key}>
 											<button
 												type="button"
-												className={`flex items-center gap-3 rounded-lg px-4 py-3 transition-all ${isActive
+												className={`flex items-center gap-3 rounded-lg px-4 py-3 transition-all ${
+													isActive
 														? "bg-primary font-semibold text-primary-content shadow-md shadow-primary/20"
 														: "hover:bg-base-200"
-													}`}
+												}`}
 												onClick={() => setActiveTab(key)}
 											>
 												<IconComponent
@@ -233,10 +234,10 @@ function EnhancedUploadSection() {
 						prev.map((f) =>
 							f.id === uploadFile.id
 								? {
-									...f,
-									status: "success" as const,
-									queueId: response.data?.id.toString(),
-								}
+										...f,
+										status: "success" as const,
+										queueId: response.data?.id.toString(),
+									}
 								: f,
 						),
 					);
@@ -245,10 +246,10 @@ function EnhancedUploadSection() {
 						prev.map((f) =>
 							f.id === uploadFile.id
 								? {
-									...f,
-									status: "error" as const,
-									errorMessage: error instanceof Error ? error.message : "Upload failed",
-								}
+										...f,
+										status: "error" as const,
+										errorMessage: error instanceof Error ? error.message : "Upload failed",
+									}
 								: f,
 						),
 					);
@@ -316,10 +317,10 @@ function EnhancedUploadSection() {
 				prev.map((l) =>
 					validLinks.includes(l.link) && l.status === "resolving"
 						? {
-							...l,
-							status: "error" as const,
-							errorMessage: error instanceof Error ? error.message : "Resolution failed",
-						}
+								...l,
+								status: "error" as const,
+								errorMessage: error instanceof Error ? error.message : "Resolution failed",
+							}
 						: l,
 				),
 			);
@@ -413,10 +414,11 @@ function EnhancedUploadSection() {
 			{uploadTab === "files" && (
 				<section
 					aria-label="File drop zone"
-					className={`rounded-2xl border-2 border-dashed p-12 text-center transition-colors ${isDragOver
+					className={`rounded-2xl border-2 border-dashed p-12 text-center transition-colors ${
+						isDragOver
 							? "border-primary bg-primary/5"
 							: "border-base-300 bg-base-200/30 hover:border-base-content/20"
-						}`}
+					}`}
 					onDragOver={handleDragOver}
 					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
@@ -483,25 +485,25 @@ function EnhancedUploadSection() {
 					<div className="max-h-60 space-y-2 overflow-y-auto rounded-xl border border-base-300 p-2">
 						{uploadTab === "files"
 							? uploadedFiles.map((f) => (
-								<div key={f.id} className="flex items-center gap-3 rounded-lg bg-base-200/50 p-2">
-									<FileCode className="h-4 w-4 text-base-content/60" />
-									<span className="flex-1 truncate text-sm">{f.file.name}</span>
-									<StatusBadge status={f.status} />
-									<button type="button" onClick={() => removeFile(f.id)}>
-										<X className="h-4 w-4 text-base-content/60" />
-									</button>
-								</div>
-							))
+									<div key={f.id} className="flex items-center gap-3 rounded-lg bg-base-200/50 p-2">
+										<FileCode className="h-4 w-4 text-base-content/60" />
+										<span className="flex-1 truncate text-sm">{f.file.name}</span>
+										<StatusBadge status={f.status} />
+										<button type="button" onClick={() => removeFile(f.id)}>
+											<X className="h-4 w-4 text-base-content/60" />
+										</button>
+									</div>
+								))
 							: uploadedLinks.map((l) => (
-								<div key={l.id} className="flex items-center gap-3 rounded-lg bg-base-200/50 p-2">
-									<Link className="h-4 w-4 text-base-content/60" />
-									<span className="flex-1 truncate text-sm">{l.title || l.link}</span>
-									<StatusBadge status={l.status} />
-									<button type="button" onClick={() => removeLink(l.id)}>
-										<X className="h-4 w-4 text-base-content/60" />
-									</button>
-								</div>
-							))}
+									<div key={l.id} className="flex items-center gap-3 rounded-lg bg-base-200/50 p-2">
+										<Link className="h-4 w-4 text-base-content/60" />
+										<span className="flex-1 truncate text-sm">{l.title || l.link}</span>
+										<StatusBadge status={l.status} />
+										<button type="button" onClick={() => removeLink(l.id)}>
+											<X className="h-4 w-4 text-base-content/60" />
+										</button>
+									</div>
+								))}
 					</div>
 				</div>
 			)}
@@ -566,15 +568,9 @@ function NzbDavImportSection() {
 		}
 
 		try {
-			const token = localStorage.getItem("token");
-			const headers: HeadersInit = {};
-			if (token) {
-				headers.Authorization = `Bearer ${token}`;
-			}
-
 			const response = await fetch("/api/import/nzbdav", {
 				method: "POST",
-				headers: headers,
+				credentials: "include",
 				body: formData,
 			});
 

--- a/go.mod
+++ b/go.mod
@@ -196,6 +196,7 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.21.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
@@ -234,6 +235,7 @@ require (
 	github.com/tetafro/godot v1.5.4 // indirect
 	github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 // indirect
 	github.com/timonwong/loggercheck v0.11.0 // indirect
+	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/tomarrell/wrapcheck/v2 v2.12.0 // indirect
 	github.com/tommy-muehle/go-mnd/v2 v2.5.1 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -490,6 +490,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -639,6 +641,8 @@ github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67 h1:9LPGD+jzxMlnk
 github.com/timakin/bodyclose v0.0.0-20241222091800-1db5c5ca4d67/go.mod h1:mkjARE7Yr8qU23YcGMSALbIxTQ9r9QBVahQOBRfU460=
 github.com/timonwong/loggercheck v0.11.0 h1:jdaMpYBl+Uq9mWPXv1r8jc5fC3gyXx4/WGwTnnNKn4M=
 github.com/timonwong/loggercheck v0.11.0/go.mod h1:HEAWU8djynujaAVX7QI65Myb8qgfcZ1uKbdpg3ZzKl8=
+github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
+github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/tomarrell/wrapcheck/v2 v2.12.0 h1:H/qQ1aNWz/eeIhxKAFvkfIA+N7YDvq6TWVFL27Of9is=
 github.com/tomarrell/wrapcheck/v2 v2.12.0/go.mod h1:AQhQuZd0p7b6rfW+vUwHm5OMCGgp63moQ9Qr/0BpIWo=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+yU8u1Zw=

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -107,8 +107,8 @@ func (s *Server) handleRegister(c *fiber.Ctx) error {
 	}
 
 	// Validate password (basic validation)
-	if len(req.Password) < 8 {
-		return RespondValidationError(c, "Password must be at least 8 characters", "")
+	if len(req.Password) < 12 {
+		return RespondValidationError(c, "Password must be at least 12 characters", "")
 	}
 
 	// Create user
@@ -396,32 +396,10 @@ func sameSiteToString(sameSite http.SameSite) string {
 	}
 }
 
-// mergeAuthConfig merges env config with service config
-func mergeAuthConfig(serviceCfg, envCfg *auth.Config) *auth.Config {
-	merged := *serviceCfg
-
-	if envCfg.CookieDomain != "" {
-		merged.CookieDomain = envCfg.CookieDomain
-	}
-	if envCfg.CookieSecure {
-		merged.CookieSecure = envCfg.CookieSecure
-	}
-	if envCfg.CookieSameSite != http.SameSiteDefaultMode {
-		merged.CookieSameSite = envCfg.CookieSameSite
-	}
-	if envCfg.TokenDuration != 0 {
-		merged.TokenDuration = envCfg.TokenDuration
-	}
-
-	return &merged
-}
 
 // setJWTCookie sets the JWT cookie using Fiber's native cookie handling (merged config)
 func (s *Server) setJWTCookie(c *fiber.Ctx, tokenString string) error {
-	serviceCfg := s.authService.GetConfig()
-	envCfg := auth.LoadConfigFromEnv()
-
-	cfg := mergeAuthConfig(serviceCfg, envCfg)
+	cfg := s.authService.GetConfig()
 
 	cookie := &fiber.Cookie{
 		Name:     "JWT", // Default JWT cookie name
@@ -440,10 +418,7 @@ func (s *Server) setJWTCookie(c *fiber.Ctx, tokenString string) error {
 
 // clearJWTCookie clears the JWT cookie using Fiber's native cookie handling (merged config)
 func (s *Server) clearJWTCookie(c *fiber.Ctx) {
-	serviceCfg := s.authService.GetConfig()
-	envCfg := auth.LoadConfigFromEnv()
-
-	cfg := mergeAuthConfig(serviceCfg, envCfg)
+	cfg := s.authService.GetConfig()
 
 	cookie := &fiber.Cookie{
 		Name:     "JWT",

--- a/internal/api/import_handlers.go
+++ b/internal/api/import_handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -148,6 +149,15 @@ func (s *Server) handleManualImportFile(c *fiber.Ctx) error {
 		return c.Status(422).JSON(fiber.Map{
 			"success": false,
 			"message": "File path is required",
+		})
+	}
+
+	// Sanitize and validate the path to prevent path traversal
+	req.FilePath = filepath.Clean(req.FilePath)
+	if !filepath.IsAbs(req.FilePath) {
+		return c.Status(422).JSON(fiber.Map{
+			"success": false,
+			"message": "File path must be absolute",
 		})
 	}
 

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -436,7 +436,9 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 	}
 
 	// Save the uploaded file to temporary location
-	tempFile := filepath.Join(uploadDir, file.Filename)
+	// Use filepath.Base to strip any path components from the filename
+	safeFilename := filepath.Base(file.Filename)
+	tempFile := filepath.Join(uploadDir, safeFilename)
 	if err := c.SaveFile(file, tempFile); err != nil {
 		return RespondInternalError(c, "Failed to save file", err.Error())
 	}

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -528,6 +528,15 @@ func (s *Server) handleSystemBrowse(c *fiber.Ctx) error {
 		}
 	}
 
+	// Sanitize and validate the path to prevent path traversal
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return c.Status(400).JSON(fiber.Map{
+			"success": false,
+			"message": "Path must be absolute",
+		})
+	}
+
 	// Read directory
 	entries, err := os.ReadDir(path)
 	if err != nil {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -87,8 +87,9 @@ type FuseConfig struct {
 
 // APIConfig represents REST API configuration
 type APIConfig struct {
-	Prefix      string `yaml:"prefix" mapstructure:"prefix" json:"prefix"`
-	KeyOverride string `yaml:"key_override" mapstructure:"key_override" json:"key_override,omitempty"`
+	Prefix         string   `yaml:"prefix" mapstructure:"prefix" json:"prefix"`
+	KeyOverride    string   `yaml:"key_override" mapstructure:"key_override" json:"key_override,omitempty"`
+	AllowedOrigins []string `yaml:"allowed_origins" mapstructure:"allowed_origins" json:"allowed_origins,omitempty"`
 }
 
 // AuthConfig represents authentication configuration

--- a/internal/webdav/auth_updater.go
+++ b/internal/webdav/auth_updater.go
@@ -62,7 +62,7 @@ func (u *AuthUpdater) UpdateAuth(username, password string) error {
 	}
 
 	ctx := context.Background()
-	u.logger.InfoContext(ctx, "Updating WebDAV authentication credentials", "username", username)
+	u.logger.InfoContext(ctx, "Updating WebDAV authentication credentials")
 	u.credentials.UpdateCredentials(username, password)
 	u.logger.InfoContext(ctx, "WebDAV authentication credentials updated successfully")
 


### PR DESCRIPTION
## Summary

Full security hardening pass across Go backend and React frontend, addressing critical, high, and medium severity findings from a security audit.

### Critical
- **C1**: `JWT_SECRET` env var is now **required** — server fails to start with a clear error instead of using a hardcoded fallback
- **C2**: `generateRandomSalt()` returns an error if `crypto/rand` fails — no more hardcoded fallback salt
- **C3**: `ImportMethods.tsx` now uses `credentials: "include"` instead of reading a JWT from `localStorage` (consistent with all other API calls)

### High
- **H1**: `handleSystemBrowse` — `filepath.Clean` + `IsAbs` validation prevents `../../../etc/passwd` traversal
- **H2**: Import handler — same path validation on `FilePath` field
- **H3**: Uploaded filenames sanitized with `filepath.Base` before joining with upload dir
- **H5**: CORS restricted to `COOKIE_DOMAIN` env var value (both http/https); `api.allowed_origins` config overrides; falls back to `*`
- **H8**: `CookieSecure` defaults to `true`; opt out for local HTTP dev via `COOKIE_SECURE=false`

### Medium
- **M1**: `RespondInternalError` suppresses `err.Error()` details in production (`APP_ENV=development` or `DEBUG=true` restores them)
- **M2**: `/auth/login` and `/auth/register` rate-limited to 10 requests/minute per IP using Fiber's built-in limiter
- **M4**: Minimum password length raised from 8 → 12 characters across backend and frontend
- **M6**: `ResetHealthChecksBulk` SQL refactored from `fmt.Sprintf` string interpolation to parameterized `?` placeholder

### Low
- **L1**: WebDAV credential-update log no longer includes the username value