### PR TITLE
Disable segment cache options when cache is disabled

### DIFF
--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -157,7 +157,7 @@ export function StreamingConfigSection({
 				</div>
 
 				{/* Cache Path */}
-				<div className="space-y-3 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+				<div className={`space-y-3 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
 					<div className="min-w-0">
 						<h4 className="font-bold text-base-content text-sm">Cache Path</h4>
 						<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
@@ -169,14 +169,14 @@ export function StreamingConfigSection({
 						type="text"
 						className="input input-bordered w-full"
 						value={cacheData.cache_path}
-						disabled={isReadOnly}
+						disabled={isReadOnly || !cacheData.enabled}
 						placeholder="/tmp/altmount-segcache"
 						onChange={(e) => handleCacheChange("cache_path", e.target.value)}
 					/>
 				</div>
 
 				{/* Max Size slider */}
-				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+				<div className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<h4 className="font-bold text-base-content text-sm">Maximum Cache Size</h4>
@@ -200,7 +200,7 @@ export function StreamingConfigSection({
 							value={cacheData.max_size_gb}
 							step="1"
 							className="range range-primary range-sm w-full [&::-webkit-slider-runnable-track]:rounded-full"
-							disabled={isReadOnly}
+							disabled={isReadOnly || !cacheData.enabled}
 							onChange={(e) =>
 								handleCacheChange("max_size_gb", Number.parseInt(e.target.value, 10))
 							}
@@ -216,7 +216,7 @@ export function StreamingConfigSection({
 				</div>
 
 				{/* Expiry slider */}
-				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+				<div className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<h4 className="overflow-visible whitespace-normal font-bold text-base-content text-sm">
@@ -242,7 +242,7 @@ export function StreamingConfigSection({
 							value={cacheData.expiry_hours}
 							step="1"
 							className="range range-primary range-sm w-full [&::-webkit-slider-runnable-track]:rounded-full"
-							disabled={isReadOnly}
+							disabled={isReadOnly || !cacheData.enabled}
 							onChange={(e) =>
 								handleCacheChange("expiry_hours", Number.parseInt(e.target.value, 10))
 							}


### PR DESCRIPTION
When the Enable Segment Cache toggle is off, the Cache Path, Maximum
Cache Size, and Cache Expiry fields are now disabled and visually dimmed
to prevent modifying irrelevant options.

https://claude.ai/code/session_015xXGdWMyox86Uw922YZvsC