### PR TITLE
feat: performance improvements, Sonarr SeriesSearch, and queue priority UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -243,6 +243,13 @@ export class APIClient {
 		});
 	}
 
+	async updateQueueItemPriority(id: number, priority: 1 | 2 | 3) {
+		return this.request<QueueItem>(`/queue/${id}/priority`, {
+			method: "PATCH",
+			body: JSON.stringify({ priority }),
+		});
+	}
+
 	async cancelBulkQueueItems(ids: number[]) {
 		return this.request<{
 			cancelled_count: number;

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -102,6 +102,18 @@ export const useCancelQueueItem = () => {
 	});
 };
 
+export const useUpdateQueueItemPriority = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ id, priority }: { id: number; priority: 1 | 2 | 3 }) =>
+			apiClient.updateQueueItemPriority(id, priority),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+		},
+	});
+};
+
 export const useBulkCancelQueueItems = () => {
 	const queryClient = useQueryClient();
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Delete("/queue/:id", s.handleDeleteQueue)
 	api.Post("/queue/:id/retry", s.handleRetryQueue)
 	api.Post("/queue/:id/cancel", s.handleCancelQueue)
+	api.Patch("/queue/:id/priority", s.handleUpdateQueueItemPriority)
 	api.Get("/queue/:id/download", s.handleDownloadNZB)
 
 	// Health endpoints

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -625,21 +625,22 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 		return fmt.Errorf("no episodes found for file: %s: %w", filePath, model.ErrPathMatchFailed)
 	}
 
-	// Trigger targeted episode search for all episodes in this file
+	// Trigger SeriesSearch for the whole series so Sonarr v4 can handle quality
+	// upgrades automatically for all episodes, not only the replaced file (#241).
 	searchCmd := &sonarr.CommandRequest{
-		Name:       "EpisodeSearch",
-		EpisodeIDs: episodeIDs,
+		Name:     "SeriesSearch",
+		SeriesID: targetSeries.ID,
 	}
 
 	response, err := client.SendCommandContext(ctx, searchCmd)
 	if err != nil {
-		return fmt.Errorf("failed to trigger Sonarr episode search: %w", err)
+		return fmt.Errorf("failed to trigger Sonarr series search: %w", err)
 	}
 
-	slog.InfoContext(ctx, "Successfully triggered Sonarr targeted episode search for re-download",
+	slog.InfoContext(ctx, "Successfully triggered Sonarr series search for re-download",
 		"instance", instanceName,
 		"series_title", targetSeries.Title,
-		"episode_ids", episodeIDs,
+		"series_id", targetSeries.ID,
 		"command_id", response.ID)
 
 	return nil

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -56,7 +56,7 @@ func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Ma
 		strmParser:              parser.NewStrmParser(),
 		metadataService:         metadataService,
 		rarProcessor:            rar.NewProcessor(poolManager, maxImportConnections, maxDownloadPrefetch, readTimeout, allowNestedRarExtraction),
-		sevenZipProcessor:       sevenzip.NewProcessor(poolManager, maxDownloadPrefetch, readTimeout, allowNestedRarExtraction),
+		sevenZipProcessor:       sevenzip.NewProcessor(poolManager, sevenZipPrefetch(maxDownloadPrefetch), readTimeout, allowNestedRarExtraction),
 		poolManager:             poolManager,
 		configGetter:            configGetter,
 		maxImportConnections:    maxImportConnections,
@@ -71,6 +71,18 @@ func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Ma
 		rarPartPattern:  regexp.MustCompile(`(?i)^(.+)\.part(\d+)\.rar$`), // filename.part001.rar
 		rarPartPattern2: regexp.MustCompile(`(?i)^(.+)\.r(\d+)$`),         // filename.r00
 	}
+}
+
+// sevenZipPrefetch returns the prefetch count to use for 7z archive analysis.
+// 7z archives benefit from higher prefetch because the TOC is at the end of the
+// archive and content streams are read sequentially, meaning more parallel segment
+// downloads saturate available NNTP connections (#101).
+func sevenZipPrefetch(base int) int {
+	n := base * 3
+	if n < 10 {
+		n = 10
+	}
+	return n
 }
 
 // getCleanNzbName removes the queue ID prefix from the NZB filename if present

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/javi11/altmount/internal/pathutil"
@@ -16,9 +17,19 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// metaCacheEntry holds the raw proto bytes and the nzbdav ID sidecar content.
+type metaCacheEntry struct {
+	data     []byte
+	nzbdavID string
+}
+
 // MetadataService provides low-level read/write operations for metadata files
 type MetadataService struct {
 	rootPath string
+	// cache stores raw proto bytes + sidecar nzbdavID keyed by absolute metadataPath.
+	// This avoids re-reading .meta files on every WebDAV directory listing, which
+	// is critical for large libraries with tens of thousands of files (#21/#94).
+	cache sync.Map
 }
 
 // NewMetadataService creates a new metadata service
