### PR TITLE
fix(api): validate numeric prefix before stripping from queue target_path

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -563,9 +564,10 @@ func ToQueueItemResponse(item *database.ImportQueueItem) *QueueItemResponse {
 	// Remove ID prefix (e.g. "123_filename")
 	parts := strings.SplitN(targetPath, "_", 2)
 	if len(parts) == 2 {
-		// Check if first part is numeric (the ID)
-		// We don't need strict validation, just heuristic
-		targetPath = parts[1]
+		// Only strip prefix if first part is actually numeric (the queue ID)
+		if _, err := strconv.Atoi(parts[0]); err == nil {
+			targetPath = parts[1]
+		}
 	}
 
 	// Transform error message for better user understanding


### PR DESCRIPTION
## Summary
- `ToQueueItemResponse` was unconditionally stripping everything before the first `_` from NZB filenames, causing names like `Mell_Kiss_JPN_PSV-HR.nzb` to lose their `Mell_` prefix in `target_path`
- Fix uses `strconv.Atoi` to validate the leading segment is actually a numeric queue ID before stripping it
- Filenames with no numeric prefix (e.g. `Release-Name.nzb` or `Mell_Kiss_JPN_PSV-HR.nzb`) are now left intact

## Test plan
- [ ] `Mell_Kiss_JPN_PSV-HR.nzb` → `target_path = "Mell_Kiss_JPN_PSV-HR"` (no stripping)
- [ ] `123_Release-Name.nzb` → `target_path = "Release-Name"` (numeric prefix still stripped)
- [ ] `Release-Name.nzb` → `target_path = "Release-Name"` (no underscore, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)