### PR TITLE
fix(api): bypass cached 301 redirects and improve render performance

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,6 +65,7 @@ export class APIClient {
 
 		const config: RequestInit = {
 			credentials: "include", // Include cookies for Safari compatibility
+			cache: "no-store",
 			headers: {
 				"Content-Type": "application/json",
 				...options.headers,
@@ -120,6 +121,7 @@ export class APIClient {
 
 		const config: RequestInit = {
 			credentials: "include", // Include cookies for Safari compatibility
+			cache: "no-store",
 			headers: {
 				"Content-Type": "application/json",
 				...options.headers,
@@ -192,7 +194,7 @@ export class APIClient {
 	}) {
 		const searchParams = new URLSearchParams();
 		if (params?.limit) searchParams.set("limit", params.limit.toString());
-		if (params?.offset) searchParams.set("offset", params.offset.toString());
+		if (params?.offset !== undefined) searchParams.set("offset", params.offset.toString());
 		if (params?.status) searchParams.set("status", params.status);
 		if (params?.since) searchParams.set("since", params.since);
 		if (params?.search) searchParams.set("search", params.search);
@@ -319,7 +321,7 @@ export class APIClient {
 	}) {
 		const searchParams = new URLSearchParams();
 		if (params?.limit) searchParams.set("limit", params.limit.toString());
-		if (params?.offset) searchParams.set("offset", params.offset.toString());
+		if (params?.offset !== undefined) searchParams.set("offset", params.offset.toString());
 		if (params?.status) searchParams.set("status", params.status);
 		if (params?.since) searchParams.set("since", params.since);
 		if (params?.search) searchParams.set("search", params.search);

--- a/frontend/src/components/queue/QueueItemCard.tsx
+++ b/frontend/src/components/queue/QueueItemCard.tsx
@@ -10,7 +10,7 @@ import {
 	Trash2,
 	XCircle,
 } from "lucide-react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { formatBytes, formatRelativeTime, truncateText } from "../../lib/utils";
 import { type QueueItem, QueueStatus } from "../../types/api";
 import { PathDisplay } from "../ui/PathDisplay";
@@ -29,7 +29,7 @@ interface QueueItemCardProps {
 	isDeletePending: boolean;
 }
 
-export function QueueItemCard({
+export const QueueItemCard = memo(function QueueItemCard({
 	item,
 	isSelected,
 	onSelectChange,
@@ -204,4 +204,4 @@ export function QueueItemCard({
 			</div>
 		</div>
 	);
-}
+});

--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Download, FileVideo, History, Play } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useActiveStreams, useImportHistory, useQueue } from "../../hooks/useApi";
 import { useProgressStream } from "../../hooks/useProgressStream";
 import { formatBytes, formatDuration, formatRelativeTime, formatSpeed } from "../../lib/utils";
@@ -8,17 +8,8 @@ import { LoadingSpinner } from "../ui/LoadingSpinner";
 
 export function ActivityHub() {
 	const [activeTab, setActiveTab] = useState<"playback" | "imports" | "history">("playback");
-	const {
-		data: allStreams,
-		isLoading: streamsLoading,
-		refetch: refetchStreams,
-	} = useActiveStreams();
+	const { data: allStreams, isLoading: streamsLoading } = useActiveStreams();
 
-	useEffect(() => {
-		if (activeTab === "playback") {
-			refetchStreams();
-		}
-	}, [activeTab, refetchStreams]);
 	const { data: queueResponse, isLoading: queueLoading } = useQueue({
 		status: "processing",
 		limit: 10,

--- a/frontend/src/pages/HealthPage.tsx
+++ b/frontend/src/pages/HealthPage.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import {
 	FileCheck,
 	RefreshCw,
@@ -7,8 +8,7 @@ import {
 	ShieldCheck,
 	Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ErrorAlert } from "../components/ui/ErrorAlert";
 import { Pagination } from "../components/ui/Pagination";
 import { useConfirm } from "../contexts/ModalContext";
@@ -36,6 +36,7 @@ import {
 	useLibrarySyncStatus,
 	useStartLibrarySync,
 } from "../hooks/useLibrarySync";
+import { debounce } from "../lib/utils";
 import { HealthPriority } from "../types/api";
 import { BulkActionsToolbar } from "./HealthPage/components/BulkActionsToolbar";
 import { CleanupModal } from "./HealthPage/components/CleanupModal";
@@ -108,13 +109,19 @@ export function HealthPage() {
 	const { showToast } = useToast();
 	const queryClient = useQueryClient();
 
-	// SSE stream for real-time health updates
+	// SSE stream for real-time health updates — debounced to avoid an HTTP GET on every event
+	const debouncedHealthRefetch = useMemo(
+		() =>
+			debounce(() => {
+				void refetch();
+				void queryClient.invalidateQueries({ queryKey: ["health", "stats"] });
+			}, 2000),
+		[refetch, queryClient],
+	);
+
 	useHealthStream({
 		enabled: activeTab === "files",
-		onHealthChanged: useCallback(() => {
-			void refetch();
-			queryClient.invalidateQueries({ queryKey: ["health", "stats"] });
-		}, [refetch, queryClient]),
+		onHealthChanged: debouncedHealthRefetch,
 	});
 
 	// Config hook
@@ -130,63 +137,72 @@ export function HealthPage() {
 	const startLibrarySync = useStartLibrarySync();
 	const cancelLibrarySync = useCancelLibrarySync();
 
-	const handleDelete = async (id: number) => {
-		const confirmed = await confirmAction(
-			"Delete Health Record",
-			"Are you sure you want to delete this health record? The actual file won´t be deleted.",
-			{
-				type: "warning",
-				confirmText: "Delete",
-				confirmButtonClass: "btn-error",
-			},
-		);
-		if (confirmed) {
-			await deleteItem.mutateAsync(id);
-		}
-	};
+	const handleDelete = useCallback(
+		async (id: number) => {
+			const confirmed = await confirmAction(
+				"Delete Health Record",
+				"Are you sure you want to delete this health record? The actual file won´t be deleted.",
+				{
+					type: "warning",
+					confirmText: "Delete",
+					confirmButtonClass: "btn-error",
+				},
+			);
+			if (confirmed) {
+				await deleteItem.mutateAsync(id);
+			}
+		},
+		[confirmAction, deleteItem],
+	);
 
-	const handleUnmask = async (id: number) => {
-		try {
-			await unmaskItem.mutateAsync(id);
-			showToast({
-				title: "File Unmasked",
-				message: "The file has been unmasked and will now be visible in mounts.",
-				type: "success",
-			});
-		} catch (err) {
-			console.error("Failed to unmask file:", err);
-			showToast({
-				title: "Unmask Failed",
-				message: "Failed to unmask file health record",
-				type: "error",
-			});
-		}
-	};
+	const handleUnmask = useCallback(
+		async (id: number) => {
+			try {
+				await unmaskItem.mutateAsync(id);
+				showToast({
+					title: "File Unmasked",
+					message: "The file has been unmasked and will now be visible in mounts.",
+					type: "success",
+				});
+			} catch (err) {
+				console.error("Failed to unmask file:", err);
+				showToast({
+					title: "Unmask Failed",
+					message: "Failed to unmask file health record",
+					type: "error",
+				});
+			}
+		},
+		[unmaskItem, showToast],
+	);
 
-	const handleSetPriority = async (id: number, priority: HealthPriority) => {
-		try {
-			await setHealthPriority.mutateAsync({ id, priority });
-			const priorityLabel =
-				priority === HealthPriority.Next
-					? "Next"
-					: priority === HealthPriority.High
-						? "High"
-						: "Normal";
+	const handleSetPriority = useCallback(
+		async (id: number, priority: HealthPriority) => {
+			try {
+				await setHealthPriority.mutateAsync({ id, priority });
+				const priorityLabel =
+					priority === HealthPriority.Next
+						? "Next"
+						: priority === HealthPriority.High
+							? "High"
+							: "Normal";
 
-			showToast({
-				title: "Priority Updated",
-				message: `File priority set to ${priorityLabel}`,
-				type: "success",
-			});
-		} catch (err) {
-			console.error("Failed to update priority:", err);
-			showToast({
-				title: "Update Failed",
-				message: "Failed to update file priority",
-				type: "error",
-			});
-		}
-	};
+				showToast({
+					title: "Priority Updated",
+					message: `File priority set to ${priorityLabel}`,
+					type: "success",
+				});
+			} catch (err) {
+				console.error("Failed to update priority:", err);
+				showToast({
+					title: "Update Failed",
+					message: "Failed to update file priority",
+					type: "error",
+				});
+			}
+		},
+		[setHealthPriority, showToast],
+	);
 
 	const handleCleanup = () => {
 		setCleanupConfig({
@@ -405,7 +421,7 @@ export function HealthPage() {
 		}
 	};
 
-	const handleSelectItem = (filePath: string, checked: boolean) => {
+	const handleSelectItem = useCallback((filePath: string, checked: boolean) => {
 		setSelectedItems((prev) => {
 			const newSet = new Set(prev);
 			if (checked) {
@@ -415,7 +431,7 @@ export function HealthPage() {
 			}
 			return newSet;
 		});
-	};
+	}, []);
 
 	const handleSelectAll = (checked: boolean) => {
 		if (checked && data) {

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -8,7 +8,7 @@ import {
 	Loader,
 	Wrench,
 } from "lucide-react";
-import { useState } from "react";
+import { memo, useState } from "react";
 import { HealthBadge } from "../../../../components/ui/StatusBadge";
 import { formatFutureTime, formatRelativeTime, truncateText } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
@@ -31,7 +31,7 @@ interface HealthItemCardProps {
 	isUnmaskPending: boolean;
 }
 
-export function HealthItemCard({
+export const HealthItemCard = memo(function HealthItemCard({
 	item,
 	isSelected,
 	onSelectChange,
@@ -222,4 +222,4 @@ export function HealthItemCard({
 			</div>
 		</div>
 	);
-}
+});

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -1,4 +1,5 @@
 import { Clock, Heart, HeartCrack, Loader, Wrench } from "lucide-react";
+import { memo } from "react";
 import { HealthBadge } from "../../../../components/ui/StatusBadge";
 import { formatFutureTime, formatRelativeTime, truncateText } from "../../../../lib/utils";
 import { type FileHealth, HealthPriority } from "../../../../types/api";
@@ -21,7 +22,7 @@ interface HealthTableRowProps {
 	onSetPriority: (id: number, priority: HealthPriority) => void;
 }
 
-export function HealthTableRow({
+export const HealthTableRow = memo(function HealthTableRow({
 	item,
 	isSelected,
 	isCancelPending,
@@ -197,4 +198,4 @@ export function HealthTableRow({
 			</td>
 		</tr>
 	);
-}
+});

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -124,31 +124,40 @@ export function QueuePage() {
 	const addTestQueueItem = useAddTestQueueItem();
 	const { confirmDelete, confirmAction } = useConfirm();
 
-	const handleDelete = async (id: number) => {
-		const confirmed = await confirmDelete("queue item");
-		if (confirmed) {
-			await deleteItem.mutateAsync(id);
-		}
-	};
+	const handleDelete = useCallback(
+		async (id: number) => {
+			const confirmed = await confirmDelete("queue item");
+			if (confirmed) {
+				await deleteItem.mutateAsync(id);
+			}
+		},
+		[confirmDelete, deleteItem],
+	);
 
-	const handleRetry = async (id: number) => {
-		await retryItem.mutateAsync(id);
-	};
+	const handleRetry = useCallback(
+		async (id: number) => {
+			await retryItem.mutateAsync(id);
+		},
+		[retryItem],
+	);
 
-	const handleCancel = async (id: number) => {
-		const confirmed = await confirmAction(
-			"Cancel Processing",
-			"Are you sure you want to cancel this processing item? The item will be marked as failed and can be retried later.",
-			{
-				type: "warning",
-				confirmText: "Cancel Item",
-				confirmButtonClass: "btn-warning",
-			},
-		);
-		if (confirmed) {
-			await cancelItem.mutateAsync(id);
-		}
-	};
+	const handleCancel = useCallback(
+		async (id: number) => {
+			const confirmed = await confirmAction(
+				"Cancel Processing",
+				"Are you sure you want to cancel this processing item? The item will be marked as failed and can be retried later.",
+				{
+					type: "warning",
+					confirmText: "Cancel Item",
+					confirmButtonClass: "btn-warning",
+				},
+			);
+			if (confirmed) {
+				await cancelItem.mutateAsync(id);
+			}
+		},
+		[confirmAction, cancelItem],
+	);
 
 	const handleDownload = async (id: number) => {
 		try {
@@ -222,14 +231,14 @@ export function QueuePage() {
 		}
 	};
 
-	const handleSelectItem = (id: number, checked: boolean) => {
+	const handleSelectItem = useCallback((id: number, checked: boolean) => {
 		setSelectedItems((prev) => {
 			const newSet = new Set(prev);
 			if (checked) newSet.add(id);
 			else newSet.delete(id);
 			return newSet;
 		});
-	};
+	}, []);
 
 	const handleSelectAll = (checked: boolean) => {
 		if (checked && enrichedQueueData) {


### PR DESCRIPTION
## Summary

- **Fix 301 redirect loop**: Add `cache: "no-store"` to all fetch requests in `APIClient` so the browser never serves stale cached redirects. This resolves ~80 failed requests per HealthPage load caused by a permanently-cached `301 → ./` for `/api/health`
- **Fix offset=0 pagination bug**: `if (params?.offset)` was falsy for `0`, silently dropping the first-page offset param in `getQueue()` and `getHealth()`
- **Reduce SSE-triggered request bursts**: Debounce the health stream `onHealthChanged` callback (2 s) so rapid SSE events don't each fire an immediate GET
- **Memo + useCallback cleanup**: Wrap `QueueItemCard`, `HealthItemCard`, `HealthTableRow` in `React.memo`; stabilise handlers in `HealthPage` and `QueuePage` with `useCallback` to avoid unnecessary child re-renders
- **Remove redundant effect**: Drop the `useEffect` in `ActivityHub` that called `refetchStreams` on tab change — SSE already keeps streams up to date

## Test plan

- [ ] Clear browser cache/storage, navigate to HealthPage — Network tab shows `/api/health?...` returning 200, no 301s
- [ ] Reload HealthPage several times — only 1 health request per load, no retry bursts
- [ ] Verify pagination at page 1 sends `offset=0` in the query string
- [ ] Confirm QueuePage and ActivityHub behave normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)