### PR TITLE
fix(frontend): fix import queue display, health % with pending, and auto-clear

### DIFF
--- a/frontend/src/components/system/HealthStatusCard.tsx
+++ b/frontend/src/components/system/HealthStatusCard.tsx
@@ -98,10 +98,18 @@ export function HealthStatusCard({ className }: HealthStatusCardProps) {
 							<div
 								className={`font-bold text-2xl ${metrics.corrupted > 0 ? "text-error" : "text-success"}`}
 							>
-								{metrics.corrupted > 0 ? metrics.corrupted : "100%"}
+								{metrics.corrupted > 0
+									? metrics.corrupted
+									: metrics.pending > 0 || metrics.checking > 0
+										? `${metrics.healthyPercent}%`
+										: "100%"}
 							</div>
 							<div className="font-semibold text-base-content/40 text-sm">
-								{metrics.corrupted > 0 ? "Corrupted" : "Healthy"}
+								{metrics.corrupted > 0
+									? "Corrupted"
+									: metrics.pending > 0
+										? `(${metrics.pending} unverified)`
+										: "Healthy"}
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

Three functional bug fixes in the dashboard status cards:

**Import Queue (ImportStatusCard)**
- Always show `completed / total` fraction — never collapses to "Idle" when items exist
- Status and fraction are highlighted in `text-error` when `failed > 0`
- Added `refetchInterval: 5000` to the processing-queue query so the card clears automatically when all jobs finish (previously it could hang showing an in-progress item)

**Library Health (HealthStatusCard)**
- No longer shows `100%` when there are `pending` (unverified) or `checking` items — shows the actual `healthyPercent` instead
- Added `(N unverified)` label next to the percentage when `pending > 0`

## Test plan

- [ ] Start an import with some failures → card shows `X / Y` in red with pending+failed detail
- [ ] Let all imports finish → card updates automatically within 5 seconds (no manual refresh needed)
- [ ] Import files → Files page health shows `95%` instead of `100%` when some are still pending check
- [ ] `bun run check` and `bun run build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)