### PR TITLE
fix(importer): merge all PAR2 index files and group RAR archives by base name

### DIFF
--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -159,14 +159,20 @@ func ProcessArchive(
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	rarContents, err := rarProcessor.AnalyzeRarContentFromNzb(ctx, archiveFiles, password, archiveProgressTracker)
-	if err != nil {
-		slog.ErrorContext(ctx, "Failed to analyze RAR archive content", "error", err)
-		return err
+	// Group archive files by their base name to handle NZBs with multiple separate RAR archives
+	archiveGroups := GroupArchivesByBaseName(archiveFiles)
+	var rarContents []Content
+	for _, group := range archiveGroups {
+		groupContents, err := rarProcessor.AnalyzeRarContentFromNzb(ctx, group, password, archiveProgressTracker)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to analyze RAR archive group", "error", err, "first_file", group[0].Filename)
+			return err
+		}
+		rarContents = append(rarContents, groupContents...)
 	}
 
 	// Expand ISO files found inside the RAR archive into their inner media files
-	rarContents, err = expandISOContents(ctx, expandBlurayIso, rarContents, poolManager, maxPrefetch, readTimeout, allowedFileExtensions)
+	rarContents, err := expandISOContents(ctx, expandBlurayIso, rarContents, poolManager, maxPrefetch, readTimeout, allowedFileExtensions)
 	if err != nil {
 		slog.WarnContext(ctx, "ISO expansion failed, proceeding without ISO contents", "error", err)
 	}
@@ -474,6 +480,26 @@ func expandISOContents(
 		result = append(result, nc)
 	}
 	return result, nil
+}
+
+// GroupArchivesByBaseName groups ParsedFiles by their RAR base name (case-insensitive).
+// Returns groups in deterministic order (sorted by base name) for testability.
+func GroupArchivesByBaseName(files []parser.ParsedFile) [][]parser.ParsedFile {
+	groupMap := make(map[string][]parser.ParsedFile)
+	var keys []string
+	for _, f := range files {
+		key := extractRarBaseName(f.Filename)
+		if _, exists := groupMap[key]; !exists {
+			keys = append(keys, key)
+		}
+		groupMap[key] = append(groupMap[key], f)
+	}
+	sort.Strings(keys)
+	groups := make([][]parser.ParsedFile, 0, len(keys))
+	for _, k := range keys {
+		groups = append(groups, groupMap[k])
+	}
+	return groups
 }
 
 // normalizeArchiveReleaseFilename aligns the filename to the NZB basename while keeping the original extension.

--- a/internal/importer/archive/rar/processor_test.go
+++ b/internal/importer/archive/rar/processor_test.go
@@ -2,6 +2,7 @@ package rar
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/javi11/altmount/internal/importer/parser"
@@ -226,4 +227,36 @@ func TestPatchMissingSegment_VerySmallShortfall(t *testing.T) {
 	// Verify the patch segment
 	patchSeg := patched[1]
 	require.Equal(t, shortfall-1, patchSeg.EndOffset, "patch should cover exactly 100 bytes")
+}
+
+func TestGroupArchivesByBaseName(t *testing.T) {
+	// Build 46 r-extension parts for first archive
+	var files []parser.ParsedFile
+	for i := 0; i <= 45; i++ {
+		files = append(files, parser.ParsedFile{
+			Filename: fmt.Sprintf("nova.s44e02.720p-dhd.r%02d", i),
+		})
+	}
+	// Add single-part .rar from the second archive (uppercase to test case-insensitivity)
+	files = append(files, parser.ParsedFile{
+		Filename: "NOVA.S44E02.School.of.the.Future.720p.HDTV.x264-DHD.part01.rar",
+	})
+
+	groups := GroupArchivesByBaseName(files)
+
+	require.Len(t, groups, 2, "should produce 2 distinct archive groups")
+
+	// Groups are sorted by base name; find by size
+	var group46, group1 []parser.ParsedFile
+	for _, g := range groups {
+		if len(g) == 46 {
+			group46 = g
+		} else {
+			group1 = g
+		}
+	}
+	require.NotNil(t, group46, "should have group with 46 parts")
+	require.NotNil(t, group1, "should have group with 1 part")
+	require.Len(t, group46, 46)
+	require.Len(t, group1, 1)
 }

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/javi11/altmount/internal/importer/archive"
 )
@@ -20,6 +21,31 @@ var (
 	rPatternNumber       = regexp.MustCompile(`\.r(\d+)$`)
 	numericPatternNumber = regexp.MustCompile(`\.(\d+)$`)
 )
