### PR TITLE
fix(importer): correct PAR2 detection when yEnc header omits .par2 extension

### DIFF
--- a/internal/importer/filesystem/utils.go
+++ b/internal/importer/filesystem/utils.go
@@ -61,7 +61,7 @@ func SeparateFiles(files []parser.ParsedFile, nzbType parser.NzbType) (regular, 
 		for _, file := range files {
 			if file.IsRarArchive {
 				archive = append(archive, file)
-			} else if IsPar2File(file.Filename) {
+			} else if file.IsPar2Archive || IsPar2File(file.Filename) {
 				par2 = append(par2, file)
 			} else {
 				regular = append(regular, file)
@@ -72,7 +72,7 @@ func SeparateFiles(files []parser.ParsedFile, nzbType parser.NzbType) (regular, 
 		for _, file := range files {
 			if file.Is7zArchive {
 				archive = append(archive, file)
-			} else if IsPar2File(file.Filename) {
+			} else if file.IsPar2Archive || IsPar2File(file.Filename) {
 				par2 = append(par2, file)
 			} else {
 				regular = append(regular, file)
@@ -82,7 +82,7 @@ func SeparateFiles(files []parser.ParsedFile, nzbType parser.NzbType) (regular, 
 	default:
 		// For single file and multi-file types, just separate PAR2 files
 		for _, file := range files {
-			if IsPar2File(file.Filename) {
+			if file.IsPar2Archive || IsPar2File(file.Filename) {
 				par2 = append(par2, file)
 			} else {
 				regular = append(regular, file)

--- a/internal/importer/parser/fileinfo/fileinfo.go
+++ b/internal/importer/parser/fileinfo/fileinfo.go
@@ -97,7 +97,9 @@ func getFileInfo(
 	// Gap 3: Detect 7z archives by magic bytes or extension
 	is7z := Has7zMagic(file.First16KB) || Is7zFile(filename)
 
-	isPar2Archive := IsPar2File(filename)
+	// Check selected, subject, and header filenames — yEnc headers often omit the .par2 extension
+	// (e.g. encoder stores "Movie.mkv" in the yEnc name= field for a "Movie.mkv.vol07+8.par2" segment)
+	isPar2Archive := IsPar2File(filename) || IsPar2File(subjectFilename) || IsPar2File(headerFilename)
 
 	return &FileInfo{
 		NzbFile:       *file.NzbFile,

--- a/internal/importer/parser/fileinfo/fileinfo_test.go
+++ b/internal/importer/parser/fileinfo/fileinfo_test.go
@@ -2,6 +2,9 @@ package fileinfo
 
 import (
 	"testing"
+
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
 )
 
 func TestIsProbablyObfuscated(t *testing.T) {
@@ -193,6 +196,62 @@ func TestCorrectExtensionFromMagicBytes(t *testing.T) {
 			got := correctExtensionFromMagicBytes(tt.filename, tt.data)
 			if got != tt.want {
 				t.Errorf("correctExtensionFromMagicBytes(%q) = %q, want %q", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetFileInfo_Par2DetectionViaSubject verifies that a file whose yEnc header
+// strips the .par2 extension is still correctly identified as a PAR2 archive when
+// the subject filename retains the full .par2 extension.
+func TestGetFileInfo_Par2DetectionViaSubject(t *testing.T) {
+	tests := []struct {
+		name            string
+		subjectFilename string // NzbFile.Filename (from subject line)
+		headerFilename  string // yEnc header name=
+		wantIsPar2      bool
+	}{
+		{
+			name:            "subject .par2 wins even when yEnc header shows .mkv",
+			subjectFilename: "Movie.Name.2023.mkv.vol07+8.par2",
+			headerFilename:  "Movie.Name.2023.mkv",
+			wantIsPar2:      true,
+		},
+		{
+			name:            "both subject and header are .par2",
+			subjectFilename: "Movie.Name.2023.mkv.vol07+8.par2",
+			headerFilename:  "Movie.Name.2023.mkv.vol07+8.par2",
+			wantIsPar2:      true,
+		},
+		{
+			name:            "neither is .par2 — not a PAR2 file",
+			subjectFilename: "Movie.Name.2023.mkv",
+			headerFilename:  "Movie.Name.2023.mkv",
+			wantIsPar2:      false,
+		},
+		{
+			name:            "header is .par2 and subject is not",
+			subjectFilename: "Movie.Name.2023.mkv",
+			headerFilename:  "Movie.Name.2023.mkv.vol07+8.par2",
+			wantIsPar2:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := &NzbFileWithFirstSegment{
+				NzbFile: &nzbparser.NzbFile{
+					Filename: tt.subjectFilename,
+				},
+				Headers: &nntppool.YEncMeta{
+					FileName: tt.headerFilename,
+				},
+				First16KB: make([]byte, 16),
+			}
+			info := getFileInfo(file, nil, "nzb-stem")
+			if info.IsPar2Archive != tt.wantIsPar2 {
+				t.Errorf("getFileInfo IsPar2Archive = %v, want %v (subject=%q header=%q selected=%q)",
+					info.IsPar2Archive, tt.wantIsPar2, tt.subjectFilename, tt.headerFilename, info.Filename)
 			}
 		})
 	}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -162,7 +162,7 @@ func (p *Parser) ParseFile(ctx context.Context, r io.Reader, nzbPath string, pro
 	}
 
 	// Get file infos with priority-based filename selection
-	// This already filters out PAR2 files
+	// GetFileInfos processes ALL files including PAR2 files; SeparateFiles handles the split
 	fileInfos := fileinfo.GetFileInfos(filesWithFirstSegment, par2Descriptors, parsed.Filename)
 	if len(fileInfos) == 0 {
 		p.log.WarnContext(ctx, "Failed to get file infos from network, falling back to NZB XML data",
@@ -815,6 +815,18 @@ func (p *Parser) fallbackGetFileInfos(files []nzbparser.NzbFile) []*fileinfo.Fil
 
 // determineNzbType analyzes the parsed files to determine the NZB type
 func (p *Parser) determineNzbType(files []ParsedFile) NzbType {
+	// Exclude PAR2 files — a single media file + N PAR2 files is still a single-file NZB
+	var mediaFiles []ParsedFile
+	for _, f := range files {
+		if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) {
+			mediaFiles = append(mediaFiles, f)
+		}
+	}
+	if len(mediaFiles) == 0 {
+		return NzbTypeMultiFile // all-PAR2 edge case; allPar2 check handles this earlier
+	}
+	files = mediaFiles
+
 	if len(files) == 1 {
 		// Single file NZB
 		if files[0].IsRarArchive {

--- a/internal/importer/parser/parser_test.go
+++ b/internal/importer/parser/parser_test.go
@@ -104,7 +104,54 @@ func TestFallbackGetFileInfos_EmptySegments(t *testing.T) {
 	}
 	
 	infos := p.fallbackGetFileInfos(files)
-	
+
 	assert.Len(t, infos, 1)
 	assert.Equal(t, "file2.txt", infos[0].Filename)
+}
+
+// TestDetermineNzbType_ExcludesPar2Files verifies that PAR2 recovery files
+// are excluded when determining NZB type, so 1 media + N PAR2 = SingleFile.
+func TestDetermineNzbType_ExcludesPar2Files(t *testing.T) {
+	p := NewParser(nil)
+
+	tests := []struct {
+		name     string
+		files    []ParsedFile
+		wantType NzbType
+	}{
+		{
+			name: "single media file + par2 files → SingleFile",
+			files: []ParsedFile{
+				{Filename: "Movie.Name.2023.mkv", IsPar2Archive: false},
+				{Filename: "Movie.Name.2023.mkv.vol00+1.par2", IsPar2Archive: true},
+				{Filename: "Movie.Name.2023.mkv.vol01+2.par2", IsPar2Archive: true},
+				{Filename: "Movie.Name.2023.mkv.vol03+4.par2", IsPar2Archive: true},
+			},
+			wantType: NzbTypeSingleFile,
+		},
+		{
+			name: "multiple media files → MultiFile",
+			files: []ParsedFile{
+				{Filename: "Movie.Part1.mkv", IsPar2Archive: false},
+				{Filename: "Movie.Part2.mkv", IsPar2Archive: false},
+				{Filename: "Movie.Part1.mkv.vol00+1.par2", IsPar2Archive: true},
+			},
+			wantType: NzbTypeMultiFile,
+		},
+		{
+			name: "par2 IsPar2Archive=false but filename ends in .par2",
+			files: []ParsedFile{
+				{Filename: "Movie.Name.2023.mkv", IsPar2Archive: false},
+				{Filename: "Movie.Name.2023.mkv.vol07+8.par2", IsPar2Archive: false},
+			},
+			wantType: NzbTypeSingleFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.determineNzbType(tt.files)
+			assert.Equal(t, tt.wantType, got)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- **Root cause**: yEnc encoders often store the base media filename (e.g. `Movie.mkv`) in the `name=` header field for PAR2 segments, omitting the `.par2` extension. The priority scoring system then selected this stripped name, `IsPar2File()` returned false, and the PAR2 recovery block masqueraded as the media file — showing ~76 MB instead of ~975 MB in the queue.
- **Secondary bug**: `determineNzbType` counted all files including PAR2s, so a 1-video + 6-PAR2 NZB was classified as `NzbTypeMultiFile` instead of `NzbTypeSingleFile`.

## Changes

- `fileinfo/fileinfo.go`: `isPar2Archive` now checks the selected filename **and** the raw subject/header filenames, so a `.par2` subject always wins regardless of what the yEnc header says.
- `filesystem/utils.go`: `SeparateFiles` checks `file.IsPar2Archive || IsPar2File(file.Filename)` in all branches, routing correctly-flagged files to the PAR2 bucket even when their selected filename lost the extension.
- `parser/parser.go`: `determineNzbType` filters out PAR2 files before counting, so 1 media + N PAR2 → `NzbTypeSingleFile`.
- `parser/parser.go`: Fixed misleading comment on `GetFileInfos` call.

## Test plan

- [ ] `go test ./internal/importer/...` passes (new tests added for both bugs)
- [ ] Import a single-MKV + multi-PAR2 NZB and verify queue shows correct total size (~975 MB)
- [ ] Verify the imported file in VFS shows the correct size
- [ ] Verify single-video + multi-PAR2 NZBs are classified as `NzbTypeSingleFile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)