### PR TITLE
feat(sse): replace polling with SSE streams for health and queue pages

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -165,7 +165,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	webdav.RegisterConfigHandlers(ctx, configManager, webdavHandler)
 	api.RegisterLogLevelHandler(ctx, configManager, debugMode)
 
-	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService)
+	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService, progressBroadcaster)
 	if err != nil {
 		logger.Warn("Health worker initialization failed", "err", err)
 	}

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -377,6 +377,7 @@ func startHealthWorker(
 	configManager *config.Manager,
 	rcloneClient rclonecli.RcloneRcClient,
 	arrsService *arrs.Service,
+	broadcaster *progress.ProgressBroadcaster,
 ) (*health.HealthWorker, *health.LibrarySyncWorker, error) {
 	// Create metadata service for health worker
 	metadataService := metadata.NewMetadataService(cfg.Metadata.RootPath)
@@ -396,6 +397,7 @@ func startHealthWorker(
 		metadataService,
 		arrsService,
 		configManager.GetConfigGetter(),
+		broadcaster,
 	)
 
 	// Create library sync worker (always create, but only start if enabled)

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -32,7 +32,6 @@ export const useQueueStats = () => {
 	return useQuery({
 		queryKey: ["queue", "stats"],
 		queryFn: () => apiClient.getQueueStats(),
-		refetchInterval: 5000, // Refetch every 5 seconds
 	});
 };
 
@@ -173,16 +172,7 @@ export const useHealth = (params?: {
 	return useQuery({
 		queryKey: ["health", params],
 		queryFn: () => apiClient.getHealth(params),
-		refetchInterval: (query) => {
-			// Use custom refetch interval if provided
-			if (params?.refetchInterval !== undefined) {
-				return params.refetchInterval;
-			}
-			// Otherwise, poll every 5 seconds if any items are in "checking" status
-			const data = query.state.data?.data;
-			const hasCheckingItems = data?.some((item) => item.status === "checking");
-			return hasCheckingItems ? 5000 : false;
-		},
+		refetchInterval: false,
 	});
 };
 
@@ -205,7 +195,6 @@ export const useHealthStats = () => {
 	return useQuery({
 		queryKey: ["health", "stats"],
 		queryFn: () => apiClient.getHealthStats(),
-		refetchInterval: 5000, // Refetch every 5 seconds
 	});
 };
 

--- a/frontend/src/hooks/useHealthStream.ts
+++ b/frontend/src/hooks/useHealthStream.ts
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseHealthStreamOptions {
+	enabled?: boolean;
+	onHealthChanged?: () => void;
+}
+
+interface UseHealthStreamReturn {
+	isConnected: boolean;
+	error: Error | null;
+}
+
+/**
+ * Hook for consuming Server-Sent Events (SSE) health stream updates.
+ * Fires onHealthChanged on initial connection and on every health state change.
+ * @param options.enabled - Whether to enable the SSE connection (default: true)
+ * @param options.onHealthChanged - Callback fired when health state changes
+ */
+export function useHealthStream(options: UseHealthStreamOptions = {}): UseHealthStreamReturn {
+	const { enabled = true, onHealthChanged } = options;
+	const [isConnected, setIsConnected] = useState(false);
+	const [error, setError] = useState<Error | null>(null);
+	const eventSourceRef = useRef<EventSource | null>(null);
+	const reconnectTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+	const reconnectAttemptsRef = useRef<number>(0);
+	const onHealthChangedRef = useRef(onHealthChanged);
+	onHealthChangedRef.current = onHealthChanged;
+	const maxReconnectAttempts = 10;
+
+	useEffect(() => {
+		if (!enabled) {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+				eventSourceRef.current = null;
+			}
+			if (reconnectTimeoutRef.current) {
+				clearTimeout(reconnectTimeoutRef.current);
+				reconnectTimeoutRef.current = undefined;
+			}
+			setIsConnected(false);
+			setError(null);
+			return;
+		}
+
+		const connect = () => {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+			}
+
+			try {
+				const eventSource = new EventSource("/api/health/stream");
+				eventSourceRef.current = eventSource;
+
+				eventSource.onopen = () => {
+					setIsConnected(true);
+					setError(null);
+					reconnectAttemptsRef.current = 0;
+				};
+
+				eventSource.onmessage = (event) => {
+					try {
+						const data = JSON.parse(event.data) as { type: "initial" | "update" };
+						if (data.type === "initial" || data.type === "update") {
+							onHealthChangedRef.current?.();
+						}
+					} catch (err) {
+						console.error("Failed to parse health stream update:", err);
+					}
+				};
+
+				eventSource.onerror = () => {
+					setIsConnected(false);
+					setError(new Error("Connection lost"));
+					eventSource.close();
+
+					if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+						const backoffTime = Math.min(1000 * 2 ** reconnectAttemptsRef.current, 30000);
+						reconnectAttemptsRef.current += 1;
+						reconnectTimeoutRef.current = setTimeout(() => {
+							connect();
+						}, backoffTime);
+					} else {
+						setError(new Error("Failed to reconnect after multiple attempts"));
+					}
+				};
+			} catch (err) {
+				setError(err instanceof Error ? err : new Error("Unknown error"));
+				setIsConnected(false);
+			}
+		};
+
+		connect();
+
+		return () => {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+			}
+			if (reconnectTimeoutRef.current) {
+				clearTimeout(reconnectTimeoutRef.current);
+			}
+		};
+	}, [enabled]);
+
+	return { isConnected, error };
+}

