### PR TITLE
FUSE: offset-native `ReadAt` reads, stable streaming prefetch, and tunable read-ahead

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -134,6 +134,7 @@ fuse:
     entry_timeout_seconds: 1
     max_cache_size_mb: 128
     max_read_ahead_mb: 128
+    use_read_at: true
 providers: []
 mount_path: ''
 profiler_enabled: false

--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -57,7 +57,9 @@ fuse:
   attr_timeout_seconds: 30
   entry_timeout_seconds: 1
   max_cache_size_mb: 128
-  max_read_ahead_mb: 128
+  max_read_ahead_mb: 24
+  # Prefer offset-native reads (default true). Set false only for debugging legacy Seek+Read behavior.
+  use_read_at: true
 
 segment_cache:
   enabled: true
@@ -79,7 +81,20 @@ segment_cache:
 | `attr_timeout_seconds`  | `30`                      | How long the kernel caches file attributes (size, timestamps)                                        |
 | `entry_timeout_seconds` | `1`                       | How long the kernel caches directory entries — lower values refresh faster                            |
 | `max_cache_size_mb`     | `128`                     | Maximum kernel-level cache size in MB                                                                |
-| `max_read_ahead_mb`     | `128`                     | Kernel-level read-ahead buffer size in MB                                                            |
+| `max_read_ahead_mb`     | `24`                      | Kernel read-ahead buffer (MiB). Lower values reduce speculative reads far ahead of playback and improve FUSE stability for many clients; increase (e.g. 64–128) on very high-latency links if you see extra syscall overhead. |
+| `use_read_at`           | `true`                    | When true, FUSE uses offset-based reads (`ReadAt` / `ReadAtContext`) when the virtual file supports them, avoiding cursor `Seek` churn that can reset the streaming pipeline. |
+
+**Throughput note:** With `use_read_at: true`, sequential reads reuse one Usenet streaming pipeline per open file (offset-native, no per-syscall reader teardown), and the hanwen backend serializes `ReadAt` per file handle so prefetch stays coherent. Non-sequential offsets (probes, large backward jumps) still use short-lived range readers so correctness is preserved. The cgofuse backend already serialized reads per handle.
+
+#### Playback glitches on native FUSE
+
+If you see macroblocking or brief artifacts **only** on `mount_type: fuse` but not when using rclone against WebDAV, try:
+
+1. **Lower** `fuse.max_read_ahead_mb` (e.g. 16–32) — large read-ahead causes more non-sequential kernel reads.
+2. Ensure **`use_read_at: true`** (default) so reads stay offset-native.
+3. Keep **segment cache** enabled so repeated ranges hit disk instead of Usenet.
+
+Existing installs that relied on `max_read_ahead_mb: 128` can raise it again if throughput drops and playback is already stable.
 
 #### Segment Cache Options
 

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4441,6 +4441,9 @@ components:
           type: integer
         max_read_ahead_mb:
           type: integer
+        use_read_at:
+          description: Prefer offset-native FUSE reads (ReadAt) when the opened file supports it. Defaults to true when omitted.
+          type: boolean
         mount_path:
           type: string
       type: object

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4440,6 +4440,7 @@ components:
         max_cache_size_mb:
           type: integer
         max_read_ahead_mb:
+          description: Kernel FUSE read-ahead size in MiB. Default 24 after validation; lower reduces speculative read churn (see streaming docs).
           type: integer
         use_read_at:
           description: Prefer offset-native FUSE reads (ReadAt) when the opened file supports it. Defaults to true when omitted.

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -6820,10 +6820,15 @@
                     "type": "integer"
                 },
                 "max_read_ahead_mb": {
+                    "description": "Kernel FUSE read-ahead size in MiB (default 24 when unset/invalid; tunable per environment)",
                     "type": "integer"
                 },
                 "mount_path": {
                     "type": "string"
+                },
+                "use_read_at": {
+                    "description": "Prefer offset-native FUSE reads (ReadAt) when the opened file supports it. Defaults to true when omitted.",
+                    "type": "boolean"
                 }
             }
         },

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1105,6 +1105,9 @@ definitions:
         type: integer
       max_read_ahead_mb:
         type: integer
+      use_read_at:
+        description: Prefer offset-native FUSE reads (ReadAt) when the opened file supports it. Defaults to true when omitted.
+        type: boolean
       mount_path:
         type: string
     type: object

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1104,6 +1104,7 @@ definitions:
       max_cache_size_mb:
         type: integer
       max_read_ahead_mb:
+        description: Kernel FUSE read-ahead size in MiB (default 24 when unset/invalid; tunable per environment)
         type: integer
       use_read_at:
         description: Prefer offset-native FUSE reads (ReadAt) when the opened file supports it. Defaults to true when omitted.

