### PR TITLE
fix: address 14 code review issues across Go backend

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/javi11/altmount/internal/arrs/clients"
 	"github.com/javi11/altmount/internal/arrs/data"
@@ -107,16 +108,32 @@ func (m *Manager) findInstanceForFilePath(ctx context.Context, filePath string, 
 
 func (m *Manager) managesFile(ctx context.Context, instanceType string, client any, filePath string) bool {
 	if instanceType == "radarr" {
-		return m.radarrManagesFile(ctx, client.(*radarr.Radarr), filePath)
+		rc, ok := client.(*radarr.Radarr)
+		if !ok {
+			return false
+		}
+		return m.radarrManagesFile(ctx, rc, filePath)
 	}
-	return m.sonarrManagesFile(ctx, client.(*sonarr.Sonarr), filePath)
+	sc, ok := client.(*sonarr.Sonarr)
+	if !ok {
+		return false
+	}
+	return m.sonarrManagesFile(ctx, sc, filePath)
 }
 
 func (m *Manager) hasFile(ctx context.Context, instanceType string, client any, instanceName, relativePath string) bool {
 	if instanceType == "radarr" {
-		return m.radarrHasFile(ctx, client.(*radarr.Radarr), instanceName, relativePath)
+		rc, ok := client.(*radarr.Radarr)
+		if !ok {
+			return false
+		}
+		return m.radarrHasFile(ctx, rc, instanceName, relativePath)
 	}
-	return m.sonarrHasFile(ctx, client.(*sonarr.Sonarr), instanceName, relativePath)
+	sc, ok := client.(*sonarr.Sonarr)
+	if !ok {
+		return false
+	}
+	return m.sonarrHasFile(ctx, sc, instanceName, relativePath)
 }
 
 // radarrManagesFile checks if Radarr manages the given file path using root folders (checkrr approach)
@@ -135,7 +152,7 @@ func (m *Manager) radarrManagesFile(ctx context.Context, client *radarr.Radarr, 
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Radarr root folder", "folder_path", folder.Path, "file_path", filePath)
 		// Check for direct prefix match or if the filePath contains the folder.Path (common in Docker/Remote setups)
-		if strings.HasPrefix(filePath, folder.Path) || strings.Contains(filePath, folder.Path) {
+		if strings.HasPrefix(filePath, folder.Path) {
 			slog.DebugContext(ctx, "File matches Radarr root folder", "folder_path", folder.Path)
 			return true
 		}
@@ -160,8 +177,7 @@ func (m *Manager) sonarrManagesFile(ctx context.Context, client *sonarr.Sonarr, 
 	// Check if file path starts with any root folder path
 	for _, folder := range rootFolders {
 		slog.DebugContext(ctx, "Checking Sonarr root folder", "folder_path", folder.Path, "file_path", filePath)
-		// Check for direct prefix match or if the filePath contains the folder.Path (common in Docker/Remote setups)
-		if strings.HasPrefix(filePath, folder.Path) || strings.Contains(filePath, folder.Path) {
+		if strings.HasPrefix(filePath, folder.Path) {
 			slog.DebugContext(ctx, "File matches Sonarr root folder", "folder_path", folder.Path)
 			return true
 		}
@@ -277,8 +293,8 @@ func (m *Manager) TriggerScanForFile(ctx context.Context, filePath string) error
 
 	// Launch scan in background to not block caller
 	go func() {
-		// Use a new background context for the async call
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
 		switch instance.Type {
 		case "radarr":
@@ -325,8 +341,8 @@ func (m *Manager) TriggerDownloadScan(ctx context.Context, instanceType string) 
 		slog.DebugContext(ctx, "Triggering download client scan", "instance", instance.Name, "type", instance.Type)
 
 		go func(inst *model.ConfigInstance) {
-			// Use a new background context for the async call
-			bgCtx := context.Background()
+			bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
 
 			switch inst.Type {
 			case "radarr":

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -291,6 +291,10 @@ func (r *QueueRepository) UpdateQueueItemStatus(ctx context.Context, id int64, s
 
 // IncrementDailyStat increments the completed or failed count for the current day
 func (r *QueueRepository) IncrementDailyStat(ctx context.Context, statType string) error {
+	if statType != "completed" && statType != "failed" {
+		return fmt.Errorf("invalid stat type: %q (must be \"completed\" or \"failed\")", statType)
+	}
+
 	column := "completed_count"
 	if statType == "failed" {
 		column = "failed_count"
@@ -314,6 +318,10 @@ func (r *QueueRepository) IncrementDailyStat(ctx context.Context, statType strin
 
 // IncrementHourlyStat increments the completed or failed count for the current hour
 func (r *QueueRepository) IncrementHourlyStat(ctx context.Context, statType string) error {
+	if statType != "completed" && statType != "failed" {
+		return fmt.Errorf("invalid stat type: %q (must be \"completed\" or \"failed\")", statType)
+	}
+
 	column := "completed_count"
 	if statType == "failed" {
 		column = "failed_count"
@@ -390,7 +398,7 @@ func (r *QueueRepository) GetImportDailyStats(ctx context.Context, days int) ([]
 		stats = append(stats, &s)
 	}
 
-	return stats, nil
+	return stats, rows.Err()
 }
 
 // GetImportHistory retrieves historical import statistics for the last N days (Alias for GetImportDailyStats)

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -19,7 +19,7 @@ import (
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pathutil"
 	"github.com/javi11/altmount/internal/progress"
-	"github.com/sourcegraph/conc"
+	"github.com/sourcegraph/conc/pool"
 )
 
 // ARRsRepairService abstracts the ARR repair operations needed by HealthWorker.
@@ -697,15 +697,15 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		"total", totalFiles,
 		"max_concurrent_jobs", maxJobs)
 
-	// Process files in parallel using conc
-	wg := conc.NewWaitGroup()
+	// Process files in parallel with bounded concurrency
+	p := pool.New().WithMaxGoroutines(maxJobs)
 	var results []database.HealthStatusUpdate
 	var resultsMu sync.Mutex
 
 	// Process health check files
 	for _, fileHealth := range unhealthyFiles {
 		fh := fileHealth // Capture for closure
-		wg.Go(func() {
+		p.Go(func() {
 			slog.InfoContext(ctx, "Checking unhealthy file", "file_path", fh.FilePath)
 
 			// Set checking status
@@ -749,7 +749,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 
 	for _, fileHealth := range repairFiles {
 		fh := fileHealth // Capture for closure
-		wg.Go(func() {
+		p.Go(func() {
 			slog.InfoContext(ctx, "Re-triggering repair for file", "file_path", fh.FilePath)
 
 			updatePtr, sideEffect := hw.prepareRepairNotificationUpdate(ctx, fh)
@@ -773,7 +773,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 	}
 
 	// Wait for all files to complete processing
-	wg.Wait()
+	p.Wait()
 
 	// Build list of protected directories (categories and complete dir)
 	cfg = hw.configGetter()

--- a/internal/importer/postprocessor/arr_notifier.go
+++ b/internal/importer/postprocessor/arr_notifier.go
@@ -6,26 +6,36 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 )
 
 // NotifyARR notifies ARR applications about imported content
 func (c *Coordinator) NotifyARR(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
-	if c.arrsService == nil {
+	c.mu.RLock()
+	arrsService := c.arrsService
+	c.mu.RUnlock()
+
+	return c.notifyARRWith(ctx, arrsService, item, resultingPath)
+}
+
+// notifyARRWith notifies ARR using the provided service (avoids re-locking)
+func (c *Coordinator) notifyARRWith(ctx context.Context, arrsService *arrs.Service, item *database.ImportQueueItem, resultingPath string) error {
+	if arrsService == nil {
 		return nil
 	}
 
 	// When a forced target path is set, scan that path directly (no category required).
 	if item.TargetPath != nil && *item.TargetPath != "" {
-		if err := c.arrsService.TriggerScanForFile(ctx, *item.TargetPath); err != nil {
+		if err := arrsService.TriggerScanForFile(ctx, *item.TargetPath); err != nil {
 			c.log.WarnContext(ctx, "Failed to trigger ARR scan for target path",
 				"path", *item.TargetPath, "error", err)
 		}
 		return nil
 	}
 
-	if item.Category == nil {
+	if item.Category == nil || *item.Category == "" {
 		return nil
 	}
 
@@ -78,19 +88,22 @@ func (c *Coordinator) NotifyARR(ctx context.Context, item *database.ImportQueueI
 	pathForARR := filepath.Join(pathParts...)
 	pathForARR = filepath.ToSlash(filepath.Clean(pathForARR))
 
-	if err := c.arrsService.TriggerScanForFile(ctx, pathForARR); err != nil {
+	if err := arrsService.TriggerScanForFile(ctx, pathForARR); err != nil {
 		// Fallback: broadcast to all instances of the type
 		c.log.DebugContext(ctx, "Could not find specific ARR instance for file, broadcasting scan",
 			"path", pathForARR, "error", err)
 
-		return c.broadcastToARRType(ctx, item)
+		return c.broadcastToARRType(ctx, arrsService, item)
 	}
 
 	return nil
 }
 
 // broadcastToARRType broadcasts scan to all instances of the determined ARR type
-func (c *Coordinator) broadcastToARRType(ctx context.Context, item *database.ImportQueueItem) error {
+func (c *Coordinator) broadcastToARRType(ctx context.Context, arrsService *arrs.Service, item *database.ImportQueueItem) error {
+	if item.Category == nil {
+		return fmt.Errorf("cannot determine ARR type: category is nil")
+	}
 	categoryName := *item.Category
 	category := strings.ToLower(categoryName)
 	arrType := ""
@@ -115,7 +128,7 @@ func (c *Coordinator) broadcastToARRType(ctx context.Context, item *database.Imp
 	}
 
 	if arrType != "" {
-		c.arrsService.TriggerDownloadScan(ctx, arrType)
+		arrsService.TriggerDownloadScan(ctx, arrType)
 		return nil
 	}
 

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -6,6 +6,7 @@ package postprocessor
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/javi11/altmount/internal/arrs"
@@ -18,6 +19,7 @@ import (
 
 // Coordinator orchestrates all post-import processing steps
 type Coordinator struct {
+	mu              sync.RWMutex
 	configGetter    config.ConfigGetter
 	metadataService *metadata.MetadataService
 	rcloneClient    rclonecli.RcloneRcClient
@@ -52,11 +54,15 @@ func NewCoordinator(cfg Config) *Coordinator {
 
 // SetRcloneClient updates the rclone client (called when config changes)
 func (c *Coordinator) SetRcloneClient(client rclonecli.RcloneRcClient) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.rcloneClient = client
 }
 
 // SetArrsService updates the ARRs service (called after initialization)
 func (c *Coordinator) SetArrsService(service *arrs.Service) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.arrsService = service
 }
 
@@ -72,10 +78,15 @@ type ProcessingResult struct {
 
 // HandleSuccess performs all post-processing for successful imports
 func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) (*ProcessingResult, error) {
+	c.mu.RLock()
+	rcloneClient := c.rcloneClient
+	arrsService := c.arrsService
+	c.mu.RUnlock()
+
 	result := &ProcessingResult{}
 
 	// 1. Notify VFS (blocking to ensure visibility)
-	c.NotifyVFS(ctx, resultingPath, false)
+	c.notifyVFSWith(ctx, rcloneClient, resultingPath, false)
 	result.VFSNotified = true
 
 	// Small delay to allow FUSE mount propagation through kernel and into other containers
@@ -123,7 +134,7 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 	}
 
 	// 6. Notify ARR applications
-	if err := c.NotifyARR(ctx, item, resultingPath); err != nil {
+	if err := c.notifyARRWith(ctx, arrsService, item, resultingPath); err != nil {
 		c.log.DebugContext(ctx, "ARR notification not sent",
 			"path", resultingPath,
 			"error", err)
@@ -136,7 +147,7 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 }
 
 // HandleFailure performs cleanup and fallback for failed imports
-func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) error {
+func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQueueItem, _ error) error {
 	cfg := c.configGetter()
 
 	// Attempt SABnzbd fallback if configured

--- a/internal/importer/postprocessor/vfs_notifier.go
+++ b/internal/importer/postprocessor/vfs_notifier.go
@@ -9,11 +9,21 @@ import (
 	"time"
 
 	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/pkg/rclonecli"
 )
 
 // NotifyVFS notifies rclone VFS about file changes
 func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async bool) {
-	if c.rcloneClient == nil {
+	c.mu.RLock()
+	rcloneClient := c.rcloneClient
+	c.mu.RUnlock()
+
+	c.notifyVFSWith(ctx, rcloneClient, resultingPath, async)
+}
+
+// notifyVFSWith notifies rclone VFS using the provided client (avoids re-locking)
+func (c *Coordinator) notifyVFSWith(ctx context.Context, rcloneClient rclonecli.RcloneRcClient, resultingPath string, async bool) {
+	if rcloneClient == nil {
 		return
 	}
 
@@ -58,7 +68,7 @@ func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async
 
 		slog.DebugContext(refreshCtx, "Notifying rclone VFS refresh", "dirs", dirsToRefresh, "vfs", vfsName)
 
-		err := c.rcloneClient.RefreshDir(refreshCtx, vfsName, dirsToRefresh)
+		err := rcloneClient.RefreshDir(refreshCtx, vfsName, dirsToRefresh)
 		if err != nil {
 			slog.WarnContext(refreshCtx, "Failed to notify rclone VFS refresh",
 				"dirs", dirsToRefresh,
@@ -78,7 +88,11 @@ func (c *Coordinator) NotifyVFS(ctx context.Context, resultingPath string, async
 
 // RefreshMountPathIfNeeded refreshes the mount path cache if required
 func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPath string, itemID int64) {
-	if c.rcloneClient == nil {
+	c.mu.RLock()
+	rcloneClient := c.rcloneClient
+	c.mu.RUnlock()
+
+	if rcloneClient == nil {
 		return
 	}
 
@@ -101,7 +115,7 @@ func (c *Coordinator) RefreshMountPathIfNeeded(ctx context.Context, resultingPat
 			}
 
 			// Refresh the root path if the mount path is not found
-			if err := c.rcloneClient.RefreshDir(ctx, vfsName, []string{"/"}); err != nil {
+			if err := rcloneClient.RefreshDir(ctx, vfsName, []string{"/"}); err != nil {
 				c.log.ErrorContext(ctx, "Failed to refresh mount path",
 					"queue_id", itemID,
 					"path", mountPath,

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -369,7 +369,10 @@ func (s *Service) IsPaused() bool {
 }
 
 func (s *Service) RegisterConfigChangeHandler(configManager any) {
-	mgr := configManager.(*config.Manager)
+	mgr, ok := configManager.(*config.Manager)
+	if !ok {
+		return
+	}
 	mgr.OnConfigChange(func(oldConfig, newConfig *config.Config) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -441,7 +444,12 @@ func (s *Service) IsRunning() bool {
 func (s *Service) SetRcloneClient(client any) {
 	var rc rclonecli.RcloneRcClient
 	if client != nil {
-		rc = client.(rclonecli.RcloneRcClient)
+		var ok bool
+		rc, ok = client.(rclonecli.RcloneRcClient)
+		if !ok {
+			s.log.ErrorContext(s.ctx, "SetRcloneClient: unexpected client type", "type", fmt.Sprintf("%T", client))
+			return
+		}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -460,7 +468,12 @@ func (s *Service) SetRcloneClient(client any) {
 func (s *Service) SetArrsService(service any) {
 	var as *arrs.Service
 	if service != nil {
-		as = service.(*arrs.Service)
+		var ok bool
+		as, ok = service.(*arrs.Service)
+		if !ok {
+			s.log.ErrorContext(s.ctx, "SetArrsService: unexpected service type", "type", fmt.Sprintf("%T", service))
+			return
+		}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1161,7 +1174,9 @@ func (s *Service) cleanupFailedItems(ctx context.Context) {
 		}
 	}
 
-	s.broadcaster.BroadcastQueueChanged()
+	if s.broadcaster != nil {
+		s.broadcaster.BroadcastQueueChanged()
+	}
 	s.log.InfoContext(ctx, "Cleaned up stale failed queue items",
 		"count", len(deletedItems),
 		"retention_hours", retentionHours)
@@ -1172,7 +1187,9 @@ func (s *Service) CancelProcessing(itemID int64) error {
 	return s.queueManager.CancelProcessing(itemID)
 }
 
-// ProcessItemInBackground processes a specific queue item in the background
+// ProcessItemInBackground processes a specific queue item in the background.
+// NOTE: This intentionally runs outside the worker pool — it is used for manual retries
+// of specific items and should not compete with the normal import queue workers.
 func (s *Service) ProcessItemInBackground(ctx context.Context, itemID int64) {
 	go func() {
 		s.log.DebugContext(ctx, "Starting background processing of queue item", "item_id", itemID, "background", true)

--- a/internal/metadata/backup_worker.go
+++ b/internal/metadata/backup_worker.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -82,15 +83,19 @@ func (w *BackupWorker) runWorker() {
 			now := time.Now().UTC()
 			parts := strings.Split(cfg.Metadata.Backup.BackupTime, ":")
 			if len(parts) == 2 {
-				hour, _ := strconv.Atoi(parts[0])
-				minute, _ := strconv.Atoi(parts[1])
-
-				target := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC)
-				if target.Before(now) || target.Equal(now) {
-					target = target.Add(24 * time.Hour)
+				hour, errH := strconv.Atoi(parts[0])
+				minute, errM := strconv.Atoi(parts[1])
+				if errH != nil || errM != nil {
+					slog.WarnContext(w.workerCtx, "Invalid backup_time format, falling back to interval",
+						"backup_time", cfg.Metadata.Backup.BackupTime, "hour_err", errH, "minute_err", errM)
+				} else {
+					target := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, time.UTC)
+					if target.Before(now) || target.Equal(now) {
+						target = target.Add(24 * time.Hour)
+					}
+					nextRun = target.Sub(now)
+					slog.InfoContext(w.workerCtx, "Scheduled next metadata backup", "at", target.Format("2006-01-02 15:04:05 UTC"), "in", nextRun.String())
 				}
-				nextRun = target.Sub(now)
-				slog.InfoContext(w.workerCtx, "Scheduled next metadata backup", "at", target.Format("2006-01-02 15:04:05 UTC"), "in", nextRun.String())
 			}
 		}
 
@@ -165,7 +170,7 @@ func (w *BackupWorker) performBackup() {
 	})
 
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			slog.InfoContext(w.workerCtx, "Metadata backup canceled")
 		} else {
 			slog.ErrorContext(w.workerCtx, "Failed to complete metadata backup", "error", err)


### PR DESCRIPTION
## Summary

- **Critical**: Nil guard on broadcaster in `cleanupFailedItems`, 30s timeout on background goroutines in scanner to prevent leaks, safe comma-ok type assertions in scanner `managesFile`/`hasFile`
- **High**: `sync.RWMutex` on `Coordinator` to prevent data races on `rcloneClient`/`arrsService`, `strconv.Atoi` error handling in backup worker, document `ProcessItemInBackground` intentional design
- **Medium**: Nil check for `item.Category` in `broadcastToARRType`, remove overly permissive `strings.Contains` in root folder matching, safe type assertions in `RegisterConfigChangeHandler`/`SetRcloneClient`/`SetArrsService`, bounded goroutine pool in health worker, missing `rows.Err()` in `GetImportDailyStats`, `errors.Is()` for `context.Canceled`, explicit allowlist validation for SQL column interpolation

## Files Changed (8)

| File | Issues Fixed |
|------|-------------|
| `internal/importer/service.go` | #1 nil guard, #7 document design, #10 safe assertion, #11 safe assertions |
| `internal/arrs/scanner/manager.go` | #2 goroutine timeout, #3 safe assertions, #9 remove Contains |
| `internal/importer/postprocessor/coordinator.go` | #4 data race mutex |
| `internal/importer/postprocessor/arr_notifier.go` | #8 nil check |
| `internal/importer/postprocessor/vfs_notifier.go` | #4 read locks |
| `internal/metadata/backup_worker.go` | #6 parse error, #14 errors.Is |
| `internal/health/worker.go` | #12 bounded goroutines |
| `internal/database/queue_repository.go` | #13 rows.Err(), #15 SQL validation |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/importer/... ./internal/arrs/... ./internal/database/... ./internal/health/... ./internal/metadata/... ./internal/usenet/...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)