### PR TITLE
feat(auth): align auth pages with DaisyUI theme + harden JWT secret handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ services:
       - PUID=1000
       - PGID=1000
       - PORT=8080
+      - JWT_SECRET=change-me-to-a-strong-random-secret # Required when login is enabled (auth.login_required: true)
       - COOKIE_DOMAIN=localhost # Must match the domain/IP where web interface is accessed
     volumes:
       - ./config:/config

--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -135,7 +135,12 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	// 6. Setup web services
 	app, debugMode := createFiberApp(ctx, cfg)
-	authService := setupAuthService(ctx, repos.UserRepo)
+	loginRequired := cfg.Auth.LoginRequired != nil && *cfg.Auth.LoginRequired
+	authService, err := setupAuthService(ctx, repos.UserRepo, loginRequired)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to initialize authentication service", "err", err)
+		return err
+	}
 
 	streamTracker.StartCleanup(ctx) // Periodic cleanup of stale streams
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,6 +10,7 @@ services:
       - PUID=1000
       - PGID=1000
       - PORT=8080
+      - JWT_SECRET=change-me-to-a-strong-random-secret # Required when login is enabled (auth.login_required: true)
       - COOKIE_DOMAIN=localhost # Must match the domain/IP where web interface is accessed
     volumes:
       - ./config:/config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - PUID=1000
       - PGID=1000
       - PORT=8080
+      - JWT_SECRET=change-me-to-a-strong-random-secret # Required when login is enabled (auth.login_required: true)
       - COOKIE_DOMAIN=localhost # Must match the domain/IP where web interface is accessed
     volumes:
       - ./config:/config

--- a/docs/docs/1. intro.md
+++ b/docs/docs/1. intro.md
@@ -29,6 +29,7 @@ services:
       - PUID=1000
       - PGID=1000
       - PORT=8080
+      - JWT_SECRET=change-me-to-a-strong-random-secret # Required: used to sign JWT tokens
       - COOKIE_DOMAIN=localhost
     volumes:
       - ./config:/config
@@ -51,6 +52,8 @@ mkdir -p ./config/metadata
 docker-compose up -d
 ```
 
+> `JWT_SECRET` is **required when login is enabled** (`auth.login_required: true` in your config). Set it to a strong random string (e.g. `openssl rand -hex 32`). The server will not start without it if login is enabled.
+>
 > Set `COOKIE_DOMAIN` to match how you access the web interface (e.g., `localhost`, `192.168.1.100`, or `altmount.example.com`).
 
 ### 2. Register

--- a/frontend/src/components/auth/DirectLoginForm.tsx
+++ b/frontend/src/components/auth/DirectLoginForm.tsx
@@ -1,3 +1,4 @@
+import { AlertCircle } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { useAuth } from "../../hooks/useAuth";
@@ -34,11 +35,9 @@ export function DirectLoginForm({ onSuccess }: DirectLoginFormProps) {
 	};
 
 	return (
-		<form onSubmit={handleSubmit} className="space-y-6">
-			<div>
-				<label htmlFor="username" className="block font-medium text-gray-700 text-sm">
-					Username or Email
-				</label>
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Username or Email</legend>
 				<input
 					id="username"
 					name="username"
@@ -47,15 +46,13 @@ export function DirectLoginForm({ onSuccess }: DirectLoginFormProps) {
 					required
 					value={formData.username}
 					onChange={handleChange}
-					className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+					className="input w-full"
 					placeholder="Enter your username or email"
 				/>
-			</div>
+			</fieldset>
 
-			<div>
-				<label htmlFor="password" className="block font-medium text-gray-700 text-sm">
-					Password
-				</label>
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Password</legend>
 				<input
 					id="password"
 					name="password"
@@ -64,54 +61,35 @@ export function DirectLoginForm({ onSuccess }: DirectLoginFormProps) {
 					required
 					value={formData.password}
 					onChange={handleChange}
-					className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500"
+					className="input w-full"
 					placeholder="Enter your password"
 				/>
-			</div>
+			</fieldset>
 
 			{error && (
-				<div className="rounded-md bg-red-50 p-4">
-					<div className="flex">
-						<div className="flex-shrink-0">
-							<svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-								<title>Error icon</title>
-								<path
-									fillRule="evenodd"
-									d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-									clipRule="evenodd"
-								/>
-							</svg>
-						</div>
-						<div className="ml-3">
-							<h3 className="font-medium text-red-800 text-sm">Login Failed</h3>
-							<div className="mt-2 text-red-700 text-sm">
-								<p>{error}</p>
-							</div>
-						</div>
+				<div role="alert" className="alert alert-error">
+					<AlertCircle className="h-5 w-5" aria-hidden="true" />
+					<div>
+						<div className="font-medium">Login Failed</div>
+						<div className="text-sm">{error}</div>
 					</div>
 				</div>
 			)}
 
-			<div>
-				<button
-					type="submit"
-					disabled={isLoading || !formData.username || !formData.password}
-					className={`flex w-full justify-center rounded-md border border-transparent px-4 py-2 font-medium text-sm text-white shadow-sm ${
-						isLoading || !formData.username || !formData.password
-							? "cursor-not-allowed bg-gray-400"
-							: "bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-					}`}
-				>
-					{isLoading ? (
-						<div className="flex items-center">
-							<div className="mr-2 h-4 w-4 animate-spin rounded-full border-white border-b-2" />
-							Signing in...
-						</div>
-					) : (
-						"Sign in"
-					)}
-				</button>
-			</div>
+			<button
+				type="submit"
+				disabled={isLoading || !formData.username || !formData.password}
+				className="btn btn-primary w-full"
+			>
+				{isLoading ? (
+					<>
+						<span className="loading loading-spinner loading-sm" />
+						Signing in...
+					</>
+				) : (
+					"Sign in"
+				)}
+			</button>
 		</form>
 	);
 }