--- a/frontend/src/hooks/useQueueStream.ts
+++ b/frontend/src/hooks/useQueueStream.ts
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react";
+
+interface ProgressUpdate {
+	queue_id: number;
+	percentage: number;
+	status?: string;
+	timestamp: string;
+}
+
+interface QueueStreamData {
+	type: "initial" | "update";
+	data: Record<number, number> | ProgressUpdate;
+}
+
+interface UseQueueStreamReturn {
+	progress: Record<number, number>;
+	isConnected: boolean;
+	error: Error | null;
+}
+
+interface UseQueueStreamOptions {
+	enabled?: boolean;
+	onQueueChanged?: () => void;
+}
+
+/**
+ * Hook for consuming Server-Sent Events (SSE) queue stream updates.
+ * Provides real-time progress tracking and queue-change notifications.
+ * @param options.enabled - Whether to enable the SSE connection (default: true)
+ * @param options.onQueueChanged - Callback fired when the queue list changes
+ */
+export function useQueueStream(options: UseQueueStreamOptions = {}): UseQueueStreamReturn {
+	const { enabled = true, onQueueChanged } = options;
+	const [progress, setProgress] = useState<Record<number, number>>({});
+	const [isConnected, setIsConnected] = useState(false);
+	const [error, setError] = useState<Error | null>(null);
+	const eventSourceRef = useRef<EventSource | null>(null);
+	const reconnectTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+	const reconnectAttemptsRef = useRef<number>(0);
+	const onQueueChangedRef = useRef(onQueueChanged);
+	onQueueChangedRef.current = onQueueChanged;
+	const maxReconnectAttempts = 10;
+
+	useEffect(() => {
+		if (!enabled) {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+				eventSourceRef.current = null;
+			}
+			if (reconnectTimeoutRef.current) {
+				clearTimeout(reconnectTimeoutRef.current);
+				reconnectTimeoutRef.current = undefined;
+			}
+			setIsConnected(false);
+			setError(null);
+			return;
+		}
+
+		const connect = () => {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+			}
+
+			try {
+				const eventSource = new EventSource("/api/queue/stream");
+				eventSourceRef.current = eventSource;
+
+				eventSource.onopen = () => {
+					setIsConnected(true);
+					setError(null);
+					reconnectAttemptsRef.current = 0;
+				};
+
+				eventSource.onmessage = (event) => {
+					try {
+						const data: QueueStreamData = JSON.parse(event.data);
+
+						if (data.type === "initial") {
+							setProgress(data.data as Record<number, number>);
+							onQueueChangedRef.current?.();
+						} else if (data.type === "update") {
+							const update = data.data as ProgressUpdate;
+
+							if (update.status === "queue_changed") {
+								onQueueChangedRef.current?.();
+								return;
+							}
+
+							if (update.status === "completed" || update.status === "failed") {
+								onQueueChangedRef.current?.();
+								setProgress((prev) => {
+									const next = { ...prev };
+									delete next[update.queue_id];
+									return next;
+								});
+								return;
+							}
+
+							setProgress((prev) => {
+								const next = { ...prev };
+								if (update.percentage >= 100) {
+									delete next[update.queue_id];
+								} else {
+									next[update.queue_id] = update.percentage;
+								}
+								return next;
+							});
+						}
+					} catch (err) {
+						console.error("Failed to parse queue stream update:", err);
+					}
+				};
+
+				eventSource.onerror = (err) => {
+					console.error("Queue stream error:", err);
+					setIsConnected(false);
+					setError(new Error("Connection lost"));
+					eventSource.close();
+
+					if (reconnectAttemptsRef.current < maxReconnectAttempts) {
+						const backoffTime = Math.min(1000 * 2 ** reconnectAttemptsRef.current, 30000);
+						reconnectAttemptsRef.current += 1;
+						reconnectTimeoutRef.current = setTimeout(() => {
+							connect();
+						}, backoffTime);
+					} else {
+						setError(new Error("Failed to reconnect after multiple attempts"));
+					}
+				};
+			} catch (err) {
+				console.error("Failed to create EventSource:", err);
+				setError(err instanceof Error ? err : new Error("Unknown error"));
+				setIsConnected(false);
+			}
+		};
+
+		connect();
+
+		return () => {
+			if (eventSourceRef.current) {
+				eventSourceRef.current.close();
+			}
+			if (reconnectTimeoutRef.current) {
+				clearTimeout(reconnectTimeoutRef.current);
+			}
+		};
+	}, [enabled]);
+
+	return { progress, isConnected, error };
+}

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,5 +1,4 @@
 import {
-	Clock,
 	FileCheck,
 	RefreshCw,
 	RotateCcw,
@@ -9,6 +8,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "../components/ui/ErrorAlert";
 import { Pagination } from "../components/ui/Pagination";
 import { useConfirm } from "../contexts/ModalContext";
@@ -30,6 +30,7 @@ import {
 	useUnmaskHealthItem,
 } from "../hooks/useApi";
 import { useConfig } from "../hooks/useConfig";
+import { useHealthStream } from "../hooks/useHealthStream";
 import {
 	useCancelLibrarySync,
 	useLibrarySyncStatus,
@@ -71,11 +72,6 @@ export function HealthPage() {
 		older_than: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 16),
 		delete_files: false,
 	});
