### PR TITLE
perf(metadata): in-memory cache to avoid re-reading .meta files on large libraries

### DIFF
--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -660,6 +660,9 @@ func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath stri
 		_ = os.Rename(idPath, targetPath+".id")
 	}
 
+	// Evict cache entry so subsequent reads return nil instead of stale data.
+	ms.cache.Delete(metadataPath)
+
 	slog.InfoContext(ctx, "Moved corrupted metadata to safety folder preserving structure",
 		"original", metadataPath,
 		"target", targetPath)


### PR DESCRIPTION
## Problem

Closes #21
Closes #94

On libraries with 18k+ NZBs, every WebDAV PROPFIND triggered `ListDirectoryContents` which called `ReadFileMetadata` (disk read + proto unmarshal) for **every** `.meta` file in the directory. This caused the app to become unresponsive and saturate CPU/RAM.

## Solution

Added a `sync.Map` byte-cache to `MetadataService` keyed by absolute `.meta` filesystem path.

- `ReadFileMetadata` checks the cache first; only reads from disk on a miss and populates the cache
- `WriteFileMetadata` stores freshly written bytes into the cache after a successful write
- `DeleteFileMetadataWithSourceNzb` evicts the entry before removing the file
- `RenameFileMetadata` moves the key atomically using `LoadAndDelete` + `Store`

The first directory listing remains a cold read; all subsequent listings are served from memory.

## Test plan

- [ ] `go test ./internal/metadata/...`
- [ ] Import/list a large library and confirm no CPU spike on repeated WebDAV listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)