### PR TITLE
feat(queue): manual priority control with up/down arrows in queue UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -243,6 +243,13 @@ export class APIClient {
 		});
 	}
 
+	async updateQueueItemPriority(id: number, priority: 1 | 2 | 3) {
+		return this.request<QueueItem>(`/queue/${id}/priority`, {
+			method: "PATCH",
+			body: JSON.stringify({ priority }),
+		});
+	}
+
 	async cancelBulkQueueItems(ids: number[]) {
 		return this.request<{
 			cancelled_count: number;

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -102,6 +102,18 @@ export const useCancelQueueItem = () => {
 	});
 };
 
+export const useUpdateQueueItemPriority = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ id, priority }: { id: number; priority: 1 | 2 | 3 }) =>
+			apiClient.updateQueueItemPriority(id, priority),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+		},
+	});
+};
+
 export const useBulkCancelQueueItems = () => {
 	const queryClient = useQueryClient();
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -214,6 +214,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Delete("/queue/:id", s.handleDeleteQueue)
 	api.Post("/queue/:id/retry", s.handleRetryQueue)
 	api.Post("/queue/:id/cancel", s.handleCancelQueue)
+	api.Patch("/queue/:id/priority", s.handleUpdateQueueItemPriority)
 	api.Get("/queue/:id/download", s.handleDownloadNZB)
 
 	// Health endpoints


### PR DESCRIPTION
## Problem

Closes #97

There was no way to manually change the processing priority of queued items from the UI, even though the database already had a `priority` field and `UpdateQueueItemPriority()` method.

## Solution

### Backend — `PATCH /api/queue/{id}/priority`

```
PATCH /api/queue/{id}/priority
Body: { "priority": 1 | 2 | 3 }
```

- `1` = High, `2` = Normal, `3` = Low
- Returns `409 Conflict` if the item is currently processing
- Calls the existing `UpdateQueueItemPriority()` repository method
- Route registered in `server.go`

### Frontend

- `updateQueueItemPriority(id, priority)` method added to `api/client.ts`
- `useUpdateQueueItemPriority()` React Query mutation hook added to `hooks/useApi.ts`
- `QueuePage`: each non-processing, non-completed row gets:
  - A priority badge: **High** (red), **Normal** (outline), **Low** (ghost)
  - ▲ / ▼ arrow buttons to increase/decrease priority
  - Buttons are disabled at the min/max boundary or while a mutation is pending
  - Queue list auto-refreshes on success via `queryClient.invalidateQueries`

## Test plan

- [ ] `go test ./internal/api/...`
- [ ] `bun run check`
- [ ] Queue an item, change its priority with ▲/▼, confirm the badge updates and processing order reflects the new priority

🤖 Generated with [Claude Code](https://claude.com/claude-code)