### PR TITLE
fix(auth): re-evaluate auth state immediately after disabling login requirement

### DIFF
--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -157,7 +157,9 @@ export function StreamingConfigSection({
 				</div>
 
 				{/* Cache Path */}
-				<div className={`space-y-3 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
+				<div
+					className={`space-y-3 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}
+				>
 					<div className="min-w-0">
 						<h4 className="font-bold text-base-content text-sm">Cache Path</h4>
 						<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
@@ -176,7 +178,9 @@ export function StreamingConfigSection({
 				</div>
 
 				{/* Max Size slider */}
-				<div className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
+				<div
+					className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}
+				>
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<h4 className="font-bold text-base-content text-sm">Maximum Cache Size</h4>
@@ -216,7 +220,9 @@ export function StreamingConfigSection({
 				</div>
 
 				{/* Expiry slider */}
-				<div className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}>
+				<div
+					className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!cacheData.enabled ? "opacity-50" : ""}`}
+				>
 					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<h4 className="overflow-visible whitespace-normal font-bold text-base-content text-sm">

--- a/frontend/src/components/system/ProviderCard.tsx
+++ b/frontend/src/components/system/ProviderCard.tsx
@@ -136,13 +136,13 @@ export function ProviderCard({ provider, className }: ProviderCardProps) {
 				<div className="mt-2 space-y-1 border-base-200 border-t pt-2">
 					<div className="flex items-center justify-between text-[10px]">
 						<span className="text-base-content/50 uppercase tracking-tight">Total Downloaded</span>
-						<span className="font-mono font-bold text-base-content/70">
+						<span className="font-bold font-mono text-base-content/70">
 							<BytesDisplay bytes={provider.byte_count} />
 						</span>
 					</div>
 					<div className="flex items-center justify-between text-[10px]">
 						<span className="text-base-content/50 uppercase tracking-tight">Last 24h</span>
-						<span className="font-mono font-bold text-primary">
+						<span className="font-bold font-mono text-primary">
 							<BytesDisplay bytes={provider.byte_count_24h} />
 						</span>
 					</div>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { createContext, useContext, useEffect, useReducer, useRef } from "react";
+import { createContext, useCallback, useContext, useEffect, useReducer, useRef } from "react";
 import { apiClient } from "../api/client";
 import type { User } from "../types/api";
 
@@ -104,6 +104,7 @@ interface AuthContextType extends AuthState {
 		registration_enabled: boolean;
 		user_count: number;
 	}>;
+	recheckAuth: () => Promise<void>;
 }
 
 // Create context
@@ -136,33 +137,36 @@ export function AuthProvider({ children }: AuthProviderProps) {
 		return () => window.removeEventListener("api:unauthorized", handleUnauthorized);
 	}, []);
 
-	// Check for existing authentication on mount
-	useEffect(() => {
-		const checkAuth = async () => {
-			try {
-				// First check if login is required
-				const authConfig = await apiClient.getAuthConfig();
-				dispatch({ type: "SET_LOGIN_REQUIRED", payload: authConfig.login_required });
+	// Check for existing authentication; also exposed as recheckAuth for use after config changes
+	const checkAuth = useCallback(async () => {
+		let loginRequired = true;
+		try {
+			const authConfig = await apiClient.getAuthConfig();
+			loginRequired = authConfig.login_required;
+			dispatch({ type: "SET_LOGIN_REQUIRED", payload: loginRequired });
+		} catch {
+			// Can't reach auth config endpoint — default to requiring auth
+			dispatch({ type: "SET_LOGIN_REQUIRED", payload: true });
+		}
 
-				// If login is not required, treat as authenticated anonymous admin
-				if (!authConfig.login_required) {
-					dispatch({ type: "AUTH_SKIP" });
-					return;
-				}
+		if (!loginRequired) {
+			dispatch({ type: "AUTH_SKIP" });
+			return;
+		}
 
-				// If login is required, check for existing authentication
-				dispatch({ type: "AUTH_START" });
-				const user = await apiClient.getCurrentUser();
-				dispatch({ type: "AUTH_SUCCESS", payload: user });
-			} catch (_error) {
-				// If getCurrentUser fails, user is not authenticated
-				// Don't dispatch error for this case since it's expected
-				dispatch({ type: "AUTH_LOGOUT" });
-			}
-		};
-
-		checkAuth();
+		try {
+			dispatch({ type: "AUTH_START" });
+			const user = await apiClient.getCurrentUser();
+			dispatch({ type: "AUTH_SUCCESS", payload: user });
+		} catch {
+			// Expected when user has no valid session
+			dispatch({ type: "AUTH_LOGOUT" });
+		}
 	}, []);
+
+	useEffect(() => {
+		checkAuth();
+	}, [checkAuth]);
 
 	// Login function (direct authentication)
 	const login = async (username: string, password: string): Promise<boolean> => {
@@ -255,6 +259,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
 		refreshToken,
 		clearError,
 		checkRegistrationStatus,
+		recheckAuth: checkAuth,
 	};
 
 	return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -34,6 +34,7 @@ import { ErrorAlert } from "../components/ui/ErrorAlert";
 import { LoadingSpinner } from "../components/ui/LoadingSpinner";
 import { RestartRequiredBanner } from "../components/ui/RestartRequiredBanner";
 import { useConfirm } from "../contexts/ModalContext";
+import { useAuth } from "../hooks/useAuth";
 import {
 	useConfig,
 	useLibrarySyncNeeded,
@@ -103,6 +104,7 @@ export function ConfigurationPage() {
 	const reloadConfig = useReloadConfig();
 	const restartServer = useRestartServer();
 	const updateConfigSection = useUpdateConfigSection();
+	const { recheckAuth } = useAuth();
 	const { data: syncNeeded } = useLibrarySyncNeeded();
 	const triggerLibrarySync = useTriggerLibrarySync();
 	const { confirmAction } = useConfirm();
@@ -209,6 +211,8 @@ export function ConfigurationPage() {
 					section: "auth",
 					config: { auth: data as unknown as AuthConfig },
 				});
+				// Re-evaluate auth state so loginRequired reflects the new config immediately
+				await recheckAuth();
 			} else if (section === "streaming") {
 				await updateConfigSection.mutateAsync({
 					section: "streaming",


### PR DESCRIPTION
## Summary

- When auth was disabled via the config page, `loginRequired` stayed `true` in the frontend until a full page reload. If a JWT then expired or a 401 was received, `ProtectedRoute` rendered `LoginPage` despite auth being off.
- Extracts `checkAuth` into a `useCallback` and exposes it as `recheckAuth` from `AuthContext`, then calls it in `ConfigurationPage` after saving the `auth` section so the state updates in-place immediately.
- Splits the single `try/catch` in `checkAuth` into two separate blocks: one for `getAuthConfig` failures (defaults to requiring auth) and one for `getCurrentUser` failures (expected when no session exists).

## Test plan

- [ ] With auth enabled and a valid session, go to Config → Auth, disable login, save — app should remain accessible without a page reload
- [ ] Open a new tab after disabling auth — should go directly to dashboard, not login page
- [ ] Re-enable auth, save — next navigation to a protected route should prompt login
- [ ] With auth disabled from a fresh install, page load should go straight to dashboard

🤖 Generated with [Claude Code](https://claude.ai/claude-code)