### PR TITLE
fix(arrs): use SeriesSearch instead of EpisodeSearch for Sonarr v4 post-import

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -625,21 +625,22 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 		return fmt.Errorf("no episodes found for file: %s: %w", filePath, model.ErrPathMatchFailed)
 	}
 
-	// Trigger targeted episode search for all episodes in this file
+	// Trigger SeriesSearch for the whole series so Sonarr v4 can handle quality
+	// upgrades automatically for all episodes, not only the replaced file (#241).
 	searchCmd := &sonarr.CommandRequest{
-		Name:       "EpisodeSearch",
-		EpisodeIDs: episodeIDs,
+		Name:     "SeriesSearch",
+		SeriesID: targetSeries.ID,
 	}
 
 	response, err := client.SendCommandContext(ctx, searchCmd)
 	if err != nil {
-		return fmt.Errorf("failed to trigger Sonarr episode search: %w", err)
+		return fmt.Errorf("failed to trigger Sonarr series search: %w", err)
 	}
 
-	slog.InfoContext(ctx, "Successfully triggered Sonarr targeted episode search for re-download",
+	slog.InfoContext(ctx, "Successfully triggered Sonarr series search for re-download",
 		"instance", instanceName,
 		"series_title", targetSeries.Title,
-		"episode_ids", episodeIDs,
+		"series_id", targetSeries.ID,
 		"command_id", response.ID)
 
 	return nil


### PR DESCRIPTION
## Problem

Closes #241

After completing an import, altmount sent Sonarr an `EpisodeSearch` command with individual episode IDs. On Sonarr v4, this did not reliably trigger quality upgrades for the rest of the series and could miss episodes that weren't tracked yet.

## Solution

Replace the post-import search command:

**Before:**
```go
CommandRequest{Name: "EpisodeSearch", EpisodeIDs: episodeIDs}
```

**After:**
```go
CommandRequest{Name: "SeriesSearch", SeriesID: targetSeries.ID}
```

`SeriesSearch` covers the whole series and triggers quality upgrades for already-downloaded episodes, which is the expected behaviour for Sonarr v4.

> **Note:** The `episodeIDs` slice is still computed and used for zombie-detection (`allSatisfied` check) and the `"no episodes found"` guard — only the final search command was changed.

## Test plan

- [ ] `go test ./internal/arrs/...`
- [ ] Import a season pack via Sonarr v4 and confirm a series-wide quality-upgrade search is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)