### PR TITLE
fix(importer): remove duplicate folder when nested RAR subfolder matches virtual dir name

### DIFF
--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -275,6 +275,16 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 		baseFilename := filepath.Base(normalizedInternalPath)
 		internalSubDir := filepath.ToSlash(filepath.Dir(normalizedInternalPath))
 
+		// Deduplicate: if internalSubDir matches the base name of virtualDir, collapse it.
+		// e.g. virtualDir="movies/MyMovie", internalSubDir="MyMovie" → "."
+		//      virtualDir="movies/MyMovie", internalSubDir="MyMovie/Extras" → "Extras"
+		virtualDirBase := filepath.Base(virtualDir)
+		if internalSubDir == virtualDirBase {
+			internalSubDir = "."
+		} else if after, ok := strings.CutPrefix(internalSubDir, virtualDirBase+"/"); ok {
+			internalSubDir = after
+		}
+
 		if !utils.IsAllowedFile(rarContent.InternalPath, rarContent.Size, allowedFileExtensions, filterSamples) &&
 			!utils.IsAllowedFile(rarContent.Filename, rarContent.Size, allowedFileExtensions, filterSamples) {
 			continue

--- a/internal/importer/archive/rar/aggregator_test.go
+++ b/internal/importer/archive/rar/aggregator_test.go
@@ -94,6 +94,28 @@ func TestProcessArchivePreservesInternalFolderStructure(t *testing.T) {
 			},
 		},
 		{
+			name:       "nested RAR folder same as virtual dir base: deduplicated",
+			virtualDir: "movies/MyMovie",
+			nzbPath:    "movies/MyMovie.nzb",
+			contents: []Content{
+				{InternalPath: "MyMovie/video.mkv", Filename: "video.mkv", Size: 1000,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 999}}},
+			},
+			wantMetaPaths:    []string{"movies/MyMovie/video.mkv"},
+			notWantMetaPaths: []string{"movies/MyMovie/MyMovie/video.mkv"},
+		},
+		{
+			name:       "nested RAR folder same as virtual dir base with subfolder: prefix stripped",
+			virtualDir: "movies/MyMovie",
+			nzbPath:    "movies/MyMovie.nzb",
+			contents: []Content{
+				{InternalPath: "MyMovie/Extras/bonus.mkv", Filename: "bonus.mkv", Size: 500,
+					Segments: []*metapb.SegmentData{{Id: "seg1", StartOffset: 0, EndOffset: 499}}},
+			},
+			wantMetaPaths:    []string{"movies/MyMovie/Extras/bonus.mkv"},
+			notWantMetaPaths: []string{"movies/MyMovie/MyMovie/Extras/bonus.mkv"},
+		},
+		{
 			name:            "single file with rename: placed flat ignoring internal subdir",
 			virtualDir:      "movies/MyMovie",
 			nzbPath:         "movies/MyMovie.nzb",


### PR DESCRIPTION
## Summary

- When a RAR archive has an internal subfolder with the same name as the NZB's virtual directory base (e.g. `virtualDir="movies/MyMovie"` and RAR internal path `MyMovie/video.mkv`), the virtual path was incorrectly doubled to `movies/MyMovie/MyMovie/video.mkv`
- Applied the same deduplication logic already present in `filesystem.DetermineFileLocation()` and `CreateDirectoriesForFiles()` to the RAR aggregator's path-building step in `aggregator.go`
- Added two test cases: direct name match and subfolder-within-same-name scenarios

## Test plan

- [x] `TestProcessArchivePreservesInternalFolderStructure/nested_RAR_folder_same_as_virtual_dir_base:_deduplicated` — verifies `movies/MyMovie/MyMovie/video.mkv` is NOT created and `movies/MyMovie/video.mkv` IS created
- [x] `TestProcessArchivePreservesInternalFolderStructure/nested_RAR_folder_same_as_virtual_dir_base_with_subfolder:_prefix_stripped` — verifies prefix stripping when subfolder is nested deeper (e.g. `MyMovie/Extras/bonus.mkv` → `movies/MyMovie/Extras/bonus.mkv`)
- [x] All existing tests continue to pass