### PR TITLE
fix(rclone): set DiskSpaceTotalSize to match VFSCacheMaxSize

### DIFF
--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -134,6 +134,9 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 		}
 		if cfg.RClone.VFSCacheMaxSize != "" {
 			vfsOpt["CacheMaxSize"] = cfg.RClone.VFSCacheMaxSize
+			// Ensure the reported total disk space matches the configured cache size
+			// so media servers see accurate available space
+			vfsOpt["DiskSpaceTotalSize"] = cfg.RClone.VFSCacheMaxSize
 		}
 		if cfg.RClone.VFSCachePollInterval != "" {
 			vfsOpt["CachePollInterval"] = cfg.RClone.VFSCachePollInterval


### PR DESCRIPTION
## Summary
- When `VFSCacheMaxSize` is configured, automatically set `DiskSpaceTotalSize` to the same value
- Prevents media servers from seeing rclone's default 1G disk total when the cache is much larger
- No UI changes needed — the disk space total now mirrors the already-visible cache size setting

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] After mounting, verify reported total disk space matches the configured VFS cache max size

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)