-	const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
-	const [refreshInterval] = useState(5000);
-	const [nextRefreshTime, setNextRefreshTime] = useState<Date | null>(null);
-	const [userInteracting, setUserInteracting] = useState(false);
-	const [countdown, setCountdown] = useState(0);
 	const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
 	const [sortBy, setSortBy] = useState<SortBy>("created_at");
 	const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
@@ -93,7 +89,6 @@ export function HealthPage() {
 		status: statusFilter || undefined,
 		sort_by: sortBy,
 		sort_order: sortOrder,
-		refetchInterval: autoRefreshEnabled && !userInteracting ? refreshInterval : undefined,
 	});
 
 	const { data: stats } = useHealthStats();
@@ -111,6 +106,16 @@ export function HealthPage() {
 	const unmaskItem = useUnmaskHealthItem();
 	const { confirmAction } = useConfirm();
 	const { showToast } = useToast();
+	const queryClient = useQueryClient();
+
+	// SSE stream for real-time health updates
+	useHealthStream({
+		enabled: activeTab === "files",
+		onHealthChanged: useCallback(() => {
+			void refetch();
+			queryClient.invalidateQueries({ queryKey: ["health", "stats"] });
+		}, [refetch, queryClient]),
+	});
 
 	// Config hook
 	const { data: config } = useConfig();
@@ -400,11 +405,6 @@ export function HealthPage() {
 		}
 	};
 
