### PR TITLE
fix(arrs): use dynamic hostname and port for default webhook and download client URLs

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -247,8 +247,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 
 		if apiKey != "" {
-			logger.InfoContext(bgCtx, "Triggering automatic ARR webhook registration")
-			if err := arrsService.EnsureWebhookRegistration(bgCtx, "http://altmount:8080", apiKey); err != nil {
+			logger.InfoContext(bgCtx, "Triggering automatic ARR webhook registration", "webhook_url", cfg.GetWebhookBaseURL())
+			if err := arrsService.EnsureWebhookRegistration(bgCtx, cfg.GetWebhookBaseURL(), apiKey); err != nil {
 				logger.ErrorContext(bgCtx, "Failed to register ARR webhooks on startup", "error", err)
 			}
 		} else {

--- a/docs/docs/3. Configuration/integration.md
+++ b/docs/docs/3. Configuration/integration.md
@@ -118,6 +118,7 @@ No `import_dir` or `mount_path` is needed. Media is accessed directly via the mo
 Creates `.strm` files that contain WebDAV URLs. Useful when your media player can resolve HTTP URLs directly:
 
 ```yaml
+# Replace with your actual AltMount hostname/port if changed
 mount_path: http://altmount:8080
 
 import:
@@ -153,7 +154,7 @@ AltMount can automatically monitor ARR queues and remove failed imports to keep 
 ```yaml
 arrs:
   enabled: true
-  webhook_base_url: "http://altmount:8080" # Base URL for webhook callbacks (default)
+  webhook_base_url: "" # Base URL for webhook callbacks (defaults to http://<host>:<port>)
   queue_cleanup_enabled: true
   queue_cleanup_interval_seconds: 300
   queue_cleanup_grace_period_minutes: 10 # Wait before cleaning up (default: 10)
@@ -171,7 +172,7 @@ arrs:
 | `queue_cleanup_interval_seconds`     | How often to check ARR queues (in seconds)                                                              |
 | `queue_cleanup_grace_period_minutes` | Minimum age (in minutes) before a failed item is cleaned up (default: 10)                               |
 | `cleanup_automatic_import_failure`   | Clean up items with "Automatic import is not possible" errors                                           |
-| `webhook_base_url`                   | Base URL ARRs use to reach AltMount for webhooks (default: `http://altmount:8080`)                      |
+| `webhook_base_url`                   | Base URL ARRs use to reach AltMount for webhooks (default: `http://<host>:<port>`)                      |
 | `queue_cleanup_allowlist`            | Error messages to treat as safe for cleanup. Each entry has a `message` string and an `enabled` boolean |
 
 ## Verifying the Setup

--- a/frontend/src/components/config/ArrsConfigSection.tsx
+++ b/frontend/src/components/config/ArrsConfigSection.tsx
@@ -48,6 +48,7 @@ export function ArrsConfigSection({
 	const [newIgnoreMessage, setNewIgnoreMessage] = useState("");
 
 	const registerWebhooks = useRegisterArrsWebhooks();
+	const defaultWebhookUrl = `http://${config.webdav.host || "altmount"}:${config.webdav.port}`;
 
 	// Sync form data when config changes from external sources (reload)
 	useEffect(() => {
@@ -282,9 +283,9 @@ export function ArrsConfigSection({
 									<input
 										type="url"
 										className="input input-bordered w-full bg-base-100 font-mono text-sm"
-										value={formData.webhook_base_url ?? "http://altmount:8080"}
+										value={formData.webhook_base_url ?? defaultWebhookUrl}
 										onChange={(e) => handleFormChange("webhook_base_url", e.target.value)}
-										placeholder="http://altmount:8080"
+										placeholder={defaultWebhookUrl}
 										disabled={isReadOnly}
 									/>
 								</fieldset>

--- a/frontend/src/components/config/SABnzbdConfigSection.tsx
+++ b/frontend/src/components/config/SABnzbdConfigSection.tsx
@@ -57,6 +57,7 @@ export function SABnzbdConfigSection({
 
 	const registerDownloadClient = useRegisterArrsDownloadClients();
 	const testDownloadClient = useTestArrsDownloadClients();
+	const defaultDownloadClientUrl = `http://${config.webdav.host || "altmount"}:${config.webdav.port}/sabnzbd`;
 
 	// Sync form data when config changes from external sources (reload)
 	useEffect(() => {
@@ -234,9 +235,9 @@ export function SABnzbdConfigSection({
 									<input
 										type="url"
 										className="input input-bordered w-full bg-base-100 font-mono text-sm"
-										value={formData.download_client_base_url || ""}
+										value={formData.download_client_base_url || defaultDownloadClientUrl}
 										onChange={(e) => updateFormData({ download_client_base_url: e.target.value })}
-										placeholder="http://altmount:8080/sabnzbd"
+										placeholder={defaultDownloadClientUrl}
 										disabled={isReadOnly}
 									/>
 									<p className="label break-words text-base-content/70 text-xs">

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -749,12 +749,12 @@ func (s *Server) handleRegisterArrsWebhooks(c *fiber.Ctx) error {
 	}
 
 	// Get configured base URL or use default
-	baseURL := "http://altmount:8080"
+	var baseURL string
 	if s.configManager != nil {
 		cfg := s.configManager.GetConfig()
-		if cfg.Arrs.WebhookBaseURL != "" {
-			baseURL = cfg.Arrs.WebhookBaseURL
-		}
+		baseURL = cfg.GetWebhookBaseURL()
+	} else {
+		baseURL = "http://altmount:8080" // Fallback if no config manager is available
 	}
 
 	if err := s.arrsService.EnsureWebhookRegistration(c.Context(), baseURL, apiKey); err != nil {
@@ -800,8 +800,7 @@ func (s *Server) handleRegisterArrsDownloadClients(c *fiber.Ctx) error {
 	}
 	urlBase := "sabnzbd"
 
-	if cfg.SABnzbd.DownloadClientBaseURL != "" {
-		rawURL := cfg.SABnzbd.DownloadClientBaseURL
+	if rawURL := cfg.GetDownloadClientBaseURL(); rawURL != "" {
 		if !strings.Contains(rawURL, "://") {
 			rawURL = "http://" + rawURL
 		}
@@ -873,8 +872,7 @@ func (s *Server) handleTestArrsDownloadClients(c *fiber.Ctx) error {
 	}
 	urlBase := "sabnzbd"
 
-	if cfg.SABnzbd.DownloadClientBaseURL != "" {
-		rawURL := cfg.SABnzbd.DownloadClientBaseURL
+	if rawURL := cfg.GetDownloadClientBaseURL(); rawURL != "" {
 		if !strings.Contains(rawURL, "://") {
 			rawURL = "http://" + rawURL
 		}

--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -91,10 +91,7 @@ func (s *Service) RegisterInstance(ctx context.Context, arrURL, apiKey string) e
 			key := s.GetFirstAdminAPIKey(bgCtx)
 			if key != "" {
 				cfg := s.configGetter()
-				baseURL := cfg.Arrs.WebhookBaseURL
-				if baseURL == "" {
-					baseURL = "http://altmount:8080"
-				}
+				baseURL := cfg.GetWebhookBaseURL()
 				_ = s.registrar.EnsureWebhookRegistration(bgCtx, baseURL, key)
 			}
 		}()

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -407,6 +407,30 @@ func (c *Config) DeepCopy() *Config {
 	return copyCfg
 }
 
+// GetWebhookBaseURL returns the configured webhook base URL or a default one based on the current port.
+func (c *Config) GetWebhookBaseURL() string {
+	if c.Arrs.WebhookBaseURL != "" {
+		return c.Arrs.WebhookBaseURL
+	}
+	host := c.WebDAV.Host
+	if host == "" {
+		host = "altmount"
+	}
+	return fmt.Sprintf("http://%s:%d", host, c.WebDAV.Port)
+}
+
+// GetDownloadClientBaseURL returns the configured download client base URL or a default one based on the current port.
+func (c *Config) GetDownloadClientBaseURL() string {
+	if c.SABnzbd.DownloadClientBaseURL != "" {
+		return c.SABnzbd.DownloadClientBaseURL
+	}
+	host := c.WebDAV.Host
+	if host == "" {
+		host = "altmount"
+	}
+	return fmt.Sprintf("http://%s:%d/sabnzbd", host, c.WebDAV.Port)
+}
+
 // Validate validates the configuration
 func (c *Config) Validate() error {
 	if c.WebDAV.Port <= 0 || c.WebDAV.Port > 65535 {
@@ -1332,7 +1356,7 @@ func DefaultConfig(configDir ...string) *Config {
 		SABnzbd: SABnzbdConfig{
 			Enabled:               &sabnzbdEnabled,
 			CompleteDir:           "/complete",
-			DownloadClientBaseURL: "http://altmount:8080/sabnzbd",
+			DownloadClientBaseURL: "",
 			Categories: []SABnzbdCategory{
 				{
 					Name:     "movies",
@@ -1352,7 +1376,7 @@ func DefaultConfig(configDir ...string) *Config {
 		Arrs: ArrsConfig{
 			Enabled:                        &scrapperEnabled, // Disabled by default
 			MaxWorkers:                     5,                // Default to 5 concurrent workers
-			WebhookBaseURL:                 "http://altmount:8080",
+			WebhookBaseURL:                 "",
 			RadarrInstances:                []ArrsInstanceConfig{},
 			SonarrInstances:                []ArrsInstanceConfig{},
 			CleanupAutomaticImportFailure:  &cleanupAutomaticImportFailure,

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -121,3 +121,106 @@ func TestConfig_Validate_MountPaths(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_GetWebhookBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected string
+	}{
+		{
+			name: "explicitly set",
+			config: Config{
+				Arrs: ArrsConfig{
+					WebhookBaseURL: "http://custom:1234",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8080,
+				},
+			},
+			expected: "http://custom:1234",
+		},
+		{
+			name: "default with port 8080",
+			config: Config{
+				Arrs: ArrsConfig{
+					WebhookBaseURL: "",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8080,
+				},
+			},
+			expected: "http://altmount:8080",
+		},
+		{
+			name: "default with port 8084",
+			config: Config{
+				Arrs: ArrsConfig{
+					WebhookBaseURL: "",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8084,
+				},
+			},
+			expected: "http://altmount:8084",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.GetWebhookBaseURL())
+		})
+	}
+}
+
+func TestConfig_GetDownloadClientBaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected string
+	}{
+		{
+			name: "explicitly set",
+			config: Config{
+				SABnzbd: SABnzbdConfig{
+					DownloadClientBaseURL: "http://custom:1234/sab",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8080,
+				},
+			},
+			expected: "http://custom:1234/sab",
+		},
+		{
+			name: "default with port 8080",
+			config: Config{
+				SABnzbd: SABnzbdConfig{
+					DownloadClientBaseURL: "",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8080,
+				},
+			},
+			expected: "http://altmount:8080/sabnzbd",
+		},
+		{
+			name: "default with port 8084",
+			config: Config{
+				SABnzbd: SABnzbdConfig{
+					DownloadClientBaseURL: "",
+				},
+				WebDAV: WebDAVConfig{
+					Port: 8084,
+				},
+			},
+			expected: "http://altmount:8084/sabnzbd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.config.GetDownloadClientBaseURL())
+		})
+	}
+}
+


### PR DESCRIPTION
This PR replaces the hardcoded 'http://altmount:8080' default for ARR webhooks and download client URLs with dynamic values derived from the configured WebDAV port and host.

- Added 'GetWebhookBaseURL()' and 'GetDownloadClientBaseURL()' helpers in the configuration system.
- Updated backend registration to use these helpers, ensuring environment variable overrides (like 'PORT') are respected.
- Modified frontend placeholders and defaults to reflect the dynamic nature.
- Updated documentation.
- Added unit tests for the new URL helpers.