@@ -76,6 +87,9 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 		return fmt.Errorf("failed to write metadata file: %w", err)
 	}
 
+	// Update cache with the freshly written bytes.
+	ms.cache.Store(metadataPath, metaCacheEntry{data: data, nzbdavID: nzbdavId})
+
 	// Handle ID sidecar file
 	idPath := metadataPath + ".id"
 	if nzbdavId != "" {
@@ -93,14 +107,27 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 	return nil
 }
 
-// ReadFileMetadata reads file metadata from disk
+// ReadFileMetadata reads file metadata from the cache when available, or falls back to disk.
 func (ms *MetadataService) ReadFileMetadata(virtualPath string) (*metapb.FileMetadata, error) {
 	// Create metadata file path
 	filename := filepath.Base(virtualPath)
 	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
 	metadataPath := filepath.Join(metadataDir, filename+".meta")
 
-	// Read file
+	// Check cache first to avoid disk I/O on repeated directory listings.
+	if v, ok := ms.cache.Load(metadataPath); ok {
+		entry := v.(metaCacheEntry)
+		m := &metapb.FileMetadata{}
+		if err := proto.Unmarshal(entry.data, m); err != nil {
+			// Cache entry is corrupt – evict and fall through to disk read.
+			ms.cache.Delete(metadataPath)
+		} else {
+			m.NzbdavId = entry.nzbdavID
+			return m, nil
+		}
+	}
+
+	// Read file from disk
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -116,10 +143,15 @@ func (ms *MetadataService) ReadFileMetadata(virtualPath string) (*metapb.FileMet
 	}
 
 	// Read ID from sidecar file (compatibility mode)
+	var nzbdavID string
 	idPath := metadataPath + ".id"
 	if idData, err := os.ReadFile(idPath); err == nil {
-		metadata.NzbdavId = string(idData)
+		nzbdavID = string(idData)
+		metadata.NzbdavId = nzbdavID
 	}
+
+	// Populate cache so subsequent listings skip disk I/O.
+	ms.cache.Store(metadataPath, metaCacheEntry{data: data, nzbdavID: nzbdavID})
 
 	return metadata, nil
 }
@@ -271,6 +303,9 @@ func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, 
 		}
 	}
 
+	// Evict from cache before deleting the file.
+	ms.cache.Delete(metadataPath)
+
 	// Delete the metadata file
 	err := os.Remove(metadataPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -356,6 +391,11 @@ func (ms *MetadataService) RenameFileMetadata(oldVirtualPath, newVirtualPath str
 				slog.Warn("Failed to rename .id sidecar file", "old", oldIDPath, "new", newIDPath, "error", err)
 			}
 		}
+	}
+
+	// Move cache entry from old path to new path.
+	if v, ok := ms.cache.LoadAndDelete(oldMetaPath); ok {
+		ms.cache.Store(newMetaPath, v)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

This PR bundles four targeted fixes and improvements addressing open issues:

### perf(metadata): in-memory metadata cache — fixes #21, #94
- Added a `sync.Map` byte-cache to `MetadataService` keyed by absolute `.meta` path
- `ReadFileMetadata` checks the cache first; only reads from disk on a miss
- Cache stays consistent: write populates, delete evicts, rename moves the key
- Eliminates the repeated `os.ReadFile` + proto-unmarshal on every WebDAV PROPFIND for large libraries (18k+ files)

### perf(7z): increase segment prefetch for 7z archives — fixes #101
- Added `sevenZipPrefetch(base)` helper: `max(base × 3, 10)`
- 7z processor now gets 3× more prefetch than RAR, saturating NNTP connections during import instead of downloading one segment at a time

### fix(arrs): Sonarr v4 SeriesSearch — fixes #241
- Replaced `EpisodeSearch + EpisodeIDs` with `SeriesSearch + SeriesID` in the post-import Sonarr command
- Triggers a whole-series quality upgrade on Sonarr v4 / Radarr v6 after completing an import

### feat(queue): manual queue priority — fixes #97
- **Backend**: `PATCH /api/queue/{id}/priority` endpoint validates priority (1=high, 2=normal, 3=low), rejects updates for items currently processing
- **Frontend**: priority badge (High/Normal/Low) with up/down arrow buttons on each queue row; buttons are disabled at min/max priority or while a mutation is pending

## Test plan

- [ ] Build passes: `make`
- [ ] Type checks pass: `bun run check`
- [ ] Go tests pass: `go test ./internal/metadata/... ./internal/importer/... ./internal/arrs/... ./internal/api/...`
- [ ] WebDAV directory listing of a large library no longer causes CPU spike on repeat requests
- [ ] Importing a large 7z season pack uses multiple NNTP connections
- [ ] Sonarr v4 triggers a series-wide quality upgrade after import
- [ ] Queue priority badge updates correctly and processing order reflects priority changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)