### PR TITLE
fix: make hanwen FUSE Handle.Read() context-aware

### DIFF
--- a/internal/fuse/backend/hanwen/handle.go
+++ b/internal/fuse/backend/hanwen/handle.go
@@ -53,6 +53,45 @@ func NewHandle(
 	}
 }
 
+// readWithContext wraps a blocking file.Read in a goroutine with context cancellation.
+// On context expiry, returns ctx.Err(); the goroutine completes when file is closed.
+func readWithContext(ctx context.Context, file afero.File, dest []byte) (int, error) {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, err := file.Read(dest)
+		ch <- result{n, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.n, res.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
+// seekWithContext wraps a blocking file.Seek in a goroutine with context cancellation.
+func seekWithContext(ctx context.Context, file afero.File, offset int64, whence int) (int64, error) {
+	type result struct {
+		pos int64
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		pos, err := file.Seek(offset, whence)
+		ch <- result{pos, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.pos, res.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
+}
+
 // Read handles a read request using Seek+Read.
 // This keeps the persistent UsenetReader alive across reads, allowing
 // the downloadManager prefetch pipeline to stay effective.
@@ -63,13 +102,17 @@ func (h *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadRes
 
 	// Skip seek if already at the correct position (sequential read optimization)
 	if off != h.position.Load() {
-		if _, err := h.file.Seek(off, io.SeekStart); err != nil {
+		if _, err := seekWithContext(ctx, h.file, off, io.SeekStart); err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				h.logger.DebugContext(ctx, "Seek canceled", "path", h.path, "offset", off)
+				return nil, syscall.EINTR
+			}
 			h.logger.ErrorContext(ctx, "Seek failed", "path", h.path, "offset", off, "error", err)
 			return nil, syscall.EIO
 		}
 	}
 
-	n, err := h.file.Read(dest)
+	n, err := readWithContext(ctx, h.file, dest)
 
 	if n > 0 {
 		newPos := off + int64(n)

--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -221,6 +221,110 @@ func TestHandle_Read_SeekError(t *testing.T) {
 	mockFile.AssertNotCalled(t, "Read", mock.Anything)
 }
 
+func TestHandle_Read_ContextCanceled(t *testing.T) {
+	logger := slog.Default()
+
+	// Use blockingFile so the goroutine doesn't panic on unexpected calls
+	bf := &blockingFile{readBlock: make(chan struct{})}
+	handle := NewHandle(bf, logger, "testfile", nil, nil)
+
+	// Pre-cancelled context — should return EINTR promptly
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	dest := make([]byte, 10)
+	_, status := handle.Read(ctx, dest, 0)
+	assert.Equal(t, syscall.EINTR, status)
+
+	// Unblock the orphaned goroutine
+	close(bf.readBlock)
+}
+
+func TestHandle_Read_BlockingReadContextCanceled(t *testing.T) {
+	logger := slog.Default()
+
+	// blockingFile blocks on Read until Close is called
+	bf := &blockingFile{readBlock: make(chan struct{})}
+
+	handle := NewHandle(bf, logger, "testfile", nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := make([]byte, 10)
+
+	done := make(chan syscall.Errno, 1)
+	go func() {
+		_, status := handle.Read(ctx, dest, 0)
+		done <- status
+	}()
+
+	// Cancel context while Read is blocked
+	cancel()
+
+	status := <-done
+	assert.Equal(t, syscall.EINTR, status)
+
+	// Unblock the orphaned goroutine so it can complete
+	close(bf.readBlock)
+}
+
+func TestHandle_Read_BlockingSeekContextCanceled(t *testing.T) {
+	logger := slog.Default()
+
+	bf := &blockingFile{seekBlock: make(chan struct{})}
+
+	handle := NewHandle(bf, logger, "testfile", nil, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	dest := make([]byte, 10)
+
+	done := make(chan syscall.Errno, 1)
+	go func() {
+		// offset 100 != position 0, so Seek will be called
+		_, status := handle.Read(ctx, dest, 100)
+		done <- status
+	}()
+
+	cancel()
+
+	status := <-done
+	assert.Equal(t, syscall.EINTR, status)
+
+	close(bf.seekBlock)
+}
+
+// blockingFile is a minimal afero.File that blocks on Read/Seek until the
+// corresponding channel is closed. Used to test context cancellation.
+type blockingFile struct {
+	readBlock chan struct{} // if non-nil, Read blocks until closed
+	seekBlock chan struct{} // if non-nil, Seek blocks until closed
+}
+
+func (f *blockingFile) Read(p []byte) (int, error) {
+	if f.readBlock != nil {
+		<-f.readBlock
+	}
+	return 0, io.EOF
+}
+
+func (f *blockingFile) Seek(offset int64, whence int) (int64, error) {
+	if f.seekBlock != nil {
+		<-f.seekBlock
+	}
+	return offset, nil
+}
+
+func (f *blockingFile) Close() error                                 { return nil }
+func (f *blockingFile) ReadAt(p []byte, off int64) (int, error)      { return 0, nil }
+func (f *blockingFile) Write(p []byte) (int, error)                  { return 0, nil }
+func (f *blockingFile) WriteAt(p []byte, off int64) (int, error)     { return 0, nil }
+func (f *blockingFile) Name() string                                 { return "blocking" }
+func (f *blockingFile) Readdir(count int) ([]os.FileInfo, error)     { return nil, nil }
+func (f *blockingFile) Readdirnames(n int) ([]string, error)         { return nil, nil }
+func (f *blockingFile) Stat() (os.FileInfo, error)                   { return nil, nil }
+func (f *blockingFile) Sync() error                                  { return nil }
+func (f *blockingFile) Truncate(size int64) error                    { return nil }
+func (f *blockingFile) WriteString(s string) (int, error)            { return 0, nil }
+
 func TestHandle_Release_Idempotent(t *testing.T) {
 	mockFile := new(MockFile)
 	logger := slog.Default()


### PR DESCRIPTION
## Summary

- FUSE reads could block indefinitely when NNTP servers hang, prefetch throttles deadlock, or pool connections are exhausted — unlike WebDAV which escapes via HTTP request context
- Added `readWithContext()` and `seekWithContext()` helpers that wrap blocking I/O in goroutines with context select, returning `EINTR` on cancellation
- Mirrors the proven `readFullContext` pattern already used in `MetadataVirtualFile.ReadAt()`

## Test plan

- [x] `go test ./internal/fuse/backend/hanwen/... -race -v` — all 10 tests pass (3 new)
- [x] `go vet ./internal/fuse/...` — no issues
- [x] `go build ./...` — builds cleanly
- [ ] Manual test: mount via FUSE, kill NNTP server mid-read, verify handle returns promptly instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)