### PR TITLE
feat(docs): upgrade API spec to OpenAPI 3.0 and fix dark-mode styles

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -20,6 +20,7 @@
         "@docusaurus/module-type-aliases": "3.8.1",
         "@docusaurus/tsconfig": "3.8.1",
         "@docusaurus/types": "3.8.1",
+        "swagger2openapi": "^7.0.8",
         "typescript": "~5.6.2",
       },
     },
@@ -439,6 +440,8 @@
 
     "@docusaurus/utils-validation": ["@docusaurus/utils-validation@3.8.1", "", { "dependencies": { "@docusaurus/logger": "3.8.1", "@docusaurus/utils": "3.8.1", "@docusaurus/utils-common": "3.8.1", "fs-extra": "^11.2.0", "joi": "^17.9.2", "js-yaml": "^4.1.0", "lodash": "^4.17.21", "tslib": "^2.6.0" } }, "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA=="],
 
+    "@exodus/schemasafe": ["@exodus/schemasafe@1.3.0", "", {}, "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw=="],
+
     "@hapi/hoek": ["@hapi/hoek@9.3.0", "", {}, "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="],
 
     "@hapi/topo": ["@hapi/topo@5.1.0", "", { "dependencies": { "@hapi/hoek": "^9.0.0" } }, "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg=="],
@@ -835,7 +838,7 @@
 
     "ansi-html-community": ["ansi-html-community@0.0.8", "", { "bin": { "ansi-html": "bin/ansi-html" } }, "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw=="],
 
-    "ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -915,6 +918,8 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camel-case": ["camel-case@4.1.2", "", { "dependencies": { "pascal-case": "^3.1.2", "tslib": "^2.0.3" } }, "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw=="],
@@ -962,6 +967,8 @@
     "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
 
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone-deep": ["clone-deep@4.0.1", "", { "dependencies": { "is-plain-object": "^2.0.4", "kind-of": "^6.0.2", "shallow-clone": "^3.0.0" } }, "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ=="],
 
@@ -1215,7 +1222,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.214", "", {}, "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
@@ -1240,6 +1247,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "es6-promise": ["es6-promise@3.3.1", "", {}, "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1307,6 +1316,8 @@
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
@@ -1358,6 +1369,8 @@
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
@@ -1460,6 +1473,8 @@
     "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
 
     "http-proxy-middleware": ["http-proxy-middleware@2.0.9", "", { "dependencies": { "@types/http-proxy": "^1.17.8", "http-proxy": "^1.18.1", "is-glob": "^4.0.1", "is-plain-obj": "^3.0.0", "micromatch": "^4.0.2" }, "peerDependencies": { "@types/express": "^4.17.13" } }, "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q=="],
+
+    "http2-client": ["http2-client@1.3.5", "", {}, "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA=="],
 
     "http2-wrapper": ["http2-wrapper@2.2.1", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.2.0" } }, "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ=="],
 
@@ -1825,11 +1840,17 @@
 
     "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-fetch-commonjs": ["node-fetch-commonjs@3.3.2", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A=="],
+
+    "node-fetch-h2": ["node-fetch-h2@2.3.0", "", { "dependencies": { "http2-client": "^1.2.5" } }, "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg=="],
 
     "node-forge": ["node-forge@1.3.1", "", {}, "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
+
+    "node-readfiles": ["node-readfiles@0.2.0", "", { "dependencies": { "es6-promise": "^3.2.1" } }, "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA=="],
 
     "node-releases": ["node-releases@2.0.20", "", {}, "sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA=="],
 
@@ -1846,6 +1867,16 @@
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
     "null-loader": ["null-loader@4.0.1", "", { "dependencies": { "loader-utils": "^2.0.0", "schema-utils": "^3.0.0" }, "peerDependencies": { "webpack": "^4.0.0 || ^5.0.0" } }, "sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg=="],
+
+    "oas-kit-common": ["oas-kit-common@1.0.8", "", { "dependencies": { "fast-safe-stringify": "^2.0.7" } }, "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ=="],
+
+    "oas-linter": ["oas-linter@3.2.2", "", { "dependencies": { "@exodus/schemasafe": "^1.0.0-rc.2", "should": "^13.2.1", "yaml": "^1.10.0" } }, "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ=="],
+
+    "oas-resolver": ["oas-resolver@2.5.6", "", { "dependencies": { "node-fetch-h2": "^2.3.0", "oas-kit-common": "^1.0.8", "reftools": "^1.1.9", "yaml": "^1.10.0", "yargs": "^17.0.1" }, "bin": { "resolve": "resolve.js" } }, "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ=="],
+
+    "oas-schema-walker": ["oas-schema-walker@1.1.5", "", {}, "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ=="],
+
+    "oas-validator": ["oas-validator@5.0.8", "", { "dependencies": { "call-me-maybe": "^1.0.1", "oas-kit-common": "^1.0.8", "oas-linter": "^3.2.2", "oas-resolver": "^2.5.6", "oas-schema-walker": "^1.1.5", "reftools": "^1.1.9", "should": "^13.2.1", "yaml": "^1.10.0" } }, "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -2179,6 +2210,8 @@
 
     "refractor": ["refractor@5.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/prismjs": "^1.0.0", "hastscript": "^9.0.0", "parse-entities": "^4.0.0" } }, "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw=="],
 
+    "reftools": ["reftools@1.1.9", "", {}, "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w=="],
+
     "regenerate": ["regenerate@1.4.2", "", {}, "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="],
 
     "regenerate-unicode-properties": ["regenerate-unicode-properties@10.2.0", "", { "dependencies": { "regenerate": "^1.4.2" } }, "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA=="],
@@ -2220,6 +2253,8 @@
     "renderkid": ["renderkid@3.0.0", "", { "dependencies": { "css-select": "^4.1.3", "dom-converter": "^0.2.0", "htmlparser2": "^6.1.0", "lodash": "^4.17.21", "strip-ansi": "^6.0.1" } }, "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg=="],
 
     "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
+
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
@@ -2311,6 +2346,18 @@
 
     "short-unique-id": ["short-unique-id@5.3.2", "", { "bin": { "short-unique-id": "bin/short-unique-id", "suid": "bin/short-unique-id" } }, "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg=="],
 
+    "should": ["should@13.2.3", "", { "dependencies": { "should-equal": "^2.0.0", "should-format": "^3.0.3", "should-type": "^1.4.0", "should-type-adaptors": "^1.0.1", "should-util": "^1.0.0" } }, "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ=="],
+
+    "should-equal": ["should-equal@2.0.0", "", { "dependencies": { "should-type": "^1.4.0" } }, "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA=="],
+
+    "should-format": ["should-format@3.0.3", "", { "dependencies": { "should-type": "^1.3.0", "should-type-adaptors": "^1.0.1" } }, "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q=="],
+
+    "should-type": ["should-type@1.4.0", "", {}, "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ=="],
+
+    "should-type-adaptors": ["should-type-adaptors@1.1.0", "", { "dependencies": { "should-type": "^1.3.0", "should-util": "^1.0.0" } }, "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA=="],
+
+    "should-util": ["should-util@1.0.1", "", {}, "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -2357,7 +2404,7 @@
 
     "std-env": ["std-env@3.9.0", "", {}, "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="],
 
-    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -2365,7 +2412,7 @@
 
     "stringify-object": ["stringify-object@3.3.0", "", { "dependencies": { "get-own-enumerable-property-symbols": "^3.0.0", "is-obj": "^1.0.1", "is-regexp": "^1.0.0" } }, "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw=="],
 
-    "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
@@ -2393,6 +2440,8 @@
 
     "swagger-ui-react": ["swagger-ui-react@5.32.0", "", { "dependencies": { "@babel/runtime-corejs3": "^7.27.1", "@scarf/scarf": "=1.4.0", "base64-js": "^1.5.1", "buffer": "^6.0.3", "classnames": "^2.5.1", "css.escape": "1.5.1", "deep-extend": "0.6.0", "dompurify": "=3.2.6", "ieee754": "^1.2.1", "immutable": "^3.x.x", "js-file-download": "^0.4.12", "js-yaml": "=4.1.1", "lodash": "^4.17.21", "prop-types": "^15.8.1", "randexp": "^0.5.3", "randombytes": "^2.1.0", "react-copy-to-clipboard": "5.1.0", "react-debounce-input": "=3.3.0", "react-immutable-proptypes": "2.2.0", "react-immutable-pure-component": "^2.2.0", "react-inspector": "^6.0.1", "react-redux": "^9.2.0", "react-syntax-highlighter": "^16.0.0", "redux": "^5.0.1", "redux-immutable": "^4.0.0", "remarkable": "^2.0.1", "reselect": "^5.1.1", "serialize-error": "^8.1.0", "sha.js": "^2.4.12", "swagger-client": "^3.37.0", "url-parse": "^1.5.10", "xml": "=1.0.1", "xml-but-prettier": "^1.0.1", "zenscroll": "^4.0.2" }, "peerDependencies": { "react": ">=16.8.0 <20", "react-dom": ">=16.8.0 <20" } }, "sha512-2mmrtvfp0EA90pdT8qXTMu26ex03TG2bsjvDAwXhdfCm+9foyadYJN+nEvDHM6/c6/xtXbdAsb6cVxBvbltnpw=="],
 
+    "swagger2openapi": ["swagger2openapi@7.0.8", "", { "dependencies": { "call-me-maybe": "^1.0.1", "node-fetch": "^2.6.1", "node-fetch-h2": "^2.3.0", "node-readfiles": "^0.2.0", "oas-kit-common": "^1.0.8", "oas-resolver": "^2.5.6", "oas-schema-walker": "^1.1.5", "oas-validator": "^5.0.8", "reftools": "^1.1.9", "yaml": "^1.10.0", "yargs": "^17.0.1" }, "bin": { "swagger2openapi": "swagger2openapi.js", "oas-validate": "oas-validate.js", "boast": "boast.js" } }, "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g=="],
+
     "tapable": ["tapable@2.2.3", "", {}, "sha512-ZL6DDuAlRlLGghwcfmSn9sK3Hr6ArtyudlSAiCqQ6IfE+b+HHbydbYDIG15IfS5do+7XQQBdBiubF/cV2dnDzg=="],
 
     "terser": ["terser@5.44.0", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": "bin/terser" }, "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w=="],
@@ -2418,6 +2467,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-sitter": ["tree-sitter@0.21.1", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.0" } }, "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ=="],
 
@@ -2537,6 +2588,8 @@
 
     "web-tree-sitter": ["web-tree-sitter@0.24.5", "", {}, "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "webpack": ["webpack@5.101.3", "", { "dependencies": { "@types/eslint-scope": "^3.7.7", "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.15.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.24.0", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.17.3", "es-module-lexer": "^1.2.1", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "json-parse-even-better-errors": "^2.3.1", "loader-runner": "^4.2.0", "mime-types": "^2.1.27", "neo-async": "^2.6.2", "schema-utils": "^4.3.2", "tapable": "^2.1.1", "terser-webpack-plugin": "^5.3.11", "watchpack": "^2.4.1", "webpack-sources": "^3.3.3" }, "bin": "bin/webpack.js" }, "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A=="],
 
     "webpack-bundle-analyzer": ["webpack-bundle-analyzer@4.10.2", "", { "dependencies": { "@discoveryjs/json-ext": "0.5.7", "acorn": "^8.0.4", "acorn-walk": "^8.0.0", "commander": "^7.2.0", "debounce": "^1.2.1", "escape-string-regexp": "^4.0.0", "gzip-size": "^6.0.0", "html-escaper": "^2.0.2", "opener": "^1.5.2", "picocolors": "^1.0.0", "sirv": "^2.0.3", "ws": "^7.3.1" }, "bin": "lib/bin/analyzer.js" }, "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw=="],
