### PR TITLE
fix(postprocessor): use 0775 group write permissions for created directories

### DIFF
--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -168,7 +168,7 @@ func (c *Coordinator) createSingleStrmFile(ctx context.Context, strmResultingPat
 
 	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(strings.TrimPrefix(strmResultingPath, "/")))
 
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0775); err != nil {
 		return fmt.Errorf("failed to create STRM directory: %w", err)
 	}
 

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -182,7 +182,7 @@ func (c *Coordinator) createSingleSymlink(actualPath, resultingPath string) erro
 
 	baseDir := filepath.Join(*cfg.Import.ImportDir, filepath.Dir(strings.TrimPrefix(resultingPath, "/")))
 
-	if err := os.MkdirAll(baseDir, 0755); err != nil {
+	if err := os.MkdirAll(baseDir, 0775); err != nil {
 		return fmt.Errorf("failed to create symlink category directory: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Changes `os.MkdirAll` permission from `0755` to `0775` in `symlink_creator.go` and `strm_generator.go`
- Grants group write access to directories created during import post-processing
- Fixes Docker deployments where the container user and media server user share a group but the group lacks write access

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Verify import directories are created with `rwxrwxr-x` permissions after an import

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)