### PR TITLE
feat(stremio): prefer TVDB series search with IMDb fallback

### DIFF
--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -159,13 +159,43 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 
 	// Search Prowlarr -- return play-URL options immediately, no download yet
 	client := prowlarr.NewClient(prowlarrCfg.Host, prowlarrCfg.APIKey)
-	results, err := client.Search(ctx, imdbID, prowlarrType, prowlarrCfg.Categories, season, episode)
-	if err != nil {
-		slog.WarnContext(ctx, "Prowlarr search failed", "error", err, "imdb_id", imdbID)
-		return emptyStreamsResponse(c)
+	var (
+		results []prowlarr.NZBResult
+		err     error
+		tvdbID  string
+	)
+
+	// For series, prefer TvdbId queries when possible and fall back to ImdbId.
+	if streamType == "series" {
+		tvdbID, err = resolveTVDBFromIMDb(ctx, imdbID)
+		if err != nil {
+			slog.WarnContext(ctx, "Failed to resolve TVDB ID from IMDb ID",
+				"error", err, "imdb_id", imdbID)
+			tvdbID = ""
+		}
+
+		if tvdbID != "" {
+			slog.InfoContext(ctx, "Searching Prowlarr using TVDB ID for series",
+				"imdb_id", imdbID, "tvdb_id", tvdbID, "season", season, "episode", episode)
+			results, err = client.SearchByTVDB(ctx, tvdbID, prowlarrType, prowlarrCfg.Categories, season, episode)
+			if err != nil {
+				slog.WarnContext(ctx, "Prowlarr TVDB search failed; falling back to IMDb search",
+					"error", err, "imdb_id", imdbID, "tvdb_id", tvdbID)
+				results = nil
+			}
+		}
 	}
+
 	if len(results) == 0 {
-		slog.InfoContext(ctx, "No Prowlarr results found", "imdb_id", imdbID)
+		results, err = client.Search(ctx, imdbID, prowlarrType, prowlarrCfg.Categories, season, episode)
+		if err != nil {
+			slog.WarnContext(ctx, "Prowlarr search failed", "error", err, "imdb_id", imdbID, "tvdb_id", tvdbID)
+			return emptyStreamsResponse(c)
+		}
+	}
+
+	if len(results) == 0 {
+		slog.InfoContext(ctx, "No Prowlarr results found", "imdb_id", imdbID, "tvdb_id", tvdbID)
 		return emptyStreamsResponse(c)
 	}
 

--- a/internal/api/tvdb_lookup.go
+++ b/internal/api/tvdb_lookup.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+var tvmazeLookupClient = &http.Client{
+	Timeout: 8 * time.Second,
+}
+
+type tvmazeLookupResponse struct {
+	Externals struct {
+		TheTVDB int `json:"thetvdb"`
+	} `json:"externals"`
+}
+
+// resolveTVDBFromIMDb resolves a TVDB ID from an IMDb ID via the TVMaze lookup API.
+// Returns an empty ID without error when the mapping does not exist.
+func resolveTVDBFromIMDb(ctx context.Context, imdbID string) (string, error) {
+	if imdbID == "" {
+		return "", nil
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://api.tvmaze.com/lookup/shows?imdb="+url.QueryEscape(imdbID),
+		nil,
+	)
+	if err != nil {
+		return "", fmt.Errorf("create TVDB lookup request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "altmount-stremio-tvdb-lookup")
+
+	resp, err := tvmazeLookupClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("TVDB lookup request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", fmt.Errorf("TVDB lookup returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var data tvmazeLookupResponse
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", fmt.Errorf("decode TVDB lookup response: %w", err)
+	}
+	if data.Externals.TheTVDB <= 0 {
+		return "", nil
+	}
+
+	return strconv.Itoa(data.Externals.TheTVDB), nil
+}

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -196,9 +196,19 @@ func InferReleaseMeta(title string) ReleaseMeta {
 // season and episode are optional (pass 0 to omit); used for tvsearch to scope results to a specific episode.
 // Results are returned sorted by publish date descending (newest first).
 func (c *Client) Search(ctx context.Context, imdbID, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
+	return c.searchWithID(ctx, "ImdbId", imdbID, searchType, categories, season, episode)
+}
+
+// SearchByTVDB queries Prowlarr for NZB releases using TVDB ID and categories.
+// This is primarily used by TV series lookups when indexers support TvdbId but not ImdbId.
+func (c *Client) SearchByTVDB(ctx context.Context, tvdbID, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
+	return c.searchWithID(ctx, "TvdbId", tvdbID, searchType, categories, season, episode)
+}
+
+func (c *Client) searchWithID(ctx context.Context, idField, idValue, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
 	var query strings.Builder
-	if imdbID != "" {
-		query.WriteString("{ImdbId:" + imdbID + "}")
+	if idValue != "" {
+		query.WriteString("{" + idField + ":" + idValue + "}")
 	}
 	if season > 0 {
 		query.WriteString("{Season:" + strconv.Itoa(season) + "}")


### PR DESCRIPTION
## Summary
- prefer `TvdbId` queries for Stremio `series` searches when possible
- keep existing IMDb behavior as fallback when TVDB lookup fails or returns empty
- preserve current movie search path and existing Stremio output contract

## What changed
- added `resolveTVDBFromIMDb()` in `internal/api/tvdb_lookup.go` using TVMaze lookup API
- updated `handleStremioAddonStream` to:
  - resolve IMDb -> TVDB for `series`
  - search Prowlarr with `TvdbId` first for `tvsearch`
  - fall back to `ImdbId` search on errors or empty TVDB result set
- refactored Prowlarr client search builder:
  - introduced `searchWithID(...)`
  - added `SearchByTVDB(...)`

## Why
Some indexers behind Prowlarr support TV episode discovery only with `TvdbId` for `tvsearch`. Existing IMDb-only series queries return zero results in those setups.

## Behavior notes
- no config migration required
- no breaking API/UI changes
- series search is now more compatible while retaining previous fallback behavior