-	const toggleAutoRefresh = () => {
-		setAutoRefreshEnabled(!autoRefreshEnabled);
-		setNextRefreshTime(null);
-	};
-
 	const handleSelectItem = (filePath: string, checked: boolean) => {
 		setSelectedItems((prev) => {
 			const newSet = new Set(prev);
@@ -542,58 +542,8 @@ export function HealthPage() {
 		clearSelection();
 	};
 
-	const handleUserInteractionStart = () => {
-		setUserInteracting(true);
-	};
-
-	const handleUserInteractionEnd = () => {
-		const timer = setTimeout(() => {
-			setUserInteracting(false);
-		}, 2000);
-
-		return () => clearTimeout(timer);
-	};
-
 	const data = healthResponse?.data;
 	const meta = healthResponse?.meta;
-
-	// Update next refresh time when auto-refresh is enabled
-	useEffect(() => {
-		if (!autoRefreshEnabled || userInteracting) {
-			setNextRefreshTime(null);
-			return;
-		}
-
-		setNextRefreshTime(new Date(Date.now() + refreshInterval));
-
-		const interval = setInterval(() => {
-			setNextRefreshTime(new Date(Date.now() + refreshInterval));
-		}, refreshInterval);
-
-		return () => clearInterval(interval);
-	}, [autoRefreshEnabled, refreshInterval, userInteracting]);
-
-	// Update countdown timer every second
-	useEffect(() => {
-		if (!nextRefreshTime || !autoRefreshEnabled || userInteracting) {
-			setCountdown(0);
-			return;
-		}
-
-		const updateCountdown = () => {
-			const remaining = Math.max(0, Math.ceil((nextRefreshTime.getTime() - Date.now()) / 1000));
-			setCountdown(remaining);
-
-			if (remaining === 0) {
-				setNextRefreshTime(new Date(Date.now() + refreshInterval));
-			}
-		};
-
-		updateCountdown();
-		const timer = setInterval(updateCountdown, 1000);
-
-		return () => clearInterval(timer);
-	}, [nextRefreshTime, autoRefreshEnabled, userInteracting, refreshInterval]);
 
 	// Reset page when search term or status filter changes
 	useEffect(() => {
@@ -657,34 +607,19 @@ export function HealthPage() {
 						</ul>
 					</div>
 
-					<div className="join">
-						<button
-							type="button"
-							className={`btn btn-outline btn-sm join-item ${autoRefreshEnabled ? "btn-primary" : ""}`}
-							onClick={toggleAutoRefresh}
-						>
-							{autoRefreshEnabled ? (
-								<Clock className="h-3.5 w-3.5" />
-							) : (
-								<Clock className="h-3.5 w-3.5 text-base-content/70" />
-							)}
-							{autoRefreshEnabled ? `${countdown}s` : "Off"}
-						</button>
-
-						<button
-							type="button"
-							className="btn btn-outline btn-sm join-item"
-							onClick={() => refetch()}
-							disabled={isLoading}
-						>
-							{isLoading ? (
-								<span className="loading loading-spinner loading-xs" />
-							) : (
-								<RefreshCw className="h-3.5 w-3.5" />
-							)}
-							Refresh
-						</button>
-					</div>
+					<button
+						type="button"
+						className="btn btn-outline btn-sm"
+						onClick={() => refetch()}
+						disabled={isLoading}
+					>
+						{isLoading ? (
+							<span className="loading loading-spinner loading-xs" />
+						) : (
+							<RefreshCw className="h-3.5 w-3.5" />
+						)}
+						Refresh
+					</button>
 				</div>
 			</div>
 
@@ -784,8 +719,6 @@ export function HealthPage() {
 											statusFilter={statusFilter}
 											onSearchChange={setSearchTerm}
 											onStatusFilterChange={setStatusFilter}
-											onUserInteractionStart={handleUserInteractionStart}
-											onUserInteractionEnd={handleUserInteractionEnd}
 										/>
 
 										<BulkActionsToolbar

--- a/frontend/src/pages/HealthPage/components/HealthFilters.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthFilters.tsx
@@ -3,8 +3,6 @@ interface HealthFiltersProps {
 	statusFilter: string;
 	onSearchChange: (value: string) => void;
 	onStatusFilterChange: (value: string) => void;
-	onUserInteractionStart: () => void;
-	onUserInteractionEnd: () => void;
 }
 
 export function HealthFilters({
@@ -12,8 +10,6 @@ export function HealthFilters({
 	statusFilter,
 	onSearchChange,
 	onStatusFilterChange,
-	onUserInteractionStart,
-	onUserInteractionEnd,
 }: HealthFiltersProps) {
 	return (
 		<div className="card bg-base-100 shadow-lg">
@@ -28,8 +24,6 @@ export function HealthFilters({
 							className="input"
 							value={searchTerm}
 							onChange={(e) => onSearchChange(e.target.value)}
-							onFocus={onUserInteractionStart}
-							onBlur={onUserInteractionEnd}
 						/>
 					</fieldset>
 
@@ -40,8 +34,6 @@ export function HealthFilters({
 							className="select"
 							value={statusFilter}
 							onChange={(e) => onStatusFilterChange(e.target.value)}
-							onFocus={onUserInteractionStart}
-							onBlur={onUserInteractionEnd}
 						>
 							<option value="">All Statuses</option>
 							<option value="pending">Pending</option>

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	Activity,
 	AlertCircle,
@@ -46,7 +47,7 @@ import {
 	useRetryQueueItem,
 	useUpdateQueueItemPriority,
 } from "../hooks/useApi";
-import { useProgressStream } from "../hooks/useProgressStream";
+import { useQueueStream } from "../hooks/useQueueStream";
 import { formatBytes, formatRelativeTime, truncateText } from "../lib/utils";
 import { type QueueItem, QueueStatus } from "../types/api";
 
@@ -66,16 +67,13 @@ export function QueuePage() {
 	const [page, setPage] = useState(0);
 	const [statusFilter, setStatusFilter] = useState<QueueFilter>("");
 	const [searchTerm, setSearchTerm] = useState("");
-	const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
-	const [refreshInterval] = useState(5000);
-	const [nextRefreshTime, setNextRefreshTime] = useState<Date | null>(null);
-	const [userInteracting, setUserInteracting] = useState(false);
-	const [countdown, setCountdown] = useState(0);
 	const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
 	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(
 		"updated_at",
 	);
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+
+	const queryClient = useQueryClient();
 
 	const pageSize = 20;
 	const {
@@ -90,20 +88,18 @@ export function QueuePage() {
 		search: searchTerm || undefined,
 		sort_by: sortBy,
 		sort_order: sortOrder,
-		refetchInterval:
-			autoRefreshEnabled && !userInteracting && view === "list" ? refreshInterval : undefined,
 	});
 
 	const queueData = queueResponse?.data;
 	const meta = queueResponse?.meta;
 	const totalPages = meta?.total ? Math.ceil(meta.total / pageSize) : 0;
 
-	const hasProcessingItems = useMemo(() => {
-		return queueData?.some((item) => item.status === QueueStatus.PROCESSING) ?? false;
-	}, [queueData]);
-
-	const { progress: liveProgress } = useProgressStream({
-		enabled: hasProcessingItems && view === "list",
+	const { progress: liveProgress } = useQueueStream({
+		enabled: view === "list",
+		onQueueChanged: useCallback(() => {
+			refetch();
+			queryClient.invalidateQueries({ queryKey: ["queue", "stats"] });
+		}, [refetch, queryClient]),
 	});
 
 	const enrichedQueueData = useMemo(() => {
@@ -226,11 +222,6 @@ export function QueuePage() {
 		}
 	};
 
-	const toggleAutoRefresh = () => {
-		setAutoRefreshEnabled(!autoRefreshEnabled);
-		setNextRefreshTime(null);
-	};
-
 	const handleSelectItem = (id: number, checked: boolean) => {
 		setSelectedItems((prev) => {
 			const newSet = new Set(prev);
@@ -316,37 +307,6 @@ export function QueuePage() {
 	const isAllSelected =
 		queueData && queueData.length > 0 && queueData.every((item) => selectedItems.has(item.id));
 	const isIndeterminate = queueData && selectedItems.size > 0 && !isAllSelected;
-
-	useEffect(() => {
-		if (autoRefreshEnabled && !userInteracting && view === "list") {
-			setNextRefreshTime(new Date(Date.now() + refreshInterval));
-			const interval = setInterval(() => {
-				setNextRefreshTime(new Date(Date.now() + refreshInterval));
-			}, refreshInterval);
-			return () => clearInterval(interval);
-		}
-		setNextRefreshTime(null);
-	}, [autoRefreshEnabled, refreshInterval, userInteracting, view]);
-
-	const handleUserInteractionStart = () => setUserInteracting(true);
-	const handleUserInteractionEnd = () => {
-		const timer = setTimeout(() => setUserInteracting(false), 2000);
-		return () => clearTimeout(timer);
-	};
-
-	useEffect(() => {
-		if (nextRefreshTime && autoRefreshEnabled && !userInteracting && view === "list") {
-			const updateCountdown = () => {
-				const remaining = Math.max(0, Math.ceil((nextRefreshTime.getTime() - Date.now()) / 1000));
-				setCountdown(remaining);
-				if (remaining === 0) setNextRefreshTime(new Date(Date.now() + refreshInterval));
-			};
-			updateCountdown();
-			const timer = setInterval(updateCountdown, 1000);
-			return () => clearInterval(timer);
-		}
-		setCountdown(0);
-	}, [nextRefreshTime, autoRefreshEnabled, userInteracting, refreshInterval, view]);
 
 	useEffect(() => {
 		setPage(0);
@@ -461,28 +421,15 @@ export function QueuePage() {
 								</ul>
 							</div>
 
-							<div className="join">
-								<button
-									type="button"
-									className={`btn btn-outline btn-sm join-item ${autoRefreshEnabled ? "btn-primary" : ""}`}
-									onClick={toggleAutoRefresh}
-								>
-									<Clock
-										className={`h-3.5 w-3.5 ${autoRefreshEnabled ? "" : "text-base-content/70"}`}
-									/>
-									{autoRefreshEnabled ? `${countdown}s` : "Off"}
-								</button>
-
-								<button
-									type="button"
-									className="btn btn-outline btn-sm join-item"
-									onClick={() => refetch()}
-									disabled={isLoading}
-								>
-									{isLoading ? <LoadingSpinner size="sm" /> : <RefreshCw className="h-3.5 w-3.5" />}
-									Refresh
-								</button>
-							</div>
+							<button
+								type="button"
+								className="btn btn-outline btn-sm"
+								onClick={() => refetch()}
+								disabled={isLoading}
+							>
+								{isLoading ? <LoadingSpinner size="sm" /> : <RefreshCw className="h-3.5 w-3.5" />}
+								Refresh
+							</button>
 						</>
 					)}
 				</div>
@@ -568,8 +515,6 @@ export function QueuePage() {
 											className="input input-sm w-full bg-base-200/50 pl-9 text-xs"
 											value={searchTerm}
 											onChange={(e) => setSearchTerm(e.target.value)}
-											onFocus={handleUserInteractionStart}
-											onBlur={handleUserInteractionEnd}
 										/>
 									</div>
 								</div>

--- a/internal/api/progress_handlers.go
+++ b/internal/api/progress_handlers.go
@@ -11,9 +11,61 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// handleProgressStream handles GET /api/queue/progress/stream
-// Server-Sent Events endpoint for real-time progress updates
-func (s *Server) handleProgressStream(c *fiber.Ctx) error {
+// handleHealthStream handles GET /api/health/stream
+// Server-Sent Events endpoint for real-time health-change notifications
+func (s *Server) handleHealthStream(c *fiber.Ctx) error {
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("Transfer-Encoding", "chunked")
+	c.Set("X-Accel-Buffering", "no")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		subID, updateCh := s.progressBroadcaster.Subscribe()
+		defer s.progressBroadcaster.Unsubscribe(subID)
+
+		// Initial ping — tells frontend to fetch current health state immediately
+		fmt.Fprintf(w, "data: {\"type\":\"initial\"}\n\n")
+		if err := w.Flush(); err != nil {
+			return
+		}
+
+		keepAliveTicker := time.NewTicker(30 * time.Second)
+		defer keepAliveTicker.Stop()
+
+		for {
+			select {
+			case update, ok := <-updateCh:
+				if !ok {
+					return
+				}
+				if update.Status != "health_changed" {
+					continue
+				}
+				fmt.Fprintf(w, "data: {\"type\":\"update\"}\n\n")
+				if err := w.Flush(); err != nil {
+					return
+				}
+			case <-keepAliveTicker.C:
+				fmt.Fprintf(w, ": keep-alive\n\n")
+				if err := w.Flush(); err != nil {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+
+	return nil
+}
+
+// handleQueueStream handles GET /api/queue/stream
+// Server-Sent Events endpoint for real-time progress and queue-change updates
+func (s *Server) handleQueueStream(c *fiber.Ctx) error {
 	// Set SSE headers
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -230,6 +230,10 @@ func (s *Server) handleDeleteQueue(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Failed to delete queue item", err.Error())
 	}
 
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
+
 	return RespondNoContent(c)
 }
 
@@ -283,6 +287,10 @@ func (s *Server) handleRetryQueue(c *fiber.Ctx) error {
 	// Trigger background processing immediately
 	if s.importerService != nil {
 		s.importerService.ProcessItemInBackground(c.Context(), id)
+	}
+
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
 	}
 
 	// Get updated item
@@ -435,6 +443,10 @@ func (s *Server) handleClearCompletedQueue(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Failed to clear completed queue items", err.Error())
 	}
 
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
+
 	return RespondSuccess(c, fiber.Map{"removed_count": count})
 }
 
@@ -456,6 +468,10 @@ func (s *Server) handleClearFailedQueue(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Failed to clear failed queue items", err.Error())
 	}
 
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
+
 	return RespondSuccess(c, fiber.Map{"removed_count": count})
 }
 
@@ -475,6 +491,10 @@ func (s *Server) handleClearPendingQueue(c *fiber.Ctx) error {
 	count, err := s.queueRepo.ClearPendingQueueItems(c.Context())
 	if err != nil {
 		return RespondInternalError(c, "Failed to clear pending queue items", err.Error())
+	}
+
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
 	}
 
 	return RespondSuccess(c, fiber.Map{"removed_count": count})
@@ -518,6 +538,10 @@ func (s *Server) handleDeleteQueueBulk(c *fiber.Ctx) error {
 		}
 
 		return RespondInternalError(c, "Failed to delete queue items", err.Error())
+	}
+
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
 	}
 
 	return RespondSuccess(c, fiber.Map{
@@ -974,6 +998,10 @@ func (s *Server) handleRestartQueueBulk(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Failed to restart queue items", err.Error())
 	}
 
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
+
 	return RespondSuccess(c, fiber.Map{
 		"restarted_count": len(request.IDs) - notFoundCount,
 		"message":         fmt.Sprintf("Successfully restarted %d queue items", len(request.IDs)-notFoundCount),
@@ -1204,6 +1232,10 @@ func (s *Server) handleUpdateQueueItemPriority(c *fiber.Ctx) error {
 
 	if err := s.queueRepo.UpdateQueueItemPriority(c.Context(), id, database.QueuePriority(req.Priority)); err != nil {
 		return RespondInternalError(c, "Failed to update priority", err.Error())
+	}
+
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
 	}
 
 	updated, err := s.queueRepo.GetQueueItem(c.Context(), id)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -224,7 +224,8 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Get("/queue", s.handleListQueue)
 	api.Get("/queue/stats", s.handleGetQueueStats)
 	api.Get("/queue/stats/history", s.handleGetQueueHistoricalStats)
-	api.Get("/queue/progress/stream", s.handleProgressStream) // SSE endpoint for real-time progress
+	api.Get("/queue/stream", s.handleQueueStream)   // SSE endpoint for real-time queue updates
+	api.Get("/health/stream", s.handleHealthStream) // SSE endpoint for real-time health updates
 	api.Delete("/queue/completed", s.handleClearCompletedQueue)
 	api.Delete("/queue/failed", s.handleClearFailedQueue)
 	api.Delete("/queue/pending", s.handleClearPendingQueue)

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -130,6 +130,7 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error) *repairTestEn
 		metadataService,
 		mockARRs,
 		configManager.GetConfig,
+		nil,
 	)
 
 	return &repairTestEnv{

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/progress"
 	"github.com/sourcegraph/conc"
 )
 
@@ -51,11 +52,12 @@ type WorkerStats struct {
 
 // HealthWorker manages continuous health monitoring and manual check requests
 type HealthWorker struct {
-	healthChecker   *HealthChecker
-	healthRepo      *database.HealthRepository
-	metadataService *metadata.MetadataService
-	arrsService     ARRsRepairService
-	configGetter    config.ConfigGetter
+	healthChecker       *HealthChecker
+	healthRepo          *database.HealthRepository
+	metadataService     *metadata.MetadataService
+	arrsService         ARRsRepairService
+	configGetter        config.ConfigGetter
+	progressBroadcaster *progress.ProgressBroadcaster // optional, may be nil
 
 	// Worker state
 	status       WorkerStatus
@@ -81,19 +83,28 @@ func NewHealthWorker(
 	metadataService *metadata.MetadataService,
 	arrsService ARRsRepairService,
 	configGetter config.ConfigGetter,
+	broadcaster *progress.ProgressBroadcaster,
 ) *HealthWorker {
 	return &HealthWorker{
-		healthChecker:   healthChecker,
-		healthRepo:      healthRepo,
-		metadataService: metadataService,
-		arrsService:     arrsService,
-		configGetter:    configGetter,
-		status:          WorkerStatusStopped,
-		stopChan:        make(chan struct{}),
-		activeChecks:    make(map[string]context.CancelFunc),
+		healthChecker:       healthChecker,
+		healthRepo:          healthRepo,
+		metadataService:     metadataService,
+		arrsService:         arrsService,
+		configGetter:        configGetter,
+		progressBroadcaster: broadcaster,
+		status:              WorkerStatusStopped,
+		stopChan:            make(chan struct{}),
+		activeChecks:        make(map[string]context.CancelFunc),
 		stats: WorkerStats{
 			Status: WorkerStatusStopped,
 		},
+	}
+}
+
+// broadcastHealthChanged notifies SSE subscribers that health state has changed.
+func (hw *HealthWorker) broadcastHealthChanged() {
+	if hw.progressBroadcaster != nil {
+		hw.progressBroadcaster.BroadcastHealthChanged()
 	}
 }
 
@@ -221,6 +232,7 @@ func (hw *HealthWorker) CancelHealthCheck(ctx context.Context, filePath string) 
 		return fmt.Errorf("failed to update file status after cancellation: %w", err)
 	}
 
+	hw.broadcastHealthChanged()
 	slog.InfoContext(ctx, "Health check cancelled", "file_path", filePath)
 	return nil
 }
@@ -599,6 +611,7 @@ func (hw *HealthWorker) performDirectCheck(ctx context.Context, filePath string)
 		if err := hw.healthRepo.UpdateHealthStatusBulk(ctx, []database.HealthStatusUpdate{*updatePtr}); err != nil {
 			return fmt.Errorf("failed to update health status: %w", err)
 		}
+		hw.broadcastHealthChanged()
 	}
 
 	// Notify rclone VFS about the status change
@@ -773,6 +786,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		if err := hw.healthRepo.UpdateHealthStatusBulk(ctx, results); err != nil {
 			slog.ErrorContext(ctx, "Failed to perform bulk health status update", "error", err)
 		}
+		hw.broadcastHealthChanged()
 	}
 
 	// Update final stats

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -10,6 +10,11 @@ import (
 	"github.com/javi11/altmount/internal/database"
 )
 
+// QueueEventListener receives notifications about queue item lifecycle events.
+type QueueEventListener interface {
+	OnItemClaimed(ctx context.Context, item *database.ImportQueueItem)
+}
+
 // ItemProcessor defines the interface for processing queue items
 type ItemProcessor interface {
 	// ProcessItem processes a single queue item and returns the resulting path or an error
@@ -32,6 +37,7 @@ type Manager struct {
 	repository   *database.QueueRepository
 	claimer      *Claimer
 	processor    ItemProcessor
+	listener     QueueEventListener
 	configGetter config.ConfigGetter
 	log          *slog.Logger
 
@@ -52,7 +58,7 @@ type Manager struct {
 }
 
 // NewManager creates a new queue manager
-func NewManager(cfg ManagerConfig, repository *database.QueueRepository, processor ItemProcessor) *Manager {
+func NewManager(cfg ManagerConfig, repository *database.QueueRepository, processor ItemProcessor, listener QueueEventListener) *Manager {
 	if cfg.Workers == 0 {
 		cfg.Workers = 2
 	}
@@ -64,6 +70,7 @@ func NewManager(cfg ManagerConfig, repository *database.QueueRepository, process
 		repository:   repository,
 		claimer:      NewClaimer(repository),
 		processor:    processor,
+		listener:     listener,
 		configGetter: cfg.ConfigGetter,
 		log:          slog.Default().With("component", "queue-manager"),
 		ctx:          ctx,
@@ -223,6 +230,10 @@ func (m *Manager) processNextItem(ctx context.Context, workerID int) {
 
 	if item == nil {
 		return // No work to do
+	}
+
+	if m.listener != nil {
+		m.listener.OnItemClaimed(ctx, item)
 	}
 
 	m.log.DebugContext(ctx, "Processing claimed queue item", "worker_id", workerID, "queue_id", item.ID, "file", item.NzbPath)

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -263,7 +263,8 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 			ConfigGetter: configGetter,
 		},
 		database.Repository,
-		service,
+		service, // ItemProcessor
+		service, // QueueEventListener
 	)
 
 	return service, nil
@@ -626,6 +627,10 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 		return nil, err
 	}
 
+	if s.broadcaster != nil {
+		s.broadcaster.BroadcastQueueChanged()
+	}
+
 	if fileSize != nil {
 		s.log.InfoContext(ctx, "Added NZB file to queue", "file", item.NzbPath, "queue_id", item.ID, "file_size", *fileSize)
 	} else {
@@ -976,6 +981,7 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 	// Notify completion and clear progress tracking
 	if s.broadcaster != nil {
 		s.broadcaster.NotifyComplete(int(item.ID), "completed")
+		s.broadcaster.BroadcastQueueChanged()
 	}
 
 	s.log.InfoContext(ctx, "Successfully processed queue item", "queue_id", item.ID, "file", item.NzbPath)
@@ -990,6 +996,14 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 	}
 
 	return nil
+}
+
+// OnItemClaimed implements queue.QueueEventListener. It broadcasts a queue-changed
+// notification whenever a worker claims a pending item (pending → processing transition).
+func (s *Service) OnItemClaimed(ctx context.Context, item *database.ImportQueueItem) {
+	if s.broadcaster != nil {
+		s.broadcaster.BroadcastQueueChanged()
+	}
 }
 
 // cleanupWrittenPaths deletes metadata files/directories written during a failed import.
@@ -1052,6 +1066,7 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 	// Notify failure and clear progress tracking
 	if s.broadcaster != nil {
 		s.broadcaster.NotifyComplete(int(item.ID), "failed")
+		s.broadcaster.BroadcastQueueChanged()
 	}
 
 	// Delegate fallback handling to post-processor
@@ -1145,6 +1160,10 @@ func (s *Service) ProcessItemInBackground(ctx context.Context, itemID int64) {
 		if err := s.database.Repository.UpdateQueueItemStatus(ctx, itemID, database.QueueStatusProcessing, nil); err != nil {
 			s.log.ErrorContext(ctx, "Failed to update item status to processing", "item_id", itemID, "error", err)
 			return
+		}
+
+		if s.broadcaster != nil {
+			s.broadcaster.BroadcastQueueChanged()
 		}
 
 		// Create cancellable context for this item

--- a/internal/progress/progress_broadcaster.go
+++ b/internal/progress/progress_broadcaster.go
@@ -169,3 +169,43 @@ func (pb *ProgressBroadcaster) HasSubscribers() bool {
 	defer pb.subMu.RUnlock()
 	return len(pb.subscribers) > 0
 }
+
+// BroadcastHealthChanged sends a health-change notification to all SSE subscribers.
+// Uses QueueID=0 and Status="health_changed" as a sentinel for health state changes.
+func (pb *ProgressBroadcaster) BroadcastHealthChanged() {
+	update := ProgressUpdate{
+		QueueID:   0,
+		Status:    "health_changed",
+		Timestamp: time.Now(),
+	}
+	pb.subMu.RLock()
+	defer pb.subMu.RUnlock()
+	for subID, ch := range pb.subscribers {
+		select {
+		case ch <- update:
+		default:
+			pb.log.WarnContext(context.Background(),
+				"subscriber channel full, skipping health_changed", "subscriber_id", subID)
+		}
+	}
+}
+
+// BroadcastQueueChanged sends a queue-change notification to all SSE subscribers.
+// Uses QueueID=0 and Status="queue_changed" as a sentinel for non-progress queue events.
+func (pb *ProgressBroadcaster) BroadcastQueueChanged() {
+	update := ProgressUpdate{
+		QueueID:   0,
+		Status:    "queue_changed",
+		Timestamp: time.Now(),
+	}
+	pb.subMu.RLock()
+	defer pb.subMu.RUnlock()
+	for subID, ch := range pb.subscribers {
+		select {
+		case ch <- update:
+		default:
+			pb.log.WarnContext(context.Background(),
+				"subscriber channel full, skipping queue_changed", "subscriber_id", subID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **New SSE endpoints**: `/api/health/stream` and `/api/queue/stream` replace the old `/api/queue/progress/stream`
- **Backend broadcast wiring**: `ProgressBroadcaster` gains `BroadcastHealthChanged` and `BroadcastQueueChanged`; health worker and importer service broadcast on every meaningful state transition (check cycles, item claim/complete/fail, add to queue, cancel)
- **Frontend hooks**: New `useHealthStream` and `useQueueStream` hooks subscribe to the respective SSE endpoints with automatic reconnect; remove `useProgressStream`
- **Remove polling**: `useHealth`, `useHealthStats`, and `useQueueStats` no longer use `refetchInterval` — the SSE stream drives all updates
- **Remove auto-refresh UI**: Countdown timer, auto-refresh toggle, and user-interaction guards removed from both Health and Queue pages

## Test plan

- [ ] Start backend and open Health page → DevTools Network shows persistent `EventSource` to `/api/health/stream`
- [ ] Open Queue page → DevTools Network shows persistent `EventSource` to `/api/queue/stream`
- [ ] Confirm no 5-second polling calls to `/api/health`, `/api/health/stats`, or `/api/queue/stats`
- [ ] Trigger a health check → status transitions appear immediately without a 5s wait
- [ ] Add/delete/retry a queue item → list and stats refresh immediately via SSE
- [ ] Reload page → initial SSE ping causes immediate data fetch
- [ ] `go test ./internal/health/...` passes (nil broadcaster in test env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)