### PR TITLE
refactor: deduplicate shared types between rar and sevenzip packages

### DIFF
--- a/internal/importer/archive/common.go
+++ b/internal/importer/archive/common.go
@@ -1,5 +1,14 @@
 package archive
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
 // ParseInt safely converts string to int
 func ParseInt(s string) int {
 	num := 0
@@ -11,4 +20,119 @@ func ParseInt(s string) int {
 		}
 	}
 	return num
+}
+
+// HasExtension checks if a filename has an extension
+func HasExtension(filename string) bool {
+	return filepath.Ext(filename) != ""
+}
+
+var (
+	// ErrNoAllowedFiles indicates that the archive contains no files matching allowed extensions
+	ErrNoAllowedFiles = errors.New("archive contains no files with allowed extensions")
+	// ErrNoFilesProcessed indicates that no files were successfully processed (all files failed validation)
+	ErrNoFilesProcessed = errors.New("no files were successfully processed (all files failed validation)")
+)
+
+// NestedSource represents one inner archive volume's contribution to a nested file.
+// Used when a file is inside an inner archive that is itself inside an outer archive.
+type NestedSource struct {
+	Segments        []*metapb.SegmentData // Outer archive segments covering this inner volume
+	AesKey          []byte                // Outer AES key (empty if unencrypted)
+	AesIV           []byte                // Outer AES IV
+	InnerOffset     int64                 // Offset within decrypted inner volume where file data starts
+	InnerLength     int64                 // Bytes of target file from this source
+	InnerVolumeSize int64                 // Total decrypted size of inner volume (for AES cipher)
+}
+
+// Content represents a file within an archive for processing
+type Content struct {
+	InternalPath  string                `json:"internal_path"`
+	Filename      string                `json:"filename"`
+	Size          int64                 `json:"size"`                     // Uncompressed size (for file metadata)
+	PackedSize    int64                 `json:"packed_size"`              // Compressed size in archive (for segment validation)
+	Segments      []*metapb.SegmentData `json:"segments"`                 // Segment data for this file
+	IsDirectory   bool                  `json:"is_directory,omitempty"`   // Indicates if this is a directory
+	AesKey        []byte                `json:"aes_key,omitempty"`        // AES encryption key (if encrypted)
+	AesIV         []byte                `json:"aes_iv,omitempty"`         // AES initialization vector (if encrypted)
+	NzbdavID      string                `json:"nzbdav_id,omitempty"`      // Original ID from nzbdav
+	NestedSources []NestedSource        `json:"nested_sources,omitempty"` // Nested archive sources (encrypted outer)
+	// ISOExpansionIndex is non-zero for files expanded from an ISO archive.
+	// It is the 1-based position of this file when all ISO files in the archive
+	// are sorted by size descending (1 = largest / main feature).
+	// Zero means this Content did not come from an ISO.
+	ISOExpansionIndex int `json:"iso_expansion_index,omitempty"`
+}
+
+// GetContentSegmentCount returns the total number of segments for a Content,
+// counting NestedSources segments for encrypted nested archive content.
+func GetContentSegmentCount(content Content) int {
+	if len(content.NestedSources) > 0 {
+		total := 0
+		for _, ns := range content.NestedSources {
+			total += len(ns.Segments)
+		}
+		return total
+	}
+	return len(content.Segments)
+}
+
+// GetContentSegments returns all segments for a Content,
+// collecting from NestedSources for encrypted nested archive content.
+func GetContentSegments(content Content) []*metapb.SegmentData {
+	if len(content.NestedSources) > 0 {
+		var all []*metapb.SegmentData
+		for _, ns := range content.NestedSources {
+			all = append(all, ns.Segments...)
+		}
+		return all
+	}
+	return content.Segments
+}
+
+// ValidateSegmentIntegrity checks if the segments provided for a file actually cover the expected size.
+// Returns an error if segment coverage is significantly lower than expected (1% shortfall threshold).
+func ValidateSegmentIntegrity(ctx context.Context, content Content) error {
+	const shortfallThresholdPercent = 1 // Fail if more than 1% of the file is missing
+
+	if len(content.NestedSources) > 0 {
+		// For nested sources, validate each source independently
+		for _, ns := range content.NestedSources {
+			var covered int64
+			for _, seg := range ns.Segments {
+				covered += (seg.EndOffset - seg.StartOffset + 1)
+			}
+
+			shortfall := ns.InnerLength - covered
+			if shortfall > 0 {
+				shortfallPercent := (shortfall * 100) / ns.InnerLength
+				if shortfallPercent >= shortfallThresholdPercent {
+					return fmt.Errorf("corrupted nested source: missing %d bytes (%d%% of part)", shortfall, shortfallPercent)
+				}
+			}
+		}
+	} else {
+		// For standard files, validate total segment coverage against PackedSize (if available)
+		var totalCovered int64
+		for _, seg := range content.Segments {
+			totalCovered += (seg.EndOffset - seg.StartOffset + 1)
+		}
+
+		expectedSize := content.PackedSize
+		if expectedSize <= 0 {
+			expectedSize = content.Size
+		}
+
+		if expectedSize > 0 {
+			shortfall := expectedSize - totalCovered
+			if shortfall > 0 {
+				shortfallPercent := (shortfall * 100) / expectedSize
+				if shortfallPercent >= shortfallThresholdPercent {
+					return fmt.Errorf("corrupted file: missing %d bytes (%d%% of total size)", shortfall, shortfallPercent)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -2,7 +2,6 @@ package rar
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/javi11/altmount/internal/encryption/aes"
+	"github.com/javi11/altmount/internal/importer/archive"
 	"github.com/javi11/altmount/internal/importer/archive/iso"
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/utils"
@@ -25,82 +25,24 @@ import (
 
 var (
 	// ErrNoAllowedFiles indicates that the archive contains no files matching allowed extensions
-	ErrNoAllowedFiles = errors.New("archive contains no files with allowed extensions")
+	ErrNoAllowedFiles = archive.ErrNoAllowedFiles
 	// ErrNoFilesProcessed indicates that no files were successfully processed (all files failed validation)
-	ErrNoFilesProcessed = errors.New("no files were successfully processed (all files failed validation)")
+	ErrNoFilesProcessed = archive.ErrNoFilesProcessed
 )
 
-// getContentSegmentCount returns the total number of segments for a Content,
-// counting NestedSources segments for encrypted nested RAR content.
+// getContentSegmentCount delegates to archive.GetContentSegmentCount.
 func getContentSegmentCount(content Content) int {
-	if len(content.NestedSources) > 0 {
-		total := 0
-		for _, ns := range content.NestedSources {
-			total += len(ns.Segments)
-		}
-		return total
-	}
-	return len(content.Segments)
+	return archive.GetContentSegmentCount(content)
 }
 
-// getContentSegments returns all segments for a Content,
-// collecting from NestedSources for encrypted nested RAR content.
+// getContentSegments delegates to archive.GetContentSegments.
 func getContentSegments(content Content) []*metapb.SegmentData {
-	if len(content.NestedSources) > 0 {
-		var all []*metapb.SegmentData
-		for _, ns := range content.NestedSources {
-			all = append(all, ns.Segments...)
-		}
-		return all
-	}
-	return content.Segments
+	return archive.GetContentSegments(content)
 }
 
-// validateSegmentIntegrity checks if the segments provided for a file actually cover the expected size.
-// Returns an error if segment coverage is significantly lower than expected (1% shortfall threshold).
+// validateSegmentIntegrity delegates to archive.ValidateSegmentIntegrity.
 func validateSegmentIntegrity(ctx context.Context, content Content) error {
-	const shortfallThresholdPercent = 1 // Fail if more than 1% of the file is missing
-
-	if len(content.NestedSources) > 0 {
-		// For nested sources, validate each source independently
-		for _, ns := range content.NestedSources {
-			var covered int64
-			for _, seg := range ns.Segments {
-				covered += (seg.EndOffset - seg.StartOffset + 1)
-			}
-
-			shortfall := ns.InnerLength - covered
-			if shortfall > 0 {
-				shortfallPercent := (shortfall * 100) / ns.InnerLength
-				if shortfallPercent >= shortfallThresholdPercent {
-					return fmt.Errorf("corrupted nested source: missing %d bytes (%d%% of part)", shortfall, shortfallPercent)
-				}
-			}
-		}
-	} else {
-		// For standard files, validate total segment coverage against PackedSize (for RARs)
-		var totalCovered int64
-		for _, seg := range content.Segments {
-			totalCovered += (seg.EndOffset - seg.StartOffset + 1)
-		}
-
-		expectedSize := content.PackedSize
-		if expectedSize <= 0 {
-			expectedSize = content.Size
-		}
-
-		if expectedSize > 0 {
-			shortfall := expectedSize - totalCovered
-			if shortfall > 0 {
-				shortfallPercent := (shortfall * 100) / expectedSize
-				if shortfallPercent >= shortfallThresholdPercent {
-					return fmt.Errorf("corrupted file: missing %d bytes (%d%% of total size)", shortfall, shortfallPercent)
-				}
-			}
-		}
-	}
-
-	return nil
+	return archive.ValidateSegmentIntegrity(ctx, content)
 }
 
 // calculateSegmentsToValidate calculates the actual number of segments that will be validated

--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -95,7 +95,7 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	// Check if ALL files have no extension - if so, we'll add .partXX.rar extensions
 	allFilesNoExt := true
 	for _, file := range rarFiles {
-		if hasExtension(file.Filename) {
+		if archive.HasExtension(file.Filename) {
 			allFilesNoExt = false
 			break
 		}
@@ -321,7 +321,7 @@ func (rh *rarProcessor) parseRarFilename(filename string) (base string, part int
 	lowerFilename := strings.ToLower(filename)
 
 	// Pattern 1: filename.part###.rar (e.g., movie.part001.rar, movie.part01.rar)
-	if matches := partPattern.FindStringSubmatch(filename); len(matches) > 2 {
+	if matches := PartPattern.FindStringSubmatch(filename); len(matches) > 2 {
 		base = matches[1]
 		if partNum := archive.ParseInt(matches[2]); partNum >= 0 {
 			// Convert 1-based part numbers to 0-based (part001 becomes 0, part002 becomes 1)
@@ -339,7 +339,7 @@ func (rh *rarProcessor) parseRarFilename(filename string) (base string, part int
 	}
 
 	// Pattern 3: filename.r## or filename.r### (e.g., movie.r00, movie.r01)
-	if matches := rPattern.FindStringSubmatch(filename); len(matches) > 2 {
+	if matches := RPattern.FindStringSubmatch(filename); len(matches) > 2 {
 		base = matches[1]
 		if partNum := archive.ParseInt(matches[2]); partNum >= 0 {
 			// .r00 is part 0, .r01 is part 1, etc.
@@ -348,7 +348,7 @@ func (rh *rarProcessor) parseRarFilename(filename string) (base string, part int
 	}
 
 	// Pattern 4: filename.### (numeric extensions like .001, .002)
-	if matches := numericPattern.FindStringSubmatch(filename); len(matches) > 2 {
+	if matches := NumericPattern.FindStringSubmatch(filename); len(matches) > 2 {
 		base = matches[1]
 		if partNum := archive.ParseInt(matches[2]); partNum >= 0 {
 			// .001 becomes part 0, .002 becomes part 1, etc.
@@ -522,7 +522,7 @@ func isRarArchiveFile(filename string) bool {
 	if strings.HasSuffix(lower, ".rar") {
 		return true
 	}
-	if rPattern.MatchString(lower) {
+	if RPattern.MatchString(lower) {
 		return true
 	}
 	return false

--- a/internal/importer/archive/rar/types.go
+++ b/internal/importer/archive/rar/types.go
@@ -3,10 +3,17 @@ package rar
 import (
 	"context"
 
+	"github.com/javi11/altmount/internal/importer/archive"
 	"github.com/javi11/altmount/internal/importer/parser"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/progress"
 )
+
+// Content is an alias for archive.Content
+type Content = archive.Content
+
+// NestedSource is an alias for archive.NestedSource
+type NestedSource = archive.NestedSource
 
 // Processor interface for analyzing RAR content from NZB data
 type Processor interface {
@@ -18,34 +25,4 @@ type Processor interface {
 	// CreateFileMetadataFromRarContent creates FileMetadata from Content for the metadata
 	// system. This is used to convert Content into the protobuf format used by the metadata system.
 	CreateFileMetadataFromRarContent(content Content, sourceNzbPath string, releaseDate int64, nzbdavId string) *metapb.FileMetadata
-}
-
-// NestedSource represents one inner RAR volume's contribution to a nested file.
-// Used when a file is inside an inner RAR that is itself inside an outer RAR.
-type NestedSource struct {
-	Segments        []*metapb.SegmentData // Outer RAR segments covering this inner volume
-	AesKey          []byte                // Outer AES key (empty if unencrypted)
-	AesIV           []byte                // Outer AES IV
-	InnerOffset     int64                 // Offset within decrypted inner volume where file data starts
-	InnerLength     int64                 // Bytes of target file from this source
-	InnerVolumeSize int64                 // Total decrypted size of inner volume (for AES cipher)
-}
-
-// Content represents a file within a RAR archive for processing
-type Content struct {
-	InternalPath  string                `json:"internal_path"`
-	Filename      string                `json:"filename"`
-	Size          int64                 `json:"size"`                     // Uncompressed size (for file metadata)
-	PackedSize    int64                 `json:"packed_size"`              // Compressed size in RAR (for segment validation)
-	Segments      []*metapb.SegmentData `json:"segments"`                 // Segment data for this file
-	IsDirectory   bool                  `json:"is_directory,omitempty"`   // Indicates if this is a directory
-	AesKey        []byte                `json:"aes_key,omitempty"`        // AES encryption key (if encrypted)
-	AesIV         []byte                `json:"aes_iv,omitempty"`         // AES initialization vector (if encrypted)
-	NzbdavID      string                `json:"nzbdav_id,omitempty"`      // Original ID from nzbdav
-	NestedSources []NestedSource        `json:"nested_sources,omitempty"` // Nested RAR sources (encrypted outer)
-	// ISOExpansionIndex is non-zero for files expanded from an ISO archive.
-	// It is the 1-based position of this file when all ISO files in the archive
-	// are sorted by size descending (1 = largest / main feature).
-	// Zero means this Content did not come from an ISO.
-	ISOExpansionIndex int `json:"iso_expansion_index,omitempty"`
 }

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -11,12 +11,12 @@ import (
 )
 
 var (
-	// filename.part###.rar (e.g., movie.part001.rar, movie.part01.rar)
-	partPattern = regexp.MustCompile(`^(.+)\.part(\d+)\.rar$`)
-	// filename.### (numeric extensions like .001, .002)
-	numericPattern = regexp.MustCompile(`^(.+)\.(\d+)$`)
-	//filename.r## or filename.r### (e.g., movie.r00, movie.r01)
-	rPattern             = regexp.MustCompile(`^(.+)\.r(\d+)$`)
+	// PartPattern matches filename.part###.rar (e.g., movie.part001.rar, movie.part01.rar)
+	PartPattern = regexp.MustCompile(`^(.+)\.part(\d+)\.rar$`)
+	// NumericPattern matches filename.### (numeric extensions like .001, .002)
+	NumericPattern = regexp.MustCompile(`^(.+)\.(\d+)$`)
+	// RPattern matches filename.r## or filename.r### (e.g., movie.r00, movie.r01)
+	RPattern             = regexp.MustCompile(`^(.+)\.r(\d+)$`)
 	partPatternNumber    = regexp.MustCompile(`\.part(\d+)\.rar$`)
 	rPatternNumber       = regexp.MustCompile(`\.r(\d+)$`)
 	numericPatternNumber = regexp.MustCompile(`\.(\d+)$`)
@@ -29,7 +29,7 @@ func extractRarBaseName(filename string) string {
 	lower := strings.ToLower(filepath.Base(filename))
 
 	// Pattern 1: filename.part###.rar
-	if m := partPattern.FindStringSubmatch(lower); len(m) > 1 {
+	if m := PartPattern.FindStringSubmatch(lower); len(m) > 1 {
 		return m[1]
 	}
 	// Pattern 2: filename.rar (single part)
@@ -37,20 +37,14 @@ func extractRarBaseName(filename string) string {
 		return before
 	}
 	// Pattern 3: filename.r##
-	if m := rPattern.FindStringSubmatch(lower); len(m) > 1 {
+	if m := RPattern.FindStringSubmatch(lower); len(m) > 1 {
 		return m[1]
 	}
 	// Pattern 4: filename.### (numeric)
-	if m := numericPattern.FindStringSubmatch(lower); len(m) > 1 {
+	if m := NumericPattern.FindStringSubmatch(lower); len(m) > 1 {
 		return m[1]
 	}
 	return lower
-}
-
-// hasExtension checks if a filename has an extension
-func hasExtension(filename string) bool {
-	ext := filepath.Ext(filename)
-	return ext != ""
 }
 
 // normalizeRarPartFilename normalizes RAR part numbers while preserving padding width
@@ -69,7 +63,7 @@ func normalizeRarPartFilename(filename string, index int, allFilesNoExt bool, to
 	// If all files have no extension, use baseFilename with .rXX extension
 	// This ensures all parts of the same archive have the same base filename
 	// Using RAR multi-volume convention: .r00, .r01, .r02, etc. (0-based)
-	if allFilesNoExt && !hasExtension(filename) && baseFilename != "" {
+	if allFilesNoExt && !archive.HasExtension(filename) && baseFilename != "" {
 		// Calculate padding width based on total number of files (0-based, so totalFiles-1)
 		width := len(strconv.Itoa(totalFiles - 1))
 		// Format with zero-padding (index is already 0-based from OriginalIndex)

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -2,7 +2,6 @@ package sevenzip
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/javi11/altmount/internal/importer/archive"
 	"github.com/javi11/altmount/internal/importer/archive/iso"
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/utils"
@@ -23,82 +23,24 @@ import (
 
 var (
 	// ErrNoAllowedFiles indicates that the archive contains no files matching allowed extensions
-	ErrNoAllowedFiles = errors.New("archive contains no files with allowed extensions")
+	ErrNoAllowedFiles = archive.ErrNoAllowedFiles
 	// ErrNoFilesProcessed indicates that no files were successfully processed (all files failed validation)
-	ErrNoFilesProcessed = errors.New("no files were successfully processed (all files failed validation)")
+	ErrNoFilesProcessed = archive.ErrNoFilesProcessed
 )
 
-// getContentSegmentCount returns the total number of segments for a Content,
-// counting NestedSources segments for encrypted nested RAR content.
+// getContentSegmentCount delegates to archive.GetContentSegmentCount.
 func getContentSegmentCount(content Content) int {
-	if len(content.NestedSources) > 0 {
-		total := 0
-		for _, ns := range content.NestedSources {
-			total += len(ns.Segments)
-		}
-		return total
-	}
-	return len(content.Segments)
+	return archive.GetContentSegmentCount(content)
 }
 
-// getContentSegments returns all segments for a Content,
-// collecting from NestedSources for encrypted nested RAR content.
+// getContentSegments delegates to archive.GetContentSegments.
 func getContentSegments(content Content) []*metapb.SegmentData {
-	if len(content.NestedSources) > 0 {
-		var all []*metapb.SegmentData
-		for _, ns := range content.NestedSources {
-			all = append(all, ns.Segments...)
-		}
-		return all
-	}
-	return content.Segments
+	return archive.GetContentSegments(content)
 }
 
-// validateSegmentIntegrity checks if the segments provided for a file actually cover the expected size.
-// Returns an error if segment coverage is significantly lower than expected (1% shortfall threshold).
+// validateSegmentIntegrity delegates to archive.ValidateSegmentIntegrity.
 func validateSegmentIntegrity(ctx context.Context, content Content) error {
-	const shortfallThresholdPercent = 1 // Fail if more than 1% of the file is missing
-
-	if len(content.NestedSources) > 0 {
-		// For nested sources, validate each source independently
-		for _, ns := range content.NestedSources {
-			var covered int64
-			for _, seg := range ns.Segments {
-				covered += (seg.EndOffset - seg.StartOffset + 1)
-			}
-
-			shortfall := ns.InnerLength - covered
-			if shortfall > 0 {
-				shortfallPercent := (shortfall * 100) / ns.InnerLength
-				if shortfallPercent >= shortfallThresholdPercent {
-					return fmt.Errorf("corrupted nested source: missing %d bytes (%d%% of part)", shortfall, shortfallPercent)
-				}
-			}
-		}
-	} else {
-		// For standard files, validate total segment coverage against PackedSize (if available)
-		var totalCovered int64
-		for _, seg := range content.Segments {
-			totalCovered += (seg.EndOffset - seg.StartOffset + 1)
-		}
-
-		expectedSize := content.PackedSize
-		if expectedSize <= 0 {
-			expectedSize = content.Size
-		}
-
-		if expectedSize > 0 {
-			shortfall := expectedSize - totalCovered
-			if shortfall > 0 {
-				shortfallPercent := (shortfall * 100) / expectedSize
-				if shortfallPercent >= shortfallThresholdPercent {
-					return fmt.Errorf("corrupted file: missing %d bytes (%d%% of total size)", shortfall, shortfallPercent)
-				}
-			}
-		}
-	}
-
-	return nil
+	return archive.ValidateSegmentIntegrity(ctx, content)
 }
 
 // calculateSegmentsToValidate calculates the actual number of segments that will be validated

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/javi11/altmount/internal/errors"
 	"github.com/javi11/altmount/internal/importer/archive"
+	"github.com/javi11/altmount/internal/importer/archive/rar"
 	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/parser"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
@@ -53,11 +54,11 @@ var (
 	sevenZipPartNumberPattern = regexp.MustCompile(`\.7z\.(\d+)$`)
 )
 
-// Pre-compiled regex patterns for nested RAR detection (duplicated from rar package since unexported)
+// RAR regex patterns imported from the rar package for nested RAR detection
 var (
-	rarPartPattern    = regexp.MustCompile(`^(.+)\.part(\d+)\.rar$`)
-	rarRPattern       = regexp.MustCompile(`^(.+)\.r(\d+)$`)
-	rarNumericPattern = regexp.MustCompile(`^(.+)\.(\d+)$`)
+	rarPartPattern    = rar.PartPattern
+	rarRPattern       = rar.RPattern
+	rarNumericPattern = rar.NumericPattern
 )
 
 // CreateFileMetadataFromSevenZipContent creates FileMetadata from SevenZipContent for the metadata system
@@ -556,7 +557,7 @@ func renameSevenZipFilesAndSort(sevenZipFiles []parser.ParsedFile) []parser.Pars
 	// Check if ALL files have no extension - if so, we'll add .XXX extensions
 	allFilesNoExt := true
 	for _, file := range sevenZipFiles {
-		if hasExtension(file.Filename) {
+		if archive.HasExtension(file.Filename) {
 			allFilesNoExt = false
 			break
 		}

--- a/internal/importer/archive/sevenzip/types.go
+++ b/internal/importer/archive/sevenzip/types.go
@@ -3,10 +3,17 @@ package sevenzip
 import (
 	"context"
 
+	"github.com/javi11/altmount/internal/importer/archive"
 	"github.com/javi11/altmount/internal/importer/parser"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/progress"
 )
+
+// Content is an alias for archive.Content
+type Content = archive.Content
+
+// NestedSource is an alias for archive.NestedSource
+type NestedSource = archive.NestedSource
 
 // Processor interface for analyzing 7zip content from NZB data
 type Processor interface {
@@ -18,34 +25,4 @@ type Processor interface {
 	// CreateFileMetadataFromSevenZipContent creates FileMetadata from Content for the metadata
 	// system. This is used to convert Content into the protobuf format used by the metadata system.
 	CreateFileMetadataFromSevenZipContent(content Content, sourceNzbPath string, releaseDate int64, nzbdavId string) *metapb.FileMetadata
-}
-
-// NestedSource represents one inner RAR volume's contribution to a nested file.
-// Used when a file is inside an inner RAR that is itself inside an outer 7zip.
-type NestedSource struct {
-	Segments        []*metapb.SegmentData // Outer 7zip segments covering this inner volume
-	AesKey          []byte                // Outer AES key (empty if unencrypted)
-	AesIV           []byte                // Outer AES IV
-	InnerOffset     int64                 // Offset within decrypted inner volume where file data starts
-	InnerLength     int64                 // Bytes of target file from this source
-	InnerVolumeSize int64                 // Total decrypted size of inner volume (for AES cipher)
-}
-
-// Content represents a file within a 7zip archive for processing
-type Content struct {
-	InternalPath  string                `json:"internal_path"`
-	Filename      string                `json:"filename"`
-	Size          int64                 `json:"size"`
-	PackedSize    int64                 `json:"packed_size"`              // Packed/compressed size for nested content validation
-	Segments      []*metapb.SegmentData `json:"segments"`                 // Segment data for this file
-	IsDirectory   bool                  `json:"is_directory,omitempty"`   // Indicates if this is a directory
-	AesKey        []byte                `json:"aes_key,omitempty"`        // AES encryption key (if encrypted)
-	AesIV         []byte                `json:"aes_iv,omitempty"`         // AES initialization vector (if encrypted)
-	NzbdavID      string                `json:"nzbdav_id,omitempty"`      // Original ID from nzbdav
-	NestedSources []NestedSource        `json:"nested_sources,omitempty"` // Nested RAR sources (encrypted outer 7z)
-	// ISOExpansionIndex is non-zero for files expanded from an ISO archive.
-	// It is the 1-based position of this file when all ISO files in the archive
-	// are sorted by size descending (1 = largest / main feature).
-	// Zero means this Content did not come from an ISO.
-	ISOExpansionIndex int `json:"iso_expansion_index,omitempty"`
 }

--- a/internal/importer/archive/sevenzip/utils.go
+++ b/internal/importer/archive/sevenzip/utils.go
@@ -2,7 +2,6 @@ package sevenzip
 
 import (
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -15,12 +14,6 @@ var (
 	// Pattern for numeric extensions: filename.001, filename.002
 	numericPatternNumber = regexp.MustCompile(`\.(\d+)$`)
 )
-
-// hasExtension checks if a filename has an extension
-func hasExtension(filename string) bool {
-	ext := filepath.Ext(filename)
-	return ext != ""
-}
 
 // normalize7zPartFilename normalizes 7zip part filenames while preserving original number formatting
 // If allFilesNoExt is true, uses baseFilename for all parts with .XXX extension
@@ -37,7 +30,7 @@ func normalize7zPartFilename(filename string, index int, allFilesNoExt bool, tot
 	// If all files have no extension, use baseFilename with .XXX extension
 	// This ensures all parts of the same archive have the same base filename
 	// Using 7zip multi-volume convention: .001, .002, .003, etc. (1-based)
-	if allFilesNoExt && !hasExtension(filename) && baseFilename != "" {
+	if allFilesNoExt && !archive.HasExtension(filename) && baseFilename != "" {
 		// Calculate padding width based on total number of files (1-based, so totalFiles)
 		width := len(strconv.Itoa(totalFiles))
 		// Format with zero-padding (convert 0-based index to 1-based: index+1)

--- a/internal/importer/utils/file_validation.go
+++ b/internal/importer/utils/file_validation.go
@@ -54,13 +54,17 @@ func IsAllowedFile(filename string, size int64, allowedExtensions []string, filt
 
 	ext := strings.ToLower(filepath.Ext(filename))
 
+	// Build the extension map once for both checks below
+	var extMap map[string]bool
+	if len(allowedExtensions) > 0 {
+		extMap = createExtensionMap(allowedExtensions)
+	}
+
 	// Always allow subtitle files
 	if whitelistedExtensions[ext] {
 		// Still check if the extension is in the allowed list if it's provided
-		if len(allowedExtensions) > 0 {
-			normalizedExt := strings.TrimPrefix(ext, ".")
-			extMap := createExtensionMap(allowedExtensions)
-			return extMap[normalizedExt]
+		if extMap != nil {
+			return extMap[strings.TrimPrefix(ext, ".")]
 		}
 		return true
 	}
@@ -71,13 +75,11 @@ func IsAllowedFile(filename string, size int64, allowedExtensions []string, filt
 	}
 
 	// Empty list = allow all files
-	if len(allowedExtensions) == 0 {
+	if extMap == nil {
 		return true
 	}
 
-	normalizedExt := strings.TrimPrefix(ext, ".")
-	extMap := createExtensionMap(allowedExtensions)
-	return extMap[normalizedExt]
+	return extMap[strings.TrimPrefix(ext, ".")]
 }
 
 // HasAllowedFilesInRegular checks if any regular (non-archive) files match allowed extensions


### PR DESCRIPTION
## Summary

- Extract identical `Content`, `NestedSource` structs, error sentinels (`ErrNoAllowedFiles`, `ErrNoFilesProcessed`), and helper functions (`GetContentSegmentCount`, `GetContentSegments`, `ValidateSegmentIntegrity`, `HasExtension`) into `archive/common.go`
- Both `rar` and `sevenzip` sub-packages now use type aliases and delegate to shared implementations, eliminating ~200 lines of duplication
- Export RAR regex patterns (`PartPattern`, `RPattern`, `NumericPattern`) so `sevenzip` imports them instead of duplicating
- Cache the extension map in `IsAllowedFile` to avoid redundant map allocations per call

## Test plan

- [x] `go build ./...` — no compilation errors or import cycles
- [x] `go test ./internal/importer/...` — all existing tests pass
- [ ] Verify no behavioral changes in archive processing end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)