### PR TITLE
fix(sabnzbd): use Content-Disposition header for NZB filename on addurl

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -407,12 +408,30 @@ func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 		return s.writeSABnzbdErrorFiber(c, "Failed to create upload directory")
 	}
 
-	// Extract filename from URL or use default
-	filename := "downloaded.nzb"
-	if u, err := url.Parse(nzbUrl); err == nil && u.Path != "" {
-		if base := filepath.Base(u.Path); base != "" && base != "." {
-			filename = base
+	// Extract filename: prefer Content-Disposition header, then URL path, then default
+	filename := ""
+
+	// 1. Try Content-Disposition header
+	if cd := resp.Header.Get("Content-Disposition"); cd != "" {
+		if _, params, err := mime.ParseMediaType(cd); err == nil {
+			if fn := params["filename"]; fn != "" {
+				filename = filepath.Base(fn)
+			}
 		}
+	}
+
+	// 2. Fall back to URL path
+	if filename == "" {
+		if u, err := url.Parse(nzbUrl); err == nil && u.Path != "" {
+			if base := filepath.Base(u.Path); base != "" && base != "." {
+				filename = base
+			}
+		}
+	}
+
+	// 3. Final fallback
+	if filename == "" {
+		filename = "downloaded.nzb"
 	}
 
 	// Ensure .nzb extension


### PR DESCRIPTION
## Summary

- When downloading NZBs via the SABnzbd `addurl` command, indexers like NZBHydra2 (`/getnzb/user/123456`) or Prowlarr (`/api`) return meaningless URL-based filenames
- Parse the `Content-Disposition` response header first to get the human-readable filename (e.g. `Some Awesome Video Part1.nzb`)
- Fall back to URL path basename, then `downloaded.nzb` if neither is available
- The existing `.nzb` extension enforcement is unchanged and handles all paths correctly

## Test plan

- [ ] `make` builds successfully (no compilation errors)
- [ ] Send `addurl` with a URL whose response includes `Content-Disposition: inline; filename="My Show S01E01.nzb"` — verify queue item is named `My Show S01E01`
- [ ] Confirm fallback: URL without `Content-Disposition` still uses URL path basename
- [ ] Confirm final fallback: opaque URL with no `Content-Disposition` uses `downloaded.nzb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

FIX https://github.com/javi11/altmount/issues/403