### PR TITLE
fix(ui): replace misleading Worker # with Queue # in ActivityHub imports

### DIFF
--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -258,7 +258,7 @@ export function ActivityHub() {
 														<span className="font-bold text-secondary text-xs">IMPORTING</span>
 														<span className="text-base-content/40 text-xs">•</span>
 														<span className="text-base-content/60 text-xs">
-															Worker #{item.id % 10}
+															Queue #{item.id}
 														</span>
 														{item.file_size && (
 															<>


### PR DESCRIPTION
## Summary
- Replaces `Worker #{item.id % 10}` with `Queue #{item.id}` in the ActivityHub imports tab
- The old label used modulo 10 to fake a worker slot number, causing users to see numbers higher than their configured worker count (e.g. "Worker #11" with only 4 workers configured)
- The queue item ID is now shown directly, which is the accurate identifier for the item being processed

## Test plan
- [ ] Start an import and verify the ActivityHub imports tab shows "Queue #X" (where X is the actual queue item ID) instead of "Worker #X"
- [ ] Confirm the number no longer exceeds or confusingly relates to the configured worker count

Closes #482