### PR TITLE
fix: restore correct passwords after provider reorder

### DIFF
--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -208,7 +208,21 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 	// Decode into the specific section based on the URL parameter
 	var err error
 	switch section {
-	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "providers", "stremio":
+	case "providers":
+		err = c.BodyParser(newConfig)
+		if err == nil {
+			// encoding/json updates slice elements in-place, preserving json:"-" fields
+			// (Password) from their original positions. When the order changes this mixes
+			// passwords across providers. Re-map each password to its correct provider by ID.
+			oldPwdByID := make(map[string]string, len(currentConfig.Providers))
+			for _, p := range currentConfig.Providers {
+				oldPwdByID[p.ID] = p.Password
+			}
+			for i := range newConfig.Providers {
+				newConfig.Providers[i].Password = oldPwdByID[newConfig.Providers[i].ID]
+			}
+		}
+	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "stremio":
 		err = c.BodyParser(newConfig)
 		// BodyParser will map fields like "profiler_enabled" from JSON to the root of newConfig
 		// because Config struct has it with `json:"profiler_enabled"`.


### PR DESCRIPTION
## Summary

- Go's `encoding/json` updates slice elements **in-place** rather than resetting them to zero and appending fresh elements. When `handlePatchConfigSection` decodes a reordered providers list into a `DeepCopy` of the current config, the `Password` field (`json:"-"`) is left unchanged at each slice position.
- This causes each provider to inherit the password from whatever provider previously occupied that slot — mixing credentials after drag-and-drop reorder.
- Fix: extract `"providers"` as its own `switch` case; after `BodyParser`, build an ID→password map from the pre-parse config and assign each provider its correct password by ID.

## Test plan

- [ ] `go test ./internal/api/... ./internal/config/... -race` passes
- [ ] Create 2 providers with distinct passwords, drag to swap order, save — both still connect successfully
- [ ] YAML file reflects new order with correct passwords preserved per provider

🤖 Generated with [Claude Code](https://claude.ai/claude-code)