--- a/frontend/src/components/config/ArrsConfigSection.tsx
+++ b/frontend/src/components/config/ArrsConfigSection.tsx
@@ -286,8 +286,8 @@ export function ArrsConfigSection({
 							<div>
 								<h5 className="font-bold text-sm">AltMount Webhooks</h5>
 								<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
-									Automatically configure hooks in ARR applications to notify AltMount of upgrades and
-									renames.
+									Automatically configure hooks in ARR applications to notify AltMount of upgrades
+									and renames.
 								</p>
 							</div>
 
@@ -520,7 +520,11 @@ export function ArrsConfigSection({
 											type="button"
 											className="btn btn-sm btn-primary px-4"
 											onClick={() => {
-												setNewInstance({ ...DEFAULT_NEW_INSTANCE, type, category: defaultCategory });
+												setNewInstance({
+													...DEFAULT_NEW_INSTANCE,
+													type,
+													category: defaultCategory,
+												});
 												setShowAddInstance(true);
 											}}
 											disabled={isReadOnly}

--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -311,8 +311,8 @@ export function HealthConfigSection({
 								onChange={(e) => handleInputChange("library_dir", e.target.value || undefined)}
 							/>
 							<div className="mt-2 whitespace-normal text-base-content/50 text-xs leading-relaxed">
-								Path where your permanent media folders are located. Required for
-								mapping virtual files to physical ARR library paths.
+								Path where your permanent media folders are located. Required for mapping virtual
+								files to physical ARR library paths.
 							</div>
 						</div>
 					</fieldset>

--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -947,7 +947,8 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 		attr_timeout_seconds: 30,
 		entry_timeout_seconds: 1,
 		max_cache_size_mb: 128,
-		max_read_ahead_mb: 128,
+		max_read_ahead_mb: 24,
+		use_read_at: true,
 	});
 
 	useEffect(() => {
@@ -1016,7 +1017,7 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 							<input
 								type="number"
 								className="input input-bordered join-item w-full bg-base-100 font-mono text-sm"
-								value={formData.max_read_ahead_mb ?? 128}
+								value={formData.max_read_ahead_mb ?? 24}
 								onChange={(e) =>
 									updateField({
 										max_read_ahead_mb: Number.parseInt(e.target.value, 10) || 0,
@@ -1028,6 +1029,26 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 								MB
 							</span>
 						</div>
+						<p className="label text-xs">
+							Lower values reduce speculative kernel read-ahead and can improve FUSE streaming
+							stability; raise toward 64–128 if you need more buffering on slow links.
+						</p>
+					</fieldset>
+					<fieldset className="fieldset sm:col-span-2">
+						<legend className="fieldset-legend">Offset-native reads (ReadAt)</legend>
+						<label className="label cursor-pointer justify-start gap-3">
+							<input
+								type="checkbox"
+								className="checkbox checkbox-primary checkbox-sm"
+								checked={formData.use_read_at ?? true}
+								onChange={(e) => updateField({ use_read_at: e.target.checked })}
+								disabled={isRunning}
+							/>
+							<span className="label-text text-xs">
+								Prefer ReadAt for FUSE file reads when supported (recommended; reduces seek churn on
+								media playback)
+							</span>
+						</label>
 					</fieldset>
 				</div>
 			</div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -205,6 +205,8 @@ export interface FuseConfig {
 	entry_timeout_seconds: number;
 	max_cache_size_mb: number;
 	max_read_ahead_mb: number;
+	/** Prefer offset-native FUSE reads (ReadAt) when the file supports it. Omitted defaults to true. */
+	use_read_at?: boolean;
 }
 
 // Import strategy type

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -736,7 +736,7 @@ func (c *Config) Validate() error {
 		c.Fuse.MaxCacheSizeMB = 32 // Default
 	}
 	if c.Fuse.MaxReadAheadMB <= 0 {
-		c.Fuse.MaxReadAheadMB = 128 // Default 128MB
+		c.Fuse.MaxReadAheadMB = 24 // Default: moderate read-ahead for stable FUSE streaming (override for high-latency links)
 	}
 	if c.Fuse.UseReadAt == nil {
 		v := true
@@ -1456,7 +1456,7 @@ func DefaultConfig(configDir ...string) *Config {
 			AttrTimeoutSeconds:  30,
 			EntryTimeoutSeconds: 1,
 			MaxCacheSizeMB:      128,
-			MaxReadAheadMB:      128,
+			MaxReadAheadMB:      24,
 			UseReadAt:           &fuseUseReadAt,
 		},
 		MountPath: "",            // Empty by default - required when ARRs is enabled

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -94,7 +94,19 @@ type FuseConfig struct {
 	EntryTimeoutSeconds int    `yaml:"entry_timeout_seconds" mapstructure:"entry_timeout_seconds" json:"entry_timeout_seconds"`
 	MaxCacheSizeMB      int    `yaml:"max_cache_size_mb" mapstructure:"max_cache_size_mb" json:"max_cache_size_mb"`
 	MaxReadAheadMB      int    `yaml:"max_read_ahead_mb" mapstructure:"max_read_ahead_mb" json:"max_read_ahead_mb"`
-	Backend             string `yaml:"backend" mapstructure:"backend" json:"backend"` // "hanwen" or "cgo" (empty = platform default)
+	// UseReadAt, when true, directs the FUSE read path to prefer io.ReaderAt when the opened file supports it
+	// (offset-native reads). Omitted or nil defaults to true after Validate.
+	UseReadAt *bool `yaml:"use_read_at" mapstructure:"use_read_at" json:"use_read_at,omitempty"`
+	Backend   string `yaml:"backend" mapstructure:"backend" json:"backend"` // "hanwen" or "cgo" (empty = platform default)
+}
+
+// UseReadAtEnabled reports whether FUSE should prefer ReadAt-based reads when the underlying file implements io.ReaderAt.
+// Nil means "use default" and is treated as true (matches post-Validate default).
+func (c FuseConfig) UseReadAtEnabled() bool {
+	if c.UseReadAt == nil {
+		return true
+	}
+	return *c.UseReadAt
 }
 
 // APIConfig represents REST API configuration
@@ -726,6 +738,10 @@ func (c *Config) Validate() error {
 	if c.Fuse.MaxReadAheadMB <= 0 {
 		c.Fuse.MaxReadAheadMB = 128 // Default 128MB
 	}
+	if c.Fuse.UseReadAt == nil {
+		v := true
+		c.Fuse.UseReadAt = &v
+	}
 
 	return nil
 }
@@ -1204,6 +1220,7 @@ func DefaultConfig(configDir ...string) *Config {
 	sabnzbdEnabled := false
 	scrapperEnabled := false
 	fuseEnabled := false
+	fuseUseReadAt := true // Prefer offset-native FUSE reads when supported (see fuse.use_read_at)
 	loginRequired := true      // Require login by default
 	stremioEnabled := false    // Stremio endpoint disabled by default
 	prowlarrEnabled := false   // Prowlarr integration disabled by default
@@ -1440,6 +1457,7 @@ func DefaultConfig(configDir ...string) *Config {
 			EntryTimeoutSeconds: 1,
 			MaxCacheSizeMB:      128,
 			MaxReadAheadMB:      128,
+			UseReadAt:           &fuseUseReadAt,
 		},
 		MountPath: "",            // Empty by default - required when ARRs is enabled
 		MountType: MountTypeNone, // No mount system active by default

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate_MountPaths(t *testing.T) {
@@ -222,5 +223,24 @@ func TestConfig_GetDownloadClientBaseURL(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.config.GetDownloadClientBaseURL())
 		})
 	}
+}
+
+func TestFuseConfig_UseReadAt_DefaultsAndHelper(t *testing.T) {
+	cfg := DefaultConfig("/tmp/altmount-test-fuse-use-read-at")
+	require.NoError(t, cfg.Validate())
+	require.NotNil(t, cfg.Fuse.UseReadAt)
+	assert.True(t, *cfg.Fuse.UseReadAt)
+	assert.True(t, cfg.Fuse.UseReadAtEnabled())
+
+	cfgOff := DefaultConfig("/tmp/altmount-test-fuse-use-read-at-off")
+	disabled := false
+	cfgOff.Fuse.UseReadAt = &disabled
+	require.NoError(t, cfgOff.Validate())
+	assert.False(t, cfgOff.Fuse.UseReadAtEnabled())
+
+	var unset FuseConfig
+	assert.True(t, unset.UseReadAtEnabled())
+	unset.UseReadAt = &disabled
+	assert.False(t, unset.UseReadAtEnabled())
 }
 

--- a/internal/fuse/backend/cgofuse/fs.go
+++ b/internal/fuse/backend/cgofuse/fs.go
@@ -20,6 +20,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+// readAtContexter matches nzbfilesystem.MetadataVirtualFile.ReadAtContext.
+type readAtContexter interface {
+	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
+}
+
 // ensure FS implements cgofuse interfaces
 var _ cgofuse.FileSystemInterface = (*FS)(nil)
 var _ cgofuse.FileSystemOpenEx = (*FS)(nil)
@@ -30,14 +35,15 @@ func (f *FS) CreateEx(path string, mode uint32, fi *cgofuse.FileInfo_t) int {
 }
 
 // openHandle tracks an open file and its associated stream.
-// Uses mutex-protected Seek+Read to preserve UsenetReader prefetch state.
+// When useReadAt is true and the file supports ReadAtContext or io.ReaderAt,
+// reads are offset-native under the handle mutex (no Seek on the virtual cursor).
 type openHandle struct {
-	file   afero.File
-	stream *nzbfilesystem.ActiveStream
-	path   string
-	closed atomic.Bool
+	file      afero.File
+	stream    *nzbfilesystem.ActiveStream
+	path      string
+	closed    atomic.Bool
+	useReadAt bool
 
-	// Seek+Read serialization
 	mu       sync.Mutex
 	position int64
 }
@@ -284,9 +290,10 @@ func (f *FS) OpenEx(path string, fi *cgofuse.FileInfo_t) int {
 	}
 
 	h := &openHandle{
-		file:   file,
-		stream: stream,
-		path:   clean,
+		file:      file,
+		stream:    stream,
+		path:      clean,
+		useReadAt: f.cfg.FuseConfig.UseReadAtEnabled(),
 	}
 
 	fi.Fh = f.allocHandle(h)
@@ -309,9 +316,7 @@ func (f *FS) Open(path string, flags int) (int, uint64) {
 	return errc, fi.Fh
 }
 
-// Read reads data from an open file using mutex-protected Seek+Read.
-// This keeps the persistent UsenetReader alive across reads, allowing
-// the downloadManager prefetch pipeline to stay effective.
+// Read reads data from an open file.
 func (f *FS) Read(path string, buff []byte, ofst int64, fh uint64) int {
 	h := f.getHandle(fh)
 	if h == nil {
@@ -321,7 +326,41 @@ func (f *FS) Read(path string, buff []byte, ofst int64, fh uint64) int {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Skip seek if already at the correct position (sequential read optimization)
+	ctx := context.Background()
+
+	if h.useReadAt {
+		if rac, ok := h.file.(readAtContexter); ok {
+			n, err := rac.ReadAtContext(ctx, buff, ofst)
+			if n > 0 {
+				h.position = ofst + int64(n)
+				if h.stream != nil && f.cfg.StreamTracker != nil {
+					f.cfg.StreamTracker.UpdateProgress(h.stream.ID, int64(n))
+					atomic.StoreInt64(&h.stream.CurrentOffset, h.position)
+				}
+			}
+			if err != nil && err != io.EOF {
+				f.logger.Error("ReadAtContext failed", "path", path, "offset", ofst, "error", err)
+				return -cgofuse.EIO
+			}
+			return n
+		}
+		if ra, ok := h.file.(io.ReaderAt); ok {
+			n, err := ra.ReadAt(buff, ofst)
+			if n > 0 {
+				h.position = ofst + int64(n)
+				if h.stream != nil && f.cfg.StreamTracker != nil {
+					f.cfg.StreamTracker.UpdateProgress(h.stream.ID, int64(n))
+					atomic.StoreInt64(&h.stream.CurrentOffset, h.position)
+				}
+			}
+			if err != nil && err != io.EOF {
+				f.logger.Error("ReadAt failed", "path", path, "offset", ofst, "error", err)
+				return -cgofuse.EIO
+			}
+			return n
+		}
+	}
+
 	if ofst != h.position {
 		if _, err := h.file.Seek(ofst, io.SeekStart); err != nil {
 			f.logger.Error("Read seek failed", "path", path, "offset", ofst, "error", err)

--- a/internal/fuse/backend/hanwen/backend.go
+++ b/internal/fuse/backend/hanwen/backend.go
@@ -50,7 +50,7 @@ func (b *Backend) Type() backend.Type {
 func (b *Backend) Mount(ctx context.Context, onReady func()) error {
 	b.cleanup()
 
-	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker)
+	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker, b.cfg.FuseConfig.UseReadAtEnabled())
 
 	attrTimeout := time.Duration(b.cfg.FuseConfig.AttrTimeoutSeconds) * time.Second
 	entryTimeout := time.Duration(b.cfg.FuseConfig.EntryTimeoutSeconds) * time.Second
@@ -64,7 +64,7 @@ func (b *Backend) Mount(ctx context.Context, onReady func()) error {
 
 	maxReadAhead := b.cfg.FuseConfig.MaxReadAheadMB * 1024 * 1024
 	if maxReadAhead == 0 {
-		maxReadAhead = 128 * 1024 * 1024 // 128MB default
+		maxReadAhead = 24 * 1024 * 1024 // matches default fuse.max_read_ahead_mb when unset
 	}
 
 	opts := &fs.Options{

--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -37,6 +37,7 @@ type Dir struct {
 	isRootDir     bool
 	uid           uint32
 	gid           uint32
+	useReadAt     bool
 }
 
 // NewDir creates a new directory node for the FUSE filesystem.
@@ -46,6 +47,7 @@ func NewDir(
 	logger *slog.Logger,
 	uid, gid uint32,
 	st backend.StreamTracker,
+	useReadAt bool,
 ) *Dir {
 	return &Dir{
 		nzbfs:         nzbfs,
@@ -55,6 +57,7 @@ func NewDir(
 		isRootDir:     path == "" || path == "/",
 		uid:           uid,
 		gid:           gid,
+		useReadAt:     useReadAt,
 	}
 }
 
@@ -155,6 +158,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 			logger:        d.logger,
 			uid:           d.uid,
 			gid:           d.gid,
+			useReadAt:     d.useReadAt,
 		}
 		return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
 	}
@@ -167,6 +171,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		size:          info.Size(),
 		uid:           d.uid,
 		gid:           d.gid,
+		useReadAt:     d.useReadAt,
 	}
 	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG}), 0
 }

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -32,6 +32,7 @@ type File struct {
 	size          int64
 	uid           uint32
 	gid           uint32
+	useReadAt     bool
 }
 
 // Getattr implements fs.NodeGetattrer.
@@ -90,7 +91,7 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 		warmable.WarmUp()
 	}
 
-	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker)
+	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker, f.useReadAt)
 
 	// Use DIRECT_IO when file size is unknown/zero to prevent the kernel
 	// from caching pages with stale size metadata (rclone mount2 pattern).

--- a/internal/fuse/backend/hanwen/handle.go
+++ b/internal/fuse/backend/hanwen/handle.go
@@ -50,41 +50,52 @@ var ioResultChanPool = sync.Pool{
 	},
 }
 
-// Handle wraps an afero.File for Seek+Read-based reads.
-// A single background IO worker goroutine serializes all file operations,
-// replacing the previous design that allocated a new goroutine and channel
-// on every FUSE read call.
+// readAtContexter is implemented by virtual files that honor per-read cancellation
+// (e.g. MetadataVirtualFile). Checked before io.ReaderAt.
+type readAtContexter interface {
+	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
+}
+
+// Handle wraps an afero.File for FUSE reads.
+// When useReadAt is true and the file implements ReadAtContext or io.ReaderAt,
+// reads use offset-native APIs on the calling goroutine (no Seek cursor churn).
+// Otherwise a background IO worker serializes Seek+Read.
 //
-// FUSE serializes reads per handle in production; the atomic position tracks
-// state for the sequential-read optimization and keeps the race detector happy
-// under concurrent tests.
+// The atomic position tracks the last completed read end offset for logging and
+// stream tracking; it does not gate correctness when using ReadAt.
 type Handle struct {
 	file          afero.File
+	useReadAt     bool
 	closed        atomic.Bool
 	logger        *slog.Logger
 	path          string
 	stream        *nzbfilesystem.ActiveStream
 	streamTracker backend.StreamTracker
 
-	// Position tracking for the skip-seek sequential optimization.
 	position atomic.Int64
 
-	// Single background IO worker: reqCh feeds requests, wg tracks its lifetime.
-	// reqCh is buffered (1) so the caller can dispatch without stalling.
+	// readAtMu serializes offset-native reads per handle so MetadataVirtualFile can
+	// safely reuse a shared streaming reader without concurrent ReadAt corruption.
+	readAtMu sync.Mutex
+
 	reqCh chan ioReq
 	wg    sync.WaitGroup
 }
 
 // NewHandle creates a Handle and starts its background IO worker goroutine.
+// useReadAt selects the offset-native read path when the file supports it
+// (see config fuse.use_read_at).
 func NewHandle(
 	file afero.File,
 	logger *slog.Logger,
 	path string,
 	stream *nzbfilesystem.ActiveStream,
 	st backend.StreamTracker,
+	useReadAt bool,
 ) *Handle {
 	h := &Handle{
 		file:          file,
+		useReadAt:     useReadAt,
 		logger:        logger,
 		path:          path,
 		stream:        stream,
@@ -137,12 +148,66 @@ func (h *Handle) execIO(ctx context.Context, req ioReq) (ioResult, error) {
 	}
 }
 
-// Read handles a FUSE read request using the persistent IO worker.
-// This keeps the UsenetReader's prefetch pipeline alive across reads while
-// avoiding per-call goroutine and channel allocations.
+func (h *Handle) applyReadResult(off int64, n int, readErr error) syscall.Errno {
+	if n > 0 {
+		newPos := off + int64(n)
+		h.position.Store(newPos)
+		if h.stream != nil && h.streamTracker != nil {
+			h.streamTracker.UpdateProgress(h.stream.ID, int64(n))
+			atomic.StoreInt64(&h.stream.CurrentOffset, newPos)
+		}
+	}
+	if readErr != nil && readErr != io.EOF {
+		return syscall.EIO
+	}
+	return 0
+}
+
+// Read handles a FUSE read request.
 func (h *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
 	if h.closed.Load() {
 		return nil, syscall.EIO
+	}
+
+	if h.useReadAt {
+		if rac, ok := h.file.(readAtContexter); ok {
+			h.readAtMu.Lock()
+			defer h.readAtMu.Unlock()
+			n, err := rac.ReadAtContext(ctx, dest, off)
+			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					h.logger.DebugContext(ctx, "ReadAtContext canceled", "path", h.path, "offset", off)
+					return nil, syscall.EINTR
+				}
+				if err != io.EOF {
+					h.logger.ErrorContext(ctx, "ReadAtContext failed", "path", h.path, "offset", off, "size", len(dest), "error", err)
+					return nil, syscall.EIO
+				}
+			}
+			if errno := h.applyReadResult(off, n, err); errno != 0 {
+				return nil, errno
+			}
+			return fuse.ReadResultData(dest[:n]), 0
+		}
+		if ra, ok := h.file.(io.ReaderAt); ok {
+			h.readAtMu.Lock()
+			defer h.readAtMu.Unlock()
+			n, err := ra.ReadAt(dest, off)
+			if err != nil {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					h.logger.DebugContext(ctx, "ReadAt canceled", "path", h.path, "offset", off)
+					return nil, syscall.EINTR
+				}
+				if err != io.EOF {
+					h.logger.ErrorContext(ctx, "ReadAt failed", "path", h.path, "offset", off, "size", len(dest), "error", err)
+					return nil, syscall.EIO
+				}
+			}
+			if errno := h.applyReadResult(off, n, err); errno != 0 {
+				return nil, errno
+			}
+			return fuse.ReadResultData(dest[:n]), 0
+		}
 	}
 
 	// Skip seek when already at the correct position (sequential-read optimisation).
@@ -173,20 +238,10 @@ func (h *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadRes
 	}
 
 	n := res.n
-	if n > 0 {
-		newPos := off + int64(n)
-		h.position.Store(newPos)
-		if h.stream != nil {
-			h.streamTracker.UpdateProgress(h.stream.ID, int64(n))
-			atomic.StoreInt64(&h.stream.CurrentOffset, newPos)
-		}
-	}
-
-	if res.err != nil && res.err != io.EOF {
+	if errno := h.applyReadResult(off, n, res.err); errno != 0 {
 		h.logger.ErrorContext(ctx, "Read failed", "path", h.path, "offset", off, "size", len(dest), "error", res.err)
 		return nil, syscall.EIO
 	}
-
 	return fuse.ReadResultData(dest[:n]), 0
 }
 

--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -32,6 +33,11 @@ func (m *MockFile) Read(p []byte) (n int, err error) {
 
 func (m *MockFile) ReadAt(p []byte, off int64) (n int, err error) {
 	args := m.Called(p, off)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockFile) ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error) {
+	args := m.Called(ctx, p, off)
 	return args.Int(0), args.Error(1)
 }
 
@@ -101,7 +107,7 @@ func TestHandle_Read_InterleavedOffsets_BaselineSeekRead(t *testing.T) {
 	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(16, nil).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -116,6 +122,38 @@ func TestHandle_Read_InterleavedOffsets_BaselineSeekRead(t *testing.T) {
 
 	handle.Release(ctx)
 	mockFile.AssertExpectations(t)
+	mockFile.AssertNotCalled(t, "ReadAt", mock.Anything, mock.Anything)
+	mockFile.AssertNotCalled(t, "ReadAtContext", mock.Anything, mock.Anything, mock.Anything)
+}
+
+// TestHandle_Read_InterleavedOffsets_UsesReadAt verifies offset-native reads: no Seek,
+// and ReadAtContext is used (MetadataVirtualFile implements it; mocks may implement both).
+func TestHandle_Read_InterleavedOffsets_UsesReadAt(t *testing.T) {
+	mockFile := new(MockFile)
+	logger := slog.Default()
+
+	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(0)).Return(16, nil).Once()
+	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(65536)).Return(16, nil).Once()
+	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(4096)).Return(16, nil).Once()
+	mockFile.On("Close").Return(nil)
+
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, true)
+	defer handle.Release(context.Background())
+
+	ctx := context.Background()
+	dest := make([]byte, 16)
+
+	_, st := handle.Read(ctx, dest, 0)
+	assert.Equal(t, syscall.Errno(0), st)
+	_, st = handle.Read(ctx, dest, 65536)
+	assert.Equal(t, syscall.Errno(0), st)
+	_, st = handle.Read(ctx, dest, 4096)
+	assert.Equal(t, syscall.Errno(0), st)
+
+	handle.Release(ctx)
+	mockFile.AssertExpectations(t)
+	mockFile.AssertNotCalled(t, "Seek", mock.Anything, mock.Anything)
+	mockFile.AssertNotCalled(t, "Read", mock.Anything)
 	mockFile.AssertNotCalled(t, "ReadAt", mock.Anything, mock.Anything)
 }
 
@@ -133,7 +171,7 @@ func TestHandle_Read_SeekAndRead(t *testing.T) {
 
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -148,6 +186,7 @@ func TestHandle_Read_SeekAndRead(t *testing.T) {
 	handle.Release(ctx)
 	mockFile.AssertExpectations(t)
 	mockFile.AssertNotCalled(t, "ReadAt", mock.Anything, mock.Anything)
+	mockFile.AssertNotCalled(t, "ReadAtContext", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestHandle_Read_SequentialSkipsSeek(t *testing.T) {
@@ -158,7 +197,7 @@ func TestHandle_Read_SequentialSkipsSeek(t *testing.T) {
 	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(10, nil).Twice()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -177,6 +216,70 @@ func TestHandle_Read_SequentialSkipsSeek(t *testing.T) {
 	mockFile.AssertNotCalled(t, "Seek", mock.Anything, mock.Anything)
 }
 
+// readAtDepthFile counts overlapping ReadAtContext calls (no pool / MVF).
+type readAtDepthFile struct {
+	mu        sync.Mutex
+	inRead    int
+	maxInRead int
+}
+
+func (f *readAtDepthFile) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
+	f.mu.Lock()
+	f.inRead++
+	if f.inRead > f.maxInRead {
+		f.maxInRead = f.inRead
+	}
+	f.mu.Unlock()
+	time.Sleep(8 * time.Millisecond)
+	f.mu.Lock()
+	f.inRead--
+	f.mu.Unlock()
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+func (f *readAtDepthFile) Close() error { return nil }
+func (f *readAtDepthFile) Read(p []byte) (int, error)                       { return 0, io.EOF }
+func (f *readAtDepthFile) ReadAt(p []byte, off int64) (int, error)          { return 0, nil }
+func (f *readAtDepthFile) Seek(offset int64, whence int) (int64, error)     { return 0, nil }
+func (f *readAtDepthFile) Write(p []byte) (int, error)                      { return 0, nil }
+func (f *readAtDepthFile) WriteAt(p []byte, off int64) (int, error)         { return 0, nil }
+func (f *readAtDepthFile) Name() string                                    { return "depth" }
+func (f *readAtDepthFile) Readdir(count int) ([]os.FileInfo, error)         { return nil, nil }
+func (f *readAtDepthFile) Readdirnames(n int) ([]string, error)             { return nil, nil }
+func (f *readAtDepthFile) Stat() (os.FileInfo, error)                      { return nil, nil }
+func (f *readAtDepthFile) Sync() error                                     { return nil }
+func (f *readAtDepthFile) Truncate(size int64) error                        { return nil }
+func (f *readAtDepthFile) WriteString(s string) (int, error)                { return 0, nil }
+
+func TestHandle_Read_ConcurrentReadAtSerialized(t *testing.T) {
+	df := &readAtDepthFile{}
+	logger := slog.Default()
+	handle := NewHandle(df, logger, "testfile", nil, nil, true)
+	defer handle.Release(context.Background())
+
+	ctx := context.Background()
+	dest := make([]byte, 16)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, st := handle.Read(ctx, dest, 0)
+		assert.Equal(t, syscall.Errno(0), st)
+	}()
+	go func() {
+		defer wg.Done()
+		_, st := handle.Read(ctx, dest, 100)
+		assert.Equal(t, syscall.Errno(0), st)
+	}()
+	wg.Wait()
+
+	assert.Equal(t, 1, df.maxInRead, "per-handle ReadAt mutex should prevent overlapping ReadAtContext")
+}
+
 func TestHandle_Read_Concurrency(t *testing.T) {
 	mockFile := new(MockFile)
 	logger := slog.Default()
@@ -186,7 +289,7 @@ func TestHandle_Read_Concurrency(t *testing.T) {
 	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(10, nil)
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -220,7 +323,7 @@ func TestHandle_Read_ReadError(t *testing.T) {
 	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(0, os.ErrPermission).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -240,7 +343,7 @@ func TestHandle_Read_EOF(t *testing.T) {
 	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(5, io.EOF).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -262,7 +365,7 @@ func TestHandle_Read_SeekError(t *testing.T) {
 	mockFile.On("Seek", int64(500), io.SeekStart).Return(int64(0), os.ErrInvalid).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -280,7 +383,7 @@ func TestHandle_Read_ContextCanceled(t *testing.T) {
 	logger := slog.Default()
 
 	bf := &blockingFile{readBlock: make(chan struct{})}
-	handle := NewHandle(bf, logger, "testfile", nil, nil)
+	handle := NewHandle(bf, logger, "testfile", nil, nil, false)
 	// Release will close bf (unblocking any blocked worker) and stop the worker.
 	defer handle.Release(context.Background())
 
@@ -298,7 +401,7 @@ func TestHandle_Read_BlockingReadContextCanceled(t *testing.T) {
 
 	// blockingFile blocks on Read until Close is called (or readBlock is closed)
 	bf := &blockingFile{readBlock: make(chan struct{})}
-	handle := NewHandle(bf, logger, "testfile", nil, nil)
+	handle := NewHandle(bf, logger, "testfile", nil, nil, false)
 	// Release closes bf.Close() which unblocks the worker, then waits for it.
 	defer handle.Release(context.Background())
 
@@ -322,7 +425,7 @@ func TestHandle_Read_BlockingSeekContextCanceled(t *testing.T) {
 	logger := slog.Default()
 
 	bf := &blockingFile{seekBlock: make(chan struct{})}
-	handle := NewHandle(bf, logger, "testfile", nil, nil)
+	handle := NewHandle(bf, logger, "testfile", nil, nil, false)
 	defer handle.Release(context.Background())
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -401,7 +504,7 @@ func TestHandle_Release_Idempotent(t *testing.T) {
 
 	mockFile.On("Close").Return(nil).Once()
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, false)
 
 	ctx := context.Background()
 

--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -85,6 +85,40 @@ func (m *MockFile) WriteString(s string) (ret int, err error) {
 	return args.Int(0), args.Error(1)
 }
 
+// TestHandle_Read_InterleavedOffsets_BaselineSeekRead models kernel/player behavior: non-sequential
+// offsets (e.g. read-ahead far ahead, then metadata/index probes). Baseline path is Seek+Read per jump;
+// Phase 1+ will prefer io.ReaderAt when fuse.use_read_at is enabled.
+func TestHandle_Read_InterleavedOffsets_BaselineSeekRead(t *testing.T) {
+	mockFile := new(MockFile)
+	logger := slog.Default()
+
+	// First at 0: position already 0 — no Seek.
+	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(16, nil).Once()
+	// Jump to 64 KiB (read-ahead), then back to 4 KiB (typical non-seq pattern).
+	mockFile.On("Seek", int64(65536), io.SeekStart).Return(int64(65536), nil).Once()
+	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(16, nil).Once()
+	mockFile.On("Seek", int64(4096), io.SeekStart).Return(int64(4096), nil).Once()
+	mockFile.On("Read", mock.AnythingOfType("[]uint8")).Return(16, nil).Once()
+	mockFile.On("Close").Return(nil)
+
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	defer handle.Release(context.Background())
+
+	ctx := context.Background()
+	dest := make([]byte, 16)
+
+	_, st := handle.Read(ctx, dest, 0)
+	assert.Equal(t, syscall.Errno(0), st)
+	_, st = handle.Read(ctx, dest, 65536)
+	assert.Equal(t, syscall.Errno(0), st)
+	_, st = handle.Read(ctx, dest, 4096)
+	assert.Equal(t, syscall.Errno(0), st)
+
+	handle.Release(ctx)
+	mockFile.AssertExpectations(t)
+	mockFile.AssertNotCalled(t, "ReadAt", mock.Anything, mock.Anything)
+}
+
 func TestHandle_Read_SeekAndRead(t *testing.T) {
 	mockFile := new(MockFile)
 	logger := slog.Default()

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/javi11/altmount/internal/config"
@@ -784,6 +785,27 @@ type MetadataVirtualFile struct {
 
 	mu      sync.Mutex
 	closeWg sync.WaitGroup // tracks background reader closes during seek
+
+	// readAtSharedNext is the next file offset that may reuse mvf.reader in ReadAt
+	// (long-lived prefetch pipeline). -1 means the sequential cursor was invalidated
+	// (e.g. random ReadAt) and the next shared reuse must match mvf.position after
+	// a fresh ensureReader (typically following Seek).
+	readAtSharedNext int64
+}
+
+// readAtPathMetrics counts ReadAt routing for tests and tuning (optional observability).
+var (
+	readAtSharedPathInvocations  atomic.Uint64
+	readAtEphemeralInvocations  atomic.Uint64
+)
+
+func readAtPathMetricsForTest() (shared, ephemeral uint64) {
+	return readAtSharedPathInvocations.Load(), readAtEphemeralInvocations.Load()
+}
+
+func resetReadAtPathMetricsForTest() {
+	readAtSharedPathInvocations.Store(0)
+	readAtEphemeralInvocations.Store(0)
 }
 
 // segmentOffsetIndex provides O(1) lookup for offset→segment mapping using binary search
@@ -864,6 +886,15 @@ func (mvf *MetadataVirtualFile) GetStreamID() string {
 	return mvf.streamID
 }
 
+// fileContext returns the open-file context for reader construction and range parsing.
+// Callers may omit ctx in tests; nil is treated as context.Background so Value/WithTimeout never run on a nil Context.
+func (mvf *MetadataVirtualFile) fileContext() context.Context {
+	if mvf.ctx != nil {
+		return mvf.ctx
+	}
+	return context.Background()
+}
+
 // WarmUp triggers a background pre-fetch of the file start
 func (mvf *MetadataVirtualFile) WarmUp() {
 	go func() {
@@ -880,6 +911,8 @@ func (mvf *MetadataVirtualFile) WarmUp() {
 			// Just log/ignore, the actual Read will handle it later
 			return
 		}
+
+		mvf.readAtSharedNext = mvf.position
 
 		// If the reader supports manual starting (UsenetReader), trigger it
 		// This starts the background workers to fetch data into the cache
@@ -907,6 +940,9 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 		totalRead, readErr := mvf.reader.Read(p[n:])
 		n += totalRead
 		mvf.position += int64(totalRead)
+		if totalRead > 0 {
+			mvf.readAtSharedNext = mvf.position
+		}
 
 		if totalRead > 0 && mvf.streamTracker != nil && mvf.streamID != "" {
 			mvf.streamTracker.UpdateProgress(mvf.streamID, int64(totalRead))
@@ -922,6 +958,7 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 			if errors.Is(readErr, io.EOF) && mvf.hasMoreDataToRead() {
 				// Close current reader and try to get a new one for the next range in next iteration
 				mvf.closeCurrentReader()
+				mvf.readAtSharedNext = mvf.position
 				continue
 			}
 
@@ -942,15 +979,29 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// ReadAt implements afero.File.ReadAt with concurrent random access support.
-// Unlike Read(), this method creates an independent reader for each call,
-// allowing concurrent reads at different offsets without mutex serialization.
+// ReadAt implements afero.File.ReadAt.
+// Sequential reads at the tracked cursor reuse the shared mvf.reader so prefetch
+// can run ahead; other offsets use a short-lived range reader. All ReadAt calls
+// are serialized on mvf.mu so the shared path stays consistent under concurrency.
 func (mvf *MetadataVirtualFile) ReadAt(p []byte, off int64) (n int, err error) {
+	return mvf.readAtWithContext(mvf.fileContext(), p, off)
+}
+
+// ReadAtContext is like ReadAt but uses readCtx for cancellation while the byte
+// range is read (e.g. FUSE per-request context). Reader construction still uses
+// the open-file context.
+func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte, off int64) (n int, err error) {
+	if readCtx == nil {
+		readCtx = mvf.fileContext()
+	}
+	return mvf.readAtWithContext(readCtx, p, off)
+}
+
+func (mvf *MetadataVirtualFile) readAtWithContext(readCtx context.Context, p []byte, off int64) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
 
-	// Validate offset bounds
 	if off < 0 {
 		return 0, ErrNegativeOffset
 	}
@@ -958,29 +1009,59 @@ func (mvf *MetadataVirtualFile) ReadAt(p []byte, off int64) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	// Calculate end position (don't read beyond file size)
 	end := off + int64(len(p)) - 1
 	if end >= mvf.fileMeta.FileSize {
 		end = mvf.fileMeta.FileSize - 1
 	}
+	buf := p[:end-off+1]
 
-	// Create an independent reader for this specific offset range
-	// This reader is self-contained and doesn't affect the file's main position
+	mvf.mu.Lock()
+	defer mvf.mu.Unlock()
+
+	useShared := (mvf.readAtSharedNext >= 0 && off == mvf.readAtSharedNext) ||
+		(mvf.readAtSharedNext < 0 && !mvf.readerInitialized && off == mvf.position)
+
+	if useShared {
+		if err := mvf.ensureReader(); err != nil {
+			return 0, err
+		}
+		readAtSharedPathInvocations.Add(1)
+		n, err = readFullContext(readCtx, mvf.reader, buf)
+		if err == io.ErrUnexpectedEOF {
+			err = nil
+		}
+		if n > 0 {
+			mvf.readAtSharedNext = off + int64(n)
+		}
+		if n > 0 && mvf.streamTracker != nil && mvf.streamID != "" {
+			nextOff := off + int64(n)
+			mvf.streamTracker.UpdateProgress(mvf.streamID, int64(n))
+			mvf.streamTracker.UpdateCurrentOffset(mvf.streamID, nextOff)
+			if ur, ok := mvf.reader.(interface{ GetBufferedOffset() int64 }); ok {
+				mvf.streamTracker.UpdateBufferedOffset(mvf.streamID, ur.GetBufferedOffset())
+			}
+		}
+		return n, err
+	}
+
+	readAtEphemeralInvocations.Add(1)
+	if mvf.reader != nil {
+		mvf.closeCurrentReader()
+	}
+	mvf.readAtSharedNext = -1
+
 	reader, err := mvf.createReaderAtOffset(off, end)
 	if err != nil {
 		return 0, err
 	}
 	defer reader.Close()
 
-	// Read the requested data using a context-aware wrapper.
-	// This ensures reads are cancelled if the FUSE context expires,
-	// even if the underlying reader blocks.
-	ctx := mvf.ctx
-	buf := p[:end-off+1]
-	n, err = readFullContext(ctx, reader, buf)
+	n, err = readFullContext(readCtx, reader, buf)
 	if err == io.ErrUnexpectedEOF {
-		// Partial read is acceptable for ReadAt at end of file
 		err = nil
+	}
+	if err == nil && n > 0 {
+		mvf.readAtSharedNext = off + int64(n)
 	}
 
 	return n, err
@@ -1007,7 +1088,7 @@ func (mvf *MetadataVirtualFile) createReaderAtOffset(start, end int64) (io.ReadC
 		return mvf.createEncryptedReaderAtOffset(start, end)
 	}
 
-	return mvf.createUsenetReader(mvf.ctx, start, end)
+	return mvf.createUsenetReader(mvf.fileContext(), start, end)
 }
 
 // createEncryptedReaderAtOffset creates an encrypted reader for a specific offset range
@@ -1028,7 +1109,7 @@ func (mvf *MetadataVirtualFile) createEncryptedReaderAtOffset(start, end int64) 
 		}
 
 		return mvf.rcloneCipher.Open(
-			mvf.ctx,
+			mvf.fileContext(),
 			&utils.RangeHeader{Start: start, End: end},
 			mvf.fileMeta.FileSize,
 			password,
@@ -1050,7 +1131,7 @@ func (mvf *MetadataVirtualFile) createEncryptedReaderAtOffset(start, end int64) 
 		}
 
 		return mvf.aesCipher.Open(
-			mvf.ctx,
+			mvf.fileContext(),
 			&utils.RangeHeader{Start: start, End: end},
 			mvf.fileMeta.FileSize,
 			mvf.fileMeta.AesKey,
@@ -1108,6 +1189,7 @@ func (mvf *MetadataVirtualFile) Seek(offset int64, whence int) (int64, error) {
 	}
 
 	mvf.position = abs
+	mvf.readAtSharedNext = abs
 	return abs, nil
 }
 
@@ -1236,6 +1318,17 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 	// Get request range from args or use default range starting from current position
 	start, end := mvf.getRequestRange()
 
+	// Sequential ReadAt can advance readAtSharedNext while mvf.position stays at the
+	// Read/Seek cursor (ReadAt does not move position). Open the reader at the shared
+	// cursor when it lies within the same HTTP / logical byte window as getRequestRange.
+	if !mvf.readerInitialized &&
+		mvf.readAtSharedNext >= 0 &&
+		mvf.readAtSharedNext < mvf.fileMeta.FileSize &&
+		start < mvf.readAtSharedNext &&
+		(end < 0 || mvf.readAtSharedNext <= end) {
+		start = mvf.readAtSharedNext
+	}
+
 	if end == -1 {
 		end = mvf.fileMeta.FileSize - 1
 	}
@@ -1261,7 +1354,7 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 		mvf.reader = decryptedReader
 	} else {
 		// Create plain usenet reader
-		ur, err := mvf.createUsenetReader(mvf.ctx, start, end)
+		ur, err := mvf.createUsenetReader(mvf.fileContext(), start, end)
 		if err != nil {
 			return err
 		}
@@ -1278,7 +1371,7 @@ func (mvf *MetadataVirtualFile) getRequestRange() (start, end int64) {
 	// If this is the first read, check for HTTP range header and save original end
 	if !mvf.readerInitialized && mvf.originalRangeEnd == 0 {
 		// Extract range from context
-		if rangeStr, ok := mvf.ctx.Value(utils.RangeKey).(string); ok && rangeStr != "" {
+		if rangeStr, ok := mvf.fileContext().Value(utils.RangeKey).(string); ok && rangeStr != "" {
 			rangeHeader, err := utils.ParseRangeHeader(rangeStr)
 			if err == nil && rangeHeader != nil {
 				mvf.originalRangeEnd = rangeHeader.End
@@ -1433,7 +1526,7 @@ func (mvf *MetadataVirtualFile) createNestedSourceReader(
 		}
 
 		return mvf.aesCipher.Open(
-			mvf.ctx,
+			mvf.fileContext(),
 			rh,
 			src.InnerVolumeSize,
 			src.AesKey,
@@ -1445,7 +1538,7 @@ func (mvf *MetadataVirtualFile) createNestedSourceReader(
 	}
 
 	// Unencrypted source: read directly from segments at inner offset
-	return mvf.createUsenetReaderFromSegments(mvf.ctx, src.Segments, absoluteStart, absoluteStart+readLen-1)
+	return mvf.createUsenetReaderFromSegments(mvf.fileContext(), src.Segments, absoluteStart, absoluteStart+readLen-1)
 }
 
 // createUsenetReaderFromSegments creates a usenet reader from a specific set of segments
@@ -1550,7 +1643,7 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 
 		// Wrap with rclone decryption
 		decryptedReader, err := mvf.rcloneCipher.Open(
-			mvf.ctx,
+			mvf.fileContext(),
 			&utils.RangeHeader{Start: start, End: end},
 			mvf.fileMeta.FileSize,
 			password,
@@ -1578,7 +1671,7 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 
 		// Wrap with AES decryption - pass key and IV directly
 		decryptedReader, err := mvf.aesCipher.Open(
-			mvf.ctx,
+			mvf.fileContext(),
 			&utils.RangeHeader{Start: start, End: end},
 			mvf.fileMeta.FileSize,
 			mvf.fileMeta.AesKey,
@@ -1602,7 +1695,7 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 // Uses synchronous operations with timeout to prevent goroutine leaks.
 func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usenet.DataCorruptionError, noRetry bool) {
 	// Use a short timeout context to prevent blocking indefinitely
-	ctx, cancel := context.WithTimeout(mvf.ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(mvf.fileContext(), 5*time.Second)
 	defer cancel()
 
 	// Any file with missing segments or corruption is marked as corrupted in metadata

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -1,6 +1,7 @@
 package nzbfilesystem
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"sync"
@@ -612,4 +613,93 @@ func TestConcurrentSegmentIndexAccess(t *testing.T) {
 		}(int64(i * 30))
 	}
 	wg.Wait()
+}
+
+// TestMetadataVirtualFile_ReadAt_SequentialReusesSharedReader verifies that
+// sequential ReadAt calls on an existing reader hit the shared path (metrics)
+// and return correct bytes without creating ephemeral range readers.
+func TestMetadataVirtualFile_ReadAt_SequentialReusesSharedReader(t *testing.T) {
+	resetReadAtPathMetricsForTest()
+	t.Cleanup(resetReadAtPathMetricsForTest)
+
+	data := make([]byte, 256)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	br := bytes.NewReader(data)
+	mvf := &MetadataVirtualFile{
+		fileMeta: &metapb.FileMetadata{
+			FileSize: int64(len(data)),
+			SegmentData: []*metapb.SegmentData{
+				{StartOffset: 0, EndOffset: int64(len(data)) - 1, SegmentSize: int64(len(data))},
+			},
+		},
+		reader:              io.NopCloser(br),
+		readerInitialized: true,
+		readAtSharedNext:  0,
+	}
+
+	buf := make([]byte, 10)
+	n, err := mvf.ReadAtContext(context.Background(), buf, 0)
+	if err != nil || n != 10 {
+		t.Fatalf("ReadAtContext(0): n=%d err=%v", n, err)
+	}
+	for i := range 10 {
+		if buf[i] != byte(i) {
+			t.Fatalf("byte %d: got %d want %d", i, buf[i], i)
+		}
+	}
+
+	n2, err := mvf.ReadAtContext(context.Background(), buf, 10)
+	if err != nil || n2 != 10 {
+		t.Fatalf("ReadAtContext(10): n=%d err=%v", n2, err)
+	}
+	for i := range 10 {
+		if buf[i] != byte(10+i) {
+			t.Fatalf("offset 10 byte %d: got %d want %d", i, buf[i], 10+i)
+		}
+	}
+
+	shared, ephemeral := readAtPathMetricsForTest()
+	if shared != 2 {
+		t.Fatalf("shared path invocations = %d, want 2", shared)
+	}
+	if ephemeral != 0 {
+		t.Fatalf("ephemeral path invocations = %d, want 0", ephemeral)
+	}
+}
+
+// TestMetadataVirtualFile_ReadAt_OutOfOrderUsesEphemeral checks that a backward
+// jump records an ephemeral-path attempt (counted before pool allocation).
+func TestMetadataVirtualFile_ReadAt_OutOfOrderUsesEphemeral(t *testing.T) {
+	resetReadAtPathMetricsForTest()
+	t.Cleanup(resetReadAtPathMetricsForTest)
+
+	data := make([]byte, 256)
+	br := bytes.NewReader(data)
+	mvf := &MetadataVirtualFile{
+		fileMeta: &metapb.FileMetadata{
+			FileSize: int64(len(data)),
+			SegmentData: []*metapb.SegmentData{
+				{StartOffset: 0, EndOffset: int64(len(data)) - 1, SegmentSize: int64(len(data))},
+			},
+		},
+		reader:              io.NopCloser(br),
+		readerInitialized: true,
+		readAtSharedNext:  0,
+	}
+
+	buf := make([]byte, 10)
+	if _, err := mvf.ReadAtContext(context.Background(), buf, 0); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = mvf.ReadAtContext(context.Background(), buf, 0)
+
+	shared, ephemeral := readAtPathMetricsForTest()
+	if shared < 1 {
+		t.Fatalf("expected at least 1 shared read, got %d", shared)
+	}
+	if ephemeral < 1 {
+		t.Fatalf("expected at least 1 ephemeral read, got %d", ephemeral)
+	}
 }


### PR DESCRIPTION
## Summary

Improves native **FUSE** playback with a single, coherent read path: kernel reads are served **offset-natively** via `ReadAt` / `ReadAtContext` instead of **`Seek` + `Read`**, avoiding repeated teardown of the forward Usenet reader that showed up as playback artifacts under aggressive read-ahead. **Sequential** `ReadAt` offsets reuse **one** streaming pipeline and prefetch; **non-sequential** offsets (probes, large backward jumps) still use **short-lived range readers** so correctness is preserved. **Hanwen** serializes `ReadAt` per open file handle so prefetch stays coherent under concurrent FUSE RPCs; **cgofuse** already serialized reads per handle and uses the same policy.

Adds **`fuse.use_read_at`** (default **on**) so operators can disable the offset-native path if needed, documents behavior in **streaming** docs, wires the option through **config API** and the **mount** UI, and updates the **default read-ahead** with tuning guidance.

## Motivation

Non-sequential kernel reads (read-ahead, index probes, container metadata) plus a **stateful** virtual file made **`Seek` + `Read`** expensive: each discontinuity reset the pipeline. A design that only opened a **new reader on every `ReadAt`** without reusing a sequential pipeline would fix the cursor issue but **starve prefetch** and hurt throughput. This PR delivers **both**: offset-native reads **and** a **shared sequential reader** on the hot path, with explicit per-handle ordering on hanwen.

## Why the default `max_read_ahead_mb` was lowered

FUSE read-ahead means the kernel can issue **read RPCs ahead of the app’s logical cursor**, sometimes far ahead. A **very large** window increases speculative reads at **many different offsets**, which stacks poorly with real clients that also do **probes** and **non-monotonic** access even during “normal” playback.

With an offset-native read path and **prefetch tied to a stable sequential pipeline**, a **more conservative default** (24 MiB in the updated defaults) **reduces far-ahead speculative churn** and keeps the workload closer to what prefetch can serve efficiently. The tradeoff is **somewhat more syscall/FUSE traffic** on very slow or very high-latency links.

Installs that previously relied on a **large** read-ahead (e.g. 128 MiB) for burst throughput can **raise `fuse.max_read_ahead_mb` again** after confirming stability—especially on high-latency paths where a bigger kernel window helps amortize round trips. The streaming docs describe this explicitly.

## Key changes

- **`internal/fuse/backend/hanwen/handle.go`**: `ReadAt` / `ReadAtContext` when enabled; per-handle ordering for the ReadAt path.
- **`internal/fuse/backend/cgofuse/fs.go`**: capability detection and ReadAt path where supported.
- **`internal/nzbfilesystem/metadata_remote_file.go`**: sequential `ReadAt` reuses the main reader; non-sequential fallback; WarmUp aligned with the path that serves bytes (see code + tests).
- **`internal/config/manager.go`**, OpenAPI/static swagger, **`MountConfigSection`**: **`fuse.use_read_at`**, read-ahead default updates, tests.
- **`docs/docs/3. Configuration/streaming.md`**: behavior, defaults, and tuning notes.

## Config / migration

- **`fuse.use_read_at`** (default **true**). Set **`false`** only as a fallback for an unexpected client; it restores the legacy read shape with known artifact tradeoffs on some workloads.
- **`fuse.max_read_ahead_mb`** reflects the new default in fresh defaults / UI; existing configs with an explicit value are unchanged. Operators who want the old throughput profile can set read-ahead back after validating playback.

## Testing

- Extended **`handle_test`** and **`metadata_remote_file`** coverage for ReadAt, interleaved offsets, and shared-path behavior.
- Please run **`make`** / project checks before merge (per repo convention).

---

**Disclaimer:** This pull request was produced with heavy AI assistance (“vibe-coded”).  **Please review the code, tests, and behavior carefully before merging.**