### PR TITLE
fix(importer): improve RAR/7zip error messages and password handling

### DIFF
--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -133,7 +133,7 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	opts := []rardecode.Option{rardecode.FileSystem(ufs), rardecode.SkipCheck}
 	if password != "" {
 		opts = append(opts, rardecode.Password(password))
-		rh.log.InfoContext(ctx, "Using password to unlock RAR archive")
+		rh.log.DebugContext(ctx, "Using password to unlock RAR archive", "archive", mainRarFile)
 	}
 
 	if len(normalizedFiles) > 1 {
@@ -151,7 +151,7 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	aggregatedFiles, err := rardecode.ListArchiveInfo(mainRarFile, opts...)
 	if err != nil {
 		// Check if error indicates incomplete RAR archive with missing volume segments
-		return nil, errors.NewNonRetryableError("failed to create archive iterator", err)
+		return nil, errors.NewNonRetryableError(fmt.Sprintf("failed to iterate RAR archive %q", mainRarFile), err)
 	}
 
 	if len(aggregatedFiles) == 0 {

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -160,13 +160,13 @@ func (sz *sevenZipProcessor) AnalyzeSevenZipContentFromNzb(ctx context.Context, 
 	if password != "" {
 		reader, err = sevenzip.OpenReaderWithPassword(mainSevenZipFile, password, aferoFS)
 		if err != nil {
-			return nil, errors.NewNonRetryableError("failed to open password-protected 7zip archive", err)
+			return nil, errors.NewNonRetryableError(fmt.Sprintf("failed to open password-protected 7zip archive %q", mainSevenZipFile), err)
 		}
-		sz.log.InfoContext(ctx, "Using password to unlock 7zip archive")
+		sz.log.DebugContext(ctx, "Using password to unlock 7zip archive", "archive", mainSevenZipFile)
 	} else {
 		reader, err = sevenzip.OpenReader(mainSevenZipFile, aferoFS)
 		if err != nil {
-			return nil, errors.NewNonRetryableError("failed to open 7zip archive", err)
+			return nil, errors.NewNonRetryableError(fmt.Sprintf("failed to open 7zip archive %q", mainSevenZipFile), err)
 		}
 	}
 	defer reader.Close()
@@ -174,7 +174,7 @@ func (sz *sevenZipProcessor) AnalyzeSevenZipContentFromNzb(ctx context.Context, 
 	// List files with their offsets
 	fileInfos, err := reader.ListFilesWithOffsets()
 	if err != nil {
-		return nil, errors.NewNonRetryableError("failed to list files in 7zip archive", err)
+		return nil, errors.NewNonRetryableError(fmt.Sprintf("failed to list files in 7zip archive %q", mainSevenZipFile), err)
 	}
 
 	if len(fileInfos) == 0 {


### PR DESCRIPTION
## Summary

- \`ErrNoAllowedFiles\` now includes the extensions actually found in the archive vs the configured allowed list — makes debugging much easier when imports fail silently (e.g. \`found: [.nfo, .jpg], allowed: [.mkv, .mp4]\`)
- Error messages in RAR and 7zip processors now include the archive filename and specific failure reason
- Password log level changed from info to debug to reduce log noise

## Test plan
- [ ] Import a RAR with non-standard extensions → error message shows found vs allowed extensions
- [ ] \`go test ./internal/importer/archive/...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)