### PR TITLE
fix(stremio): align default categories with Newznab API convention

### DIFF
--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -234,7 +234,8 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		}
 		playURL := baseURL + "/stremio/" + key + "/play" +
 			"?url=" + url.QueryEscape(r.DownloadURL) +
-			"&title=" + url.QueryEscape(safeTitle)
+			"&title=" + url.QueryEscape(safeTitle) +
+			"&type=" + url.QueryEscape(streamType)
 
 		sizeGB := float64(r.Size) / 1e9
 		indexerLabel := r.Indexer
@@ -394,8 +395,14 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 	}
 
 	priority := database.QueuePriorityHigh
-	stremioCategory := "stremio"
-	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &stremioCategory, &priority, nil, nil)
+	// Map Stremio stream type to Newznab category name so downloads land in the
+	// correct folder (matches default SABnzbd category config).
+	category := "Movies"
+	switch c.Query("type") {
+	case "series":
+		category = "TV"
+	}
+	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &category, &priority, nil, nil)
 	if err != nil {
 		os.Remove(tempPath)
 		slog.ErrorContext(ctx, "Failed to add Prowlarr NZB to queue", "error", err, "title", safeTitle)

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -1361,12 +1361,12 @@ func DefaultConfig(configDir ...string) *Config {
 			DownloadClientBaseURL: "",
 			Categories: []SABnzbdCategory{
 				{
-					Name:     "movies",
+					Name:     "Movies",
 					Order:    1,
 					Priority: 0,
 				},
 				{
-					Name:     "tv",
+					Name:     "TV",
 					Order:    1,
 					Priority: 1,
 				},


### PR DESCRIPTION
## Summary

- Changed default SABnzbd category names from `"movies"`/`"tv"` to `"Movies"`/`"TV"` to match the [Newznab API spec](https://torznab.github.io/spec-1.3-draft/external/newznab/api.html#predefined-categories)
- Pass `type` query param through the Stremio play URL so the play handler knows the content type
- Play handler now maps `type=movie` → `"Movies"` and `type=series` → `"TV"` instead of hardcoded `"stremio"` category, ensuring downloads land in the correct folder

## Test plan

- [ ] Trigger a Stremio movie stream — verify the NZB is queued under the `Movies` category/folder
- [ ] Trigger a Stremio series stream — verify the NZB is queued under the `TV` category/folder
- [ ] Verify existing SABnzbd/Radarr/Sonarr category mapping still works (case-insensitive match in `resolveCategoryPath`)
- [ ] Verify new installs get `Movies`/`TV` as default category names

Fixes #452