### PR TITLE
Add optional rclone cache cleanup when switching mount type

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -106,6 +106,31 @@ export function MountConfigSection({ config, onUpdate, isUpdating }: MountConfig
 				{ type: "warning", confirmText: "Switch", confirmButtonClass: "btn-warning" },
 			);
 			if (!confirmed) return;
+
+			if (mountType === "rclone") {
+				const clearCache = await confirmAction(
+					"Clear RClone Cache?",
+					"Do you want to delete the rclone VFS cache to free up disk space? This cannot be undone.",
+					{ type: "info", confirmText: "Clear Cache", confirmButtonClass: "btn-error" },
+				);
+				if (clearCache) {
+					try {
+						const response = await fetch("/api/rclone/cache", { method: "DELETE" });
+						const result = await response.json();
+						if (result.success) {
+							showToast({ type: "success", title: "RClone cache cleared" });
+						} else {
+							showToast({ type: "error", title: "Failed to clear cache", message: result.error?.message });
+						}
+					} catch (err) {
+						showToast({
+							type: "error",
+							title: "Failed to clear cache",
+							message: err instanceof Error ? err.message : "Unknown error",
+						});
+					}
+				}
+			}
 		}
 		setMountType(newType);
 		subSectionDataRef.current = {};


### PR DESCRIPTION
When switching from internal rclone to any other mount type, offer an
optional prompt to clear the rclone VFS cache directory. This prevents
orphaned cache files from consuming disk space after the rclone mount
is no longer in use.

- Backend: new DELETE /api/rclone/cache endpoint in RCloneHandlers that
  reads the configured cache_dir, removes all contents, and recreates
  the directory empty
- Frontend: after confirming the mount type switch, a second optional
  dialog asks whether to clear the cache; only shown when switching FROM
  the internal rclone type

https://claude.ai/code/session_012vi8AGdo7tviFhYrE3Xm2i