### PR TITLE
feat(config): move import section to Automation group in sidebar

### DIFF
--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -90,11 +90,11 @@ const SECTION_GROUPS = [
 	},
 	{
 		title: "Automation",
-		sections: ["sabnzbd", "arrs", "health", "stremio"],
+		sections: ["sabnzbd", "arrs", "health", "stremio", "import"],
 	},
 	{
 		title: "System",
-		sections: ["auth", "import", "system"],
+		sections: ["auth", "system"],
 	},
 ];
 


### PR DESCRIPTION
## Summary
- Moves the "Import" config section from the "System" group to the "Automation" group in the configuration sidebar

## Test plan
- [ ] Navigate to `/config` and verify "Import" appears under the "Automation" group
- [ ] Verify "System" group no longer contains "Import"

🤖 Generated with [Claude Code](https://claude.com/claude-code)