### PR TITLE
fix(health): reset stuck pending jobs on startup and add disable toggle

### DIFF
--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -125,3 +125,11 @@ func (c *Config) GetFuseMountPath() string {
 	}
 	return c.MountPath
 }
+
+// GetHealthEnabled returns whether health checking is enabled (defaults to true)
+func (c *Config) GetHealthEnabled() bool {
+	if c.Health.Enabled == nil {
+		return true
+	}
+	return *c.Health.Enabled
+}


### PR DESCRIPTION
## Summary

- **Fix stuck pending jobs**: Files stuck in `pending` with `retry_count >= max_retries` were silently excluded from the `GetUnhealthyFiles()` query and never re-checked. A new `ResetStalePendingFiles()` call during worker startup resets their retry count so they get picked up in the next cycle.
- **Add disable toggle**: Health checking can now be disabled by setting `health.enabled: false` in config. The `Health.Enabled` field already existed in the config struct but was never checked — `GetHealthEnabled()` is now checked at the start of `Start()`.

## Test plan
- [ ] Add files to health check with retry_count = max_retries → restart worker → verify files are rechecked in the next cycle
- [ ] Set `health.enabled: false` in config → restart → verify worker does not start (log: "Health worker is disabled via configuration")
- [ ] Set `health.enabled: true` or omit → verify worker starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)