### PR TITLE
feat(frontend): show file format labels in FileExplorer

### DIFF
--- a/frontend/src/components/files/FileInfoModal.tsx
+++ b/frontend/src/components/files/FileInfoModal.tsx
@@ -11,7 +11,7 @@ import type {
 	SegmentInfo,
 } from "../../types/api";
 import type { WebDAVFile } from "../../types/webdav";
-import { formatFileSize } from "../../utils/fileUtils";
+import { formatFileSize, getFormatLabel } from "../../utils/fileUtils";
 import { HealthBadge } from "../ui/StatusBadge";
 
 interface FileInfoModalProps {
@@ -269,6 +269,12 @@ export function FileInfoModal({
 									{metadata.available_segments}
 								</span>
 							</div>
+							{getFormatLabel(file.basename) && (
+								<div className="flex justify-between">
+									<span className="text-base-content/70">Format:</span>
+									<span>{getFormatLabel(file.basename)}</span>
+								</div>
+							)}
 							<div className="flex justify-between">
 								<span className="text-base-content/70">Encryption:</span>
 								<div className="flex items-center gap-1">

--- a/frontend/src/components/files/FileList.tsx
+++ b/frontend/src/components/files/FileList.tsx
@@ -3,6 +3,7 @@ import { File, FileArchive, FileImage, FileText, FileVideo, Folder, Music } from
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WebDAVFile } from "../../types/webdav";
+import { getFormatLabel } from "../../utils/fileUtils";
 import { FileActions } from "./FileActions";
 
 interface FileListProps {
@@ -139,7 +140,7 @@ export function FileList({
 				return <FileVideo className={iconClass} />;
 			case ["mp3", "wav", "flac", "aac", "ogg"].includes(extension):
 				return <Music className={iconClass} />;
-			case ["zip", "rar", "7z", "tar", "gz"].includes(extension):
+			case ["zip", "rar", "7z", "tar", "gz", "iso"].includes(extension):
 				return <FileArchive className={iconClass} />;
 			case ["txt", "md", "log", "json", "xml", "csv"].includes(extension):
 				return <FileText className={iconClass} />;
@@ -359,7 +360,11 @@ function FileCard({
 					</div>
 					<div className="flex justify-between">
 						<span>Type:</span>
-						<span className="capitalize">{file.type}</span>
+						<span className="capitalize">
+							{file.type === "file"
+								? (getFormatLabel(file.basename) ?? file.mime ?? "File")
+								: file.type}
+						</span>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/utils/fileUtils.ts
+++ b/frontend/src/utils/fileUtils.ts
@@ -96,7 +96,7 @@ export function getFileTypeInfo(filename: string, mimeType?: string): FileTypeIn
 	}
 
 	// Archive files
-	if (["zip", "rar", "7z", "tar", "gz", "bz2", "xz"].includes(extension)) {
+	if (["zip", "rar", "7z", "tar", "gz", "bz2", "xz", "iso"].includes(extension)) {
 		return {
 			category: "archive",
 			isPreviewable: false,
@@ -177,6 +177,45 @@ export function getCodeLanguage(filename: string): string {
 	};
 
 	return languageMap[extension] || "text";
+}
+
+export function getFormatLabel(filename: string): string | null {
+	const extension = filename.split(".").pop()?.toLowerCase() || "";
+
+	const formatMap: Record<string, string> = {
+		rar: "RAR Archive",
+		"7z": "7-Zip Archive",
+		iso: "ISO Image",
+		zip: "ZIP Archive",
+		tar: "TAR Archive",
+		gz: "GZ Archive",
+		bz2: "BZ2 Archive",
+		xz: "XZ Archive",
+		mkv: "MKV Video",
+		mp4: "MP4 Video",
+		avi: "AVI Video",
+		mov: "MOV Video",
+		webm: "WebM Video",
+		wmv: "WMV Video",
+		flv: "FLV Video",
+		m4v: "M4V Video",
+		mp3: "MP3 Audio",
+		flac: "FLAC Audio",
+		wav: "WAV Audio",
+		aac: "AAC Audio",
+		ogg: "OGG Audio",
+		m4a: "M4A Audio",
+		wma: "WMA Audio",
+		jpg: "JPEG Image",
+		jpeg: "JPEG Image",
+		png: "PNG Image",
+		gif: "GIF Image",
+		webp: "WebP Image",
+		svg: "SVG Image",
+		pdf: "PDF Document",
+	};
+
+	return formatMap[extension] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a `getFormatLabel()` utility in `fileUtils.ts` that maps common file extensions to human-readable labels (e.g. `"RAR Archive"`, `"ISO Image"`, `"MKV Video"`, `"PDF Document"`)
- Adds `iso` to the archive extensions list so ISO files receive the `FileArchive` icon instead of the generic `File` icon
- Replaces the generic `"Type: file"` row in `FileCard` with the format label (falls back to mime type, then `"File"`)
- Adds a `"Format:"` row above `"Encryption:"` in the `FileInfoModal` overview tab, rendered only when a recognized format label exists

## Test plan

- [ ] `.rar` file → card shows "RAR Archive", modal shows "Format: RAR Archive"
- [ ] `.7z` file → card shows "7-Zip Archive", modal shows "Format: 7-Zip Archive"
- [ ] `.iso` file → card shows `FileArchive` icon + "ISO Image", modal shows "Format: ISO Image"
- [ ] `.mkv` file → card shows "MKV Video", modal shows "Format: MKV Video"
- [ ] File with unrecognized extension → falls back to mime type or "File", no Format row in modal
- [ ] `bun run check` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)