@@ -2554,6 +2607,8 @@
     "websocket-driver": ["websocket-driver@0.7.4", "", { "dependencies": { "http-parser-js": ">=0.5.1", "safe-buffer": ">=5.1.0", "websocket-extensions": ">=0.1.1" } }, "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="],
 
     "websocket-extensions": ["websocket-extensions@0.1.4", "", {}, "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -2579,7 +2634,15 @@
 
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": "bin/cli.js" }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
+
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
 
@@ -2617,8 +2680,6 @@
 
     "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
-    "ansi-align/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2627,11 +2688,13 @@
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
     "cheerio-select/css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
     "clean-css/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
-    "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "compressible/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -2865,8 +2928,6 @@
 
     "renderkid/htmlparser2": ["htmlparser2@6.1.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.0.0", "domutils": "^2.5.2", "entities": "^2.0.0" } }, "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A=="],
 
-    "renderkid/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "send/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
@@ -2915,19 +2976,21 @@
 
     "webpackbar/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "widest-line/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "@swagger-api/apidom-reference/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "ansi-align/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
-    "ansi-align/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "cli-table3/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "boxen/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "boxen/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "compression/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
@@ -2977,8 +3040,6 @@
 
     "renderkid/htmlparser2/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
-    "renderkid/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "serve-handler/mime-types/mime-db": ["mime-db@1.33.0", "", {}, "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="],
@@ -2997,19 +3058,23 @@
 
     "update-notifier/boxen/camelcase": ["camelcase@7.0.1", "", {}, "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw=="],
 
+    "update-notifier/boxen/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
     "url-loader/schema-utils/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
     "url-loader/schema-utils/ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
 
-    "webpackbar/wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "widest-line/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "webpackbar/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+    "widest-line/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "@swagger-api/apidom-reference/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "css-select/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
@@ -3019,10 +3084,14 @@
 
     "renderkid/htmlparser2/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
+    "update-notifier/boxen/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "update-notifier/boxen/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "url-loader/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
-    "webpackbar/wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "widest-line/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
-    "webpackbar/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "update-notifier/boxen/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "gen-swagger": "cd .. && go tool swag init --generalInfo doc.go --dir ./internal/api,./internal/database,./internal/config --output docs/static --outputTypes yaml,json --parseInternal"
+    "gen-swagger": "cd .. && go tool swag init --generalInfo doc.go --dir ./internal/api,./internal/database,./internal/config --output docs/static --outputTypes yaml,json --parseInternal && swagger2openapi docs/static/swagger.yaml -o docs/static/openapi.yaml"
   },
   "dependencies": {
     "@docusaurus/core": "3.8.1",
@@ -31,6 +31,7 @@
     "@docusaurus/module-type-aliases": "3.8.1",
     "@docusaurus/tsconfig": "3.8.1",
     "@docusaurus/types": "3.8.1",
+    "swagger2openapi": "^7.0.8",
     "typescript": "~5.6.2"
   },
   "browserslist": {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -28,3 +28,172 @@
   --ifm-color-primary-lightest: #e8e8d5;
   --docusaurus-highlighted-code-line-bg: rgba(199, 201, 165, 0.15);
 }
