### PR TITLE
feat(errors): introduce ErrArticlesNotFound for missing NZB segments

### DIFF
--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/database"
+	internalerrors "github.com/javi11/altmount/internal/errors"
 	"github.com/javi11/altmount/internal/nzblnk"
 )
 
@@ -25,9 +26,9 @@ func transformQueueError(err *string) string {
 		return ""
 	}
 
-	// Check if it's the article not found error
-	if strings.Contains(*err, "article is not found") {
-		return "The file is incomplete or missing parts. Some segments of this file could not be found on any of the configured Usenet providers. This often happens with older or less popular files."
+	// Check if it's the article not found error (old raw NNTP message or new sentinel message)
+	if strings.Contains(*err, "article is not found") || *err == internalerrors.ErrArticlesNotFound.Error() {
+		return internalerrors.ErrArticlesNotFound.Error()
 	}
 
 	// Return the original error message for other errors

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,4 +69,10 @@ var (
 		message: "SABnzbd fallback not configured",
 		cause:   nil,
 	}
+
+	// ErrArticlesNotFound indicates that one or more NZB segments could not be found on any provider.
+	ErrArticlesNotFound = &NonRetryableError{
+		message: "The file is incomplete or missing parts. Some segments of this file could not be found on any of the configured Usenet providers. This often happens with older or less popular files.",
+		cause:   nil,
+	}
 )

--- a/internal/importer/errors.go
+++ b/internal/importer/errors.go
@@ -21,4 +21,7 @@ var (
 
 	// ErrFallbackNotConfigured indicates that SABnzbd fallback is not enabled or configured.
 	ErrFallbackNotConfigured = sharedErrors.ErrFallbackNotConfigured
+
+	// ErrArticlesNotFound indicates that one or more NZB segments could not be found on any provider.
+	ErrArticlesNotFound = sharedErrors.ErrArticlesNotFound
 )

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -2,6 +2,7 @@ package importer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -9,6 +10,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/javi11/nntppool/v4"
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
@@ -283,6 +286,8 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	// Update progress: complete
 	if err == nil {
 		proc.updateProgress(queueID, 100)
+	} else if errors.Is(err, nntppool.ErrArticleNotFound) {
+		return result, ErrArticlesNotFound
 	}
 
 	return result, err


### PR DESCRIPTION
- Added ErrArticlesNotFound to internal/errors to indicate when NZB segments are not found on any provider.
- Updated transformQueueError function in queue_handlers.go to return the new error message for article not found scenarios.
- Propagated ErrArticlesNotFound in processor.go when encountering nntppool.ErrArticleNotFound.

This change improves error handling and provides clearer feedback for users regarding missing NZB segments.