### PR TITLE
fix(frontend): resolve sidebar always showing 0.0.0 version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,9 @@ docker-build-ci: build-frontend
 
 .PHONY: build-frontend
 build-frontend:
-	cd frontend && bun install --frozen-lockfile && bun run build
+	@VERSION=$$(git describe --tags --always --dirty 2>/dev/null || echo "dev"); \
+	COMMIT=$$(git rev-parse --short HEAD 2>/dev/null || echo "unknown"); \
+	cd frontend && bun install --frozen-lockfile && APP_VERSION=$$VERSION GIT_COMMIT=$$COMMIT bun run build
 
 .PHONY: build-docs
 build-docs:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,13 +1,32 @@
+import { execSync } from "child_process";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+
+function getGitCommit(): string {
+	if (process.env.GIT_COMMIT) return process.env.GIT_COMMIT;
+	try {
+		return execSync("git rev-parse --short HEAD").toString().trim();
+	} catch {
+		return "unknown";
+	}
+}
+
+function getAppVersion(): string {
+	if (process.env.APP_VERSION) return process.env.APP_VERSION;
+	try {
+		return execSync("git describe --tags --always --dirty").toString().trim();
+	} catch {
+		return process.env.npm_package_version || "0.0.0";
+	}
+}
 
 // https://vite.dev/config/
 export default defineConfig({
 	plugins: [react(), tailwindcss()],
 	define: {
-		__APP_VERSION__: JSON.stringify(process.env.npm_package_version || "0.0.0"),
-		__GIT_COMMIT__: JSON.stringify(process.env.GIT_COMMIT || "unknown"),
+		__APP_VERSION__: JSON.stringify(getAppVersion()),
+		__GIT_COMMIT__: JSON.stringify(getGitCommit()),
 		__GITHUB_URL__: JSON.stringify("https://github.com/javi11/altmount"),
 	},
 	server: {


### PR DESCRIPTION
## Summary

- **`frontend/vite.config.ts`**: Added `getAppVersion()` and `getGitCommit()` helpers that use Node's `execSync` as fallback when `APP_VERSION`/`GIT_COMMIT` env vars are not set. During `bun run dev`, the sidebar now shows the actual git-derived version and commit hash instead of `0.0.0` / `unknown`.
- **`Makefile` `build-frontend`**: Resolves `VERSION` and `COMMIT` via `git describe` / `git rev-parse` before the build and passes them as `APP_VERSION`/`GIT_COMMIT`, matching the values used by `build-cli`'s ldflags.

## Test plan

- [ ] Run `cd frontend && bun run dev` — sidebar should show git-derived version (e.g. `v1.2.3-5-gabcdef`) and commit hash
- [ ] Run `make build-frontend` — values should match Go binary ldflags
- [ ] In a repo without tags, `git describe --always` still returns a commit hash; sidebar degrades gracefully
- [ ] In a directory without git, values fall back to `"0.0.0"` / `"unknown"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)