+
+// extractRarBaseName returns the lowercase base name of a RAR filename,
+// stripping the part number and extension used for multi-volume sets.
+// Used to group related RAR parts before archive analysis.
+func extractRarBaseName(filename string) string {
+	lower := strings.ToLower(filepath.Base(filename))
+
+	// Pattern 1: filename.part###.rar
+	if m := partPattern.FindStringSubmatch(lower); len(m) > 1 {
+		return m[1]
+	}
+	// Pattern 2: filename.rar (single part)
+	if strings.HasSuffix(lower, ".rar") {
+		return strings.TrimSuffix(lower, ".rar")
+	}
+	// Pattern 3: filename.r##
+	if m := rPattern.FindStringSubmatch(lower); len(m) > 1 {
+		return m[1]
+	}
+	// Pattern 4: filename.### (numeric)
+	if m := numericPattern.FindStringSubmatch(lower); len(m) > 1 {
+		return m[1]
+	}
+	return lower
+}
 
 // hasExtension checks if a filename has an extension
 func hasExtension(filename string) bool {

--- a/internal/importer/parser/par2/descriptor.go
+++ b/internal/importer/parser/par2/descriptor.go
@@ -12,6 +12,10 @@ import (
 	"github.com/javi11/nzbparser"
 )
 
+// maxIndexSegments is the upper bound for treating a PAR2 file as an index file
+// (no recovery blocks). Recovery block files have many more segments.
+const maxIndexSegments = 5
+
 // nzbSegmentLoader adapts []nzbparser.NzbSegment into usenet.SegmentLoader.
 // Each raw NZB segment maps with Start=0, End=Bytes-1 (all data is usable).
 type nzbSegmentLoader struct {
@@ -54,43 +58,32 @@ func GetFileDescriptors(
 		return descriptors, nil
 	}
 
-	// Find the PAR2 index file (smallest file with PAR2 magic bytes)
-	// Similar to C# code: files.Where(x => HasPar2MagicBytes).MinBy(x => segments.Count)
-	var par2IndexFile *nzbparser.NzbFile
-	smallestSegmentCount := -1
-
+	// Read all small PAR2 files (index files) and merge their descriptors.
+	// Index files never contain recovery blocks so they have few segments (≤ maxIndexSegments).
+	// Recovery block files have many segments and are skipped.
+	// Merging handles releases with multiple PAR2 sets (e.g. main archive + sample).
 	for _, cachedData := range firstSegmentCache {
-		// Skip invalid entries
 		if cachedData == nil || cachedData.File == nil || len(cachedData.File.Segments) == 0 {
 			continue
 		}
-
-		// Check for PAR2 magic bytes using cached data
-		if HasMagicBytes(cachedData.RawBytes) {
-			segmentCount := len(cachedData.File.Segments)
-
-			// Select the PAR2 file with the smallest segment count (likely the index file)
-			if smallestSegmentCount == -1 || segmentCount < smallestSegmentCount {
-				smallestSegmentCount = segmentCount
-				par2IndexFile = cachedData.File
+		if !HasMagicBytes(cachedData.RawBytes) {
+			continue
+		}
+		if len(cachedData.File.Segments) > maxIndexSegments {
+			continue // Skip large recovery block files
+		}
+		fileDescriptors, err := readFileDescriptors(ctx, cachedData.File, poolManager)
+		if err != nil {
+			slog.DebugContext(ctx, "Failed to read PAR2 file descriptors, skipping",
+				"error", err, "segments", len(cachedData.File.Segments))
+			continue
+		}
+		for i := range fileDescriptors {
+			desc := &fileDescriptors[i]
+			if _, exists := descriptors[desc.Hash16k]; !exists {
+				descriptors[desc.Hash16k] = desc // first occurrence wins (identical across set files)
 			}
 		}
-	}
-
-	if par2IndexFile == nil {
-		return descriptors, nil
-	}
-
-	// Parse the PAR2 file and extract file descriptors
-	fileDescriptors, err := readFileDescriptors(ctx, par2IndexFile, poolManager)
-	if err != nil {
-		return descriptors, fmt.Errorf("failed to read PAR2 file descriptors: %w", err)
-	}
-
-	// Build lookup map by Hash16k for fast matching
-	for i := range fileDescriptors {
-		desc := &fileDescriptors[i]
-		descriptors[desc.Hash16k] = desc
 	}
 
 	return descriptors, nil


### PR DESCRIPTION
## Summary

- **PAR2 fix**: `GetFileDescriptors` now reads all small PAR2 index files (≤5 segments) and merges their descriptors by `Hash16k`, instead of picking the single smallest file. Releases with multiple PAR2 sets (e.g. main archive + sample) previously returned only the sample's 1-entry map, leaving 46+ archive files with obfuscated names unmatched.
- **RAR grouping**: `ProcessArchive` now groups RAR files by base name before calling `AnalyzeRarContentFromNzb`, so NZBs containing multiple separate RAR archives (main + sample) are analysed independently rather than mixing their parts.
- **New helper**: `GroupArchivesByBaseName` extracted to `aggregator.go` (exported, tested) and `extractRarBaseName` added to `utils.go`.

## Test plan

- [ ] `go test ./internal/importer/archive/rar/...` — new `TestGroupArchivesByBaseName` passes
- [ ] `go test ./internal/importer/...` — all existing tests pass
- [ ] Release with 47-file main PAR2 + 1-file sample PAR2 now renames all archive files correctly without needing SRR

🤖 Generated with [Claude Code](https://claude.com/claude-code)