### PR TITLE
fix(auth): auto-detect COOKIE_SECURE from request

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -388,6 +388,15 @@ func sameSiteToString(sameSite http.SameSite) string {
 }
 
 
+// resolveSecureFlag returns the Secure flag for a cookie, auto-detecting from the
+// request protocol when CookieSecureAutoDetect is enabled.
+func resolveSecureFlag(c *fiber.Ctx, cfg *auth.Config) bool {
+	if cfg.CookieSecureAutoDetect {
+		return c.Protocol() == "https"
+	}
+	return cfg.CookieSecure
+}
+
 // setJWTCookie sets the JWT cookie using Fiber's native cookie handling (merged config)
 func (s *Server) setJWTCookie(c *fiber.Ctx, tokenString string) error {
 	cfg := s.authService.GetConfig()
@@ -398,7 +407,7 @@ func (s *Server) setJWTCookie(c *fiber.Ctx, tokenString string) error {
 		Path:     "/",
 		Domain:   cfg.CookieDomain,
 		Expires:  time.Now().Add(cfg.TokenDuration),
-		Secure:   cfg.CookieSecure,
+		Secure:   resolveSecureFlag(c, cfg),
 		HTTPOnly: true,
 		SameSite: sameSiteToString(cfg.CookieSameSite),
 	}
@@ -417,7 +426,7 @@ func (s *Server) clearJWTCookie(c *fiber.Ctx) {
 		Path:     "/",
 		Domain:   cfg.CookieDomain,
 		Expires:  time.Now().Add(-time.Hour), // Expire in the past
-		Secure:   cfg.CookieSecure,
+		Secure:   resolveSecureFlag(c, cfg),
 		HTTPOnly: true,
 		SameSite: sameSiteToString(cfg.CookieSameSite),
 	}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -27,11 +27,12 @@ type Service struct {
 // Config represents authentication service configuration
 type Config struct {
 	// JWT configuration
-	JWTSecret      string        // JWT signing secret
-	TokenDuration  time.Duration // JWT token duration
-	CookieDomain   string        // Cookie domain
-	CookieSecure   bool          // Secure cookie flag
-	CookieSameSite http.SameSite // SameSite cookie attribute
+	JWTSecret              string        // JWT signing secret
+	TokenDuration          time.Duration // JWT token duration
+	CookieDomain           string        // Cookie domain
+	CookieSecure           bool          // Secure cookie flag (used only when CookieSecureAutoDetect is false)
+	CookieSecureAutoDetect bool          // When true, derive Secure flag from request protocol at runtime
+	CookieSameSite         http.SameSite // SameSite cookie attribute
 
 	// Direct authentication
 	DirectAuthEnabled bool   // Enable direct username/password authentication
@@ -45,13 +46,14 @@ type Config struct {
 // DefaultConfig returns default authentication configuration
 func DefaultConfig() *Config {
 	return &Config{
-		TokenDuration:     24 * time.Hour,       // 24 hours
-		CookieDomain:      "",                   // Empty string allows browser to use current domain
-		CookieSecure:      true,                 // Set to false via COOKIE_SECURE=false for local HTTP dev
-		CookieSameSite:    http.SameSiteLaxMode, // Use Lax mode for Safari compatibility
-		DirectAuthEnabled: true,
-		Issuer:            "altmount",
-		Audience:          "altmount-api",
+		TokenDuration:          24 * time.Hour,       // 24 hours
+		CookieDomain:           "",                   // Empty string allows browser to use current domain
+		CookieSecure:           false,                // Only used when CookieSecureAutoDetect is false
+		CookieSecureAutoDetect: true,                 // Auto-detect Secure flag from request protocol
+		CookieSameSite:         http.SameSiteLaxMode, // Use Lax mode for Safari compatibility
+		DirectAuthEnabled:      true,
+		Issuer:                 "altmount",
+		Audience:               "altmount-api",
 	}
 }
 
@@ -70,8 +72,10 @@ func LoadConfigFromEnv() (*Config, error) {
 		config.CookieDomain = domain
 	}
 
-	if secure := os.Getenv("COOKIE_SECURE"); secure == "false" {
-		config.CookieSecure = false
+	if secure := os.Getenv("COOKIE_SECURE"); secure != "" {
+		// Explicit env var disables auto-detection and forces a fixed value
+		config.CookieSecureAutoDetect = false
+		config.CookieSecure = secure != "false"
 	}
 
 	if salt := os.Getenv("DIRECT_AUTH_SALT"); salt != "" {
@@ -109,6 +113,11 @@ func NewService(config *Config, userRepo *database.UserRepository) (*Service, er
 		urlDomain = "localhost"
 	}
 
+	// When auto-detect is enabled, the actual Secure flag is resolved per-request
+	// in setJWTCookie/clearJWTCookie. The go-pkgz/auth library option is set to false
+	// so it does not reject token reads on HTTP connections.
+	secureCookiesForLib := config.CookieSecure && !config.CookieSecureAutoDetect
+
 	opts := auth.Opts{
 		SecretReader: token.SecretFunc(func(string) (string, error) {
 			return config.JWTSecret, nil
@@ -116,7 +125,7 @@ func NewService(config *Config, userRepo *database.UserRepository) (*Service, er
 		TokenDuration:   config.TokenDuration,
 		CookieDuration:  config.TokenDuration,
 		DisableXSRF:     true, // SameSite: Lax cookie already prevents CSRF
-		SecureCookies:   config.CookieSecure,
+		SecureCookies:   secureCookiesForLib,
 		JWTCookieName:   "JWT",
 		JWTCookieDomain: config.CookieDomain,
 		SameSiteCookie:  config.CookieSameSite,


### PR DESCRIPTION
The COOKIE_SECURE flag was hardcoded to true since the security hardening in alpha6. Browsers silently drop cookies marked Secure on plain HTTP connections, so any user accessing via http://192.168.x.x:8080 or http://localhost would see login succeed (200) but all subsequent API calls fail with 401.

Change the default to auto-detect the Secure flag from the incoming request protocol at cookie-set time:
  - HTTP request  → Secure=false (cookie sent, login works)
  - HTTPS request → Secure=true  (cookie HTTPS-only, maximally secure)

Explicit COOKIE_SECURE env var overrides auto-detection for edge cases such as reverse proxies that terminate TLS before reaching Go.

Fixes #374 