### PR TITLE
fix: add linux build tag to hanwen handle_test.go

### DIFF
--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package hanwen
 
 import (


### PR DESCRIPTION
## Summary
- `handle.go` has `//go:build linux` but `handle_test.go` was missing the matching build constraint
- On macOS, `handle.go` is excluded from compilation but the test file was still compiled, causing `undefined: NewHandle` errors in `go test ./...`
- Fix: add `//go:build linux` to `handle_test.go`

## Test plan
- [ ] Run `go test ./...` on macOS — no build failures
- [ ] Run `go test ./internal/fuse/backend/hanwen/...` on Linux — tests compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)