+
+/* ── Swagger UI dark mode overrides ── */
+[data-theme='dark'] .swagger-ui {
+  color: var(--ifm-font-color-base);
+}
+
+/* Main wrapper backgrounds */
+[data-theme='dark'] .swagger-ui .wrapper,
+[data-theme='dark'] .swagger-ui .opblock-tag,
+[data-theme='dark'] .swagger-ui .opblock-tag:hover {
+  background: transparent;
+}
+
+[data-theme='dark'] .swagger-ui .scheme-container {
+  background: var(--ifm-background-surface-color);
+  box-shadow: none;
+}
+
+/* Typography */
+[data-theme='dark'] .swagger-ui .opblock-tag,
+[data-theme='dark'] .swagger-ui .opblock-description-wrapper p,
+[data-theme='dark'] .swagger-ui .opblock-external-docs-wrapper p,
+[data-theme='dark'] .swagger-ui .info .title,
+[data-theme='dark'] .swagger-ui .info p,
+[data-theme='dark'] .swagger-ui .info li,
+[data-theme='dark'] .swagger-ui .info a,
+[data-theme='dark'] .swagger-ui label,
+[data-theme='dark'] .swagger-ui .parameter__name,
+[data-theme='dark'] .swagger-ui .parameter__type,
+[data-theme='dark'] .swagger-ui .parameter__deprecated,
+[data-theme='dark'] .swagger-ui .response-col_status,
+[data-theme='dark'] .swagger-ui .response-col_description,
+[data-theme='dark'] .swagger-ui .response-col_links,
+[data-theme='dark'] .swagger-ui table thead tr th,
+[data-theme='dark'] .swagger-ui table thead tr td,
+[data-theme='dark'] .swagger-ui .model,
+[data-theme='dark'] .swagger-ui .model-title,
+[data-theme='dark'] .swagger-ui .model-box,
+[data-theme='dark'] .swagger-ui .prop-type,
+[data-theme='dark'] .swagger-ui .prop-format,
+[data-theme='dark'] .swagger-ui section.models h4,
+[data-theme='dark'] .swagger-ui section.models h5,
+[data-theme='dark'] .swagger-ui .tab li,
+[data-theme='dark'] .swagger-ui .opblock .opblock-summary-description {
+  color: var(--ifm-font-color-base);
+}
+
+/* Operation block backgrounds */
+[data-theme='dark'] .swagger-ui .opblock .opblock-section-header {
+  background: var(--ifm-background-surface-color);
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
+[data-theme='dark'] .swagger-ui .opblock .opblock-section-header label,
+[data-theme='dark'] .swagger-ui .opblock .opblock-section-header h4 {
+  color: var(--ifm-font-color-base);
+}
+
+[data-theme='dark'] .swagger-ui .opblock .opblock-body {
+  background: var(--ifm-background-color);
+}
+
+/* Models section */
+[data-theme='dark'] .swagger-ui section.models,
+[data-theme='dark'] .swagger-ui section.models .model-container,
+[data-theme='dark'] .swagger-ui .model-box {
+  background: var(--ifm-background-surface-color);
+  border-color: var(--ifm-toc-border-color);
+}
+
+[data-theme='dark'] .swagger-ui section.models .model-box:hover {
+  background: var(--ifm-background-color);
+}
+
+/* Tables */
+[data-theme='dark'] .swagger-ui table tbody tr td {
+  color: var(--ifm-font-color-base);
+  border-color: var(--ifm-toc-border-color);
+}
+
+/* Inputs, textareas, selects */
+[data-theme='dark'] .swagger-ui input[type='text'],
+[data-theme='dark'] .swagger-ui input[type='email'],
+[data-theme='dark'] .swagger-ui input[type='password'],
+[data-theme='dark'] .swagger-ui input[type='search'],
+[data-theme='dark'] .swagger-ui input[type='number'],
+[data-theme='dark'] .swagger-ui textarea,
+[data-theme='dark'] .swagger-ui select {
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  border-color: var(--ifm-toc-border-color);
+}
+
+[data-theme='dark'] .swagger-ui .filter .operation-filter-input {
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  border-color: var(--ifm-toc-border-color);
+}
+
+/* Code / response bodies */
+[data-theme='dark'] .swagger-ui .microlight,
+[data-theme='dark'] .swagger-ui .highlight-code {
+  background: var(--ifm-background-surface-color) !important;
+  color: var(--ifm-font-color-base) !important;
+}
+
+[data-theme='dark'] .swagger-ui .response-control-media-type__accept-message {
+  color: var(--ifm-font-color-base);
+}
+
+/* Borders */
+[data-theme='dark'] .swagger-ui .opblock,
+[data-theme='dark'] .swagger-ui .model-container {
+  border-color: var(--ifm-toc-border-color);
+}
+
+/* Authorization button / modal */
+[data-theme='dark'] .swagger-ui .dialog-ux .modal-ux {
+  background: var(--ifm-background-surface-color);
+  border-color: var(--ifm-toc-border-color);
+}
+
+[data-theme='dark'] .swagger-ui .dialog-ux .modal-ux-header h3,
+[data-theme='dark'] .swagger-ui .dialog-ux .modal-ux-content p,
+[data-theme='dark'] .swagger-ui .dialog-ux .modal-ux-content h4 {
+  color: var(--ifm-font-color-base);
+}
+
+/* Server / base URL selector */
+[data-theme='dark'] .swagger-ui .servers > label,
+[data-theme='dark'] .swagger-ui .servers-title {
+  color: var(--ifm-font-color-base);
+}
+
+/* Base URL bar in title section */
+[data-theme='dark'] .swagger-ui .info .base-url,
+[data-theme='dark'] .swagger-ui .info pre,
+[data-theme='dark'] .swagger-ui .info code {
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  border-color: var(--ifm-toc-border-color);
+}
+
+/* Endpoint URL paths */
+[data-theme='dark'] .swagger-ui .opblock-summary-path,
+[data-theme='dark'] .swagger-ui .opblock-summary-path__deprecated,
+[data-theme='dark'] .swagger-ui .opblock-summary-path a,
+[data-theme='dark'] .swagger-ui .opblock-summary-path span {
+  color: var(--ifm-font-color-base) !important;
+}
+
+/* Operation description text (inside expanded endpoint body) */
+[data-theme='dark'] .swagger-ui .opblock-description-wrapper,
+[data-theme='dark'] .swagger-ui .opblock-description-wrapper p,
+[data-theme='dark'] .swagger-ui .opblock-description-wrapper span,
+[data-theme='dark'] .swagger-ui .opblock-description-wrapper div,
+[data-theme='dark'] .swagger-ui .opblock-tag small,
+[data-theme='dark'] .swagger-ui .opblock-tag p {
+  color: var(--ifm-font-color-base);
+}
+
+/* Expand/collapse arrows (SVG fill) */
+[data-theme='dark'] .swagger-ui svg.arrow,
+[data-theme='dark'] .swagger-ui .arrow svg,
+[data-theme='dark'] .swagger-ui .opblock-summary-control svg,
+[data-theme='dark'] .swagger-ui .expand-operation svg,
+[data-theme='dark'] .swagger-ui .opblock-tag svg {
+  fill: var(--ifm-font-color-base);
+}

--- a/docs/src/pages/api-explorer.tsx
+++ b/docs/src/pages/api-explorer.tsx
@@ -13,7 +13,7 @@ function SwaggerUI() {
 				require("swagger-ui-react/swagger-ui.css");
 				return (
 					<SwaggerUIComponent
-						url="/swagger.yaml"
+						url="/openapi.yaml"
 						docExpansion="list"
 						defaultModelsExpandDepth={1}
 						filter

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -1,0 +1,4926 @@
+openapi: 3.0.0
+info:
+  contact:
+    name: AltMount
+    url: https://github.com/javi11/altmount/issues
+  description: REST API for AltMount — Usenet WebDAV server with NZB queue, health
+    monitoring, ARR integration, FUSE/rclone mounting, and Stremio addon.
+  license:
+    name: MIT
+  termsOfService: http://altmount.kipsilabs.top
+  title: AltMount API
+  version: "1.0"
+paths:
+  /arrs/download-client/register:
+    post:
+      description: Automatically registers AltMount as a download client
+        (SABnzbd-compatible) in all configured ARR instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Register ARR download clients
+      tags:
+        - ARRs
+  /arrs/download-client/test:
+    post:
+      description: Tests whether AltMount is reachable as a download client from all
+        configured ARR instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Test ARR download clients
+      tags:
+        - ARRs
+  /arrs/health:
+    get:
+      description: Returns health check results from all configured Sonarr/Radarr instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get ARR health
+      tags:
+        - ARRs
+  /arrs/instances:
+    get:
+      description: Returns all configured Sonarr/Radarr instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: List ARR instances
+      tags:
+        - ARRs
+  "/arrs/instances/{type}/{name}":
+    get:
+      description: Returns a specific Sonarr/Radarr instance by type and name.
+      parameters:
+        - description: Instance type (sonarr or radarr)
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: Instance name
+          in: path
+          name: name
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get ARR instance
+      tags:
+        - ARRs
+  /arrs/instances/test:
+    post:
+      description: Tests connectivity to a Sonarr/Radarr instance with given credentials.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ArrsInstanceRequest"
+        description: Instance connection details
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Test ARR connection
+      tags:
+        - ARRs
+  /arrs/stats:
+    get:
+      description: Returns sync statistics for all configured ARR instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get ARR statistics
+      tags:
+        - ARRs
+  /arrs/webhook:
+    post:
+      description: Receives file-import webhook events from Sonarr/Radarr and triggers
+        health checks. Authenticated via API key query parameter.
+      parameters:
+        - description: AltMount API key
+          in: query
+          name: apikey
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ArrsWebhookRequest"
+        description: Webhook payload
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: ARR webhook receiver
+      tags:
+        - ARRs
+  /arrs/webhook/register:
+    post:
+      description: Automatically registers AltMount as a webhook connection in all
+        configured Sonarr/Radarr instances.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Register ARR webhooks
+      tags:
+        - ARRs
+  /auth/config:
+    get:
+      description: Returns authentication configuration (login required flag,
+        available providers). Public endpoint.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Get auth config
+      tags:
+        - Auth
+  /auth/login:
+    post:
+      description: Authenticates with username and password and returns a JWT access
+        token. Rate-limited to 10/min per IP.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.LoginRequest"
+        description: Login credentials
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.AuthResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "429":
+          description: Too Many Requests
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Login
+      tags:
+        - Auth
+  /auth/register:
+    post:
+      description: Creates the first admin user account. Only allowed when no users
+        exist yet.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.RegisterRequest"
+        description: Registration details
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.AuthResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Register
+      tags:
+        - Auth
+  /auth/registration-status:
+    get:
+      description: Returns whether registration is currently open (i.e. no users exist yet).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Check registration status
+      tags:
+        - Auth
+  /config:
+    get:
+      description: Returns the current AltMount configuration with sensitive values masked.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ConfigAPIResponse"
+                    type: object
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get configuration
+      tags:
+        - Config
+    put:
+      description: Replaces the entire AltMount configuration. Triggers restart if required.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Complete configuration object
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Update configuration
+      tags:
+        - Config
+  "/config/{section}":
+    patch:
+      description: Updates a specific named section of the configuration (e.g. import,
+        sabnzbd, rclone).
+      parameters:
+        - description: Config section name
+          in: path
+          name: section
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Section configuration
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Patch configuration section
+      tags:
+        - Config
+  "/config/providers/{id}/speedtest":
+    post:
+      description: Runs a speed test against the specified NNTP provider and saves the
+        result to config.
+      parameters:
+        - description: Provider ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ProviderSpeedTestResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Test provider download speed
+      tags:
+        - Providers
+  /config/reload:
+    post:
+      description: Reloads the AltMount configuration from disk without restarting.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Reload configuration
+      tags:
+        - Config
+  /config/validate:
+    post:
+      description: Validates a configuration object without saving it.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Configuration to validate
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Validate configuration
+      tags:
+        - Config
+  /files/active-streams:
+    get:
+      description: Returns all currently active NZB file streams. Optionally filter by
+        type=file.
+      parameters:
+        - description: Filter by source type (e.g. file)
+          in: query
+          name: type
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: List active streams
+      tags:
+        - Files
+  "/files/active-streams/{id}":
+    delete:
+      description: Terminates an active NZB file stream by ID.
+      parameters:
+        - description: Stream ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Kill active stream
+      tags:
+        - Files
+  /files/export-batch:
+    post:
+      description: Exports multiple mounted files as NZBs packed in a single ZIP archive.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                paths:
+                  items:
+                    type: string
+                  type: array
+              type: object
+        description: Virtual paths to export
+        required: true
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          content:
+            application/zip:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/zip:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Batch export files as NZBs
+      tags:
+        - Files
+  /files/export-nzb:
+    get:
+      description: Exports the metadata of a mounted file back to a downloadable NZB file.
+      parameters:
+        - description: Virtual path to the file
+          in: query
+          name: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          content:
+            application/x-nzb:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/x-nzb:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Export file metadata as NZB
+      tags:
+        - Files
+  /files/info:
+    get:
+      description: Returns metadata for a mounted NZB file including segment info,
+        encryption, and status.
+      parameters:
+        - description: Virtual path to the file
+          in: query
+          name: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.FileMetadataResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get file metadata
+      tags:
+        - Files
+  /files/streams/history:
+    get:
+      description: Returns a history of recently completed NZB file streams.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get stream history
+      tags:
+        - Files
+  /fuse/force-stop:
+    post:
+      description: Force-unmounts the FUSE filesystem using platform-specific commands
+        (fusermount/umount).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Force stop FUSE mount
+      tags:
+        - FUSE
+  /fuse/start:
+    post:
+      description: Mounts the NZB filesystem at the given path using FUSE.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                path:
+                  type: string
+              type: object
+        description: Mount path
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Start FUSE mount
+      tags:
+        - FUSE
+  /fuse/status:
+    get:
+      description: Returns the current status of the FUSE mount (stopped, starting,
+        running, error).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get FUSE status
+      tags:
+        - FUSE
+  /fuse/stop:
+    post:
+      description: Gracefully unmounts the FUSE filesystem.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Stop FUSE mount
+      tags:
+        - FUSE
+  /health:
+    get:
+      description: Returns a paginated list of file health records with optional
+        status/search filters.
+      parameters:
+        - description: Filter by status
+          in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - pending
+              - checking
+              - corrupted
+              - repair_triggered
+              - healthy
+        - description: Search by file path
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: Sort field
+          in: query
+          name: sort_by
+          schema:
+            type: string
+            enum:
+              - file_path
+              - created_at
+              - status
+              - priority
+              - last_checked
+              - scheduled_check_at
+        - description: Sort direction
+          in: query
+          name: sort_order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+        - description: ISO8601 timestamp filter
+          in: query
+          name: since
+          schema:
+            type: string
+        - description: Page size (default 50)
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Page offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        items:
+                          $ref: "#/components/schemas/api.HealthItemResponse"
+                        type: array
+                      meta:
+                        $ref: "#/components/schemas/api.APIMeta"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: List health records
+      tags:
+        - Health
+  "/health/{id}":
+    delete:
+      description: Deletes a health record and optionally the associated physical file.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+        - description: Also delete the physical file
+          in: query
+          name: delete_file
+          schema:
+            type: boolean
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Delete health record
+      tags:
+        - Health
+    get:
+      description: Returns a single health record by ID.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get health record
+      tags:
+        - Health
+  "/health/{id}/cancel":
+    post:
+      description: Cancels an in-progress health check for a file.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cancel health check
+      tags:
+        - Health
+  "/health/{id}/check-now":
+    post:
+      description: Triggers an immediate health check for a file, bypassing the queue.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Trigger immediate health check
+      tags:
+        - Health
+  "/health/{id}/priority":
+    post:
+      description: Sets the checking priority for a health record.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                priority:
+                  type: string
+              type: object
+        description: "Priority: normal or high"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Set health check priority
+      tags:
+        - Health
+  "/health/{id}/repair":
+    post:
+      description: Triggers a repair attempt for a corrupted file.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.HealthRepairRequest"
+        description: Repair options
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Trigger health repair
+      tags:
+        - Health
+  "/health/{id}/unmask":
+    post:
+      description: Clears the streaming-failure mask on a health record so it can be
+        checked again.
+      parameters:
+        - description: Health record ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Unmask health record
+      tags:
+        - Health
+  /health/bulk/delete:
+    post:
+      description: Deletes multiple health records by ID.
+      requestBody:
+        $ref: "#/components/requestBodies/Body"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk delete health records
+      tags:
+        - Health
+  /health/bulk/repair:
+    post:
+      description: Triggers repair attempts for multiple corrupted files.
+      requestBody:
+        $ref: "#/components/requestBodies/Body"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk trigger health repair
+      tags:
+        - Health
+  /health/bulk/restart:
+    post:
+      description: Resets multiple health records to pending status for re-checking.
+      requestBody:
+        $ref: "#/components/requestBodies/Body"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk restart health checks
+      tags:
+        - Health
+  /health/check:
+    post:
+      description: Adds a file to the health monitoring queue for checking.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.HealthCheckRequest"
+        description: File to check
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Add file for health check
+      tags:
+        - Health
+  /health/cleanup:
+    delete:
+      description: Removes old health records based on age, status, or both.
+        Optionally deletes physical files.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.HealthCleanupRequest"
+        description: Cleanup filter criteria
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cleanup health records
+      tags:
+        - Health
+  /health/corrupted:
+    get:
+      description: Returns a paginated list of health records with corrupted status.
+      parameters:
+        - description: Page size (default 50)
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Page offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        items:
+                          $ref: "#/components/schemas/api.HealthItemResponse"
+                        type: array
+                      meta:
+                        $ref: "#/components/schemas/api.APIMeta"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: List corrupted files
+      tags:
+        - Health
+  /health/library-sync/cancel:
+    post:
+      description: Cancels an in-progress library sync operation.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cancel library sync
+      tags:
+        - Health
+  /health/library-sync/dry-run:
+    post:
+      description: Simulates a library sync and returns what would be changed without
+        applying it.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.DryRunSyncResult"
+                    type: object
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Dry-run library sync
+      tags:
+        - Health
+  /health/library-sync/needed:
+    get:
+      description: Returns whether a library sync is needed based on current
+        configuration state.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Check if library sync is needed
+      tags:
+        - Health
+  /health/library-sync/start:
+    post:
+      description: Triggers a library sync operation to reconcile the file system with
+        the database.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Start library sync
+      tags:
+        - Health
+  /health/library-sync/status:
+    get:
+      description: Returns the current status of the library sync worker.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get library sync status
+      tags:
+        - Health
+  /health/regenerate-symlinks:
+    post:
+      description: Regenerates all library symlinks and STRM files for files that
+        already have metadata.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Regenerate library symlinks
+      tags:
+        - Health
+  /health/reset-all:
+    post:
+      description: Resets all health records to pending status for a full re-check cycle.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Reset all health checks
+      tags:
+        - Health
+  /health/stats:
+    get:
+      description: Returns counts of health records grouped by status.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthStatsResponse"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get health statistics
+      tags:
+        - Health
+  /health/worker/status:
+    get:
+      description: Returns the current status and statistics of the background health
+        check worker.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.HealthWorkerStatusResponse"
+                    type: object
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get health worker status
+      tags:
+        - Health
+  /import/file:
+    post:
+      description: Adds an NZB file at a given filesystem path to the import queue.
+        Public endpoint (API key in query).
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ManualImportRequest"
+        description: File path to import
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ManualImportResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - ApiKeyAuth: []
+      summary: Manually import a file
+      tags:
+        - Import
+  /import/history:
+    delete:
+      description: Removes all completed import history records.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Clear import history
+      tags:
+        - Import
+    get:
+      description: Returns a paginated list of completed import records.
+      parameters:
+        - description: Page size (default 50)
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Page offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        items:
+                          $ref: "#/components/schemas/api.ImportHistoryResponse"
+                        type: array
+                      meta:
+                        $ref: "#/components/schemas/api.APIMeta"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get import history
+      tags:
+        - Import
+  /import/nzbdav:
+    delete:
+      description: Cancels the currently running NZBDav import operation.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cancel NZBDav import
+      tags:
+        - Import
+    post:
+      description: Starts an import from a WebDAV/NZBDav source, fetching NZBs from
+        the remote.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+        description: Import configuration (uses server config if omitted)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Import from NZBDav source
+      tags:
+        - Import
+  /import/nzbdav/reset:
+    post:
+      description: Resets the NZBDav import state so a new import can be started.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Reset NZBDav import status
+      tags:
+        - Import
+  /import/nzbdav/status:
+    get:
+      description: Returns the current status of the NZBDav import operation.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get NZBDav import status
+      tags:
+        - Import
+  /import/scan:
+    delete:
+      description: Cancels the currently running manual directory scan.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cancel directory scan
+      tags:
+        - Import
+    post:
+      description: Scans a directory for NZB files and adds them to the import queue.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ManualScanRequest"
+        description: Directory path to scan
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Start manual directory scan
+      tags:
+        - Import
+  /import/scan/status:
+    get:
+      description: Returns the current status of the manual directory scan operation.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ScanStatusResponse"
+                    type: object
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get scan status
+      tags:
+        - Import
+  /nzb/streams:
+    post:
+      description: Accepts an NZB file upload, queues it with high priority, and
+        synchronously waits for completion before returning Stremio-compatible
+        stream URLs for all media files found in the NZB output. Authenticated
+        via download_key form field (SHA256 of API key).
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: NZB file to process
+                  type: string
+                  format: binary
+                download_key:
+                  description: SHA256 hash of the user's API key
+                  type: string
+                category:
+                  description: "Queue category (default: stremio)"
+                  type: string
+                timeout:
+                  description: "Processing timeout in seconds (default: 300)"
+                  type: integer
+              required:
+                - file
+                - download_key
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.StremioStreamsResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Get Stremio streams for NZB file
+      tags:
+        - Stremio
+  /providers:
+    post:
+      description: Adds a new NNTP provider to the configuration.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ProviderCreateRequest"
+        description: Provider details
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ProviderAPIResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Create NNTP provider
+      tags:
+        - Providers
+  "/providers/{id}":
+    delete:
+      description: Removes an NNTP provider by ID from the configuration.
+      parameters:
+        - description: Provider ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Delete NNTP provider
+      tags:
+        - Providers
+    put:
+      description: Updates an existing NNTP provider by ID.
+      parameters:
+        - description: Provider ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ProviderUpdateRequest"
+        description: Fields to update
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.ProviderAPIResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Update NNTP provider
+      tags:
+        - Providers
+  /providers/reorder:
+    put:
+      description: Sets the priority order of NNTP providers.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ProviderReorderRequest"
+        description: Ordered list of provider IDs
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Reorder NNTP providers
+      tags:
+        - Providers
+  /providers/test:
+    post:
+      description: Tests NNTP provider connectivity with given credentials, returning
+        RTT on success.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.ProviderTestRequest"
+        description: Provider credentials to test
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.TestProviderResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Test NNTP provider
+      tags:
+        - Providers
+  /queue:
+    get:
+      description: Returns a paginated list of NZB download queue items with optional
+        filters.
+      parameters:
+        - description: Filter by status
+          in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - pending
+              - processing
+              - completed
+              - failed
+        - description: Search by filename
+          in: query
+          name: search
+          schema:
+            type: string
+        - description: Sort field
+          in: query
+          name: sort_by
+          schema:
+            type: string
+            enum:
+              - created_at
+              - updated_at
+              - status
+              - nzb_path
+        - description: Sort direction
+          in: query
+          name: sort_order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+        - description: ISO8601 timestamp filter
+          in: query
+          name: since
+          schema:
+            type: string
+        - description: Page size (default 50)
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Page offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        items:
+                          $ref: "#/components/schemas/api.QueueItemResponse"
+                        type: array
+                      meta:
+                        $ref: "#/components/schemas/api.APIMeta"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: List queue items
+      tags:
+        - Queue
+  "/queue/{id}":
+    delete:
+      description: Deletes a queue item by ID. Cannot delete items currently being
+        processed.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Delete queue item
+      tags:
+        - Queue
+    get:
+      description: Returns a single queue item by ID.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get queue item
+      tags:
+        - Queue
+  "/queue/{id}/cancel":
+    post:
+      description: Requests cancellation of a queue item that is currently being processed.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Cancel queue item
+      tags:
+        - Queue
+  "/queue/{id}/download":
+    get:
+      description: Downloads the original NZB file associated with a queue item.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          content:
+            application/x-nzb:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/x-nzb:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Download NZB file
+      tags:
+        - Queue
+  "/queue/{id}/priority":
+    patch:
+      description: Changes the priority of a pending or failed queue item.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                priority:
+                  type: integer
+              type: object
+        description: "Priority: 1=high, 2=normal, 3=low"
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Update queue item priority
+      tags:
+        - Queue
+  "/queue/{id}/retry":
+    post:
+      description: Resets a failed, pending, or completed queue item to pending and
+        triggers processing.
+      parameters:
+        - description: Queue item ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Retry queue item
+      tags:
+        - Queue
+  /queue/bulk:
+    delete:
+      description: Deletes multiple queue items by ID. Cannot delete items currently
+        being processed.
+      requestBody:
+        $ref: "#/components/requestBodies/Body2"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk delete queue items
+      tags:
+        - Queue
+  /queue/bulk/cancel:
+    post:
+      description: Requests cancellation of multiple currently-processing queue items.
+      requestBody:
+        $ref: "#/components/requestBodies/Body2"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk cancel queue items
+      tags:
+        - Queue
+  /queue/bulk/restart:
+    post:
+      description: Resets multiple queue items to pending status for reprocessing.
+      requestBody:
+        $ref: "#/components/requestBodies/Body2"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Bulk restart queue items
+      tags:
+        - Queue
+  /queue/completed:
+    delete:
+      description: Removes all completed items from the queue.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Clear completed queue items
+      tags:
+        - Queue
+  /queue/failed:
+    delete:
+      description: Removes all failed items from the queue.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Clear failed queue items
+      tags:
+        - Queue
+  /queue/pending:
+    delete:
+      description: Removes all pending items from the queue.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Clear pending queue items
+      tags:
+        - Queue
+  /queue/stats:
+    get:
+      description: Returns current queue statistics (counts by status, average
+        processing time).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueStatsResponse"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get queue statistics
+      tags:
+        - Queue
+  /queue/stats/history:
+    get:
+      description: Returns historical import statistics over a rolling window (last
+        24h, 7d, 30d, 365d).
+      parameters:
+        - description: Number of days of history (default 1, max 365)
+          in: query
+          name: days
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueHistoricalStatsResponse"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get historical queue statistics
+      tags:
+        - Queue
+  /queue/test:
+    post:
+      description: Downloads a test NZB from sabnzbd.org and adds it to the queue for
+        connectivity testing.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                size:
+                  type: string
+              type: object
+        description: "Size: 100MB, 1GB, or 10GB"
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "502":
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Add test download to queue
+      tags:
+        - Queue
+  /queue/upload:
+    post:
+      description: Uploads an NZB file and adds it to the download queue.
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  description: NZB file to upload (max 100MB)
+                  type: string
+                  format: binary
+                category:
+                  description: Optional category
+                  type: string
+                relative_path:
+                  description: Optional relative path under CompleteDir
+                  type: string
+                priority:
+                  description: "Priority: 1=high, 2=normal, 3=low"
+                  type: integer
+              required:
+                - file
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.QueueItemResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Upload NZB file to queue
+      tags:
+        - Queue
+  /queue/upload-by-name:
+    post:
+      description: Searches for an NZB by name via the configured indexer and adds the
+        result to the queue.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                category:
+                  type: string
+                name:
+                  type: string
+                password:
+                  type: string
+                priority:
+                  type: integer
+                relative_path:
+                  type: string
+              type: object
+        description: Search request
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Search NZB by name and add to queue
+      tags:
+        - Queue
+  /queue/upload-nzblnk:
+    post:
+      description: Resolves one or more nzblnk:// links and adds the resulting NZBs to
+        the queue.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                category:
+                  type: string
+                links:
+                  items:
+                    type: string
+                  type: array
+                priority:
+                  type: integer
+                relative_path:
+                  type: string
+              type: object
+        description: NZBLNK request (max 20 links)
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Add NZBLnk links to queue
+      tags:
+        - Queue
+  "/stremio/{key}/manifest.json":
+    get:
+      description: Returns the Stremio addon manifest JSON for installation. The key
+        authenticates the addon.
+      parameters:
+        - description: Download key (SHA256 of API key)
+          in: path
+          name: key
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.stremioManifest"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Stremio addon manifest
+      tags:
+        - Stremio
+  "/stremio/{key}/play":
+    get:
+      description: Downloads the NZB from Prowlarr by URL, queues it with high
+        priority, waits for download completion, then redirects (302) to the
+        first media stream URL.
+      parameters:
+        - description: Download key (SHA256 of API key)
+          in: path
+          name: key
+          required: true
+          schema:
+            type: string
+        - description: Prowlarr NZB download URL
+          in: query
+          name: url
+          required: true
+          schema:
+            type: string
+        - description: Safe filename title for the NZB
+          in: query
+          name: title
+          schema:
+            type: string
+      responses:
+        "302":
+          description: Redirects to media stream URL
+          content:
+            application/json:
+              schema:
+                type: string
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Play Stremio NZB stream
+      tags:
+        - Stremio
+  "/stremio/{key}/stream/{type}/{id}.json":
+    get:
+      description: Searches Prowlarr for matching NZBs and returns Stremio-compatible
+        stream URL options.
+      parameters:
+        - description: Download key
+          in: path
+          name: key
+          required: true
+          schema:
+            type: string
+        - description: Content type (movie or series)
+          in: path
+          name: type
+          required: true
+          schema:
+            type: string
+        - description: Stremio content ID (e.g. tt1234567)
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      summary: Stremio stream handler
+      tags:
+        - Stremio
+  /system/browse:
+    get:
+      description: Lists filesystem entries at a given path for directory/file picker UIs.
+      parameters:
+        - description: Directory path to browse (defaults to root)
+          in: query
+          name: path
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Browse filesystem
+      tags:
+        - System
+  /system/cleanup:
+    post:
+      description: Removes old queue items and health records based on age. Supports
+        dry-run mode.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.SystemCleanupRequest"
+        description: Cleanup criteria
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.SystemCleanupResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: System cleanup
+      tags:
+        - System
+  /system/health:
+    get:
+      description: Returns health status of all system components (database, workers, etc.).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.SystemHealthResponse"
+                    type: object
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get system health
+      tags:
+        - System
+  /system/pool/metrics:
+    get:
+      description: Returns download/upload metrics, speed, and per-provider connection
+        statistics.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.PoolMetricsResponse"
+                    type: object
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get NNTP pool metrics
+      tags:
+        - System
+  /system/restart:
+    post:
+      description: Schedules a graceful system restart. Use force=true to skip safety
+        checks.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api.SystemRestartRequest"
+        description: Restart options
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.SystemRestartResponse"
+                    type: object
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Restart system
+      tags:
+        - System
+  /system/stats:
+    get:
+      description: Returns combined queue, health, and system information statistics.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.SystemStatsResponse"
+                    type: object
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get system statistics
+      tags:
+        - System
+  /system/stats/reset:
+    post:
+      description: Resets accumulated system statistics counters (pool metrics,
+        download counters).
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Reset system statistics
+      tags:
+        - System
+  /system/update/apply:
+    post:
+      description: Pulls the latest Docker image and restarts the container to apply
+        the update.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                channel:
+                  type: string
+              type: object
+        description: Update channel (latest or dev)
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "503":
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Apply update
+      tags:
+        - System
+  /system/update/status:
+    get:
+      description: Checks Docker Hub for the latest available version and returns
+        whether an update is available.
+      parameters:
+        - description: Release channel
+          in: query
+          name: channel
+          schema:
+            type: string
+            enum:
+              - latest
+              - dev
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.UpdateStatusResponse"
+                    type: object
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get update status
+      tags:
+        - System
+  /user:
+    get:
+      description: Returns information about the currently authenticated user.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.UserResponse"
+                    type: object
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+        - ApiKeyAuth: []
+      summary: Get current user
+      tags:
+        - User
+  /user/api-key/regenerate:
+    post:
+      description: Generates a new API key for the authenticated user, invalidating
+        the old one.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.UserResponse"
+                    type: object
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Regenerate API key
+      tags:
+        - User
+  /user/logout:
+    post:
+      description: Invalidates the current session and JWT token.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Logout
+      tags:
+        - User
+  /user/password:
+    put:
+      description: Changes the password for the currently authenticated user.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                current_password:
+                  type: string
+                new_password:
+                  type: string
+              type: object
+        description: Password change request
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Change password
+      tags:
+        - User
+  /user/refresh:
+    post:
+      description: Issues a new JWT access token using the current valid token.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/api.APIResponse"
+                  - properties:
+                      data:
+                        $ref: "#/components/schemas/api.AuthResponse"
+                    type: object
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api.APIResponse"
+      security:
+        - BearerAuth: []
+      summary: Refresh token
+      tags:
+        - User
+tags:
+  - description: NZB download queue management
+    name: Queue
+  - description: File health monitoring and repair
+    name: Health
+  - description: File metadata, streams, and NZB export
+    name: Files
+  - description: Manual file imports and directory scanning
+    name: Import
+  - description: NNTP provider management
+    name: Providers
+  - description: Sonarr/Radarr integration
+    name: ARRs
+  - description: Configuration management
+    name: Config
+  - description: System stats, health, and maintenance
+    name: System
+  - description: FUSE mount management
+    name: FUSE
+  - description: Stremio addon and NZB stream endpoints
+    name: Stremio
+  - description: Authentication and registration
+    name: Auth
+  - description: Current user management
+    name: User
+servers:
+  - url: //localhost:8080/api
+components:
+  requestBodies:
+    Body:
+      content:
+        application/json:
+          schema:
+            properties:
+              ids:
+                items:
+                  type: integer
+                type: array
+            type: object
+      description: List of health record IDs
+      required: true
+    Body2:
+      content:
+        application/json:
+          schema:
+            properties:
+              ids:
+                items:
+                  type: integer
+                type: array
+            type: object
+      description: List of queue item IDs
+      required: true
+  securitySchemes:
+    ApiKeyAuth:
+      in: query
+      name: apikey
+      type: apiKey
+  schemas:
+    api.APIError:
+      properties:
+        code:
+          type: string
+        details:
+          type: string
+        message:
+          type: string
+      type: object
+    api.APIMeta:
+      properties:
+        count:
+          type: integer
+        limit:
+          type: integer
+        offset:
+          type: integer
+        total:
+          type: integer
+      type: object
+    api.APIResponse:
+      properties:
+        data: {}
+        error:
+          $ref: "#/components/schemas/api.APIError"
+        meta:
+          $ref: "#/components/schemas/api.APIMeta"
+        success:
+          type: boolean
+      type: object
+    api.ArrsDeletedFile:
+      properties:
+        path:
+          type: string
+      type: object
+    api.ArrsInstanceRequest:
+      properties:
+        api_key:
+          type: string
+        category:
+          type: string
+        enabled:
+          type: boolean
+        name:
+          type: string
+        sync_interval_hours:
+          type: integer
+        type:
+          type: string
+        url:
+          type: string
+      type: object
+    api.ArrsWebhookRequest:
+      properties:
+        deletedFiles:
+          items:
+            $ref: "#/components/schemas/api.ArrsDeletedFile"
+          type: array
+        episodeFile:
+          properties:
+            path:
+              type: string
+          type: object
+        eventType:
+          type: string
+        filePath:
+          type: string
+        movie:
+          description: For upgrades/renames, the file path might be in other fields or
+            need to be inferred
+          properties:
+            folderPath:
+              type: string
+          type: object
+        movieFile:
+          properties:
+            path:
+              type: string
+          type: object
+        series:
+          properties:
+            path:
+              type: string
+          type: object
+      type: object
+    api.AuthResponse:
+      properties:
+        message:
+          type: string
+        redirect_url:
+          type: string
+        user:
+          $ref: "#/components/schemas/api.UserResponse"
+      type: object
+    api.ComponentHealth:
+      properties:
+        details:
+          type: string
+        message:
+          type: string
+        status:
+          description: '"healthy", "degraded", "unhealthy"'
+          type: string
+      type: object
+    api.ConfigAPIResponse:
+      properties:
+        api:
+          $ref: "#/components/schemas/config.APIConfig"
+        api_key:
+          description: User's API key for authentication
+          type: string
+        arrs:
+          $ref: "#/components/schemas/config.ArrsConfig"
+        auth:
+          $ref: "#/components/schemas/config.AuthConfig"
+        database:
+          $ref: "#/components/schemas/config.DatabaseConfig"
+        download_key:
+          description: SHA256 of the API key, used for download/stream URLs
+          type: string
+        fuse:
+          $ref: "#/components/schemas/config.FuseConfig"
+        health:
+          $ref: "#/components/schemas/config.HealthConfig"
+        import:
+          $ref: "#/components/schemas/api.ImportAPIResponse"
+        log:
+          $ref: "#/components/schemas/config.LogConfig"
+        metadata:
+          $ref: "#/components/schemas/config.MetadataConfig"
+        mount_path:
+          type: string
+        mount_type:
+          $ref: "#/components/schemas/config.MountType"
+        profiler_enabled:
+          type: boolean
+        providers:
+          items:
+            $ref: "#/components/schemas/api.ProviderAPIResponse"
+          type: array
+        rclone:
+          $ref: "#/components/schemas/api.RCloneAPIResponse"
+        sabnzbd:
+          $ref: "#/components/schemas/api.SABnzbdAPIResponse"
+        segment_cache:
+          $ref: "#/components/schemas/config.SegmentCacheConfig"
+        streaming:
+          $ref: "#/components/schemas/config.StreamingConfig"
+        stremio:
+          $ref: "#/components/schemas/config.StremioConfig"
+        webdav:
+          $ref: "#/components/schemas/api.WebDAVAPIResponse"
+      type: object
+    api.DailyStat:
+      properties:
+        completed:
+          type: integer
+        day:
+          type: string
+        failed:
+          type: integer
+      type: object
+    api.DryRunSyncResult:
+      properties:
+        database_records_to_clean:
+          description: Number of database records to clean
+          type: integer
+        orphaned_library_files:
+          description: Number of orphaned library files (symlinks/STRM)
+          type: integer
+        orphaned_metadata_count:
+          description: Number of orphaned metadata files
+          type: integer
+        would_cleanup:
+          description: Whether cleanup would occur based on config
+          type: boolean
+      type: object
+    api.FileMetadataResponse:
+      properties:
+        available_segments:
+          type: integer
+        created_at:
+          type: string
+        encryption:
+          type: string
+        file_size:
+          type: integer
+        modified_at:
+          type: string
+        nested_sources:
+          items:
+            $ref: "#/components/schemas/api.NestedSourceResponse"
+          type: array
+        password_protected:
+          type: boolean
+        segment_count:
+          type: integer
+        segments:
+          items:
+            $ref: "#/components/schemas/api.SegmentInfoResponse"
+          type: array
+        source_nzb_path:
+          type: string
+        status:
+          type: string
+      type: object
+    api.HealthCheckRequest:
+      properties:
+        file_path:
+          type: string
+        max_retries:
+          type: integer
+        priority:
+          $ref: "#/components/schemas/database.HealthPriority"
+        source_nzb_path:
+          type: string
+      type: object
+    api.HealthCleanupRequest:
+      properties:
+        delete_files:
+          description: Whether to also delete the physical files
+          type: boolean
+        older_than:
+          type: string
+        status:
+          $ref: "#/components/schemas/database.HealthStatus"
+      type: object
+    api.HealthItemResponse:
+      properties:
+        created_at:
+          type: string
+        error_details:
+          type: string
+        file_path:
+          type: string
+        id:
+          type: integer
+        is_masked:
+          type: boolean
+        last_checked:
+          type: string
+        last_error:
+          type: string
+        library_path:
+          type: string
+        max_repair_retries:
+          type: integer
+        max_retries:
+          type: integer
+        priority:
+          $ref: "#/components/schemas/database.HealthPriority"
+        repair_retry_count:
+          type: integer
+        retry_count:
+          type: integer
+        scheduled_check_at:
+          type: string
+        source_nzb_path:
+          type: string
+        status:
+          $ref: "#/components/schemas/database.HealthStatus"
+        streaming_failure_count:
+          description: Failure masking fields
+          type: integer
+        updated_at:
+          type: string
+      type: object
+    api.HealthRepairRequest:
+      properties:
+        reset_repair_retry_count:
+          type: boolean
+      type: object
+    api.HealthStatsResponse:
+      properties:
+        checking:
+          type: integer
+        corrupted:
+          type: integer
+        healthy:
+          type: integer
+        pending:
+          type: integer
+        repair_triggered:
+          type: integer
+        total:
+          type: integer
+      type: object
+    api.HealthWorkerStatusResponse:
+      properties:
+        current_run_files_checked:
+          type: integer
+        current_run_start_time:
+          type: string
+        error_count:
+          type: integer
+        last_error:
+          type: string
+        last_run_time:
+          type: string
+        next_run_time:
+          type: string
+        status:
+          type: string
+        total_files_checked:
+          type: integer
+        total_files_corrupted:
+          type: integer
+        total_files_healthy:
+          type: integer
+        total_runs_completed:
+          type: integer
+      type: object
+    api.ImportAPIResponse:
+      properties:
+        allow_nested_rar_extraction:
+          type: boolean
+        allowed_file_extensions:
+          items:
+            type: string
+          type: array
+        import_dir:
+          type: string
+        import_strategy:
+          $ref: "#/components/schemas/config.ImportStrategy"
+        max_download_prefetch:
+          type: integer
+        max_import_connections:
+          type: integer
+        max_processor_workers:
+          type: integer
+        queue_processing_interval_seconds:
+          description: Interval in seconds
+          type: integer
+        read_timeout_seconds:
+          type: integer
+        segment_sample_percentage:
+          description: Percentage of segments to check (1-100)
+          type: integer
+        skip_health_check:
+          type: boolean
+        watch_dir:
+          type: string
+        watch_interval_seconds:
+          type: integer
+      type: object
+    api.ImportHistoryResponse:
+      properties:
+        category:
+          type: string
+        completed_at:
+          type: string
+        file_name:
+          type: string
+        file_size:
+          type: integer
+        id:
+          type: integer
+        library_path:
+          type: string
+        nzb_id:
+          type: integer
+        nzb_name:
+          type: string
+        virtual_path:
+          type: string
+      type: object
+    api.LoginRequest:
+      properties:
+        password:
+          type: string
+        username:
+          type: string
+      type: object
+    api.ManualImportRequest:
+      properties:
+        file_path:
+          type: string
+        relative_path:
+          type: string
+      type: object
+    api.ManualImportResponse:
+      properties:
+        message:
+          type: string
+        queue_id:
+          type: integer
+      type: object
+    api.ManualScanRequest:
+      properties:
+        path:
+          type: string
+      type: object
+    api.NestedSegmentResponse:
+      properties:
+        end_offset:
+          type: integer
+        message_id:
+          type: string
+        segment_size:
+          type: integer
+        start_offset:
+          type: integer
+      type: object
+    api.NestedSourceResponse:
+      properties:
+        encrypted:
+          type: boolean
+        inner_length:
+          type: integer
+        inner_volume_size:
+          type: integer
+        segment_count:
+          type: integer
+        segments:
+          items:
+            $ref: "#/components/schemas/api.NestedSegmentResponse"
+          type: array
+        volume_index:
+          type: integer
+      type: object
+    api.PoolMetricsResponse:
+      properties:
+        articles_downloaded:
+          type: integer
+        articles_posted:
+          type: integer
+        bytes_downloaded:
+          type: integer
+        bytes_downloaded_24h:
+          type: integer
+        bytes_uploaded:
+          type: integer
+        download_speed_bytes_per_sec:
+          type: number
+        max_download_speed_bytes_per_sec:
+          type: number
+        provider_errors:
+          additionalProperties:
+            format: int64
+            type: integer
+          type: object
+        providers:
+          items:
+            $ref: "#/components/schemas/api.ProviderStatusResponse"
+          type: array
+        timestamp:
+          type: string
+        total_errors:
+          type: integer
+        upload_speed_bytes_per_sec:
+          type: number
+      type: object
+    api.ProviderAPIResponse:
+      properties:
+        enabled:
+          type: boolean
+        host:
+          type: string
+        id:
+          type: string
+        inflight_requests:
+          type: integer
+        insecure_tls:
+          type: boolean
+        is_backup_provider:
+          type: boolean
+        last_rtt_ms:
+          type: integer
+        last_speed_test_mbps:
+          type: number
+        last_speed_test_time:
+          type: string
+        max_connections:
+          type: integer
+        password_set:
+          type: boolean
+        port:
+          type: integer
+        proxy_url:
+          type: string
+        tls:
+          type: boolean
+        username:
+          type: string
+      type: object
+    api.ProviderCreateRequest:
+      properties:
+        enabled:
+          type: boolean
+        host:
+          type: string
+        insecure_tls:
+          type: boolean
+        is_backup_provider:
+          type: boolean
+        max_connections:
+          type: integer
+        password:
+          type: string
+        port:
+          type: integer
+        proxy_url:
+          type: string
+        tls:
+          type: boolean
+        username:
+          type: string
+      type: object
+    api.ProviderReorderRequest:
+      properties:
+        provider_ids:
+          items:
+            type: string
+          type: array
+      type: object
+    api.ProviderSpeedTestResponse:
+      properties:
+        duration_seconds:
+          type: number
+        speed_mbps:
+          type: number
+      type: object
+    api.ProviderStatusResponse:
+      properties:
+        current_speed_bytes_per_sec:
+          type: number
+        error_count:
+          type: integer
+        failure_reason:
+          type: string
+        host:
+          type: string
+        id:
+          type: string
+        last_connection_attempt:
+          type: string
+        last_speed_test_mbps:
+          type: number
+        last_speed_test_time:
+          type: string
+        last_successful_connect:
+          type: string
+        max_connections:
+          type: integer
+        missing_count:
+          type: integer
+        missing_rate_per_minute:
+          type: number
+        missing_warning:
+          type: boolean
+        ping_ms:
+          type: integer
+        state:
+          type: string
+        used_connections:
+          type: integer
+        username:
+          type: string
+      type: object
+    api.ProviderTestRequest:
+      properties:
+        host:
+          type: string
+        insecure_tls:
+          type: boolean
+        password:
+          type: string
+        port:
+          type: integer
+        proxy_url:
+          type: string
+        tls:
+          type: boolean
+        username:
+          type: string
+      type: object
+    api.ProviderUpdateRequest:
+      properties:
+        enabled:
+          type: boolean
+        host:
+          type: string
+        insecure_tls:
+          type: boolean
+        is_backup_provider:
+          type: boolean
+        max_connections:
+          type: integer
+        password:
+          type: string
+        port:
+          type: integer
+        proxy_url:
+          type: string
+        tls:
+          type: boolean
+        username:
+          type: string
+      type: object
+    api.QueueHistoricalStatsResponse:
+      properties:
+        daily:
+          items:
+            $ref: "#/components/schemas/api.DailyStat"
+          type: array
+        last_7_days:
+          $ref: "#/components/schemas/api.QueueHistoryRange"
+        last_24_hours:
+          $ref: "#/components/schemas/api.QueueHistoryRange"
+        last_30_days:
+          $ref: "#/components/schemas/api.QueueHistoryRange"
+        last_365_days:
+          $ref: "#/components/schemas/api.QueueHistoryRange"
+      type: object
+    api.QueueHistoryRange:
+      properties:
+        completed:
+          type: integer
+        failed:
+          type: integer
+        percentage:
+          type: number
+      type: object
+    api.QueueItemResponse:
+      properties:
+        batch_id:
+          type: string
+        category:
+          type: string
+        completed_at:
+          type: string
+        created_at:
+          type: string
+        error_message:
+          type: string
+        file_size:
+          type: integer
+        id:
+          type: integer
+        max_retries:
+          type: integer
+        metadata:
+          type: string
+        nzb_path:
+          type: string
+        percentage:
+          description: Progress percentage (0-100), only for items being processed
+          type: integer
+        priority:
+          $ref: "#/components/schemas/database.QueuePriority"
+        retry_count:
+          type: integer
+        started_at:
+          type: string
+        status:
+          $ref: "#/components/schemas/database.QueueStatus"
+        target_path:
+          type: string
+        updated_at:
+          type: string
+      type: object
+    api.QueueStatsResponse:
+      properties:
+        avg_processing_time_ms:
+          type: integer
+        last_updated:
+          type: string
+        total_completed:
+          type: integer
+        total_failed:
+          type: integer
+        total_processing:
+          type: integer
+        total_queued:
+          type: integer
+      type: object
+    api.RCloneAPIResponse:
+      properties:
+        allow_non_empty:
+          type: boolean
+        allow_other:
+          description: Mount-Specific Settings
+          type: boolean
+        async_read:
+          type: boolean
+        attr_timeout:
+          type: string
+        buffer_size:
+          type: string
+        cache_dir:
+          description: VFS Cache Settings
+          type: string
+        dir_cache_time:
+          type: string
+        gid:
+          type: integer
+        links:
+          type: boolean
+        log_level:
+          description: System and filesystem options
+          type: string
+        mount_enabled:
+          description: Mount Configuration
+          type: boolean
+        mount_options:
+          additionalProperties:
+            type: string
+          type: object
+        no_checksum:
+          type: boolean
+        no_mod_time:
+          description: Advanced Settings
+          type: boolean
+        password_set:
+          description: Encryption
+          type: boolean
+        rc_enabled:
+          type: boolean
+        rc_options:
+          additionalProperties:
+            type: string
+          type: object
+        rc_pass_set:
+          type: boolean
+        rc_port:
+          type: integer
+        rc_url:
+          type: string
+        rc_user:
+          type: string
+        read_chunk_size:
+          type: string
+        read_chunk_size_limit:
+          type: string
+        read_only:
+          type: boolean
+        salt_set:
+          type: boolean
+        syslog:
+          type: boolean
+        timeout:
+          type: string
+        transfers:
+          type: integer
+        uid:
+          type: integer
+        umask:
+          type: string
+        use_mmap:
+          type: boolean
+        vfs_cache_max_age:
+          type: string
+        vfs_cache_max_size:
+          type: string
+        vfs_cache_min_free_space:
+          type: string
+        vfs_cache_mode:
+          type: string
+        vfs_disk_space_total:
+          type: string
+        vfs_fast_fingerprint:
+          type: boolean
+        vfs_name:
+          type: string
+        vfs_read_ahead:
+          type: string
+        vfs_read_chunk_streams:
+          type: integer
+      type: object
+    api.RegisterRequest:
+      properties:
+        email:
+          type: string
+        password:
+          type: string
+        username:
+          type: string
+      type: object
+    api.SABnzbdAPIResponse:
+      properties:
+        categories:
+          items:
+            $ref: "#/components/schemas/config.SABnzbdCategory"
+          type: array
+        complete_dir:
+          type: string
+        download_client_base_url:
+          type: string
+        enabled:
+          type: boolean
+        fallback_api_key:
+          description: Obfuscated if set
+          type: string
+        fallback_api_key_set:
+          description: Indicates if API key is set
+          type: boolean
+        fallback_host:
+          type: string
+      type: object
+    api.ScanStatusResponse:
+      properties:
+        current_file:
+          type: string
+        files_added:
+          type: integer
+        files_found:
+          type: integer
+        last_error:
+          type: string
+        path:
+          type: string
+        start_time:
+          type: string
+        status:
+          type: string
+      type: object
+    api.SegmentInfoResponse:
+      properties:
+        available:
+          type: boolean
+        end_offset:
+          type: integer
+        message_id:
+          type: string
+        segment_size:
+          type: integer
+        start_offset:
+          type: integer
+      type: object
+    api.StremioStream:
+      properties:
+        name:
+          type: string
+        title:
+          type: string
+        url:
+          type: string
+      type: object
+    api.StremioStreamsResponse:
+      properties:
+        _queue_item_id:
+          type: integer
+        _queue_status:
+          type: string
+        streams:
+          items:
+            $ref: "#/components/schemas/api.StremioStream"
+          type: array
+      type: object
+    api.SystemCleanupRequest:
+      properties:
+        dry_run:
+          type: boolean
+        health_older_than:
+          type: string
+        queue_older_than:
+          type: string
+      type: object
+    api.SystemCleanupResponse:
+      properties:
+        dry_run:
+          type: boolean
+        health_records_removed:
+          type: integer
+        queue_items_removed:
+          type: integer
+      type: object
+    api.SystemHealthResponse:
+      properties:
+        components:
+          additionalProperties:
+            $ref: "#/components/schemas/api.ComponentHealth"
+          type: object
+        status:
+          description: '"healthy", "degraded", "unhealthy"'
+          type: string
+        timestamp:
+          type: string
+      type: object
+    api.SystemInfoResponse:
+      properties:
+        git_commit:
+          type: string
+        go_version:
+          type: string
+        start_time:
+          type: string
+        uptime:
+          type: string
+        version:
+          type: string
+      type: object
+    api.SystemRestartRequest:
+      properties:
+        force:
+          description: Force restart even if unsafe
+          type: boolean
+      type: object
+    api.SystemRestartResponse:
+      properties:
+        message:
+          type: string
+        timestamp:
+          type: string
+      type: object
+    api.SystemStatsResponse:
+      properties:
+        health:
+          $ref: "#/components/schemas/api.HealthStatsResponse"
+        queue:
+          $ref: "#/components/schemas/api.QueueStatsResponse"
+        system:
+          $ref: "#/components/schemas/api.SystemInfoResponse"
+      type: object
+    api.TestProviderResponse:
+      properties:
+        error_message:
+          type: string
+        rtt_ms:
+          type: integer
+        success:
+          type: boolean
+      type: object
+    api.UpdateChannel:
+      enum:
+        - latest
+        - dev
+      type: string
+      x-enum-varnames:
+        - UpdateChannelLatest
+        - UpdateChannelDev
+    api.UpdateStatusResponse:
+      properties:
+        channel:
+          $ref: "#/components/schemas/api.UpdateChannel"
+        current_version:
+          type: string
+        docker_available:
+          type: boolean
+        git_commit:
+          type: string
+        latest_version:
+          type: string
+        release_url:
+          type: string
+        update_available:
+          type: boolean
+      type: object
+    api.UserResponse:
+      properties:
+        api_key:
+          type: string
+        avatar_url:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        is_admin:
+          type: boolean
+        last_login:
+          type: string
+        name:
+          type: string
+        provider:
+          type: string
+      type: object
+    api.WebDAVAPIResponse:
+      properties:
+        host:
+          type: string
+        password:
+          description: Masked if set
+          type: string
+        port:
+          type: integer
+        user:
+          type: string
+      type: object
+    api.stremioManifest:
+      properties:
+        catalogs:
+          items: {}
+          type: array
+        description:
+          type: string
+        id:
+          type: string
+        idPrefixes:
+          items:
+            type: string
+          type: array
+        name:
+          type: string
+        resources:
+          items:
+            type: string
+          type: array
+        types:
+          items:
+            type: string
+          type: array
+        version:
+          type: string
+      type: object
+    config.APIConfig:
+      properties:
+        allowed_origins:
+          items:
+            type: string
+          type: array
+        key_override:
+          type: string
+        prefix:
+          type: string
+      type: object
+    config.ArrsConfig:
+      properties:
+        cleanup_automatic_import_failure:
+          type: boolean
+        enabled:
+          type: boolean
+        max_workers:
+          type: integer
+        queue_cleanup_allowlist:
+          items:
+            $ref: "#/components/schemas/config.IgnoredMessage"
+          type: array
+        queue_cleanup_enabled:
+          type: boolean
+        queue_cleanup_grace_period_minutes:
+          type: integer
+        queue_cleanup_interval_seconds:
+          type: integer
+        radarr_instances:
+          items:
+            $ref: "#/components/schemas/config.ArrsInstanceConfig"
+          type: array
+        sonarr_instances:
+          items:
+            $ref: "#/components/schemas/config.ArrsInstanceConfig"
+          type: array
+        webhook_base_url:
+          type: string
+      type: object
+    config.ArrsInstanceConfig:
+      properties:
+        api_key:
+          type: string
+        category:
+          type: string
+        enabled:
+          type: boolean
+        name:
+          type: string
+        sync_interval_hours:
+          type: integer
+        url:
+          type: string
+      type: object
+    config.AuthConfig:
+      properties:
+        login_required:
+          type: boolean
+      type: object
+    config.DatabaseConfig:
+      properties:
+        dsn:
+          description: >-
+            DSN is the PostgreSQL connection string (postgres only).
+
+            Example: "postgres://user:password@localhost:5432/altmount?sslmode=disable"
+          type: string
+        path:
+          description: Path is the SQLite database file path (sqlite only).
+          type: string
+        type:
+          description: 'Type selects the database backend: "sqlite" (default) or
+            "postgres".'
+          type: string
+      type: object
+    config.FailureMaskingConfig:
+      properties:
+        enabled:
+          type: boolean
+        threshold:
+          type: integer
+      type: object
+    config.FuseConfig:
+      properties:
+        allow_other:
+          type: boolean
+        attr_timeout_seconds:
+          type: integer
+        backend:
+          description: '"hanwen" or "cgo" (empty = platform default)'
+          type: string
+        debug:
+          type: boolean
+        enabled:
+          type: boolean
+        entry_timeout_seconds:
+          type: integer
+        max_cache_size_mb:
+          type: integer
+        max_read_ahead_mb:
+          type: integer
+        mount_path:
+          type: string
+      type: object
+    config.HealthConfig:
+      properties:
+        acceptable_missing_segments_percentage:
+          type: number
+        check_all_segments:
+          type: boolean
+        check_interval_seconds:
+          type: integer
+        cleanup_orphaned_metadata:
+          type: boolean
+        enabled:
+          type: boolean
+        library_dir:
+          type: string
+        library_sync_concurrency:
+          type: integer
+        library_sync_interval_minutes:
+          type: integer
+        max_concurrent_jobs:
+          type: integer
+        max_connections_for_health_checks:
+          type: integer
+        repair:
+          $ref: "#/components/schemas/config.RepairConfig"
+        resolve_repair_on_import:
+          type: boolean
+        segment_sample_percentage:
+          type: integer
+        verify_data:
+          type: boolean
+      type: object
+    config.IgnoredMessage:
+      properties:
+        enabled:
+          type: boolean
+        message:
+          type: string
+      type: object
+    config.ImportConfig:
+      properties:
+        allow_nested_rar_extraction:
+          type: boolean
+        allowed_file_extensions:
+          items:
+            type: string
+          type: array
+        expand_bluray_iso:
+          type: boolean
+        import_dir:
+          type: string
+        import_strategy:
+          $ref: "#/components/schemas/config.ImportStrategy"
+        max_download_prefetch:
+          type: integer
+        max_import_connections:
+          type: integer
+        max_processor_workers:
+          type: integer
+        queue_processing_interval_seconds:
+          type: integer
+        read_timeout_seconds:
+          type: integer
+        segment_sample_percentage:
+          type: integer
+        skip_health_check:
+          type: boolean
+        watch_dir:
+          type: string
+        watch_interval_seconds:
+          type: integer
+      type: object
+    config.ImportStrategy:
+      enum:
+        - NONE
+        - SYMLINK
+        - STRM
+      type: string
+      x-enum-varnames:
+        - ImportStrategyNone
+        - ImportStrategySYMLINK
+        - ImportStrategySTRM
+    config.LogConfig:
+      properties:
+        compress:
+          description: Compress old log files
+          type: boolean
+        file:
+          description: Log file path (empty = console only)
+          type: string
+        level:
+          description: Log level (debug, info, warn, error)
+          type: string
+        max_age:
+          description: Max age in days to keep files
+          type: integer
+        max_backups:
+          description: Max number of old files to keep
+          type: integer
+        max_size:
+          description: Max size in MB before rotation
+          type: integer
+      type: object
+    config.MetadataBackupConfig:
+      properties:
+        enabled:
+          type: boolean
+        interval_hours:
+          type: integer
+        keep_backups:
+          type: integer
+        path:
+          type: string
+      type: object
+    config.MetadataConfig:
+      properties:
+        backup:
+          $ref: "#/components/schemas/config.MetadataBackupConfig"
+        delete_completed_nzb:
+          type: boolean
+        delete_failed_nzb:
+          type: boolean
+        delete_source_nzb_on_removal:
+          type: boolean
+        root_path:
+          type: string
+      type: object
+    config.MountType:
+      enum:
+        - none
+        - rclone
+        - fuse
+        - rclone_external
+      type: string
+      x-enum-varnames:
+        - MountTypeNone
+        - MountTypeRClone
+        - MountTypeFuse
+        - MountTypeRCloneExternal
+    config.ProviderConfig:
+      properties:
+        enabled:
+          type: boolean
+        host:
+          type: string
+        id:
+          type: string
+        inflight_requests:
+          type: integer
+        insecure_tls:
+          type: boolean
+        is_backup_provider:
+          type: boolean
+        last_rtt_ms:
+          type: integer
+        last_speed_test_mbps:
+          type: number
+        last_speed_test_time:
+          type: string
+        max_connections:
+          type: integer
+        port:
+          type: integer
+        proxy_url:
+          type: string
+        skip_ping:
+          type: boolean
+        tls:
+          type: boolean
+        username:
+          type: string
+      type: object
+    config.ProwlarrConfig:
+      properties:
+        api_key:
+          description: APIKey is the Prowlarr API key.
+          type: string
+        categories:
+          description: >-
+            Categories filters search results by Newznab category IDs.
+
+            Defaults to 5000 (Movies), 5010 (Movies/Foreign), 5030 (TV), 5040 (TV/HD).
+          items:
+            type: integer
+          type: array
+        enabled:
+          description: Enabled controls whether Prowlarr search is active for the Stremio
+            addon.
+          type: boolean
+        host:
+          description: Host is the Prowlarr base URL (e.g. "http://localhost:9696").
+          type: string
+        languages:
+          description: >-
+            Languages is an optional list of keywords; releases must contain at
+            least one to pass.
+
+            Empty = no filtering. Examples: ["Esp", "🇪🇸", "Spanish", "DUAL"]
+          items:
+            type: string
+          type: array
+        qualities:
+          description: >-
+            Qualities is an optional list of keywords; releases must contain at
+            least one to pass.
+
+            Empty = no filtering. Examples: ["1080p", "HD", "4K", "3D"]
+          items:
+            type: string
+          type: array
+      type: object
+    config.RCloneConfig:
+      properties:
+        allow_non_empty:
+          type: boolean
+        allow_other:
+          description: Mount-Specific Settings
+          type: boolean
+        async_read:
+          type: boolean
+        attr_timeout:
+          type: string
+        buffer_size:
+          type: string
+        cache_dir:
+          description: VFS Cache Settings
+          type: string
+        dir_cache_time:
+          type: string
+        gid:
+          type: integer
+        links:
+          type: boolean
+        log_level:
+          type: string
+        mount_enabled:
+          description: Mount Configuration
+          type: boolean
+        mount_options:
+          additionalProperties:
+            type: string
+          type: object
+        no_checksum:
+          type: boolean
+        no_mod_time:
+          description: Advanced Settings
+          type: boolean
+        path:
+          description: RClone Path
+          type: string
+        rc_enabled:
+          description: RC (Remote Control) Configuration
+          type: boolean
+        rc_options:
+          additionalProperties:
+            type: string
+          type: object
+        rc_port:
+          type: integer
+        rc_url:
+          type: string
+        rc_user:
+          type: string
+        read_chunk_size:
+          type: string
+        read_chunk_size_limit:
+          type: string
+        read_only:
+          type: boolean
+        syslog:
+          type: boolean
+        timeout:
+          type: string
+        transfers:
+          type: integer
+        uid:
+          type: integer
+        umask:
+          type: string
+        use_mmap:
+          type: boolean
+        vfs_cache_max_age:
+          type: string
+        vfs_cache_max_size:
+          type: string
+        vfs_cache_min_free_space:
+          type: string
+        vfs_cache_mode:
+          type: string
+        vfs_cache_poll_interval:
+          type: string
+        vfs_disk_space_total:
+          type: string
+        vfs_fast_fingerprint:
+          type: boolean
+        vfs_name:
+          type: string
+        vfs_read_ahead:
+          type: string
+        vfs_read_chunk_size:
+          type: string
+        vfs_read_chunk_streams:
+          type: integer
+      type: object
+    config.RepairConfig:
+      properties:
+        enabled:
+          type: boolean
+        exponential_backoff:
+          type: boolean
+        interval_minutes:
+          type: integer
+        max_cooldown_hours:
+          type: integer
+      type: object
+    config.SABnzbdCategory:
+      properties:
+        dir:
+          type: string
+        name:
+          type: string
+        order:
+          type: integer
+        priority:
+          type: integer
+        type:
+          description: '"sonarr" or "radarr"'
+          type: string
+      type: object
+    config.SABnzbdConfig:
+      properties:
+        categories:
+          items:
+            $ref: "#/components/schemas/config.SABnzbdCategory"
+          type: array
+        complete_dir:
+          type: string
+        download_client_base_url:
+          type: string
+        enabled:
+          type: boolean
+        fallback_api_key:
+          description: Masked in API responses
+          type: string
+        fallback_host:
+          description: Fallback configuration for sending failed imports to external SABnzbd
+          type: string
+      type: object
+    config.SegmentCacheConfig:
+      properties:
+        cache_path:
+          type: string
+        enabled:
+          type: boolean
+        expiry_hours:
+          type: integer
+        max_size_gb:
+          type: integer
+      type: object
+    config.StreamingConfig:
+      properties:
+        failure_masking:
+          $ref: "#/components/schemas/config.FailureMaskingConfig"
+        max_prefetch:
+          type: integer
+      type: object
+    config.StremioConfig:
+      properties:
+        base_url:
+          description: >-
+            BaseURL is the public base URL used when building Stremio stream
+            links
+
+            (e.g. "https://altmount.example.com"). Falls back to the auto-detected
+
+            request origin when not set.
+          type: string
+        enabled:
+          description: >-
+            Enabled controls whether the endpoint is active. Disabled by
+            default.
+
+            When false, the endpoint returns 404 Not Found.
+          type: boolean
+        nzb_ttl_hours:
+          description: >-
+            NzbTTLHours controls how long a completed NZB result is cached
+            before
+
+            the same NZB is re-processed on the next request.
+
+            Set to 0 to disable expiry (cache forever). Defaults to 24 hours.
+          type: integer
+        prowlarr:
+          allOf:
+            - $ref: "#/components/schemas/config.ProwlarrConfig"
+          description: Prowlarr configures the Prowlarr indexer used by the Stremio addon
+            to search for NZBs.
+      type: object
+    config.WebDAVConfig:
+      properties:
+        host:
+          type: string
+        password:
+          type: string
+        port:
+          type: integer
+        user:
+          type: string
+      type: object
+    database.HealthPriority:
+      enum:
+        - 0
+        - 1
+        - 2
+      type: integer
+      x-enum-varnames:
+        - HealthPriorityNormal
+        - HealthPriorityHigh
+        - HealthPriorityNext
+    database.HealthStatus:
+      enum:
+        - pending
+        - checking
+        - healthy
+        - repair_triggered
+        - corrupted
+      type: string
+      x-enum-comments:
+        HealthStatusChecking: File is currently being checked
+        HealthStatusCorrupted: File has missing segments or is corrupted
+        HealthStatusHealthy: File passed health check
+        HealthStatusPending: File has not been checked yet
+        HealthStatusRepairTriggered: File repair has been triggered in Arrs
+      x-enum-descriptions:
+        - File has not been checked yet
+        - File is currently being checked
+        - File passed health check
+        - File repair has been triggered in Arrs
+        - File has missing segments or is corrupted
+      x-enum-varnames:
+        - HealthStatusPending
+        - HealthStatusChecking
+        - HealthStatusHealthy
+        - HealthStatusRepairTriggered
+        - HealthStatusCorrupted
+    database.QueuePriority:
+      enum:
+        - 1
+        - 2
+        - 3
+      type: integer
+      x-enum-varnames:
+        - QueuePriorityHigh
+        - QueuePriorityNormal
+        - QueuePriorityLow
+    database.QueueStatus:
+      enum:
+        - pending
+        - processing
+        - completed
+        - failed
+        - paused
+        - fallback
+      type: string
+      x-enum-comments:
+        QueueStatusFallback: Sent to external SABnzbd as fallback
+      x-enum-descriptions:
+        - ""
+        - ""
+        - ""
+        - ""
+        - ""
+        - Sent to external SABnzbd as fallback
+      x-enum-varnames:
+        - QueueStatusPending
+        - QueueStatusProcessing
+        - QueueStatusCompleted
+        - QueueStatusFailed
+        - QueueStatusPaused
+        - QueueStatusFallback

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -7068,6 +7068,9 @@
                 "proxy_url": {
                     "type": "string"
                 },
+                "skip_ping": {
+                    "type": "boolean"
+                },
                 "tls": {
                     "type": "boolean"
                 },

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1272,6 +1272,8 @@ definitions:
         type: integer
       proxy_url:
         type: string
+      skip_ping:
+        type: boolean
       tls:
         type: boolean
       username:


### PR DESCRIPTION
## Summary

- Add `swagger2openapi` dev dep and extend `gen-swagger` script to convert `swagger.yaml` → `openapi.yaml` after swag runs
- Point the API explorer at `openapi.yaml` so Swagger UI displays the **OAS 3.0** badge
- Fix dark-theme visibility for endpoint description text (`.opblock-description-wrapper` and tag descriptions) and expand/collapse arrow SVGs (`fill` override)

## Test plan

- [ ] Run `bun run gen-swagger` in `docs/` — confirm `docs/static/openapi.yaml` starts with `openapi: 3.0.0`
- [ ] Run `bun run start` in `docs/`, navigate to `/api-explorer` — confirm "OAS 3.0" badge in header
- [ ] Switch to dark theme — confirm endpoint descriptions and expand/collapse arrows are visible
- [ ] All endpoints, schemas, and security definitions render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)