### PR TITLE
feat(import): preserve failed NZBs + auto-cleanup stale failed items

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -25,7 +25,6 @@ database:
 metadata:
   root_path: '/config/metadata' # Directory to store metadata files (required)
   delete_source_nzb_on_removal: false # Delete source NZB file when metadata is removed (default: false)
-  delete_failed_nzb: false # Delete NZB source file when import fails (default: false)
   delete_completed_nzb: false # Delete NZB source file after successful import (default: false, DANGEROUS: prevents re-import)
   backup:
     enabled: false # Enable automatic metadata backups
@@ -155,6 +154,7 @@ import:
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)
                  # Windows example: 'C:\Users\user\Videos'
   skip_health_check: true # Bypass Usenet article validation during import (default: true)
+  failed_item_retention_hours: 24 # Auto-remove failed queue items and NZB files after this many hours (0 to disable, default: 24)
 
 # Health monitoring configuration
 health:

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4492,6 +4492,8 @@ components:
           type: array
         expand_bluray_iso:
           type: boolean
+        failed_item_retention_hours:
+          type: integer
         import_dir:
           type: string
         import_strategy:
@@ -4562,8 +4564,6 @@ components:
         backup:
           $ref: "#/components/schemas/config.MetadataBackupConfig"
         delete_completed_nzb:
-          type: boolean
-        delete_failed_nzb:
           type: boolean
         delete_source_nzb_on_removal:
           type: boolean

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -6900,6 +6900,9 @@
                 "expand_bluray_iso": {
                     "type": "boolean"
                 },
+                "failed_item_retention_hours": {
+                    "type": "integer"
+                },
                 "import_dir": {
                     "type": "string"
                 },
