### PR TITLE
fix(arrs): treat 404 on queue delete as a no-op instead of an error

### DIFF
--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -261,8 +261,12 @@ func (w *Worker) cleanupRadarrQueue(ctx context.Context, instance *model.ConfigI
 		}
 		for _, id := range idsToRemove {
 			if err := client.DeleteQueueContext(ctx, id, opts); err != nil {
-				slog.ErrorContext(ctx, "Failed to delete queue item",
-					"id", id, "error", err)
+				if strings.Contains(err.Error(), "404") {
+					slog.DebugContext(ctx, "Queue item already removed from Radarr", "id", id)
+				} else {
+					slog.ErrorContext(ctx, "Failed to delete queue item",
+						"id", id, "error", err)
+				}
 			}
 		}
 		slog.InfoContext(ctx, "Cleaned up Radarr queue items",
@@ -400,8 +404,12 @@ func (w *Worker) cleanupSonarrQueue(ctx context.Context, instance *model.ConfigI
 		}
 		for _, id := range idsToRemove {
 			if err := client.DeleteQueueContext(ctx, id, opts); err != nil {
-				slog.ErrorContext(ctx, "Failed to delete queue item",
-					"id", id, "error", err)
+				if strings.Contains(err.Error(), "404") {
+					slog.DebugContext(ctx, "Queue item already removed from Sonarr", "id", id)
+				} else {
+					slog.ErrorContext(ctx, "Failed to delete queue item",
+						"id", id, "error", err)
+				}
 			}
 		}
 		slog.InfoContext(ctx, "Cleaned up Sonarr queue items",


### PR DESCRIPTION
## Summary

- When the ARR queue cleanup worker calls `DeleteQueueContext` on a Radarr or Sonarr queue item, the item may have already been removed by the arr between the scan and the delete call
- Previously this logged `ERROR Failed to delete queue item` with a 404, creating noise for a benign race condition
- 404 responses are now logged at `DEBUG` level ("Queue item already removed from Radarr/Sonarr"); all other errors still surface as `ERROR`

## Test plan

- [ ] Trigger the cleanup worker when a queue item is removed from Radarr/Sonarr before the delete call fires — confirm no ERROR log appears
- [ ] Confirm genuine delete failures (e.g. auth error, network error) still log at ERROR level

🤖 Generated with [Claude Code](https://claude.com/claude-code)