### PR TITLE
perf(importer): improve import pipeline throughput with 6 targeted optimizations

### DIFF
--- a/internal/importer/multifile/processor.go
+++ b/internal/importer/multifile/processor.go
@@ -16,7 +16,12 @@ import (
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
+	concpool "github.com/sourcegraph/conc/pool"
 )
+
+// maxConcurrentFileValidations limits parallel file validations to avoid
+// overwhelming the NNTP connection pool (each file uses up to maxValidationGoroutines connections).
+const maxConcurrentFileValidations = 4
 
 // ProcessRegularFiles processes multiple regular files
 func ProcessRegularFiles(
@@ -36,7 +41,6 @@ func ProcessRegularFiles(
 		return nil
 	}
 
-	// Validate file extensions before processing
 	if !utils.HasAllowedFilesInRegular(files, allowedFileExtensions) {
 		slog.WarnContext(ctx, "No files with allowed extensions found",
 			"allowed_extensions", allowedFileExtensions,
@@ -44,7 +48,6 @@ func ProcessRegularFiles(
 		return fmt.Errorf("no files with allowed extensions found (allowed: %v)", allowedFileExtensions)
 	}
 
-	// Convert PAR2 files to metadata format (shared across all files)
 	var par2Refs []*metapb.Par2FileReference
 	for _, par2File := range par2Files {
 		par2Refs = append(par2Refs, &metapb.Par2FileReference{
@@ -54,80 +57,81 @@ func ProcessRegularFiles(
 		})
 	}
 
+	pl := concpool.New().WithErrors().WithFirstError().WithMaxGoroutines(maxConcurrentFileValidations)
+
 	for _, file := range files {
-		parentPath, filename := filesystem.DetermineFileLocation(file, virtualDir)
+		pl.Go(func() error {
+			parentPath, filename := filesystem.DetermineFileLocation(file, virtualDir)
 
-		// Ensure parent directory exists
-		if err := filesystem.EnsureDirectoryExists(parentPath, metadataService); err != nil {
-			return fmt.Errorf("failed to create parent directory %s: %w", parentPath, err)
-		}
-
-		// Create virtual file path
-		virtualPath := filepath.Join(parentPath, filename)
-		virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
-
-		// Check if file already exists and is healthy
-		if existingMeta, err := metadataService.ReadFileMetadata(virtualPath); err == nil && existingMeta != nil {
-			if existingMeta.Status == metapb.FileStatus_FILE_STATUS_HEALTHY {
-				slog.InfoContext(ctx, "Skipping re-import of healthy file",
-					"file", filename,
-					"virtual_path", virtualPath)
-				continue
+			if err := filesystem.EnsureDirectoryExists(parentPath, metadataService); err != nil {
+				return fmt.Errorf("failed to create parent directory %s: %w", parentPath, err)
 			}
-		}
 
-		// Double check if this specific file is allowed
-		if !utils.IsAllowedFile(filename, file.Size, allowedFileExtensions) {
-			continue
-		}
+			virtualPath := filepath.Join(parentPath, filename)
+			virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
 
-		// Validate segments
-		if err := validation.ValidateSegmentsForFile(
-			ctx,
-			filename,
-			file.Size,
-			file.Segments,
-			file.Encryption,
-			poolManager,
-			maxValidationGoroutines,
-			segmentSamplePercentage,
-			nil, // No progress callback for multi-file imports
-			timeout,
-		); err != nil {
-			return err
-		}
+			if existingMeta, err := metadataService.ReadFileMetadata(virtualPath); err == nil && existingMeta != nil {
+				if existingMeta.Status == metapb.FileStatus_FILE_STATUS_HEALTHY {
+					slog.InfoContext(ctx, "Skipping re-import of healthy file",
+						"file", filename,
+						"virtual_path", virtualPath)
+					return nil
+				}
+			}
 
-		// Create file metadata
-		fileMeta := metadataService.CreateFileMetadata(
-			file.Size,
-			nzbPath,
-			metapb.FileStatus_FILE_STATUS_HEALTHY,
-			file.Segments,
-			file.Encryption,
-			file.Password,
-			file.Salt,
-			file.AesKey,
-			file.AesIv,
-			file.ReleaseDate.Unix(),
-			par2Refs,
-			file.NzbdavID,
-		)
+			if !utils.IsAllowedFile(filename, file.Size, allowedFileExtensions) {
+				return nil
+			}
 
-		// Delete old metadata if exists (simple collision handling)
-		metadataPath := metadataService.GetMetadataFilePath(virtualPath)
-		if _, err := os.Stat(metadataPath); err == nil {
-			_ = metadataService.DeleteFileMetadata(virtualPath)
-		}
+			if err := validation.ValidateSegmentsForFile(
+				ctx,
+				filename,
+				file.Size,
+				file.Segments,
+				file.Encryption,
+				poolManager,
+				maxValidationGoroutines,
+				segmentSamplePercentage,
+				nil, // No progress callback for multi-file imports
+				timeout,
+			); err != nil {
+				return err
+			}
 
-		// Write file metadata to disk
-		if err := metadataService.WriteFileMetadata(virtualPath, fileMeta); err != nil {
-			return fmt.Errorf("failed to write metadata for file %s: %w", filename, err)
-		}
+			fileMeta := metadataService.CreateFileMetadata(
+				file.Size,
+				nzbPath,
+				metapb.FileStatus_FILE_STATUS_HEALTHY,
+				file.Segments,
+				file.Encryption,
+				file.Password,
+				file.Salt,
+				file.AesKey,
+				file.AesIv,
+				file.ReleaseDate.Unix(),
+				par2Refs,
+				file.NzbdavID,
+			)
 
-		slog.DebugContext(ctx, "Created metadata file",
-			"file", filename,
-			"virtual_path", virtualPath,
-			"size", file.Size)
+			metadataPath := metadataService.GetMetadataFilePath(virtualPath)
+			if _, err := os.Stat(metadataPath); err == nil {
+				_ = metadataService.DeleteFileMetadata(virtualPath)
+			}
+
+			if err := metadataService.WriteFileMetadata(virtualPath, fileMeta); err != nil {
+				return fmt.Errorf("failed to write metadata for file %s: %w", filename, err)
+			}
+
+			slog.DebugContext(ctx, "Created metadata file",
+				"file", filename,
+				"virtual_path", virtualPath,
+				"size", file.Size)
+			return nil
+		})
+	}
+
+	if err := pl.Wait(); err != nil {
+		return err
 	}
 
 	slog.InfoContext(ctx, "Successfully processed regular files",

--- a/internal/progress/tracker.go
+++ b/internal/progress/tracker.go
@@ -29,9 +29,13 @@ func NewTracker(broadcaster Broadcaster, queueID, minPercent, maxPercent int) *T
 	}
 }
 
-// Update reports progress within the configured percentage range
+// Update reports progress within the configured percentage range.
+// Safe to call on a nil receiver (no-op).
 func (pt *Tracker) Update(current, total int) {
-	if total > 0 && pt.broadcaster != nil {
+	if pt == nil || pt.broadcaster == nil {
+		return
+	}
+	if total > 0 {
 		rangeSize := pt.maxPercent - pt.minPercent
 		percentage := pt.minPercent + (current * rangeSize / total)
 		pt.broadcaster.UpdateProgress(pt.queueID, percentage)


### PR DESCRIPTION
## Summary

- **Parallel multifile validation**: replaced sequential file loop with a bounded goroutine pool (`sourcegraph/conc`, `maxConcurrentFileValidations=4`) — near-linear speedup on multi-file NZBs (expected 2-4x for typical 100-file archives)
- **Single-pass segment validation**: exported `SelectSegmentsForValidation` + `ValidateSegmentList` from `internal/usenet/validation.go`; `validation/segments.go` now shares a single iteration for size accumulation and availability checking, eliminating the redundant first pass
- **Category-path memoization**: `sync.Map` cache on `Service` avoids repeated string operations in `calculateProcessVirtualDir` on every import; `invalidateCategoryCache()` available for future config-change hooks
- **Lazy progress tracker allocation**: `broadcaster.HasSubscribers()` guards `CreateTracker` calls in the RAR/7zip processors; `Tracker.Update` has a nil-receiver guard so passing a nil `*Tracker` is safe
- **Serialized queue claims**: single `sync.Mutex` in `queue.Manager.processNextItem` serialises DB claim transactions, eliminating SQLite lock-contention retries and their exponential backoff delays
- **Scanner depth limit**: `DirectoryScanner` defaults to `maxScanDepth=10` (configurable via `SetMaxScanDepth`) to prevent runaway traversal of deep or cyclically-linked directory trees

## Test plan

- [ ] `make` — full build (Go backend + frontend, all checks)
- [ ] `go test ./internal/importer/...` — no regressions in importer package
- [ ] `go test ./internal/usenet/...` — segment validation tests pass with refactored helpers
- [ ] `go test ./internal/progress/...` — nil-safe tracker and HasSubscribers tests pass
- [ ] Manual: import a 100+ file NZB and compare wall time vs main branch
- [ ] Manual: start 4 workers, add 10 items, confirm no "retrying claim" log lines
- [ ] Manual: scan a deeply nested directory (>10 levels) and verify it stops at depth 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)