### PR TITLE
fix: extract applyNzbRename helper and add test for rename_to_nzb_name=false

### DIFF
--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -356,15 +356,7 @@ func (proc *Processor) processSingleFile(
 
 	// Rename the file to match the NZB name to handle obfuscated filenames
 	// Keep NZB-provided subfolders but rename the leaf to the release name (preventing duplicate extensions)
-	if proc.renameToNzbName {
-		originalDir := filepath.Dir(regularFiles[0].Filename)
-		normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
-		if originalDir != "." && originalDir != "" {
-			regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
-		} else {
-			regularFiles[0].Filename = normalizedBase
-		}
-	}
+	regularFiles = applyNzbRename(proc.renameToNzbName, nzbName, regularFiles)
 
 	// Compute final parent/name, flattening only redundant nesting like file.mkv/file.mkv
 	parentPath, finalName := filesystem.DetermineFileLocation(regularFiles[0], virtualDir)
@@ -454,15 +446,7 @@ func (proc *Processor) processMultiFile(
 
 	if singleLike {
 		// Rename the leaf to the release name (prevents ext duplication) but keep NZB-provided subfolders.
-		if proc.renameToNzbName {
-			originalDir := filepath.Dir(regularFiles[0].Filename)
-			normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(regularFiles[0].Filename))
-			if originalDir != "." && originalDir != "" {
-				regularFiles[0].Filename = filepath.Join(originalDir, normalizedBase)
-			} else {
-				regularFiles[0].Filename = normalizedBase
-			}
-		}
+		regularFiles = applyNzbRename(proc.renameToNzbName, nzbName, regularFiles)
 
 		// Avoid nesting like /Season 02/<release>/<release>.mkv; drop the NZB-named folder here.
 		if err := filesystem.EnsureDirectoryExists(targetBaseDir, proc.metadataService); err != nil {
@@ -765,6 +749,22 @@ func (proc *Processor) processSevenZipArchive(
 	}
 
 	return nzbFolder, writtenPaths, nil
+}
+
+// applyNzbRename renames the first file in files to match nzbName when renameToNzbName is true.
+// Returns the slice unchanged when renameToNzbName is false or files is empty.
+func applyNzbRename(renameToNzbName bool, nzbName string, files []parser.ParsedFile) []parser.ParsedFile {
+	if !renameToNzbName || len(files) == 0 {
+		return files
+	}
+	originalDir := filepath.Dir(files[0].Filename)
+	normalizedBase := normalizeReleaseFilename(nzbName, filepath.Base(files[0].Filename))
+	if originalDir != "." && originalDir != "" {
+		files[0].Filename = filepath.Join(originalDir, normalizedBase)
+	} else {
+		files[0].Filename = normalizedBase
+	}
+	return files
 }
 
 // normalizeReleaseFilename aligns the filename to the NZB basename while keeping the original extension.

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -7,6 +7,56 @@ import (
 	"github.com/javi11/altmount/internal/importer/parser"
 )
 
+func TestApplyNzbRename(t *testing.T) {
+	tests := []struct {
+		name             string
+		renameToNzbName  bool
+		nzbName          string
+		originalFilename string
+		expected         string
+	}{
+		{
+			name:             "false: single file not renamed",
+			renameToNzbName:  false,
+			nzbName:          "release.nzb",
+			originalFilename: "obfuscated.mkv",
+			expected:         "obfuscated.mkv",
+		},
+		{
+			name:             "true: single file renamed",
+			renameToNzbName:  true,
+			nzbName:          "release.nzb",
+			originalFilename: "obfuscated.mkv",
+			expected:         "release.mkv",
+		},
+		{
+			name:             "false: preserves path with subdirectory",
+			renameToNzbName:  false,
+			nzbName:          "movie.nzb",
+			originalFilename: "sub/file.mkv",
+			expected:         "sub/file.mkv",
+		},
+		{
+			name:             "true: renames leaf only, preserves subdirectory",
+			renameToNzbName:  true,
+			nzbName:          "movie.nzb",
+			originalFilename: "sub/file.mkv",
+			expected:         "sub/movie.mkv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := []parser.ParsedFile{{Filename: tt.originalFilename}}
+			result := applyNzbRename(tt.renameToNzbName, tt.nzbName, files)
+			if result[0].Filename != tt.expected {
+				t.Fatalf("applyNzbRename(%v, %q, [{%q}]) = %q, want %q",
+					tt.renameToNzbName, tt.nzbName, tt.originalFilename, result[0].Filename, tt.expected)
+			}
+		})
+	}
+}
+
 func TestNormalizeReleaseFilename(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary
- Extract duplicate inline rename block from `processSingleFile` and `processMultiFile` into a single `applyNzbRename()` package-level helper
- Add `TestApplyNzbRename` with 4 table-driven cases covering `renameToNzbName=false` (file unchanged) and `=true` (file renamed), with and without subdirectory paths

## Test plan
- [ ] `go test ./internal/importer/ -run TestApplyNzbRename -v` — all 4 cases pass
- [ ] `go test ./internal/importer/...` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)