--- a/frontend/src/components/auth/LoginPage.tsx
+++ b/frontend/src/components/auth/LoginPage.tsx
@@ -46,21 +46,21 @@ export function LoginPage() {
 
 	if (isLoading) {
 		return (
-			<div className="flex min-h-screen items-center justify-center bg-gray-50">
+			<div className="flex min-h-screen items-center justify-center bg-base-200">
 				<span className="loading loading-spinner loading-lg text-primary" />
 			</div>
 		);
 	}
 
 	return (
-		<div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
+		<div className="flex min-h-screen items-center justify-center bg-base-200 px-4 py-12 sm:px-6 lg:px-8">
 			<div className="flex w-full max-w-md flex-col items-center justify-center space-y-8">
 				<Logo width={48} height={48} />
 				<div className="text-center">
-					<h2 className="mt-6 font-extrabold text-3xl text-gray-900">
+					<h2 className="mt-6 font-extrabold text-3xl text-base-content">
 						{showRegister ? "Create Admin Account" : "Sign in to Altmount"}
 					</h2>
-					<p className="mt-2 text-sm">
+					<p className="mt-2 text-base-content/70 text-sm">
 						{hasConnectionError
 							? "Cannot connect to server - please check your connection"
 							: showRegister
@@ -71,69 +71,75 @@ export function LoginPage() {
 					</p>
 				</div>
 
-				{!hasConnectionError && (userCount === 0 || showRegister) ? (
-					// Registration form (only for first user)
-					<div>
-						<RegisterForm
-							onSuccess={() => {
-								// After successful registration, user will be logged in automatically
-								// The auth context will handle the redirect
-							}}
-						/>
+				<div className="card w-full bg-base-100 shadow-xl">
+					<div className="card-body">
+						{!hasConnectionError && (userCount === 0 || showRegister) ? (
+							// Registration form (only for first user)
+							<div>
+								<RegisterForm
+									onSuccess={() => {
+										// After successful registration, user will be logged in automatically
+										// The auth context will handle the redirect
+									}}
+								/>
 
-						{userCount > 0 && (
-							<div className="mt-4 text-center">
-								<button
-									type="button"
-									onClick={() => setShowRegister(false)}
-									className="text-blue-600 text-sm hover:text-blue-500"
-								>
-									Already have an account? Sign in
-								</button>
+								{userCount > 0 && (
+									<div className="mt-4 text-center">
+										<button
+											type="button"
+											onClick={() => setShowRegister(false)}
+											className="text-primary text-sm hover:text-primary/70"
+										>
+											Already have an account? Sign in
+										</button>
+									</div>
+								)}
+							</div>
+						) : (
+							// Login form (for existing users)
+							<div>
+								<DirectLoginForm
+									onSuccess={() => {
+										// After successful login, user will be redirected automatically
+										// The auth context will handle the redirect
+									}}
+								/>
+
+								{registrationEnabled && (
+									<div className="mt-4 text-center">
+										<button
+											type="button"
+											onClick={() => setShowRegister(true)}
+											className="text-primary text-sm hover:text-primary/70"
+										>
+											Need to create an account? Register
+										</button>
+									</div>
+								)}
 							</div>
 						)}
 					</div>
-				) : (
-					// Login form (for existing users)
-					<div>
-						<DirectLoginForm
-							onSuccess={() => {
-								// After successful login, user will be redirected automatically
-								// The auth context will handle the redirect
-							}}
-						/>
-
-						{registrationEnabled && (
-							<div className="mt-4 text-center">
-								<button
-									type="button"
-									onClick={() => setShowRegister(true)}
-									className="text-blue-600 text-sm hover:text-blue-500"
-								>
-									Need to create an account? Register
-								</button>
-							</div>
-						)}
-					</div>
-				)}
+				</div>
 
 				<div className="text-center text-xs">
 					{hasConnectionError ? (
 						<div className="space-y-2">
-							<p className="text-red-600">Connection to server failed.</p>
+							<p className="text-error">Connection to server failed.</p>
 							<button
 								type="button"
 								onClick={() => window.location.reload()}
-								className="text-blue-600 hover:text-blue-500"
+								className="text-primary hover:text-primary/70"
 							>
 								Retry connection
 							</button>
 						</div>
 					) : (
 						<>
-							<p>By signing in, you agree to use this application responsibly.</p>
+							<p className="text-base-content/70">
+								By signing in, you agree to use this application responsibly.
+							</p>
 							{userCount === 0 && (
-								<p className="mt-1 text-blue-600">
+								<p className="mt-1 text-primary">
 									The first user will automatically receive administrator privileges.
 								</p>
 							)}

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -14,8 +14,8 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
 	// Show loading spinner while checking authentication or loading config
 	if (isLoading || loginRequired === null) {
 		return (
-			<div className="flex min-h-screen items-center justify-center">
-				<div className="h-12 w-12 animate-spin rounded-full border-blue-600 border-b-2" />
+			<div className="flex min-h-screen items-center justify-center bg-base-100">
+				<div className="loading loading-spinner loading-lg" />
 			</div>
 		);
 	}
@@ -34,12 +34,14 @@ export function ProtectedRoute({ children, requireAdmin = false }: ProtectedRout
 	// Show unauthorized message if admin required but user is not admin
 	if (requireAdmin && !isAdmin) {
 		return (
-			<div className="flex min-h-screen items-center justify-center bg-gray-50">
+			<div className="flex min-h-screen items-center justify-center bg-base-100">
 				<div className="w-full max-w-md space-y-4 text-center">
 					<div className="text-6xl">🚫</div>
-					<h2 className="font-bold text-2xl text-gray-900">Access Denied</h2>
-					<p>You need administrator privileges to access this page.</p>
-					<p className="text-sm">
+					<h2 className="font-bold text-2xl text-base-content">Access Denied</h2>
+					<p className="text-base-content/70">
+						You need administrator privileges to access this page.
+					</p>
+					<p className="text-base-content/70 text-sm">
 						Current user: {user?.name} ({user?.provider})
 					</p>
 				</div>

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -1,4 +1,4 @@
-import { User } from "lucide-react";
+import { AlertCircle, User } from "lucide-react";
 import type React from "react";
 import { useState } from "react";
 import { useAuth } from "../../hooks/useAuth";
@@ -75,27 +75,19 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 	};
 
 	return (
-		<form onSubmit={handleSubmit} className="space-y-6">
-			<div className="rounded-md border border-blue-200 bg-blue-50 p-4">
-				<div className="flex">
-					<div className="flex-shrink-0">
-						<User />
-					</div>
-					<div className="ml-3">
-						<h3 className="font-medium text-blue-800 text-sm">First User Registration</h3>
-						<div className="mt-2 text-blue-700 text-sm">
-							<p>
-								You're registering as the first user and will be granted administrator privileges.
-							</p>
-						</div>
+		<form onSubmit={handleSubmit} className="space-y-4">
+			<div role="alert" className="alert alert-info">
+				<User className="h-5 w-5" aria-hidden="true" />
+				<div>
+					<div className="font-medium text-sm">First User Registration</div>
+					<div className="text-sm">
+						You're registering as the first user and will be granted administrator privileges.
 					</div>
 				</div>
 			</div>
 
-			<div>
-				<label htmlFor="username" className="block font-medium text-gray-700 text-sm">
-					Username *
-				</label>
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Username *</legend>
 				<input
 					id="username"
 					name="username"
@@ -104,20 +96,16 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 					required
 					value={formData.username}
 					onChange={handleChange}
-					className={`mt-1 block w-full rounded-md border px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 ${
-						validationErrors.username ? "border-red-300" : "border-gray-300"
-					}`}
+					className={`input w-full ${validationErrors.username ? "input-error" : ""}`}
 					placeholder="Choose a username (min 3 characters)"
 				/>
 				{validationErrors.username && (
-					<p className="mt-1 text-red-600 text-sm">{validationErrors.username}</p>
+					<p className="text-error text-sm">{validationErrors.username}</p>
 				)}
-			</div>
+			</fieldset>
 
-			<div>
-				<label htmlFor="email" className="block font-medium text-gray-700 text-sm">
-					Email (optional)
-				</label>
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Email (optional)</legend>
 				<input
 					id="email"
 					name="email"
@@ -125,20 +113,14 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 					autoComplete="email"
 					value={formData.email}
 					onChange={handleChange}
-					className={`mt-1 block w-full rounded-md border px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 ${
-						validationErrors.email ? "border-red-300" : "border-gray-300"
-					}`}
+					className={`input w-full ${validationErrors.email ? "input-error" : ""}`}
 					placeholder="Enter your email address"
 				/>
-				{validationErrors.email && (
-					<p className="mt-1 text-red-600 text-sm">{validationErrors.email}</p>
-				)}
-			</div>
+				{validationErrors.email && <p className="text-error text-sm">{validationErrors.email}</p>}
+			</fieldset>
 
-			<div>
-				<label htmlFor="password" className="block font-medium text-gray-700 text-sm">
-					Password *
-				</label>
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Password *</legend>
 				<input
 					id="password"
 					name="password"
@@ -147,20 +129,16 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 					required
 					value={formData.password}
 					onChange={handleChange}
-					className={`mt-1 block w-full rounded-md border px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 ${
-						validationErrors.password ? "border-red-300" : "border-gray-300"
-					}`}
+					className={`input w-full ${validationErrors.password ? "input-error" : ""}`}
 					placeholder="Choose a secure password (min 12 characters)"
 				/>
 				{validationErrors.password && (
-					<p className="mt-1 text-red-600 text-sm">{validationErrors.password}</p>
+					<p className="text-error text-sm">{validationErrors.password}</p>
 				)}
-			</div>
+			</fieldset>
 
-			<div>
-				<label htmlFor="confirmPassword" className="block font-medium text-gray-700 text-sm">
-					Confirm Password *
-				</label>
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">Confirm Password *</legend>
 				<input
 					id="confirmPassword"
 					name="confirmPassword"
@@ -169,63 +147,34 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
 					required
 					value={formData.confirmPassword}
 					onChange={handleChange}
-					className={`mt-1 block w-full rounded-md border px-3 py-2 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-blue-500 ${
-						validationErrors.confirmPassword ? "border-red-300" : "border-gray-300"
-					}`}
+					className={`input w-full ${validationErrors.confirmPassword ? "input-error" : ""}`}
 					placeholder="Confirm your password"
 				/>
 				{validationErrors.confirmPassword && (
-					<p className="mt-1 text-red-600 text-sm">{validationErrors.confirmPassword}</p>
+					<p className="text-error text-sm">{validationErrors.confirmPassword}</p>
 				)}
-			</div>
+			</fieldset>
 
 			{error && (
-				<div className="rounded-md bg-red-50 p-4">
-					<div className="flex">
-						<div className="flex-shrink-0">
-							<svg
-								className="h-5 w-5 text-red-400"
-								viewBox="0 0 20 20"
-								fill="currentColor"
-								aria-hidden="true"
-							>
-								<path
-									fillRule="evenodd"
-									d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
-									clipRule="evenodd"
-								/>
-							</svg>
-						</div>
-						<div className="ml-3">
-							<h3 className="font-medium text-red-800 text-sm">Registration Failed</h3>
-							<div className="mt-2 text-red-700 text-sm">
-								<p>{error}</p>
-							</div>
-						</div>
+				<div role="alert" className="alert alert-error">
+					<AlertCircle className="h-5 w-5" aria-hidden="true" />
+					<div>
+						<div className="font-medium">Registration Failed</div>
+						<div className="text-sm">{error}</div>
 					</div>
 				</div>
 			)}
 
-			<div>
-				<button
-					type="submit"
-					disabled={isLoading}
-					className={`flex w-full justify-center rounded-md border border-transparent px-4 py-2 font-medium text-sm text-white shadow-sm ${
-						isLoading
-							? "cursor-not-allowed bg-gray-400"
-							: "bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-					}`}
-				>
-					{isLoading ? (
-						<div className="flex items-center">
-							<div className="mr-2 h-4 w-4 animate-spin rounded-full border-white border-b-2" />
-							Creating account...
-						</div>
-					) : (
-						"Create Admin Account"
-					)}
-				</button>
-			</div>
+			<button type="submit" disabled={isLoading} className="btn btn-success w-full">
+				{isLoading ? (
+					<>
+						<span className="loading loading-spinner loading-sm" />
+						Creating account...
+					</>
+				) : (
+					"Create Admin Account"
+				)}
+			</button>
 		</form>
 	);
 }

--- a/frontend/src/components/ui/Logo.tsx
+++ b/frontend/src/components/ui/Logo.tsx
@@ -12,7 +12,7 @@ export function Logo({ width, height, className }: LogoProps) {
 
 	return (
 		<div className={containerClass}>
-			<img src="/logo.jpg" alt="AltMount Logo" className="object-contain" />
+			<img src="/logo.png" alt="AltMount Logo" className="object-contain" />
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded Tailwind color classes (`gray-*`, `blue-*`, `red-*`, `green-*`) in all auth components with DaisyUI semantic tokens so pages respond correctly to theme changes (retro/business dark mode)
- Wrap login/register card in `card bg-base-100 shadow-xl` to match app card pattern
- Replace custom spinner divs and inline SVG error icons with `loading loading-spinner` and `alert alert-error`/`alert alert-info` DaisyUI components
- Replace `<label>` + `<input>` pattern with `<fieldset className="fieldset">` per project standards
- Fix `Logo.tsx` to reference `logo.png` instead of `logo.jpg`
- Harden `setupAuthService`: return an error (fail fast) when `login_required: true` but `JWT_SECRET` is not set, instead of silently returning `nil`
- Document `JWT_SECRET` requirement in README, docker-compose files, and intro docs