### PR TITLE
fix(auth): auto-redirect to login on 401 when JWT expires

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -77,6 +77,9 @@ export class APIClient {
 			const response = await fetch(url, config);
 
 			if (!response.ok) {
+				if (response.status === 401) {
+					window.dispatchEvent(new CustomEvent("api:unauthorized"));
+				}
 				const errorData = await response.json();
 				const errorMessage =
 					(typeof errorData.error === "object" ? errorData.error?.message : errorData.error) ||
@@ -129,6 +132,9 @@ export class APIClient {
 			const response = await fetch(url, config);
 
 			if (!response.ok) {
+				if (response.status === 401) {
+					window.dispatchEvent(new CustomEvent("api:unauthorized"));
+				}
 				// Try to parse error response
 				try {
 					const errorData = await response.json();

--- a/frontend/src/components/auth/UserMenu.tsx
+++ b/frontend/src/components/auth/UserMenu.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, LogOut, User, Users } from "lucide-react";
 import { useAuth, useIsAdmin } from "../../hooks/useAuth";
 
 export function UserMenu() {
-	const { user, logout, isLoading } = useAuth();
+	const { user, logout, isLoading, loginRequired } = useAuth();
 	const isAdmin = useIsAdmin();
 
 	if (!user) {
@@ -69,21 +69,25 @@ export function UserMenu() {
 					</li>
 				)}
 
-				<div className="divider my-1" />
+				{loginRequired !== false && (
+					<>
+						<div className="divider my-1" />
 
-				{/* Logout */}
-				<li>
-					<button
-						type="button"
-						onClick={handleLogout}
-						disabled={isLoading}
-						className="flex items-center gap-3 py-2 text-error transition-colors hover:bg-error/10 disabled:cursor-not-allowed disabled:text-base-content/70"
-					>
-						<LogOut className="h-4 w-4" />
-						<span>{isLoading ? "Logging out..." : "Logout"}</span>
-						{isLoading && <span className="loading loading-spinner loading-xs ml-auto" />}
-					</button>
-				</li>
+						{/* Logout */}
+						<li>
+							<button
+								type="button"
+								onClick={handleLogout}
+								disabled={isLoading}
+								className="flex items-center gap-3 py-2 text-error transition-colors hover:bg-error/10 disabled:cursor-not-allowed disabled:text-base-content/70"
+							>
+								<LogOut className="h-4 w-4" />
+								<span>{isLoading ? "Logging out..." : "Logout"}</span>
+								{isLoading && <span className="loading loading-spinner loading-xs ml-auto" />}
+							</button>
+						</li>
+					</>
+				)}
 			</ul>
 		</div>
 	);

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -162,6 +162,14 @@ func (s *Server) handleGetAuthConfig(c *fiber.Ctx) error {
 func (s *Server) handleAuthUser(c *fiber.Ctx) error {
 	user := auth.GetUserFromContext(c)
 	if user == nil {
+		if s.isAdminOrLoginDisabled(nil) {
+			return RespondSuccess(c, UserResponse{
+				ID:       "anonymous",
+				Name:     "Admin",
+				Provider: "none",
+				IsAdmin:  true,
+			})
+		}
 		return RespondUnauthorized(c, "Not authenticated", "")
 	}
 


### PR DESCRIPTION
## Summary

- Emit a custom `api:unauthorized` window event whenever any API call returns HTTP 401 (in both `request()` and `requestWithMeta()` in `APIClient`)
- `AuthProvider` listens for the event and dispatches `AUTH_LOGOUT` when the user is currently authenticated — causing `ProtectedRoute` to render `<LoginPage />` immediately
- Hides the logout button in `UserMenu` when `loginRequired === false` (auth-disabled mode)
- Returns an anonymous admin user from `GET /api/user` when auth is disabled, so the endpoint works in no-auth mode

## Problem solved

When the JWT expired, polling queries (e.g. dashboard stats every 5 s) started returning 401. The frontend had no global 401 handler, so each page showed an `<ErrorAlert>` ("Authentication required") while `isAuthenticated` remained `true`. The user was stuck.

## Test plan

- [ ] Log in with `login_required: true`
- [ ] Expire the JWT (wait or delete the cookie in DevTools)
- [ ] Next polling request triggers 401 → app automatically shows the login page
- [ ] After re-logging in, normal operation resumes
- [ ] With auth disabled (`login_required: false`), no logout button is shown and the user menu still works
- [ ] `bun run check` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)