### PR TITLE
fix(files): fix category filtering 404 for SYMLINK/STRM import strategies

### DIFF
--- a/frontend/src/pages/FilesPage.tsx
+++ b/frontend/src/pages/FilesPage.tsx
@@ -31,25 +31,9 @@ export function FilesPage() {
 		const shortcuts = [{ id: "all", title: "All Files", path: "/", icon: Folder }];
 
 		if (config?.sabnzbd?.categories) {
-			const strategy = config.import?.import_strategy || "NONE";
-			let basePath = "";
-
-			if (strategy === "NONE") {
-				// With strategy NONE, Arrs move the files to {mount_path}/{category}
-				// By default, WebDAV serves from mount_path, so the relative path is just /
-				basePath = "/";
-			} else if (config.import?.import_dir && config.mount_path) {
-				// With SYMLINK/STRM strategies, files are in import_dir
-				// Attempt to create a relative path if import_dir is inside mount_path
-				if (config.import.import_dir.startsWith(config.mount_path)) {
-					basePath = config.import.import_dir.substring(config.mount_path.length);
-				} else {
-					// Fallback if import_dir is outside the webdav mount
-					basePath = "/";
-				}
-			} else {
-				basePath = "/";
-			}
+			// WebDAV serves from the metadata virtual root where categories are always
+			// at the top level — for all import strategies (NONE, SYMLINK, STRM).
+			const basePath = "/";
 
 			// Ensure valid base path slashes
 			if (basePath && !basePath.startsWith("/")) {


### PR DESCRIPTION
## Summary

- Category shortcuts in the Files page sidebar produced 404 errors when using SYMLINK or STRM import strategies
- Root cause: the frontend incorrectly computed a relative path between `import_dir` and `mount_path` (e.g. `/library/movies`), but the WebDAV server always serves categories from the **metadata virtual root** (e.g. `/movies`) regardless of import strategy
- Fix: remove the strategy-based `basePath` calculation and always use `"/"` — categories are injected at the virtual path root for all strategies (NONE, SYMLINK, STRM)

## Test plan

- [ ] Configure AltMount with SYMLINK or STRM strategy with `import_dir` as a subdirectory inside `mount_path`
- [ ] Import files with categories (e.g. "movies", "tv")
- [ ] Open Files page — category shortcuts appear in the sidebar
- [ ] Click a category shortcut (e.g. "Movies") — navigates to `/movies` without a 404
- [ ] Verify "All Files" (root `/`) still works
- [ ] Verify NONE strategy still works (no regression — basePath was already `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)