### PR TITLE
fix: add linux build tags to hanwen backend and fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g. v0.1.0)'
+        required: true
+      skip_docker:
+        description: 'Skip Docker image build (use when images already exist)'
+        type: boolean
+        default: false
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -55,7 +64,12 @@ jobs:
       - name: Extract version info for frontend
         id: frontend-version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           COMMIT=$(git rev-parse --short HEAD)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "commit=$COMMIT" >> $GITHUB_OUTPUT
@@ -134,11 +148,25 @@ jobs:
         if: matrix.goos == 'darwin'
         run: brew install --cask macfuse
 
+      # Install WinFsp headers for Windows CGO cross-compilation
+      - name: Setup WinFsp headers (Windows CGO)
+        if: matrix.goos == 'windows'
+        run: |
+          curl -fsSL -o winfsp.zip \
+            "https://github.com/winfsp/winfsp/releases/download/v2.0/winfsp-2.0.23075.zip"
+          unzip -q winfsp.zip "inc/fuse/*" -d winfsp-sdk
+          echo "CGO_CFLAGS=-I$(pwd)/winfsp-sdk/inc/fuse" >> "$GITHUB_ENV"
+
       # Extract version info
       - name: Extract version info
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           COMMIT=$(git rev-parse --short HEAD)
           TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -212,7 +240,12 @@ jobs:
       - name: Extract version info
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       # Download darwin binaries
@@ -270,7 +303,12 @@ jobs:
       - name: Extract version info
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       # Download all artifacts
@@ -292,18 +330,20 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: |
             artifacts/altmount-cli_v${{ steps.version.outputs.version }}_*.*
             artifacts/checksums-cli.txt
           draft: false
           prerelease: false
-          generate_release_notes: true
+          generate_release_notes: ${{ github.event_name != 'workflow_dispatch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-image-amd64:
     runs-on: ubuntu-latest
     needs: [test, build-frontend]
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:
       contents: write
       packages: write
@@ -366,6 +406,7 @@ jobs:
   build-image-arm64:
     runs-on: ubuntu-latest
     needs: [test, build-frontend]
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:
       contents: write
       packages: write
@@ -428,6 +469,7 @@ jobs:
   create-manifest:
     runs-on: ubuntu-latest
     needs: [build-image-amd64, build-image-arm64]
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:
       contents: write
       packages: write
@@ -455,7 +497,12 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+            VERSION="${TAG#v}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          fi
           MAJOR=$(echo $VERSION | cut -d. -f1)
           MINOR=$(echo $VERSION | cut -d. -f2)
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/internal/fuse/backend/hanwen/backend.go
+++ b/internal/fuse/backend/hanwen/backend.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (

--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (

--- a/internal/fuse/backend/hanwen/handle.go
+++ b/internal/fuse/backend/hanwen/handle.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (

--- a/internal/fuse/backend/hanwen/utils.go
+++ b/internal/fuse/backend/hanwen/utils.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (

--- a/internal/fuse/register_hanwen.go
+++ b/internal/fuse/register_hanwen.go
@@ -1,0 +1,5 @@
+//go:build linux
+
+package fuse
+
+import _ "github.com/javi11/altmount/internal/fuse/backend/hanwen"

--- a/internal/fuse/server.go
+++ b/internal/fuse/server.go
@@ -12,9 +12,6 @@ import (
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/fuse/backend"
 	"github.com/javi11/altmount/internal/nzbfilesystem"
-
-	// Register backends via init() (cgofuse registered in register_cgofuse.go, gated by build tags)
-	_ "github.com/javi11/altmount/internal/fuse/backend/hanwen"
 )
 
 // StreamTracker is the subset of stream tracking needed by the FUSE layer.


### PR DESCRIPTION
## Summary

- Add `//go:build linux` to all `hanwen/go-fuse` backend files — prevents compilation on macOS/Windows where Linux syscalls (`fallocate`, `unix.EINVAL`, etc.) are undefined
- Move the hanwen blank import from `server.go` into a new `register_hanwen.go` gated by `//go:build linux`, matching the existing `register_cgofuse.go` pattern
- Add WinFsp SDK header download step in the Windows CI matrix build to fix `fuse_common.h not found` CGO error
- Add `workflow_dispatch` trigger with `tag` + `skip_docker` inputs so the release pipeline can be re-run for an existing tag without rebuilding Docker images
- Fix version extraction in all workflow jobs to handle `workflow_dispatch` (not just tag push)

## Test plan

- [ ] Verify `GOOS=darwin go build ./...` succeeds locally (no go-fuse syscall errors)
- [ ] Merge to main
- [ ] Go to **Actions → Build → Run workflow**, select tag `v0.1.0`, check **Skip Docker image build**, and confirm the binary build jobs pass and the release assets are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)