### PR TITLE
feat(queue): add search-by-name NZB import

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -881,6 +881,25 @@ export class APIClient {
 		});
 	}
 
+	async searchNZBByName(
+		name: string,
+		password?: string,
+		category?: string,
+		priority?: number,
+		relativePath?: string,
+	): Promise<{ queue_id: number; title: string; indexer: string }> {
+		return this.request("/queue/upload-by-name", {
+			method: "POST",
+			body: JSON.stringify({
+				name,
+				password: password || undefined,
+				category: category || undefined,
+				priority: priority ?? undefined,
+				relative_path: relativePath || undefined,
+			}),
+		});
+	}
+
 	async addTestQueueItem(size: "100MB" | "1GB" | "10GB") {
 		return this.request<APIResponse<QueueItem>>("/queue/test", {
 			method: "POST",

--- a/frontend/src/components/queue/ImportMethods.tsx
+++ b/frontend/src/components/queue/ImportMethods.tsx
@@ -10,6 +10,7 @@ import {
 	FolderOpen,
 	Link,
 	Play,
+	Search,
 	Square,
 	Upload,
 	UploadCloud,
@@ -23,6 +24,7 @@ import {
 	useNzbdavImportStatus,
 	useResetNzbdavImportStatus,
 	useScanStatus,
+	useSearchNZBByName,
 	useStartManualScan,
 	useUploadNZBLnks,
 	useUploadToQueue,
@@ -159,9 +161,13 @@ function EnhancedUploadSection() {
 	const [uploadedLinks, setUploadedLinks] = useState<UploadedLink[]>([]);
 	const [category, setCategory] = useState<string>("");
 	const [linkInput, setLinkInput] = useState<string>("");
-	const [uploadTab, setUploadTab] = useState<"files" | "nzblnk">("files");
+	const [nameInput, setNameInput] = useState<string>("");
+	const [passwordInput, setPasswordInput] = useState<string>("");
+	const [uploadTab, setUploadTab] = useState<"files" | "nzblnk" | "byname">("files");
 	const uploadMutation = useUploadToQueue();
 	const uploadLinksMutation = useUploadNZBLnks();
+	const searchByNameMutation = useSearchNZBByName();
+	const { showToast } = useToast();
 	const { data: config } = useConfig();
 
 	const categories = config?.sabnzbd?.categories ?? [];
@@ -327,6 +333,31 @@ function EnhancedUploadSection() {
 		}
 	}, [linkInput, category, uploadLinksMutation, parseLinks, validateNZBLink, extractTitleFromLink]);
 
+	const handleNameSubmit = useCallback(async () => {
+		const name = nameInput.trim();
+		if (!name) return;
+		try {
+			const result = await searchByNameMutation.mutateAsync({
+				name,
+				password: passwordInput || undefined,
+				category: category || undefined,
+			});
+			showToast({
+				title: "Added to Queue",
+				message: `"${result.title}" found via ${result.indexer} (ID: ${result.queue_id})`,
+				type: "success",
+			});
+			setNameInput("");
+			setPasswordInput("");
+		} catch (error) {
+			showToast({
+				title: "Search Failed",
+				message: error instanceof Error ? error.message : "Could not find NZB for the given name",
+				type: "error",
+			});
+		}
+	}, [nameInput, passwordInput, category, searchByNameMutation, showToast]);
+
 	const handleDragOver = useCallback((e: React.DragEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
@@ -373,7 +404,7 @@ function EnhancedUploadSection() {
 	return (
 		<div className="space-y-8">
 			{/* Tab Selector */}
-			<div role="tablist" className="tabs tabs-boxed mb-4 max-w-sm">
+			<div role="tablist" className="tabs tabs-boxed mb-4 max-w-lg">
 				<button
 					type="button"
 					role="tab"
@@ -391,6 +422,15 @@ function EnhancedUploadSection() {
 				>
 					<Link className="mr-2 h-4 w-4" />
 					NZBLNK
+				</button>
+				<button
+					type="button"
+					role="tab"
+					className={`tab ${uploadTab === "byname" ? "tab-active" : ""}`}
+					onClick={() => setUploadTab("byname")}
+				>
+					<Search className="mr-2 h-4 w-4" />
+					By Name
 				</button>
 			</div>
 
@@ -463,6 +503,45 @@ function EnhancedUploadSection() {
 							<Download className="h-4 w-4" />
 						)}
 						Resolve & Queue
+					</button>
+				</div>
+			)}
+
+			{uploadTab === "byname" && (
+				<div className="space-y-4">
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend font-semibold">Name / Title</legend>
+						<input
+							type="text"
+							className="input w-full bg-base-200/50"
+							placeholder="e.g. Some.Show.S01E01.1080p"
+							value={nameInput}
+							onChange={(e) => setNameInput(e.target.value)}
+							onKeyDown={(e) => e.key === "Enter" && handleNameSubmit()}
+						/>
+					</fieldset>
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend font-semibold">Password (optional)</legend>
+						<input
+							type="text"
+							className="input w-full bg-base-200/50"
+							placeholder="Archive password if required"
+							value={passwordInput}
+							onChange={(e) => setPasswordInput(e.target.value)}
+						/>
+					</fieldset>
+					<button
+						type="button"
+						className="btn btn-primary btn-sm"
+						onClick={handleNameSubmit}
+						disabled={!nameInput.trim() || searchByNameMutation.isPending}
+					>
+						{searchByNameMutation.isPending ? (
+							<LoadingSpinner size="sm" />
+						) : (
+							<Search className="h-4 w-4" />
+						)}
+						Search & Queue
 					</button>
 				</div>
 			)}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -535,6 +535,30 @@ export const useUploadNZBLnks = () => {
 	});
 };
 
+export const useSearchNZBByName = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			name,
+			password,
+			category,
+			priority,
+			relativePath,
+		}: {
+			name: string;
+			password?: string;
+			category?: string;
+			priority?: number;
+			relativePath?: string;
+		}) => apiClient.searchNZBByName(name, password, category, priority, relativePath),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+			queryClient.invalidateQueries({ queryKey: ["queue", "stats"] });
+		},
+	});
+};
+
 export const useAddTestQueueItem = () => {
 	const queryClient = useQueryClient();
 

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -655,6 +656,83 @@ func embedPasswordInNZB(nzbContent []byte, password string) []byte {
 	}
 
 	return []byte(content)
+}
+
+// handleSearchNZBByName handles POST /api/queue/upload-by-name
+func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
+	var req struct {
+		Name         string `json:"name"`
+		Password     string `json:"password"`
+		Category     string `json:"category"`
+		Priority     int    `json:"priority"`
+		RelativePath string `json:"relative_path"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return RespondBadRequest(c, "Invalid request body", err.Error())
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		return RespondValidationError(c, "Name is required", "")
+	}
+	if s.importerService == nil {
+		return RespondServiceUnavailable(c, "Importer service not available", "The import service is not configured or running")
+	}
+
+	// Build a synthetic nzblnk URL using name as both t= and h=
+	syntheticLink := "nzblnk:?t=" + url.QueryEscape(req.Name) + "&h=" + url.QueryEscape(req.Name)
+	if req.Password != "" {
+		syntheticLink += "&p=" + url.QueryEscape(req.Password)
+	}
+
+	resolver := nzblnk.NewResolver()
+	resolved, err := resolver.Resolve(c.Context(), syntheticLink)
+	if err != nil {
+		return RespondNotFound(c, "NZB", "Could not find NZB for name '"+req.Name+"': "+err.Error())
+	}
+
+	uploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
+	if err := os.MkdirAll(uploadDir, 0755); err != nil {
+		return RespondInternalError(c, "Failed to create upload directory", err.Error())
+	}
+	safeTitle := sanitizeFilename(resolved.Title)
+	tempFile := filepath.Join(uploadDir, safeTitle+".nzb")
+
+	nzbContent := resolved.NZBContent
+	if resolved.Password != "" {
+		nzbContent = embedPasswordInNZB(nzbContent, resolved.Password)
+		slog.DebugContext(c.Context(), "Embedded password in NZB", "title", resolved.Title)
+	}
+	if err := os.WriteFile(tempFile, nzbContent, 0644); err != nil {
+		return RespondInternalError(c, "Failed to save NZB file", err.Error())
+	}
+
+	var categoryPtr *string
+	if req.Category != "" {
+		categoryPtr = &req.Category
+	}
+
+	var basePath *string
+	if s.configManager != nil {
+		if completeDir := s.configManager.GetConfig().SABnzbd.CompleteDir; completeDir != "" {
+			p := completeDir
+			if req.RelativePath != "" {
+				p = filepath.Join(p, req.RelativePath)
+			}
+			basePath = &p
+		}
+	}
+
+	priority := database.QueuePriority(req.Priority)
+	item, err := s.importerService.AddToQueue(c.Context(), tempFile, basePath, categoryPtr, &priority)
+	if err != nil {
+		os.Remove(tempFile)
+		return RespondInternalError(c, "Failed to add to queue", err.Error())
+	}
+
+	return RespondCreated(c, fiber.Map{
+		"queue_id": item.ID,
+		"title":    resolved.Title,
+		"indexer":  resolved.Indexer,
+	})
 }
 
 // handleRestartQueueBulk handles POST /api/queue/bulk/restart

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -222,6 +222,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/queue/bulk/cancel", s.handleCancelQueueBulk)
 	api.Post("/queue/upload", s.handleUploadToQueue)
 	api.Post("/queue/upload-nzblnk", s.handleUploadNZBLnk)
+	api.Post("/queue/upload-by-name", s.handleSearchNZBByName)
 	api.Post("/queue/test", s.handleAddTestQueueItem)
 	api.Get("/queue/:id", s.handleGetQueue)
 	api.Delete("/queue/:id", s.handleDeleteQueue)


### PR DESCRIPTION
## Summary

- Adds `POST /api/queue/upload-by-name` backend endpoint that accepts a `name` (and optional `password`, `category`, `priority`, `relative_path`) and resolves the NZB via the existing `nzblnk.Resolver` by treating the name as both the `t=` and `h=` NZBLNK parameters
- Adds `searchNZBByName` API client method and `useSearchNZBByName` React Query mutation hook
- Adds a **By Name** tab to the Upload section in the Queue Import UI with name input (required), password input (optional), and "Search & Queue" button with loading state and toast feedback

## Test plan

- [ ] `POST /api/queue/upload-by-name` with `{"name":"Some.Show.S01E01"}` returns `{queue_id, title, indexer}`
- [ ] Empty name returns 400 validation error
- [ ] Name not found on any indexer returns 404 with descriptive message
- [ ] Open Queue → Import → Upload → "By Name" tab is visible and functional
- [ ] Enter a name and click "Search & Queue" → success toast and item appears in queue
- [ ] Enter a name that doesn't exist → error toast shown
- [ ] Enter key in name field submits the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)