### PR TITLE
fix(api): include allow_nested_rar_extraction in GET config response

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -125,6 +125,7 @@ type ImportAPIResponse struct {
 	SkipHealthCheck                bool                  `json:"skip_health_check"`
 	WatchDir                       *string               `json:"watch_dir,omitempty"`
 	WatchIntervalSeconds           *int                  `json:"watch_interval_seconds,omitempty"`
+	AllowNestedRarExtraction       *bool                 `json:"allow_nested_rar_extraction,omitempty"`
 }
 
 // SABnzbdAPIResponse sanitizes SABnzbd config for API responses
@@ -268,6 +269,7 @@ func ToImportAPIResponse(importConfig config.ImportConfig) ImportAPIResponse {
 		SkipHealthCheck:                importConfig.SkipHealthCheck != nil && *importConfig.SkipHealthCheck,
 		WatchDir:                       importConfig.WatchDir,
 		WatchIntervalSeconds:           importConfig.WatchIntervalSeconds,
+		AllowNestedRarExtraction:       importConfig.AllowNestedRarExtraction,
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ImportAPIResponse` was missing the `AllowNestedRarExtraction` field, causing the GET `/config` response to never include it
- `ToImportAPIResponse` was not mapping `importConfig.AllowNestedRarExtraction` to the response struct
- Frontend always received `undefined` for this field and fell back to its `?? true` default, so the toggle always showed `true` after a restart regardless of the saved value

## Test plan

- [ ] Set `allow_nested_rar_extraction` to `false` via the frontend toggle and save
- [ ] Restart the container
- [ ] Open the frontend config page — the toggle should now show `false`/off
- [ ] Confirm the GET `/config` response body includes `"allow_nested_rar_extraction": false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)