### PR TITLE
feat: add regenerate symlink button to queue page and file explorer

### DIFF
--- a/frontend/src/components/files/FileActions.tsx
+++ b/frontend/src/components/files/FileActions.tsx
@@ -1,4 +1,4 @@
-import { Download, Eye, FileDown, Info, MoreHorizontal, Trash2 } from "lucide-react";
+import { Download, Eye, FileDown, Info, Link2, MoreHorizontal, Trash2 } from "lucide-react";
 import { useConfirm } from "../../contexts/ModalContext";
 import type { WebDAVFile } from "../../types/webdav";
 import { getFileTypeInfo } from "../../utils/fileUtils";
@@ -11,9 +11,11 @@ interface FileActionsProps {
 	onInfo: (path: string) => void;
 	onExportNZB?: (path: string, filename: string) => void;
 	onPreview?: (file: WebDAVFile, currentPath: string) => void;
+	onRegenerateSymlink?: (path: string) => void;
 	isDownloading?: boolean;
 	isDeleting?: boolean;
 	isExportingNZB?: boolean;
+	isRegenerateSymlinkPending?: boolean;
 }
 
 export function FileActions({
@@ -24,9 +26,11 @@ export function FileActions({
 	onInfo,
 	onExportNZB,
 	onPreview,
+	onRegenerateSymlink,
 	isDownloading = false,
 	isDeleting = false,
 	isExportingNZB = false,
+	isRegenerateSymlinkPending = false,
 }: FileActionsProps) {
 	const filePath = currentPath
 		? `${currentPath}/${file.basename}`.replace(/\/+/g, "/")
@@ -59,6 +63,12 @@ export function FileActions({
 	const handlePreview = () => {
 		if (file.type === "file" && onPreview) {
 			onPreview(file, currentPath);
+		}
+	};
+
+	const handleRegenerateSymlink = () => {
+		if (file.type === "file" && onRegenerateSymlink) {
+			onRegenerateSymlink(filePath);
 		}
 	};
 
@@ -103,6 +113,18 @@ export function FileActions({
 						<button type="button" onClick={handleExportNZB} disabled={isExportingNZB}>
 							<FileDown className="h-4 w-4" />
 							{isExportingNZB ? "Exporting..." : "Export as NZB"}
+						</button>
+					</li>
+				)}
+				{file.type === "file" && onRegenerateSymlink && (
+					<li>
+						<button
+							type="button"
+							onClick={handleRegenerateSymlink}
+							disabled={isRegenerateSymlinkPending}
+						>
+							<Link2 className="h-4 w-4 text-primary" />
+							{isRegenerateSymlinkPending ? "Regenerating..." : "Regenerate Symlink"}
 						</button>
 					</li>
 				)}

--- a/frontend/src/components/files/FileExplorer.tsx
+++ b/frontend/src/components/files/FileExplorer.tsx
@@ -10,7 +10,7 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { useImportHistory } from "../../hooks/useApi";
+import { useImportHistory, useRegenerateSymlinks } from "../../hooks/useApi";
 import { useFilePreview } from "../../hooks/useFilePreview";
 import { useWebDAVDirectory, useWebDAVFileOperations } from "../../hooks/useWebDAV";
 import type { WebDAVFile } from "../../types/webdav";
@@ -113,6 +113,7 @@ export function FileExplorer({
 	} = useWebDAVFileOperations();
 
 	const preview = useFilePreview();
+	const regenerateSymlinks = useRegenerateSymlinks();
 
 	// Filter files based on search term
 	const filteredFiles = useMemo(() => {
@@ -152,6 +153,10 @@ export function FileExplorer({
 
 	const handleExportNZB = (path: string, filename: string) => {
 		exportNZB({ path, filename });
+	};
+
+	const handleRegenerateSymlink = (path: string) => {
+		regenerateSymlinks.mutate([path]);
 	};
 
 	const handleFileInfo = (path: string) => {
@@ -409,9 +414,11 @@ export function FileExplorer({
 								onInfo={handleFileInfo}
 								onExportNZB={handleExportNZB}
 								onPreview={preview.openPreview}
+								onRegenerateSymlink={handleRegenerateSymlink}
 								isDownloading={isDownloading}
 								isDeleting={isDeleting}
 								isExportingNZB={isExportingNZB}
+								isRegenerateSymlinkPending={regenerateSymlinks.isPending}
 							/>
 						)
 					) : null}

--- a/frontend/src/components/files/FileList.tsx
+++ b/frontend/src/components/files/FileList.tsx
@@ -15,9 +15,11 @@ interface FileListProps {
 	onInfo: (path: string) => void;
 	onExportNZB?: (path: string, filename: string) => void;
 	onPreview?: (file: WebDAVFile, currentPath: string) => void;
+	onRegenerateSymlink?: (path: string) => void;
 	isDownloading?: boolean;
 	isDeleting?: boolean;
 	isExportingNZB?: boolean;
+	isRegenerateSymlinkPending?: boolean;
 }
 
 // Virtual scrolling constants - Responsive heights for better mobile UX
@@ -49,9 +51,11 @@ export function FileList({
 	onInfo,
 	onExportNZB,
 	onPreview,
+	onRegenerateSymlink,
 	isDownloading = false,
 	isDeleting = false,
 	isExportingNZB = false,
+	isRegenerateSymlinkPending = false,
 }: FileListProps) {
 	const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
 	const [scrollTop, setScrollTop] = useState(0);
@@ -195,7 +199,9 @@ export function FileList({
 						formatFileSize={formatFileSize}
 						handleItemClick={handleItemClick}
 						onExportNZB={onExportNZB}
+						onRegenerateSymlink={onRegenerateSymlink}
 						isExportingNZB={isExportingNZB}
+						isRegenerateSymlinkPending={isRegenerateSymlinkPending}
 					/>
 				))}
 			</div>
@@ -238,8 +244,12 @@ export function FileList({
 								onDelete={onDelete}
 								onInfo={onInfo}
 								onPreview={onPreview}
+								onExportNZB={onExportNZB}
+								onRegenerateSymlink={onRegenerateSymlink}
 								isDownloading={isDownloading}
 								isDeleting={isDeleting}
+								isExportingNZB={isExportingNZB}
+								isRegenerateSymlinkPending={isRegenerateSymlinkPending}
 								getFileIcon={getFileIcon}
 								formatFileSize={formatFileSize}
 								handleItemClick={handleItemClick}
@@ -267,7 +277,9 @@ interface FileCardProps {
 	formatFileSize: (bytes: number) => string;
 	handleItemClick: (file: WebDAVFile) => void;
 	onExportNZB?: (path: string, filename: string) => void;
+	onRegenerateSymlink?: (path: string) => void;
 	isExportingNZB?: boolean;
+	isRegenerateSymlinkPending?: boolean;
 	itemHeight?: number;
 }
 
@@ -284,7 +296,9 @@ function FileCard({
 	formatFileSize,
 	handleItemClick,
 	onExportNZB,
+	onRegenerateSymlink,
 	isExportingNZB,
+	isRegenerateSymlinkPending,
 	itemHeight = 200,
 }: FileCardProps) {
 	return (
@@ -337,9 +351,11 @@ function FileCard({
 						onInfo={onInfo}
 						onExportNZB={onExportNZB}
 						onPreview={onPreview}
+						onRegenerateSymlink={onRegenerateSymlink}
 						isDownloading={isDownloading}
 						isDeleting={isDeleting}
 						isExportingNZB={isExportingNZB}
+						isRegenerateSymlinkPending={isRegenerateSymlinkPending}
 					/>
 				</div>
 

--- a/frontend/src/components/queue/QueueItemCard.tsx
+++ b/frontend/src/components/queue/QueueItemCard.tsx
@@ -5,6 +5,7 @@ import {
 	ChevronUp,
 	Download,
 	FileCode,
+	Link2,
 	MoreVertical,
 	PlayCircle,
 	Trash2,
@@ -24,9 +25,11 @@ interface QueueItemCardProps {
 	onCancel: (id: number) => void;
 	onDelete: (id: number) => void;
 	onDownload: (id: number) => void;
+	onRegenerateSymlink?: (storagePath: string) => void;
 	isRetryPending: boolean;
 	isCancelPending: boolean;
 	isDeletePending: boolean;
+	isRegenerateSymlinkPending?: boolean;
 }
 
 export const QueueItemCard = memo(function QueueItemCard({
@@ -37,9 +40,11 @@ export const QueueItemCard = memo(function QueueItemCard({
 	onCancel,
 	onDelete,
 	onDownload,
+	onRegenerateSymlink,
 	isRetryPending,
 	isCancelPending,
 	isDeletePending,
+	isRegenerateSymlinkPending,
 }: QueueItemCardProps) {
 	const [isExpanded, setIsExpanded] = useState(false);
 
@@ -126,6 +131,20 @@ export const QueueItemCard = memo(function QueueItemCard({
 									Download NZB
 								</button>
 							</li>
+							{item.status === QueueStatus.COMPLETED &&
+								item.storage_path &&
+								onRegenerateSymlink && (
+									<li>
+										<button
+											type="button"
+											onClick={() => onRegenerateSymlink(item.storage_path as string)}
+											disabled={isRegenerateSymlinkPending}
+										>
+											<Link2 className="h-4 w-4 text-primary" />
+											Regenerate Symlink
+										</button>
+									</li>
+								)}
 							<div className="divider my-1 text-base-content/70" />
 							{item.status !== QueueStatus.PROCESSING && (
 								<li>

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -13,6 +13,7 @@ import {
 	FileCode,
 	Filter,
 	Import,
+	Link2,
 	List,
 	MoreVertical,
 	PlayCircle,
@@ -43,6 +44,7 @@ import {
 	useDeleteQueueItem,
 	useQueue,
 	useQueueStats,
+	useRegenerateSymlinks,
 	useRestartBulkQueueItems,
 	useRetryQueueItem,
 	useUpdateQueueItemPriority,
@@ -123,6 +125,7 @@ export function QueuePage() {
 	const clearFailed = useClearFailedQueue();
 	const clearPending = useClearPendingQueue();
 	const addTestQueueItem = useAddTestQueueItem();
+	const regenerateSymlinks = useRegenerateSymlinks();
 	const { confirmDelete, confirmAction } = useConfirm();
 
 	const handleDelete = useCallback(
@@ -180,6 +183,24 @@ export function QueuePage() {
 			console.error("Failed to download NZB:", error);
 		}
 	};
+
+	const handleRegenerateSymlink = useCallback(
+		async (storagePath: string) => {
+			const confirmed = await confirmAction(
+				"Regenerate Symlink",
+				"Are you sure you want to regenerate the symlink for this item? This will recreate the library file link.",
+				{
+					type: "info",
+					confirmText: "Regenerate",
+					confirmButtonClass: "btn-primary",
+				},
+			);
+			if (confirmed) {
+				await regenerateSymlinks.mutateAsync([storagePath]);
+			}
+		},
+		[confirmAction, regenerateSymlinks],
+	);
 
 	const handleSetPriority = async (id: number, priority: 1 | 2 | 3) => {
 		await updatePriority.mutateAsync({ id, priority });
@@ -518,7 +539,7 @@ export function QueuePage() {
 										Search
 									</h3>
 									<div className="relative">
-										<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-3.5 w-3.5 text-base-content/60" />
+										<Search className="absolute top-1/2 left-3 h-3.5 w-3.5 -translate-y-1/2 text-base-content/60" />
 										<input
 											type="text"
 											placeholder="Find item..."
@@ -616,9 +637,11 @@ export function QueuePage() {
 														onCancel={handleCancel}
 														onDelete={handleDelete}
 														onDownload={handleDownload}
+														onRegenerateSymlink={handleRegenerateSymlink}
 														isRetryPending={retryItem.isPending}
 														isCancelPending={cancelItem.isPending}
 														isDeletePending={deleteItem.isPending}
+														isRegenerateSymlinkPending={regenerateSymlinks.isPending}
 													/>
 												))}
 											</div>
@@ -885,6 +908,21 @@ export function QueuePage() {
 																					Download NZB
 																				</button>
 																			</li>
+																			{item.status === QueueStatus.COMPLETED &&
+																				item.storage_path && (
+																					<li>
+																						<button
+																							type="button"
+																							onClick={() =>
+																								handleRegenerateSymlink(item.storage_path as string)
+																							}
+																							disabled={regenerateSymlinks.isPending}
+																						>
+																							<Link2 className="h-4 w-4 text-primary" />
+																							Regenerate Symlink
+																						</button>
+																					</li>
+																				)}
 																			<div className="divider my-1 text-base-content/70" />
 																			{item.status !== QueueStatus.PROCESSING && (
 																				<li>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -49,6 +49,7 @@ export interface QueueItem {
 	file_size?: number;
 	percentage?: number; // Progress percentage (0-100), only present for items being processed
 	stage?: string; // Human-readable stage label (e.g. "Validating segments"), injected client-side from live progress
+	storage_path?: string; // Internal FUSE mount path (populated after completion)
 }
 
 export interface ProgressUpdate {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -343,7 +343,8 @@ type QueueItemResponse struct {
 	BatchID      *string                `json:"batch_id"`
 	Metadata     *string                `json:"metadata"`
 	FileSize     *int64                 `json:"file_size"`
-	Percentage   *int                   `json:"percentage,omitempty"` // Progress percentage (0-100), only for items being processed
+	Percentage   *int                   `json:"percentage,omitempty"`    // Progress percentage (0-100), only for items being processed
+	StoragePath  *string                `json:"storage_path,omitempty"` // Internal FUSE mount path (populated after completion)
 }
 
 // QueueListRequest represents request parameters for listing queue items
@@ -604,6 +605,7 @@ func ToQueueItemResponse(item *database.ImportQueueItem) *QueueItemResponse {
 		BatchID:      item.BatchID,
 		Metadata:     item.Metadata,
 		FileSize:     item.FileSize,
+		StoragePath:  item.StoragePath,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Expose `storage_path` field in the queue item API response (`QueueItemResponse` in Go, `QueueItem` type in TypeScript)
- Add "Regenerate Symlink" action button to completed queue items in both desktop table and mobile card views on the Queue page
- Add "Regenerate Symlink" action to file context menus in the File Explorer (all view modes: grid, virtual scroll, and detail card)
- Reuses the existing `/health/regenerate-symlinks` endpoint and `useRegenerateSymlinks` hook — no new backend endpoints needed

## Test plan

- [ ] Complete a queue item and verify "Regenerate Symlink" appears in the action dropdown (desktop + mobile)
- [ ] Verify the button only appears for completed items that have a `storage_path`
- [ ] Click regenerate and confirm the symlink is recreated via the confirmation dialog
- [ ] Verify "Regenerate Symlink" appears in file explorer context menus for files
- [ ] Run `go build ./...` — passes
- [ ] Run `bun x tsc --noEmit` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)