### PR TITLE
feat: add rename_to_nzb_name and filter_sample_files import config toggles

### DIFF
--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -240,6 +240,48 @@ export function ImportConfigSection({
 								</span>
 							</div>
 						</label>
+
+						<div className="divider text-base-content/70" />
+
+						<label className="label cursor-pointer items-start justify-start gap-4">
+							<input
+								type="checkbox"
+								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
+								checked={formData.rename_to_nzb_name ?? true}
+								disabled={isReadOnly}
+								onChange={(e) => handleInputChange("rename_to_nzb_name", e.target.checked)}
+							/>
+							<div className="min-w-0 flex-1">
+								<span className="block whitespace-normal break-words font-bold text-xs">
+									Rename to NZB Name
+								</span>
+								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
+									When an import produces a single file, rename it using the NZB release name
+									instead of the original (often obfuscated) filename.
+								</span>
+							</div>
+						</label>
+
+						<div className="divider text-base-content/70" />
+
+						<label className="label cursor-pointer items-start justify-start gap-4">
+							<input
+								type="checkbox"
+								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
+								checked={formData.filter_sample_files ?? true}
+								disabled={isReadOnly}
+								onChange={(e) => handleInputChange("filter_sample_files", e.target.checked)}
+							/>
+							<div className="min-w-0 flex-1">
+								<span className="block whitespace-normal break-words font-bold text-xs">
+									Filter Sample Files
+								</span>
+								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
+									Automatically reject files that appear to be samples or proofs (e.g.,
+									movie.sample.mkv). Files larger than 200MB are never filtered.
+								</span>
+							</div>
+						</label>
 					</div>
 				</div>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -225,6 +225,8 @@ export interface ImportConfig {
 	watch_dir?: string | null;
 	watch_interval_seconds?: number | null;
 	allow_nested_rar_extraction?: boolean;
+	rename_to_nzb_name?: boolean;
+	filter_sample_files?: boolean;
 	failed_item_retention_hours?: number | null;
 }
 
@@ -419,6 +421,8 @@ export interface ImportUpdateRequest {
 	watch_dir?: string | null;
 	watch_interval_seconds?: number | null;
 	allow_nested_rar_extraction?: boolean;
+	rename_to_nzb_name?: boolean;
+	filter_sample_files?: boolean;
 }
 
 // Log update request

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -130,6 +130,8 @@ type ImportAPIResponse struct {
 
 	WatchIntervalSeconds     *int  `json:"watch_interval_seconds,omitempty"`
 	AllowNestedRarExtraction *bool `json:"allow_nested_rar_extraction,omitempty"`
+	RenameToNzbName          *bool `json:"rename_to_nzb_name,omitempty"`
+	FilterSampleFiles        *bool `json:"filter_sample_files,omitempty"`
 }
 
 // SABnzbdAPIResponse sanitizes SABnzbd config for API responses
@@ -281,6 +283,8 @@ func ToImportAPIResponse(importConfig config.ImportConfig) ImportAPIResponse {
 
 		WatchIntervalSeconds:     importConfig.WatchIntervalSeconds,
 		AllowNestedRarExtraction: importConfig.AllowNestedRarExtraction,
+		RenameToNzbName:          importConfig.RenameToNzbName,
+		FilterSampleFiles:        importConfig.FilterSampleFiles,
 	}
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -264,6 +264,8 @@ type ImportConfig struct {
 	WatchIntervalSeconds           *int           `yaml:"watch_interval_seconds" mapstructure:"watch_interval_seconds" json:"watch_interval_seconds,omitempty"`
 	AllowNestedRarExtraction       *bool          `yaml:"allow_nested_rar_extraction" mapstructure:"allow_nested_rar_extraction" json:"allow_nested_rar_extraction,omitempty"`
 	ExpandBlurayIso                *bool          `yaml:"expand_bluray_iso" mapstructure:"expand_bluray_iso" json:"expand_bluray_iso,omitempty"`
+	RenameToNzbName                *bool          `yaml:"rename_to_nzb_name" mapstructure:"rename_to_nzb_name" json:"rename_to_nzb_name,omitempty"`
+	FilterSampleFiles              *bool          `yaml:"filter_sample_files" mapstructure:"filter_sample_files" json:"filter_sample_files,omitempty"`
 	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 }
 

--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -159,15 +159,15 @@ func newErrNoAllowedFiles(rarContents []Content, allowedExtensions []string) err
 
 // hasAllowedFiles checks if any files within RAR archive contents match allowed extensions
 // If allowedExtensions is empty, all file types are allowed
-func hasAllowedFiles(rarContents []Content, allowedExtensions []string) bool {
+func hasAllowedFiles(rarContents []Content, allowedExtensions []string, filterSamples bool) bool {
 	for _, content := range rarContents {
 		// Skip directories
 		if content.IsDirectory {
 			continue
 		}
 		// Check both the internal path and filename
-		if utils.IsAllowedFile(content.InternalPath, content.Size, allowedExtensions) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedExtensions) {
+		if utils.IsAllowedFile(content.InternalPath, content.Size, allowedExtensions, filterSamples) ||
+			utils.IsAllowedFile(content.Filename, content.Size, allowedExtensions, filterSamples) {
 			return true
 		}
 	}
@@ -196,6 +196,7 @@ func ProcessArchive(
 	maxPrefetch int,
 	readTimeout time.Duration,
 	expandBlurayIso bool,
+	filterSamples bool,
 ) error {
 	if len(archiveFiles) == 0 {
 		return nil
@@ -243,7 +244,7 @@ func ProcessArchive(
 	}
 
 	// Validate file extensions before processing
-	if !hasAllowedFiles(rarContents, allowedFileExtensions) {
+	if !hasAllowedFiles(rarContents, allowedFileExtensions, filterSamples) {
 		err := newErrNoAllowedFiles(rarContents, allowedFileExtensions)
 		slog.WarnContext(ctx, "RAR archive contains no files with allowed extensions", "error", err)
 		return err
@@ -267,8 +268,8 @@ func ProcessArchive(
 	// Only do this if there's exactly one media file in the archive
 	mediaFilesCount := 0
 	for _, content := range rarContents {
-		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions)) {
+		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions, filterSamples) ||
+			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions, filterSamples)) {
 			mediaFilesCount++
 		}
 	}
@@ -296,8 +297,8 @@ func ProcessArchive(
 		baseFilename := filepath.Base(normalizedInternalPath)
 
 		// Double check if this specific file is allowed
-		if !utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions) &&
-			!utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions) {
+		if !utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions, filterSamples) &&
+			!utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions, filterSamples) {
 			continue
 		}
 
@@ -315,8 +316,8 @@ func ProcessArchive(
 			slog.InfoContext(ctx, "Renaming ISO-expanded file using NZB release name",
 				"original", rarContent.Filename,
 				"renamed", baseFilename)
-		} else if shouldNormalizeName && (utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions) ||
-			utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions)) {
+		} else if shouldNormalizeName && (utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions, filterSamples) ||
+			utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions, filterSamples)) {
 			// Normalize filename to match NZB if it's the only media file (non-ISO archives)
 			baseFilename = normalizeArchiveReleaseFilename(nzbName, baseFilename)
 			slog.InfoContext(ctx, "Normalizing obfuscated filename in RAR archive",

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -157,15 +157,15 @@ func newErrNoAllowedFiles(sevenZipContents []Content, allowedExtensions []string
 
 // hasAllowedFiles checks if any files within 7zip archive contents match allowed extensions
 // If allowedExtensions is empty, all file types are allowed
-func hasAllowedFiles(sevenZipContents []Content, allowedExtensions []string) bool {
+func hasAllowedFiles(sevenZipContents []Content, allowedExtensions []string, filterSamples bool) bool {
 	for _, content := range sevenZipContents {
 		// Skip directories
 		if content.IsDirectory {
 			continue
 		}
 		// Check both the internal path and filename
-		if utils.IsAllowedFile(content.InternalPath, content.Size, allowedExtensions) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedExtensions) {
+		if utils.IsAllowedFile(content.InternalPath, content.Size, allowedExtensions, filterSamples) ||
+			utils.IsAllowedFile(content.Filename, content.Size, allowedExtensions, filterSamples) {
 			return true
 		}
 	}
@@ -194,6 +194,7 @@ func ProcessArchive(
 	maxPrefetch int,
 	readTimeout time.Duration,
 	expandBlurayIso bool,
+	filterSamples bool,
 ) error {
 	if len(archiveFiles) == 0 {
 		return nil
@@ -220,7 +221,7 @@ func ProcessArchive(
 	}
 
 	// Validate file extensions before processing
-	if !hasAllowedFiles(sevenZipContents, allowedFileExtensions) {
+	if !hasAllowedFiles(sevenZipContents, allowedFileExtensions, filterSamples) {
 		err := newErrNoAllowedFiles(sevenZipContents, allowedFileExtensions)
 		slog.WarnContext(ctx, "7zip archive contains no files with allowed extensions", "error", err)
 		return err
@@ -244,8 +245,8 @@ func ProcessArchive(
 	// Only do this if there's exactly one media file in the archive
 	mediaFilesCount := 0
 	for _, content := range sevenZipContents {
-		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions) ||
-			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions)) {
+		if !content.IsDirectory && (utils.IsAllowedFile(content.InternalPath, content.Size, allowedFileExtensions, filterSamples) ||
+			utils.IsAllowedFile(content.Filename, content.Size, allowedFileExtensions, filterSamples)) {
 			mediaFilesCount++
 		}
 	}
@@ -273,8 +274,8 @@ func ProcessArchive(
 		baseFilename := filepath.Base(normalizedInternalPath)
 
 		// Double check if this specific file is allowed
-		if !utils.IsAllowedFile(sevenZipContent.InternalPath, sevenZipContent.Size, allowedFileExtensions) &&
-			!utils.IsAllowedFile(sevenZipContent.Filename, sevenZipContent.Size, allowedFileExtensions) {
+		if !utils.IsAllowedFile(sevenZipContent.InternalPath, sevenZipContent.Size, allowedFileExtensions, filterSamples) &&
+			!utils.IsAllowedFile(sevenZipContent.Filename, sevenZipContent.Size, allowedFileExtensions, filterSamples) {
 			continue
 		}
 
@@ -292,8 +293,8 @@ func ProcessArchive(
 			slog.InfoContext(ctx, "Renaming ISO-expanded file using NZB release name",
 				"original", sevenZipContent.Filename,
 				"renamed", baseFilename)
-		} else if shouldNormalizeName && (utils.IsAllowedFile(sevenZipContent.InternalPath, sevenZipContent.Size, allowedFileExtensions) ||
-			utils.IsAllowedFile(sevenZipContent.Filename, sevenZipContent.Size, allowedFileExtensions)) {
+		} else if shouldNormalizeName && (utils.IsAllowedFile(sevenZipContent.InternalPath, sevenZipContent.Size, allowedFileExtensions, filterSamples) ||
+			utils.IsAllowedFile(sevenZipContent.Filename, sevenZipContent.Size, allowedFileExtensions, filterSamples)) {
 			// Normalize filename to match NZB if it's the only media file (non-ISO archives)
 			baseFilename = normalizeArchiveReleaseFilename(nzbName, baseFilename)
 			slog.InfoContext(ctx, "Normalizing obfuscated filename in 7zip archive",

--- a/internal/importer/multifile/processor.go
+++ b/internal/importer/multifile/processor.go
@@ -41,12 +41,13 @@ func ProcessRegularFiles(
 	allowedFileExtensions []string,
 	timeout time.Duration,
 	tracker *progress.Tracker,
+	filterSamples bool,
 ) ([]string, error) {
 	if len(files) == 0 {
 		return nil, nil
 	}
 
-	if !utils.HasAllowedFilesInRegular(files, allowedFileExtensions) {
+	if !utils.HasAllowedFilesInRegular(files, allowedFileExtensions, filterSamples) {
 		slog.WarnContext(ctx, "No files with allowed extensions found",
 			"allowed_extensions", allowedFileExtensions,
 			"file_count", len(files))
@@ -101,7 +102,7 @@ func ProcessRegularFiles(
 				}
 			}
 
-			if !utils.IsAllowedFile(filename, file.Size, allowedFileExtensions) {
+			if !utils.IsAllowedFile(filename, file.Size, allowedFileExtensions, filterSamples) {
 				return nil
 			}
 

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -46,6 +46,8 @@ type Processor struct {
 	readTimeout             time.Duration // Read timeout for Usenet data (used by ISO reader)
 	allowedFileExtensions   []string
 	expandBlurayIso         bool // Whether to expand Bluray ISO files inside archives
+	renameToNzbName         bool // Whether to rename single-file imports to the NZB release name
+	filterSampleFiles       bool // Whether to filter out sample/proof files during import
 	log                     *slog.Logger
 	broadcaster             *progress.ProgressBroadcaster // WebSocket progress broadcaster
 	recorder                HistoryRecorder
@@ -56,7 +58,7 @@ type Processor struct {
 }
 
 // NewProcessor creates a new NZB processor using metadata storage
-func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Manager, maxImportConnections int, segmentSamplePercentage int, allowedFileExtensions []string, maxDownloadPrefetch int, readTimeout time.Duration, broadcaster *progress.ProgressBroadcaster, configGetter config.ConfigGetter, recorder HistoryRecorder, allowNestedRarExtraction bool, expandBlurayIso bool) *Processor {
+func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Manager, maxImportConnections int, segmentSamplePercentage int, allowedFileExtensions []string, maxDownloadPrefetch int, readTimeout time.Duration, broadcaster *progress.ProgressBroadcaster, configGetter config.ConfigGetter, recorder HistoryRecorder, allowNestedRarExtraction bool, expandBlurayIso bool, renameToNzbName bool, filterSampleFiles bool) *Processor {
 	return &Processor{
 		parser:                  parser.NewParser(poolManager),
 		strmParser:              parser.NewStrmParser(),
@@ -72,6 +74,8 @@ func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Ma
 		readTimeout:             readTimeout,
 		allowedFileExtensions:   allowedFileExtensions,
 		expandBlurayIso:         expandBlurayIso,
+		renameToNzbName:         renameToNzbName,
+		filterSampleFiles:       filterSampleFiles,
 		log:                     slog.Default().With("component", "nzb-processor"),
 		broadcaster:             broadcaster,
 		recorder:                recorder,
@@ -352,12 +356,14 @@ func (proc *Processor) processSingleFile(
 
 	// Rename the file to match the NZB name to handle obfuscated filenames
 	// Keep NZB-provided subfolders but rename the leaf to the release name (preventing duplicate extensions)
-	originalDir := filepath.Dir(regularFiles[0].Filename)
-	normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
-	if originalDir != "." && originalDir != "" {
-		regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
-	} else {
-		regularFiles[0].Filename = normalizedBase
+	if proc.renameToNzbName {
+		originalDir := filepath.Dir(regularFiles[0].Filename)
+		normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
+		if originalDir != "." && originalDir != "" {
+			regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
+		} else {
+			regularFiles[0].Filename = normalizedBase
+		}
 	}
 
 	// Compute final parent/name, flattening only redundant nesting like file.mkv/file.mkv
@@ -395,6 +401,7 @@ func (proc *Processor) processSingleFile(
 		allowedExtensions,
 		timeout,
 		fileTracker,
+		proc.filterSampleFiles,
 	)
 	var writtenPaths []string
 	if writtenPath != "" {
@@ -447,12 +454,14 @@ func (proc *Processor) processMultiFile(
 
 	if singleLike {
 		// Rename the leaf to the release name (prevents ext duplication) but keep NZB-provided subfolders.
-		originalDir := filepath.Dir(regularFiles[0].Filename)
-		normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
-		if originalDir != "." && originalDir != "" {
-			regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
-		} else {
-			regularFiles[0].Filename = normalizedBase
+		if proc.renameToNzbName {
+			originalDir := filepath.Dir(regularFiles[0].Filename)
+			normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
+			if originalDir != "." && originalDir != "" {
+				regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
+			} else {
+				regularFiles[0].Filename = normalizedBase
+			}
 		}
 
 		// Avoid nesting like /Season 02/<release>/<release>.mkv; drop the NZB-named folder here.
@@ -498,6 +507,7 @@ func (proc *Processor) processMultiFile(
 		allowedExtensions,
 		timeout,
 		fileTracker,
+		proc.filterSampleFiles,
 	)
 	if err != nil {
 		return "", writtenPaths, err
@@ -571,6 +581,7 @@ func (proc *Processor) processRarArchive(
 			allowedExtensions,
 			proc.validationTimeout,
 			nil, // No progress tracker for pre-archive regular files
+			proc.filterSampleFiles,
 		); err != nil {
 			slog.DebugContext(ctx, "Failed to process regular files", "error", err)
 		}
@@ -609,6 +620,7 @@ func (proc *Processor) processRarArchive(
 			proc.maxDownloadPrefetch,
 			proc.readTimeout,
 			proc.expandBlurayIso,
+			proc.filterSampleFiles,
 		)
 		if err != nil {
 			return nzbFolder, writtenPaths, err
@@ -685,6 +697,7 @@ func (proc *Processor) processSevenZipArchive(
 			allowedExtensions,
 			proc.validationTimeout,
 			nil, // No progress tracker for pre-archive regular files
+			proc.filterSampleFiles,
 		); err != nil {
 			slog.DebugContext(ctx, "Failed to process regular files", "error", err)
 		}
@@ -722,6 +735,7 @@ func (proc *Processor) processSevenZipArchive(
 			proc.maxDownloadPrefetch,
 			proc.readTimeout,
 			proc.expandBlurayIso,
+			proc.filterSampleFiles,
 		)
 		if err != nil {
 			return nzbFolder, writtenPaths, err

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -208,9 +208,17 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 	if currentConfig.Import.ExpandBlurayIso != nil {
 		expandBlurayIso = *currentConfig.Import.ExpandBlurayIso
 	}
+	renameToNzbName := true
+	if currentConfig.Import.RenameToNzbName != nil {
+		renameToNzbName = *currentConfig.Import.RenameToNzbName
+	}
+	filterSampleFiles := true
+	if currentConfig.Import.FilterSampleFiles != nil {
+		filterSampleFiles = *currentConfig.Import.FilterSampleFiles
+	}
 
 	// Create processor with poolManager for dynamic pool access
-	processor := NewProcessor(metadataService, poolManager, maxImportConnections, segmentSamplePercentage, allowedFileExtensions, maxDownloadPrefetch, readTimeout, broadcaster, configGetter, nil, allowNestedRarExtraction, expandBlurayIso)
+	processor := NewProcessor(metadataService, poolManager, maxImportConnections, segmentSamplePercentage, allowedFileExtensions, maxDownloadPrefetch, readTimeout, broadcaster, configGetter, nil, allowNestedRarExtraction, expandBlurayIso, renameToNzbName, filterSampleFiles)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/internal/importer/singlefile/processor.go
+++ b/internal/importer/singlefile/processor.go
@@ -33,9 +33,10 @@ func ProcessSingleFile(
 	allowedFileExtensions []string,
 	timeout time.Duration,
 	tracker *progress.Tracker,
+	filterSamples bool,
 ) (string, string, error) {
 	// Validate file extension before processing
-	if !utils.HasAllowedFilesInRegular([]parser.ParsedFile{file}, allowedFileExtensions) {
+	if !utils.HasAllowedFilesInRegular([]parser.ParsedFile{file}, allowedFileExtensions, filterSamples) {
 		slog.WarnContext(ctx, "File does not match allowed extensions",
 			"filename", file.Filename,
 			"allowed_extensions", allowedFileExtensions)
@@ -57,7 +58,7 @@ func ProcessSingleFile(
 	}
 
 	// Double check if this specific file is allowed
-	if !utils.IsAllowedFile(file.Filename, file.Size, allowedFileExtensions) {
+	if !utils.IsAllowedFile(file.Filename, file.Size, allowedFileExtensions, filterSamples) {
 		return "", "", fmt.Errorf("file '%s' is not allowed", file.Filename)
 	}
 

--- a/internal/importer/utils/file_validation.go
+++ b/internal/importer/utils/file_validation.go
@@ -47,7 +47,7 @@ var whitelistedExtensions = map[string]bool{
 // IsAllowedFile checks if a filename has an allowed extension
 // If allowedExtensions is empty, all files are allowed
 // size is used to prevent false positives for sample/proof checks on large files
-func IsAllowedFile(filename string, size int64, allowedExtensions []string) bool {
+func IsAllowedFile(filename string, size int64, allowedExtensions []string, filterSamples bool) bool {
 	if filename == "" {
 		return false
 	}
@@ -66,7 +66,7 @@ func IsAllowedFile(filename string, size int64, allowedExtensions []string) bool
 	}
 
 	// Check if file is a sample or proof
-	if isSampleOrProof(filename, size) {
+	if filterSamples && isSampleOrProof(filename, size) {
 		return false
 	}
 
@@ -82,9 +82,9 @@ func IsAllowedFile(filename string, size int64, allowedExtensions []string) bool
 
 // HasAllowedFilesInRegular checks if any regular (non-archive) files match allowed extensions
 // If allowedExtensions is empty, all file types are allowed
-func HasAllowedFilesInRegular(regularFiles []parser.ParsedFile, allowedExtensions []string) bool {
+func HasAllowedFilesInRegular(regularFiles []parser.ParsedFile, allowedExtensions []string, filterSamples bool) bool {
 	for _, file := range regularFiles {
-		if IsAllowedFile(file.Filename, file.Size, allowedExtensions) {
+		if IsAllowedFile(file.Filename, file.Size, allowedExtensions, filterSamples) {
 			return true
 		}
 	}

--- a/internal/importer/utils/file_validation_test.go
+++ b/internal/importer/utils/file_validation_test.go
@@ -76,7 +76,7 @@ func TestIsAllowedFile_EmptyExtensions(t *testing.T) {
 			if tt.name == "large file with sample name is allowed" {
 				size = 201 * 1024 * 1024 // > 200MB
 			}
-			result := IsAllowedFile(tt.filename, size, []string{})
+			result := IsAllowedFile(tt.filename, size, []string{}, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -139,7 +139,7 @@ func TestIsAllowedFile_WithExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsAllowedFile(tt.filename, 0, allowedExts)
+			result := IsAllowedFile(tt.filename, 0, allowedExts, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -184,7 +184,7 @@ func TestHasAllowedFilesInRegular_EmptyExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := HasAllowedFilesInRegular(tt.files, []string{})
+			result := HasAllowedFilesInRegular(tt.files, []string{}, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -243,7 +243,7 @@ func TestHasAllowedFilesInRegular_WithExtensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := HasAllowedFilesInRegular(tt.files, tt.allowed)
+			result := HasAllowedFilesInRegular(tt.files, tt.allowed, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -354,7 +354,7 @@ func TestIsAllowedFile_SampleProofPatterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsAllowedFile(tt.filename, 0, []string{})
+			result := IsAllowedFile(tt.filename, 0, []string{}, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -389,7 +389,7 @@ func TestIsAllowedFile_MixedDotFormats(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := IsAllowedFile(tt.filename, 0, tt.allowed)
+			result := IsAllowedFile(tt.filename, 0, tt.allowed, true)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary

- **rename_to_nzb_name** (default: enabled): When an import produces a single file, rename it using the NZB release name instead of the original (often obfuscated) filename. Disable to keep original filenames.
- **filter_sample_files** (default: enabled): Automatically reject files that match sample/proof patterns (e.g., `movie.sample.mkv`). Files larger than 200MB are never filtered. Disable to import sample files normally.

Both options use `*bool` with nil-defaults-to-true for backward compatibility. UI toggles added to the Validation section of the Import config page.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/importer/...` — all tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify toggles appear in UI and save correctly via PATCH /api/config/import
- [ ] Test with rename disabled: single-file import keeps original filename
- [ ] Test with filter disabled: sample files are imported instead of rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)