### PR TITLE
fix(importer): fail import on nested RAR extraction error instead of fallback

### DIFF
--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -562,17 +562,11 @@ func (rh *rarProcessor) detectAndProcessNestedRars(ctx context.Context, outerCon
 
 		innerFiles, err := rh.processNestedRarContent(ctx, innerRarContents)
 		if err != nil {
-			rh.log.WarnContext(ctx, "Failed to process nested RAR, keeping original",
-				"base", base, "error", err)
-			result = append(result, innerRarContents...)
-			continue
+			return nil, fmt.Errorf("failed to process nested RAR %q: %w", base, err)
 		}
 
 		if len(innerFiles) == 0 {
-			rh.log.WarnContext(ctx, "Nested RAR contained no files, keeping original",
-				"base", base)
-			result = append(result, innerRarContents...)
-			continue
+			return nil, fmt.Errorf("nested RAR %q contained no extractable files", base)
 		}
 
 		result = append(result, innerFiles...)

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -831,17 +831,11 @@ func (sz *sevenZipProcessor) detectAndProcessNestedRars(ctx context.Context, out
 
 		innerFiles, err := sz.processNestedRarContent(ctx, innerRarContents)
 		if err != nil {
-			sz.log.WarnContext(ctx, "Failed to process nested RAR in 7zip, keeping original",
-				"base", base, "error", err)
-			result = append(result, innerRarContents...)
-			continue
+			return nil, fmt.Errorf("failed to process nested RAR %q inside 7zip: %w", base, err)
 		}
 
 		if len(innerFiles) == 0 {
-			sz.log.WarnContext(ctx, "Nested RAR in 7zip contained no files, keeping original",
-				"base", base)
-			result = append(result, innerRarContents...)
-			continue
+			return nil, fmt.Errorf("nested RAR %q inside 7zip contained no extractable files", base)
 		}
 
 		result = append(result, innerFiles...)


### PR DESCRIPTION
## Summary

- When a nested RAR is detected inside a RAR or 7zip archive and extraction fails (compressed files, corrupt archive, etc.), the import now **fails with an error** instead of silently falling back to raw `.rar` volume files as content
- Same fix applied to both the RAR processor and the 7zip processor

## Test plan

- [ ] Import an NZB containing a nested RAR with compressed inner files → import should fail with a clear error
- [ ] Import an NZB containing a valid nested RAR → import should succeed as before
- [ ] Run `go test ./internal/importer/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)