### PR TITLE
feat(dashboard): UX improvements and restore metrics

### DIFF
--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -298,7 +298,7 @@ export function ActivityHub() {
 					)}
 
 					{activeTab === "history" && (
-						<div className="space-y-3">
+						<div className="max-h-64 space-y-3 overflow-y-auto">
 							{historyLoading ? (
 								<div className="flex justify-center py-10">
 									<LoadingSpinner />

--- a/frontend/src/components/system/PoolMetricsCard.tsx
+++ b/frontend/src/components/system/PoolMetricsCard.tsx
@@ -27,17 +27,27 @@ export function PoolMetricsCard({ className }: PoolMetricsCardProps) {
 		);
 	}
 
+	const activeConnections =
+		poolMetrics?.providers?.reduce((sum, p) => sum + p.used_connections, 0) ?? 0;
+	const maxConnections =
+		poolMetrics?.providers?.reduce((sum, p) => sum + p.max_connections, 0) ?? 0;
+
 	return (
 		<div className={`card bg-base-100 shadow-lg ${className || ""}`}>
 			<div className="card-body">
 				<div className="flex items-center justify-between">
 					<div className="flex-1">
-						<h2 className="card-title font-medium text-base-content/70 text-sm">Download Speed</h2>
+						<h2 className="card-title font-medium text-base-content/70 text-sm">Connections</h2>
 						{isLoading ? (
 							<LoadingSpinner size="sm" />
 						) : poolMetrics ? (
 							<div className="font-bold text-2xl text-primary">
-								{formatSpeed(poolMetrics.download_speed_bytes_per_sec)}
+								{activeConnections}
+								{maxConnections > 0 && (
+									<span className="ml-1 font-normal text-base text-base-content/40">
+										/ {maxConnections}
+									</span>
+								)}
 							</div>
 						) : (
 							<div className="font-bold text-2xl text-base-content/50">--</div>
@@ -48,6 +58,14 @@ export function PoolMetricsCard({ className }: PoolMetricsCardProps) {
 
 				{poolMetrics && (
 					<div className="mt-4 space-y-2">
+						{/* Download Speed */}
+						<div className="flex items-center justify-between text-sm">
+							<span className="text-base-content/70">Download Speed</span>
+							<span className="font-medium text-primary">
+								{formatSpeed(poolMetrics.download_speed_bytes_per_sec)}
+							</span>
+						</div>
+
 						{/* Total Downloaded */}
 						<div className="flex items-center justify-between text-sm">
 							<span className="text-base-content/70">Total Bytes</span>

--- a/frontend/src/components/ui/Logo.tsx
+++ b/frontend/src/components/ui/Logo.tsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 interface LogoProps {
 	width?: number;
 	height?: number;
@@ -11,8 +13,8 @@ export function Logo({ width, height, className }: LogoProps) {
 		: `flex items-center justify-center overflow-hidden ${width ? `w-${width}` : "w-12"} ${height ? `h-${height}` : "h-12"}`;
 
 	return (
-		<div className={containerClass}>
+		<Link to="/" className={`cursor-pointer ${containerClass}`}>
 			<img src="/logo.png" alt="AltMount Logo" className="object-contain" />
-		</div>
+		</Link>
 	);
 }


### PR DESCRIPTION
## Summary

- **Logo clickable**: Wraps the logo image in `<Link to="/">` so clicking navigates to the dashboard
- **Connections as hero metric**: `PoolMetricsCard` now shows active NNTP connections (`used / max`) as the primary metric; Download Speed moved to a sub-row below
- **History tab height**: Caps the ActivityHub History tab content at `max-h-64` with scroll to prevent it dominating the page

## Test plan

- [ ] Click the logo from any page → navigates to `/`
- [ ] Dashboard PoolMetricsCard shows "Connections X / Y" as the large top number
- [ ] Download Speed still visible as a sub-metric row
- [ ] History tab with many items scrolls within its container instead of expanding the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)