### PR TITLE
fix(parser): improve NZB naming resolution to match SABnzbd logic

### DIFF
--- a/internal/importer/parser/fileinfo/detector.go
+++ b/internal/importer/parser/fileinfo/detector.go
@@ -45,6 +45,11 @@ func HasRarMagic(data []byte) bool {
 	return HasRar4Magic(data) || HasRar5Magic(data)
 }
 
+// Has7zMagic checks if the data contains 7-Zip magic bytes
+func Has7zMagic(data []byte) bool {
+	return len(data) >= len(SevenZipMagic) && bytes.Equal(data[:len(SevenZipMagic)], SevenZipMagic)
+}
+
 // IsVideoFile checks if the filename is a video file based on extension
 func IsVideoFile(filename string) bool {
 	if filename == "" {

--- a/internal/importer/parser/fileinfo/fileinfo.go
+++ b/internal/importer/parser/fileinfo/fileinfo.go
@@ -2,6 +2,7 @@ package fileinfo
 
 import (
 	"crypto/md5"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -20,10 +21,14 @@ var (
 func GetFileInfos(
 	files []*NzbFileWithFirstSegment,
 	par2Descriptors map[[16]byte]*par2.FileDescriptor,
+	nzbFilename string,
 ) []*FileInfo {
+	// Strip .nzb extension for use as last-resort filename stem
+	nzbStem := strings.TrimSuffix(nzbFilename, filepath.Ext(nzbFilename))
+
 	fileInfos := make([]*FileInfo, 0, len(files))
 	for _, file := range files {
-		info := getFileInfo(file, par2Descriptors)
+		info := getFileInfo(file, par2Descriptors, nzbStem)
 		fileInfos = append(fileInfos, info)
 	}
 
@@ -34,13 +39,17 @@ func GetFileInfos(
 func getFileInfo(
 	file *NzbFileWithFirstSegment,
 	hashToDescMap map[[16]byte]*par2.FileDescriptor,
+	nzbFilenameStem string,
 ) *FileInfo {
 	par2Filename := ""
 	par2FileSize := int64(0)
 
 	if len(hashToDescMap) > 0 {
-		// Calculate MD5 hash of first 16KB for PAR2 matching
-		md5Hash := md5.Sum(file.First16KB)
+		// Gap 1: PAR2 Hash16k is MD5 of the first 16384 bytes, zero-padded if file is shorter.
+		// Without zero-padding, md5.Sum(file.First16KB) produces a wrong hash for files < 16KB.
+		padded := make([]byte, 16384)
+		copy(padded, file.First16KB)
+		md5Hash := md5.Sum(padded)
 
 		desc, ok := hashToDescMap[md5Hash]
 		if ok {
@@ -56,8 +65,22 @@ func getFileInfo(
 		headerFilename = file.Headers.FileName
 	}
 
-	// Select best filename using priority system
-	filename := selectBestFilename(par2Filename, subjectFilename, headerFilename)
+	// Select best filename using priority system (PAR2 > subject > yEnc header > subject header)
+	filename := selectBestFilename(par2Filename, subjectFilename, headerFilename, file.SubjectHeader)
+
+	// Gap 4: Correct extension based on magic bytes when filename appears obfuscated.
+	// This handles files that were uploaded with a wrong or missing extension.
+	filename = correctExtensionFromMagicBytes(filename, file.First16KB)
+
+	// Gap 5: Last resort — use NZB filename stem when all other sources are obfuscated/empty.
+	if nzbFilenameStem != "" && (filename == "" || isProbablyObfuscated(filename)) {
+		ext := filepath.Ext(filename)
+		if ext != "" {
+			filename = nzbFilenameStem + ext
+		} else {
+			filename = nzbFilenameStem
+		}
+	}
 
 	// Determine file size (PAR2 has highest priority)
 	var fileSize *int64
@@ -71,8 +94,8 @@ func getFileInfo(
 	// Detect RAR archives (by magic bytes or extension)
 	isRar := HasRarMagic(file.First16KB) || IsRarFile(filename)
 
-	// Detect 7z archives (by extension only, no magic bytes check for 7z)
-	is7z := Is7zFile(filename)
+	// Gap 3: Detect 7z archives by magic bytes or extension
+	is7z := Has7zMagic(file.First16KB) || Is7zFile(filename)
 
 	isPar2Archive := IsPar2File(filename)
 
@@ -90,10 +113,26 @@ func getFileInfo(
 	}
 }
 
+// correctExtensionFromMagicBytes fixes the extension of an obfuscated file based on its magic bytes.
+// Only applies when the filename looks obfuscated — clear names are never modified.
+func correctExtensionFromMagicBytes(filename string, data []byte) string {
+	if !isProbablyObfuscated(filename) {
+		return filename
+	}
+	base := strings.TrimSuffix(filename, filepath.Ext(filename))
+	if HasRarMagic(data) {
+		return base + ".rar"
+	}
+	if Has7zMagic(data) {
+		return base + ".7z"
+	}
+	return filename
+}
+
 // selectBestFilename selects the best filename using priority system
-// Priority: PAR2 (3) > Subject (2) > Header (1)
+// Priority: PAR2 (3) > Subject (2) > yEnc header (1) > Subject header (0)
 // With adjustments for obfuscation, important types, and extension length
-func selectBestFilename(par2Filename, subjectFilename, headerFilename string) string {
+func selectBestFilename(par2Filename, subjectFilename, headerFilename, subjectHeader string) string {
 	type candidate struct {
 		filename string
 		priority int
@@ -103,6 +142,7 @@ func selectBestFilename(par2Filename, subjectFilename, headerFilename string) st
 		{filename: par2Filename, priority: getFilenamePriority(par2Filename, 3)},
 		{filename: subjectFilename, priority: getFilenamePriority(subjectFilename, 2)},
 		{filename: headerFilename, priority: getFilenamePriority(headerFilename, 1)},
+		{filename: subjectHeader, priority: getFilenamePriority(subjectHeader, 0)},
 	}
 
 	// Find candidate with highest priority

--- a/internal/importer/parser/fileinfo/fileinfo_test.go
+++ b/internal/importer/parser/fileinfo/fileinfo_test.go
@@ -1,6 +1,8 @@
 package fileinfo
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestIsProbablyObfuscated(t *testing.T) {
 	tests := []struct {
@@ -91,6 +93,7 @@ func TestSelectBestFilename(t *testing.T) {
 		par2Filename    string
 		subjectFilename string
 		headerFilename  string
+		subjectHeader   string
 		want            string
 	}{
 		{
@@ -121,13 +124,75 @@ func TestSelectBestFilename(t *testing.T) {
 			headerFilename:  "Movie.mkv",
 			want:            "Movie.mkv",
 		},
+		{
+			name:            "Subject header used when all others obfuscated",
+			par2Filename:    "",
+			subjectFilename: "b082fa0beaa644d3aa01045d5b8d0b36.mkv",
+			headerFilename:  "",
+			subjectHeader:   "Movie.Name.2023.1080p.BluRay",
+			want:            "Movie.Name.2023.1080p.BluRay",
+		},
+		{
+			name:            "Clear subject wins over subject header",
+			par2Filename:    "",
+			subjectFilename: "Good.Movie.Name.mkv",
+			headerFilename:  "",
+			subjectHeader:   "Movie.Name.2023.1080p.BluRay",
+			want:            "Good.Movie.Name.mkv",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := selectBestFilename(tt.par2Filename, tt.subjectFilename, tt.headerFilename)
+			got := selectBestFilename(tt.par2Filename, tt.subjectFilename, tt.headerFilename, tt.subjectHeader)
 			if got != tt.want {
 				t.Errorf("selectBestFilename() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCorrectExtensionFromMagicBytes(t *testing.T) {
+	rar4Header := append([]byte(nil), Rar4Magic...)
+	sevenZipHeader := append([]byte(nil), SevenZipMagic...)
+
+	tests := []struct {
+		name     string
+		filename string
+		data     []byte
+		want     string
+	}{
+		{
+			name:     "obfuscated .bin with RAR magic → .rar",
+			filename: "b082fa0beaa644d3aa01045d5b8d0b36.bin",
+			data:     rar4Header,
+			want:     "b082fa0beaa644d3aa01045d5b8d0b36.rar",
+		},
+		{
+			name:     "obfuscated .dat with 7z magic → .7z",
+			filename: "0675e29e9abfd2.f7d069dab0b853283cc1b069a25f82.dat",
+			data:     sevenZipHeader,
+			want:     "0675e29e9abfd2.f7d069dab0b853283cc1b069a25f82.7z",
+		},
+		{
+			name:     "clear filename not changed even with RAR magic",
+			filename: "Movie.Name.2023.mkv",
+			data:     rar4Header,
+			want:     "Movie.Name.2023.mkv",
+		},
+		{
+			name:     "no magic bytes — no change",
+			filename: "b082fa0beaa644d3aa01045d5b8d0b36.bin",
+			data:     []byte{0x00, 0x01, 0x02},
+			want:     "b082fa0beaa644d3aa01045d5b8d0b36.bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := correctExtensionFromMagicBytes(tt.filename, tt.data)
+			if got != tt.want {
+				t.Errorf("correctExtensionFromMagicBytes(%q) = %q, want %q", tt.filename, got, tt.want)
 			}
 		})
 	}

--- a/internal/importer/parser/fileinfo/types.go
+++ b/internal/importer/parser/fileinfo/types.go
@@ -14,6 +14,9 @@ var (
 
 	// Rar5Magic is the magic signature for RAR 5.x archives
 	Rar5Magic = []byte{0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x01, 0x00}
+
+	// SevenZipMagic is the magic signature for 7-Zip archives
+	SevenZipMagic = []byte{0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C}
 )
 
 // FileInfo represents parsed information about an NZB file
@@ -38,5 +41,6 @@ type NzbFileWithFirstSegment struct {
 	Headers       *nntppool.YEncMeta
 	First16KB     []byte
 	ReleaseDate   time.Time
-	OriginalIndex int // Original position in the parsed NZB file list
+	SubjectHeader string // Release name prefix from the subject line (before the filename)
+	OriginalIndex int    // Original position in the parsed NZB file list
 }

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -142,18 +142,24 @@ func (p *Parser) ParseFile(ctx context.Context, r io.Reader, nzbPath string) (*P
 			continue
 		}
 
+		subjectHeader := ""
+		if s, err := nzbparser.ParseSubject(data.File.Subject); err == nil {
+			subjectHeader = s.Header
+		}
+
 		filesWithFirstSegment = append(filesWithFirstSegment, &fileinfo.NzbFileWithFirstSegment{
 			NzbFile:       data.File,
 			Headers:       &data.Headers,
 			First16KB:     data.RawBytes,
 			ReleaseDate:   time.Unix(int64(data.File.Date), 0),
+			SubjectHeader: subjectHeader,
 			OriginalIndex: data.OriginalIndex,
 		})
 	}
 
 	// Get file infos with priority-based filename selection
 	// This already filters out PAR2 files
-	fileInfos := fileinfo.GetFileInfos(filesWithFirstSegment, par2Descriptors)
+	fileInfos := fileinfo.GetFileInfos(filesWithFirstSegment, par2Descriptors, parsed.Filename)
 	if len(fileInfos) == 0 {
 		p.log.WarnContext(ctx, "Failed to get file infos from network, falling back to NZB XML data",
 			"nzb_path", nzbPath)


### PR DESCRIPTION
## Summary

- **Fix PAR2 Hash16k zero-padding bug**: The PAR2 spec defines `Hash16k` as MD5 of the first 16384 bytes, zero-padded. Files smaller than 16KB were silently failing to match because we passed raw (shorter) bytes to `md5.Sum`. Now zero-pads to exactly 16384 bytes before hashing.
- **7-Zip magic byte detection**: Added `Has7zMagic()` using the `37 7A BC AF 27 1C` signature. 7z detection now works for obfuscated files with wrong/missing extensions, not just by extension pattern.
- **Extension correction from magic bytes**: After filename selection, if the chosen filename is obfuscated and magic bytes indicate RAR or 7z, the extension is corrected (e.g. `.bin` → `.rar`). Clear filenames are never modified.
- **Subject header as release name fallback**: `nzbparser.ParseSubject().Header` (the release name prefix before the filename in the subject line, e.g. `Movie.Name.2023.1080p.BluRay`) is now surfaced as a priority-0 naming source — used when PAR2, subject filename, and yEnc header are all obfuscated.
- **NZB filename as last resort**: When all other sources remain obfuscated after the above steps, the NZB file's own name stem is used as the base filename with the detected extension preserved.

## Test plan

- [ ] Existing tests pass: `go test ./internal/importer/parser/...`
- [ ] New `TestCorrectExtensionFromMagicBytes` covers RAR magic, 7z magic, clear filename (unchanged), no magic
- [ ] New `TestSelectBestFilename` cases cover subject header fallback and priority ordering
- [ ] `go build ./...` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)