### PR TITLE
fix: render toast notifications above modals

### DIFF
--- a/frontend/src/components/ui/ToastContainer.tsx
+++ b/frontend/src/components/ui/ToastContainer.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { useToast } from "../../contexts/ToastContext";
 import { ToastComponent } from "./Toast";
 
@@ -8,9 +9,9 @@ export function ToastContainer() {
 		return null;
 	}
 
-	return (
+	return createPortal(
 		<div
-			className="pointer-events-none fixed top-4 right-4 z-50 w-full max-w-sm space-y-2"
+			className="pointer-events-none fixed top-4 right-4 z-[9999] w-full max-w-sm space-y-2"
 			aria-live="polite"
 		>
 			{toasts.map((toast) => (
@@ -18,6 +19,7 @@ export function ToastContainer() {
 					<ToastComponent toast={toast} onClose={removeToast} />
 				</div>
 			))}
-		</div>
+		</div>,
+		document.body,
 	);
 }


### PR DESCRIPTION
## Summary
- Mounts `ToastContainer` via `createPortal` directly on `document.body`, escaping any CSS stacking context
- Raises z-index from `z-50` to `z-[9999]` to ensure toasts appear above DaisyUI modals

## Root Cause
`ToastContainer` used `z-50` (z-index: 50) while DaisyUI v5 modals have a much higher default z-index. Native `<dialog>` elements opened with `showModal()` are placed in the browser's top layer, which no z-index alone can beat — hence the portal fix.

## Test plan
- [ ] Trigger a notification (e.g. save a config setting)
- [ ] Open a modal while the notification is visible
- [ ] Confirm toast renders above the modal overlay
- [ ] Confirm toast dismiss/auto-hide still works correctly