### PR TITLE
fix(auth): allow WebDAV access when login is disabled

### DIFF
--- a/internal/webdav/adapter.go
+++ b/internal/webdav/adapter.go
@@ -61,13 +61,25 @@ func NewHandler(
 
 	// Create the main handler with authentication
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if login is required from dynamic config
+		loginRequired := true
+		if configGetter != nil {
+			if cfg := configGetter(); cfg != nil && cfg.Auth.LoginRequired != nil {
+				loginRequired = *cfg.Auth.LoginRequired
+			}
+		}
+
 		// Fallback to basic authentication if JWT failed
 		username, password, hasBasicAuth := r.BasicAuth()
 
 		var authenticated bool
 		var effectiveUser string
 
-		if !hasBasicAuth {
+		// When login is not required, skip authentication entirely
+		if !loginRequired {
+			authenticated = true
+			effectiveUser = "anonymous"
+		} else if !hasBasicAuth {
 			// Try JWT token authentication first (if services are available)
 			if tokenService != nil && userRepo != nil {
 				claims, _, err := tokenService.Get(r)


### PR DESCRIPTION
## Summary

- When `auth.login_required=false` the WebDAV handler (`/webdav`) was still demanding a JWT cookie or Basic-Auth credentials, causing the Files page to always show "Offline" and every `PROPFIND` request to return 401
- The REST API correctly skipped authentication when login is disabled, but the WebDAV handler had no awareness of this setting
- Fix: read `loginRequired` from `configGetter` at request time in `internal/webdav/adapter.go` and bypass all auth checks when it is `false`, granting anonymous access

## Test plan

- [ ] Set `auth.login_required: false` in config → restart → Files page connects and lists files without login
- [ ] Set `auth.login_required: true` → Files page still requires JWT cookie (no regression)
- [ ] Basic-Auth credentials still work when `login_required: true` (media players using static credentials)
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)