### PR TITLE
fix: respect rename_to_nzb_name setting for single-file archive normalization

### DIFF
--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -139,6 +139,7 @@ func ProcessArchive(
 	readTimeout time.Duration,
 	expandBlurayIso bool,
 	filterSamples bool,
+	renameToNzbName bool,
 ) error {
 	if len(archiveFiles) == 0 {
 		return nil
@@ -217,7 +218,7 @@ func ProcessArchive(
 	}
 
 	nzbName := filepath.Base(nzbPath)
-	shouldNormalizeName := mediaFilesCount == 1
+	shouldNormalizeName := renameToNzbName && mediaFilesCount == 1
 
 	// Count ISO-expanded files so single-file ISOs omit the index suffix.
 	isoExpandedCount := 0

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -137,6 +137,7 @@ func ProcessArchive(
 	readTimeout time.Duration,
 	expandBlurayIso bool,
 	filterSamples bool,
+	renameToNzbName bool,
 ) error {
 	if len(archiveFiles) == 0 {
 		return nil
@@ -194,7 +195,7 @@ func ProcessArchive(
 	}
 
 	nzbName := filepath.Base(nzbPath)
-	shouldNormalizeName := mediaFilesCount == 1
+	shouldNormalizeName := renameToNzbName && mediaFilesCount == 1
 
 	// Count ISO-expanded files so single-file ISOs omit the index suffix.
 	isoExpandedCount := 0

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -605,6 +605,7 @@ func (proc *Processor) processRarArchive(
 			proc.readTimeout,
 			proc.expandBlurayIso,
 			proc.filterSampleFiles,
+			proc.renameToNzbName,
 		)
 		if err != nil {
 			return nzbFolder, writtenPaths, err
@@ -720,6 +721,7 @@ func (proc *Processor) processSevenZipArchive(
 			proc.readTimeout,
 			proc.expandBlurayIso,
 			proc.filterSampleFiles,
+			proc.renameToNzbName,
 		)
 		if err != nil {
 			return nzbFolder, writtenPaths, err


### PR DESCRIPTION
Previously, RAR and 7zip archive processing always normalized the filename
to match the NZB basename when there was exactly one media file, ignoring
the rename_to_nzb_name config option. Now the option is passed through to
ProcessArchive and gates the shouldNormalizeName check.

https://claude.ai/code/session_01WatkgRCQKEkKvc8Fke4Pas