### PR TITLE
feat(rclone): add --links flag support for symlink mounts

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -603,6 +603,22 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 				</div>
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 					<fieldset className="fieldset">
+						<legend className="fieldset-legend">Enable Symlinks (--links)</legend>
+						<label className="label cursor-pointer justify-start gap-3">
+							<input
+								type="checkbox"
+								className="checkbox checkbox-primary checkbox-sm"
+								checked={mountFormData.links}
+								onChange={(e) => handleMountInputChange("links", e.target.checked)}
+							/>
+							<span className="label-text break-words text-xs">
+								Translate symlinks using .rclonelink files
+							</span>
+						</label>
+					</fieldset>
+				</div>
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+					<fieldset className="fieldset">
 						<legend className="fieldset-legend">Timeout</legend>
 						<input
 							type="text"
@@ -1239,5 +1255,6 @@ function buildRCloneMountFormData(config: ConfigResponse): RCloneMountFormData {
 		async_read: config.rclone.async_read ?? true,
 		vfs_fast_fingerprint: config.rclone.vfs_fast_fingerprint || false,
 		use_mmap: config.rclone.use_mmap || false,
+		links: config.rclone.links || false,
 	};
 }

--- a/frontend/src/components/config/RCloneConfigSection.tsx
+++ b/frontend/src/components/config/RCloneConfigSection.tsx
@@ -78,6 +78,7 @@ export function RCloneConfigSection({
 		async_read: config.rclone.async_read || true,
 		vfs_fast_fingerprint: config.rclone.vfs_fast_fingerprint || false,
 		use_mmap: config.rclone.use_mmap || false,
+		links: config.rclone.links || false,
 	});
 
 	// Separate state for mount path since it's a root-level config
@@ -152,6 +153,7 @@ export function RCloneConfigSection({
 			async_read: config.rclone.async_read || true,
 			vfs_fast_fingerprint: config.rclone.vfs_fast_fingerprint || false,
 			use_mmap: config.rclone.use_mmap || false,
+		links: config.rclone.links || false,
 		};
 		setMountFormData(newMountFormData);
 		setHasMountChanges(false);

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -179,6 +179,7 @@ export interface RCloneConfig {
 	async_read: boolean;
 	vfs_fast_fingerprint: boolean;
 	use_mmap: boolean;
+	links: boolean;
 }
 
 // Fuse configuration
@@ -382,6 +383,7 @@ export interface RCloneUpdateRequest {
 	async_read?: boolean;
 	vfs_fast_fingerprint?: boolean;
 	use_mmap?: boolean;
+	links?: boolean;
 }
 
 // Import update request
@@ -546,6 +548,7 @@ export interface RCloneFormData {
 	async_read: boolean;
 	vfs_fast_fingerprint: boolean;
 	use_mmap: boolean;
+	links: boolean;
 }
 
 export interface RCloneRCFormData {
@@ -597,6 +600,7 @@ export interface RCloneMountFormData {
 	async_read: boolean;
 	vfs_fast_fingerprint: boolean;
 	use_mmap: boolean;
+	links: boolean;
 }
 
 export interface MountStatus {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -59,6 +59,7 @@ type RCloneAPIResponse struct {
 	// Mount-Specific Settings
 	AllowOther    bool   `json:"allow_other"`
 	AllowNonEmpty bool   `json:"allow_non_empty"`
+	Links         bool   `json:"links"`
 	ReadOnly      bool   `json:"read_only"`
 	Timeout       string `json:"timeout"`
 	Syslog        bool   `json:"syslog"`
@@ -187,6 +188,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		// Mount-Specific Settings
 		AllowOther:    cfg.RClone.AllowOther,
 		AllowNonEmpty: cfg.RClone.AllowNonEmpty,
+		Links:         cfg.RClone.Links,
 		ReadOnly:      cfg.RClone.ReadOnly,
 		Timeout:       cfg.RClone.Timeout,
 		Syslog:        cfg.RClone.Syslog,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -180,6 +180,7 @@ type RCloneConfig struct {
 	AsyncRead          bool `yaml:"async_read" mapstructure:"async_read" json:"async_read"`
 	VFSFastFingerprint bool `yaml:"vfs_fast_fingerprint" mapstructure:"vfs_fast_fingerprint" json:"vfs_fast_fingerprint"`
 	UseMmap            bool `yaml:"use_mmap" mapstructure:"use_mmap" json:"use_mmap"`
+	Links              bool `yaml:"links" mapstructure:"links" json:"links"`
 }
 
 // ImportStrategy represents the import strategy type

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -168,6 +168,9 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 		}
 	}
 
+	if cfg.RClone.Links {
+		vfsOpt["Links"] = true
+	}
 	mountArgs["vfsOpt"] = vfsOpt
 	mountArgs["mountOpt"] = mountOpt
 	// Make the mount request


### PR DESCRIPTION
## Summary

Fixes #326 — users setting the import strategy to `SYMLINK` received a rclone VFS error: _"symlinks not supported without the --links flag"_.

- Add `Links bool` field to `RCloneConfig` struct (yaml/mapstructure/json wired)
- Expose `Links` in `RCloneAPIResponse` and map it from config
- Pass `vfsOpt["Links"] = true` to the `mount/mount` RC call when enabled
- Add `links` field to all four TypeScript config interfaces (`RCloneConfig`, `RCloneUpdateRequest`, `RCloneFormData`, `RCloneMountFormData`)
- Add **"Enable Symlinks (--links)"** checkbox in the RClone mount settings UI

## Test plan

- [ ] Build passes: `make` (or `go build ./...` + `bun run build`)
- [ ] Set import strategy to `SYMLINK` in the UI
- [ ] Enable the "Enable Symlinks (--links)" checkbox in RClone mount settings
- [ ] Restart the mount — the rclone VFS error no longer appears
- [ ] Symlinks are visible in the mount path
- [ ] Disabling the checkbox and remounting removes the `--links` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)