### PR TITLE
perf(segcache): reduce catalog write amplification with dirty flag

### DIFF
--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -40,6 +41,7 @@ type SegmentCache struct {
 	config    Config
 	logger    *slog.Logger
 	totalSize int64
+	dirty     atomic.Bool
 }
 
 // NewSegmentCache creates a new segment cache, loading any existing catalog.
@@ -74,7 +76,10 @@ func (c *SegmentCache) Get(messageID string) ([]byte, bool) {
 		c.mu.Unlock()
 		return nil, false
 	}
-	e.LastAccess = time.Now()
+	if time.Since(e.LastAccess) > 60*time.Second {
+		e.LastAccess = time.Now()
+		c.dirty.Store(true)
+	}
 	path := e.DataPath
 	c.mu.Unlock()
 
@@ -121,6 +126,8 @@ func (c *SegmentCache) Put(messageID string, data []byte) error {
 	c.totalSize += e.Size
 	c.mu.Unlock()
 
+	c.dirty.Store(true)
+
 	return nil
 }
 
@@ -147,6 +154,7 @@ func (c *SegmentCache) Evict() {
 		return sorted[i].e.LastAccess.Before(sorted[j].e.LastAccess)
 	})
 
+	removed := false
 	for _, pair := range sorted {
 		if c.totalSize <= c.config.MaxSizeBytes {
 			break
@@ -154,6 +162,10 @@ func (c *SegmentCache) Evict() {
 		_ = os.Remove(pair.e.DataPath)
 		c.totalSize -= pair.e.Size
 		delete(c.items, pair.id)
+		removed = true
+	}
+	if removed {
+		c.dirty.Store(true)
 	}
 }
 
@@ -168,12 +180,17 @@ func (c *SegmentCache) Cleanup() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	removed := false
 	for id, e := range c.items {
 		if e.LastAccess.Before(deadline) {
 			_ = os.Remove(e.DataPath)
 			c.totalSize -= e.Size
 			delete(c.items, id)
+			removed = true
 		}
+	}
+	if removed {
+		c.dirty.Store(true)
 	}
 }
 
@@ -192,7 +209,12 @@ func (c *SegmentCache) ItemCount() int {
 }
 
 // SaveCatalog flushes the in-memory catalog to disk (catalog.json) atomically.
+// It is a no-op when the catalog has not changed since the last flush.
 func (c *SegmentCache) SaveCatalog() error {
+	if !c.dirty.Load() {
+		return nil
+	}
+
 	c.mu.Lock()
 	snapshot := make(map[string]*cacheEntry, len(c.items))
 	for k, v := range c.items {
@@ -217,6 +239,8 @@ func (c *SegmentCache) SaveCatalog() error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("segcache: rename catalog: %w", err)
 	}
+
+	c.dirty.Store(false)
 
 	return nil
 }

--- a/internal/nzbfilesystem/segcache/manager.go
+++ b/internal/nzbfilesystem/segcache/manager.go
@@ -138,7 +138,7 @@ func (m *Manager) cleanupLoop() {
 func (m *Manager) catalogFlushLoop() {
 	defer m.wg.Done()
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
## Summary

- Add an `atomic.Bool` dirty flag to `SegmentCache`; `SaveCatalog()` is now a no-op when the catalog hasn't changed since the last flush
- Throttle `LastAccess` updates in `Get()` to at most once per 60 seconds — read-only traffic no longer marks the catalog dirty
- Increase the `catalogFlushLoop` ticker from 10 s → 60 s

## Motivation

On a 10 GB cache (~13 000 entries) the `catalog.json` is 1–2 MB. Writing it unconditionally every 10 s produced **~720 MB/hr** of pure bookkeeping writes with zero data benefit — significant SSD wear during both idle and read-heavy periods.

## Test plan

- [x] `go test ./internal/nzbfilesystem/segcache/...` — all 12 tests pass
- [x] `TestCacheSaveCatalogAndReload` confirms dirty flag is set after `Put()` and catalog round-trips correctly
- [ ] Manual: rapid `Get()` calls within 60 s should not trigger `SaveCatalog()` writes (dirty stays false)
- [ ] Manual: a `Put()` followed by >60 s idle should result in one catalog write, then no-ops on subsequent ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)