### PR TITLE
fix: enable save button when skip_ping is true for new providers

### DIFF
--- a/frontend/src/components/config/ProviderModal.tsx
+++ b/frontend/src/components/config/ProviderModal.tsx
@@ -495,7 +495,7 @@ export function ProviderModal({ mode, provider, onSuccess, onCancel }: ProviderM
 						type="button"
 						className="btn btn-primary px-8 shadow-lg shadow-primary/20"
 						onClick={handleSave}
-						disabled={isSaving || (mode === "create" && !canSave)}
+						disabled={isSaving || (mode === "create" && !canSave && !formData.skip_ping)}
 					>
 						{isSaving ? <Loader className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
 						{mode === "create" ? "Create Provider" : "Save Changes"}


### PR DESCRIPTION
## Summary

- The \"Create Provider\" save button was disabled whenever `canSave` was false, even when `skip_ping=true`
- Since the test endpoint always pings (intentional — skip_ping only applies to pool initialization), servers that don't support DATE could never be added through the UI
- The save handler already had the correct logic (`!formData.skip_ping` bypass) — the button's `disabled` condition just needed to match it

## Test plan

- [ ] Create a new provider with `skip_ping=true` — save button should be **enabled** without running a test
- [ ] Create a new provider with `skip_ping=false` — save button should remain **disabled** until test passes
- [ ] Verify provider is added to the pool without a connection ping when `skip_ping=true`