### PR TITLE
feat(stremio): add configurable base_url to StremioConfig

### DIFF
--- a/docs/docs/3. Configuration/stremio.md
+++ b/docs/docs/3. Configuration/stremio.md
@@ -25,12 +25,14 @@ Add the following block to your `config.yaml`:
 stremio:
   enabled: true
   nzb_ttl_hours: 24   # 0 = keep cached streams forever
+  base_url: ""        # optional — set if auto-detection gives the wrong origin
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | bool | `false` | Enable the `/api/nzb/streams` endpoint |
 | `nzb_ttl_hours` | int | `24` | Hours before a cached NZB result expires. `0` means never expire. |
+| `base_url` | string | `""` | Public base URL used when building stream links (e.g. `https://altmount.example.com`). When empty, AltMount auto-detects the origin from the incoming request. Set this when running behind a reverse proxy or when the detected origin is wrong. |
 
 When `nzb_ttl_hours` is greater than zero, submitting the same NZB filename within the TTL window returns the cached stream URLs immediately without re-queueing or re-downloading.
 
@@ -66,7 +68,6 @@ Submit an NZB and receive stream URLs.
 |-------|----------|-------------|
 | `download_key` | Yes | SHA-256 of your API key (lowercase hex) |
 | `file` | Yes | The `.nzb` file to process (max 100 MB) |
-| `base_url` | No | Base URL for stream links (defaults to the request origin, e.g. `http://192.168.1.10:8080`) |
 | `category` | No | Download category (e.g. `movies`, `tv`) |
 | `timeout` | No | Seconds to wait before returning a 408 (default: `300`) |
 
@@ -127,7 +128,6 @@ DOWNLOAD_KEY=$(echo -n "YOUR_API_KEY" | sha256sum | awk '{print $1}')
 curl -s -X POST "http://localhost:8080/api/nzb/streams" \
   -F "download_key=${DOWNLOAD_KEY}" \
   -F "file=@/path/to/release.nzb" \
-  -F "base_url=http://localhost:8080" \
   -F "category=movies" \
   -F "timeout=300" | jq .
 ```

--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -111,8 +111,8 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		return RespondValidationError(c, "File too large", "File size must be less than 100MB")
 	}
 
-	// --- Optional parameters ---
-	baseURL := strings.TrimRight(c.FormValue("base_url"), "/")
+	// --- Resolve base URL ---
+	baseURL := strings.TrimRight(cfg.Stremio.BaseURL, "/")
 	if baseURL == "" {
 		baseURL = c.Protocol() + "://" + c.Hostname()
 	}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -102,6 +102,10 @@ type StremioConfig struct {
 	// the same NZB is re-processed on the next request.
 	// Set to 0 to disable expiry (cache forever). Defaults to 24 hours.
 	NzbTTLHours int `yaml:"nzb_ttl_hours" mapstructure:"nzb_ttl_hours" json:"nzb_ttl_hours,omitempty"`
+	// BaseURL is the public base URL used when building Stremio stream links
+	// (e.g. "https://altmount.example.com"). Falls back to the auto-detected
+	// request origin when not set.
+	BaseURL string `yaml:"base_url" mapstructure:"base_url" json:"base_url,omitempty"`
 }
 
 // AuthConfig represents authentication configuration


### PR DESCRIPTION
## Summary

- Adds `base_url` field to `StremioConfig` in `internal/config/manager.go`
- Replaces the `base_url` form parameter in `POST /api/nzb/streams` with the config value, falling back to auto-detected request origin when unset
- Updates `docs/docs/3. Configuration/stremio.md` to document the new config field and remove `base_url` from the endpoint form fields table and example curl command

## Test plan

- [ ] Set `stremio.base_url: "https://altmount.example.com"` in config and verify stream URLs use that base
- [ ] Leave `stremio.base_url` empty and verify stream URLs fall back to the request origin
- [ ] Confirm `base_url` form parameter is no longer accepted / no longer needed in curl requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)