@@ -7001,9 +7004,6 @@
                     "$ref": "#/definitions/config.MetadataBackupConfig"
                 },
                 "delete_completed_nzb": {
-                    "type": "boolean"
-                },
-                "delete_failed_nzb": {
                     "type": "boolean"
                 },
                 "delete_source_nzb_on_removal": {

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1156,6 +1156,8 @@ definitions:
         type: array
       expand_bluray_iso:
         type: boolean
+      failed_item_retention_hours:
+        type: integer
       import_dir:
         type: string
       import_strategy:
@@ -1226,8 +1228,6 @@ definitions:
       backup:
         $ref: '#/definitions/config.MetadataBackupConfig'
       delete_completed_nzb:
-        type: boolean
-      delete_failed_nzb:
         type: boolean
       delete_source_nzb_on_removal:
         type: boolean

--- a/frontend/src/components/config/MetadataConfigSection.tsx
+++ b/frontend/src/components/config/MetadataConfigSection.tsx
@@ -220,24 +220,6 @@ export function MetadataConfigSection({
 						<label className="label cursor-pointer items-start justify-start gap-4">
 							<input
 								type="checkbox"
-								className="checkbox checkbox-primary checkbox-sm mt-1 shrink-0"
-								checked={formData.delete_failed_nzb ?? true}
-								disabled={isReadOnly}
-								onChange={(e) => handleCheckboxChange("delete_failed_nzb", e.target.checked)}
-							/>
-							<div className="min-w-0 flex-1">
-								<span className="block whitespace-normal break-words font-bold text-xs">
-									Clean Failed NZBs
-								</span>
-								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-									Permanently delete NZBs that fail processing instead of moving to 'failed' folder.
-								</span>
-							</div>
-						</label>
-
-						<label className="label cursor-pointer items-start justify-start gap-4">
-							<input
-								type="checkbox"
 								className="checkbox checkbox-error checkbox-sm mt-1 shrink-0"
 								checked={formData.delete_completed_nzb ?? false}
 								disabled={isReadOnly}

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -457,6 +457,36 @@ export function ImportConfigSection({
 						</div>
 					</fieldset>
 				</div>
+				{/* Queue Maintenance */}
+				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex items-center gap-2">
+						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
+							Queue Maintenance
+						</h4>
+						<div className="h-px flex-1 bg-base-300/50" />
+					</div>
+
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend font-semibold">Failed Item Retention (Hours)</legend>
+						<input
+							type="number"
+							className="input input-bordered w-full bg-base-100 font-mono text-sm"
+							value={formData.failed_item_retention_hours ?? 24}
+							readOnly={isReadOnly}
+							min={0}
+							onChange={(e) =>
+								handleInputChange(
+									"failed_item_retention_hours",
+									Number.parseInt(e.target.value, 10) || 0,
+								)
+							}
+						/>
+						<p className="label break-words text-base-content/70 text-xs">
+							Auto-remove failed queue items and their NZB files after this many hours. Set to 0 to
+							disable.
+						</p>
+					</fieldset>
+				</div>
 			</div>
 
 			{/* Save Button */}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -56,7 +56,6 @@ export interface DatabaseConfig {
 export interface MetadataConfig {
 	root_path: string;
 	delete_source_nzb_on_removal?: boolean;
-	delete_failed_nzb?: boolean;
 	delete_completed_nzb?: boolean;
 	backup: MetadataBackupConfig;
 }
@@ -225,6 +224,7 @@ export interface ImportConfig {
 	watch_dir?: string | null;
 	watch_interval_seconds?: number | null;
 	allow_nested_rar_extraction?: boolean;
+	failed_item_retention_hours?: number | null;
 }
 
 // Log configuration

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -150,7 +150,6 @@ type DatabaseConfig struct {
 type MetadataConfig struct {
 	RootPath                 string               `yaml:"root_path" mapstructure:"root_path" json:"root_path"`
 	DeleteSourceNzbOnRemoval *bool                `yaml:"delete_source_nzb_on_removal" mapstructure:"delete_source_nzb_on_removal" json:"delete_source_nzb_on_removal,omitempty"`
-	DeleteFailedNzb          *bool                `yaml:"delete_failed_nzb" mapstructure:"delete_failed_nzb" json:"delete_failed_nzb,omitempty"`
 	DeleteCompletedNzb       *bool                `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
 	Backup                   MetadataBackupConfig `yaml:"backup" mapstructure:"backup" json:"backup"`
 }
@@ -263,6 +262,7 @@ type ImportConfig struct {
 	WatchIntervalSeconds           *int           `yaml:"watch_interval_seconds" mapstructure:"watch_interval_seconds" json:"watch_interval_seconds,omitempty"`
 	AllowNestedRarExtraction       *bool          `yaml:"allow_nested_rar_extraction" mapstructure:"allow_nested_rar_extraction" json:"allow_nested_rar_extraction,omitempty"`
 	ExpandBlurayIso                *bool          `yaml:"expand_bluray_iso" mapstructure:"expand_bluray_iso" json:"expand_bluray_iso,omitempty"`
+	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 }
 
 // LogConfig represents logging configuration with rotation support

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -689,6 +689,60 @@ func (r *QueueRepository) withQueueTransaction(ctx context.Context, fn func(*Que
 	return nil
 }
 
+// DeleteFailedItemsOlderThan deletes failed queue items older than the given time.
+// Returns the deleted items so the caller can clean up associated NZB files.
+func (r *QueueRepository) DeleteFailedItemsOlderThan(ctx context.Context, olderThan time.Time) ([]*ImportQueueItem, error) {
+	var deletedItems []*ImportQueueItem
+
+	err := r.withQueueTransaction(ctx, func(txRepo *QueueRepository) error {
+		// Select failed items older than the threshold
+		selectQuery := `SELECT id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+			started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
+			FROM import_queue WHERE status = 'failed' AND updated_at < ?`
+
+		rows, err := txRepo.db.QueryContext(ctx, selectQuery, olderThan)
+		if err != nil {
+			return fmt.Errorf("failed to select old failed items: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var item ImportQueueItem
+			if err := rows.Scan(
+				&item.ID, &item.NzbPath, &item.RelativePath, &item.Category, &item.Priority, &item.Status,
+				&item.CreatedAt, &item.UpdatedAt, &item.StartedAt, &item.CompletedAt,
+				&item.RetryCount, &item.MaxRetries, &item.ErrorMessage, &item.BatchID, &item.Metadata, &item.FileSize, &item.StoragePath, &item.TargetPath,
+			); err != nil {
+				return fmt.Errorf("failed to scan failed queue item: %w", err)
+			}
+			deletedItems = append(deletedItems, &item)
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("failed to iterate failed queue items: %w", err)
+		}
+
+		if len(deletedItems) == 0 {
+			return nil
+		}
+
+		// Delete the selected items
+		for _, item := range deletedItems {
+			deleteQuery := `DELETE FROM import_queue WHERE id = ?`
+			if _, err := txRepo.db.ExecContext(ctx, deleteQuery, item.ID); err != nil {
+				return fmt.Errorf("failed to delete failed item %d: %w", item.ID, err)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return deletedItems, nil
+}
+
 // ResetStaleItems resets processing items back to pending on service startup
 func (r *QueueRepository) ResetStaleItems(ctx context.Context) error {
 	// Reset all items that are in 'processing' status

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -313,6 +313,9 @@ func (s *Service) Start(ctx context.Context) error {
 		// Don't fail service start if watcher fails
 	}
 
+	// Start background cleanup of stale failed queue items
+	go s.runFailedItemCleanup(ctx)
+
 	s.running = true
 	s.log.InfoContext(ctx, fmt.Sprintf("NZB import service started successfully with %d workers", s.config.Workers))
 
@@ -1085,23 +1088,9 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 			"queue_id", item.ID,
 			"file", item.NzbPath)
 
-		// Handle failed NZB based on config
-		cfg := s.configGetter()
-		deleteFailed := true // Default to delete
-		if cfg.Metadata.DeleteFailedNzb != nil {
-			deleteFailed = *cfg.Metadata.DeleteFailedNzb
-		}
-
-		if deleteFailed {
-			s.log.InfoContext(ctx, "Deleting failed NZB (per config)", "file", item.NzbPath)
-			if rmErr := os.Remove(item.NzbPath); rmErr != nil {
-				s.log.WarnContext(ctx, "Failed to delete failed NZB", "file", item.NzbPath, "error", rmErr)
-			}
-		} else {
-			// Move to failed folder
-			if moveErr := s.MoveToFailedFolder(ctx, item); moveErr != nil {
-				s.log.ErrorContext(ctx, "Failed to move NZB to failed folder", "error", moveErr)
-			}
+		// Always move failed NZB to failed folder for potential retry
+		if moveErr := s.MoveToFailedFolder(ctx, item); moveErr != nil {
+			s.log.ErrorContext(ctx, "Failed to move NZB to failed folder", "error", moveErr)
 		}
 	} else {
 		s.log.ErrorContext(ctx, "Fallback handling failed",
@@ -1109,25 +1098,68 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 			"file", item.NzbPath,
 			"error", err)
 
-		// Handle failed NZB based on config
-		cfg := s.configGetter()
-		deleteFailed := true // Default to delete
-		if cfg.Metadata.DeleteFailedNzb != nil {
-			deleteFailed = *cfg.Metadata.DeleteFailedNzb
+		// Always move failed NZB to failed folder for potential retry
+		if moveErr := s.MoveToFailedFolder(ctx, item); moveErr != nil {
+			s.log.ErrorContext(ctx, "Failed to move NZB to failed folder", "error", moveErr)
 		}
+	}
+}
 
-		if deleteFailed {
-			s.log.InfoContext(ctx, "Deleting failed NZB (per config)", "file", item.NzbPath)
-			if rmErr := os.Remove(item.NzbPath); rmErr != nil {
-				s.log.WarnContext(ctx, "Failed to delete failed NZB", "file", item.NzbPath, "error", rmErr)
-			}
-		} else {
-			// Move to failed folder
-			if moveErr := s.MoveToFailedFolder(ctx, item); moveErr != nil {
-				s.log.ErrorContext(ctx, "Failed to move NZB to failed folder", "error", moveErr)
+// runFailedItemCleanup periodically removes stale failed queue items and their NZB files.
+func (s *Service) runFailedItemCleanup(ctx context.Context) {
+	// Run once at startup
+	s.cleanupFailedItems(ctx)
+
+	ticker := time.NewTicker(1 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.cleanupFailedItems(ctx)
+		}
+	}
+}
+
+// cleanupFailedItems deletes failed queue items older than the configured retention period
+// and removes their associated NZB files.
+func (s *Service) cleanupFailedItems(ctx context.Context) {
+	cfg := s.configGetter()
+	retentionHours := 24 // default
+	if cfg.Import.FailedItemRetentionHours != nil {
+		retentionHours = *cfg.Import.FailedItemRetentionHours
+	}
+
+	if retentionHours <= 0 {
+		return // disabled
+	}
+
+	cutoff := time.Now().Add(-time.Duration(retentionHours) * time.Hour)
+	deletedItems, err := s.database.Repository.DeleteFailedItemsOlderThan(ctx, cutoff)
+	if err != nil {
+		s.log.ErrorContext(ctx, "Failed to cleanup old failed queue items", "error", err)
+		return
+	}
+
+	if len(deletedItems) == 0 {
+		return
+	}
+
+	// Remove NZB files for deleted items
+	for _, item := range deletedItems {
+		if item.NzbPath != "" {
+			if rmErr := os.Remove(item.NzbPath); rmErr != nil && !os.IsNotExist(rmErr) {
+				s.log.WarnContext(ctx, "Failed to remove NZB file during cleanup", "file", item.NzbPath, "error", rmErr)
 			}
 		}
 	}
+
+	s.broadcaster.BroadcastQueueChanged()
+	s.log.InfoContext(ctx, "Cleaned up stale failed queue items",
+		"count", len(deletedItems),
+		"retention_hours", retentionHours)
 }
 
 // CancelProcessing cancels a processing queue item by cancelling its context


### PR DESCRIPTION
## Summary

- **Always preserve failed NZBs**: Removes the `delete_failed_nzb` config option — failed NZBs are now always moved to the `.nzbs/failed/` folder, enabling users to retry imports
- **Auto-cleanup stale failed items**: Adds `failed_item_retention_hours` config (default 24h, 0=disabled) that automatically removes old failed queue items and their NZB files via a background goroutine
- **Frontend updates**: Removes "Clean Failed NZBs" checkbox from Metadata settings, adds "Failed Item Retention (Hours)" input to Import/Queue Maintenance section

## Test plan

- [ ] Fail an import → verify NZB is always in `.nzbs/failed/` folder, never deleted
- [ ] Verify failed queue item + NZB file are cleaned up after retention period expires
- [ ] Set retention to 0 → verify cleanup is disabled
- [ ] Verify frontend shows retention hours field in Import config
- [ ] Verify "Clean Failed NZBs" checkbox is gone from Metadata config
- [ ] `go build ./...` passes
- [ ] `bun run check` passes
- [ ] `go test ./internal/database/...` and `go test ./internal/importer/...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)