### PR TITLE
feat(queue): bulk priority change for selected items

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -111,7 +111,7 @@ jobs:
 
   build-dev-arm64:
     name: Build Dev Image (ARM64)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build-frontend
     permissions:
       contents: read

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -142,7 +142,7 @@ jobs:
           echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.tag.outputs.tag }}"
 
   build-image-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: build-frontend
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,7 +396,7 @@ jobs:
           sbom: false
 
   build-image-arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: [test, build-frontend]
     if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -258,6 +258,16 @@ export class APIClient {
 		});
 	}
 
+	async bulkUpdateQueueItemPriority(ids: number[], priority: 1 | 2 | 3) {
+		return this.request<{ updated_count: number; skipped_count: number; message: string }>(
+			"/queue/bulk/priority",
+			{
+				method: "PATCH",
+				body: JSON.stringify({ ids, priority }),
+			},
+		);
+	}
+
 	async cancelBulkQueueItems(ids: number[]) {
 		return this.request<{
 			cancelled_count: number;

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -105,6 +105,18 @@ export const useUpdateQueueItemPriority = () => {
 	});
 };
 
+export const useBulkUpdateQueueItemPriority = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ ids, priority }: { ids: number[]; priority: 1 | 2 | 3 }) =>
+			apiClient.bulkUpdateQueueItemPriority(ids, priority),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["queue"] });
+		},
+	});
+};
+
 export const useBulkCancelQueueItems = () => {
 	const queryClient = useQueryClient();
 

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -4,6 +4,7 @@ import {
 	AlertCircle,
 	ArrowDown,
 	ArrowUp,
+	ArrowUpDown,
 	Box,
 	CheckCircle2,
 	ChevronDown,
@@ -36,6 +37,7 @@ import { useConfirm } from "../contexts/ModalContext";
 import {
 	useAddTestQueueItem,
 	useBulkCancelQueueItems,
+	useBulkUpdateQueueItemPriority,
 	useCancelQueueItem,
 	useClearCompletedQueue,
 	useClearFailedQueue,
@@ -120,6 +122,7 @@ export function QueuePage() {
 	const retryItem = useRetryQueueItem();
 	const cancelItem = useCancelQueueItem();
 	const cancelBulk = useBulkCancelQueueItems();
+	const bulkUpdatePriority = useBulkUpdateQueueItemPriority();
 	const updatePriority = useUpdateQueueItemPriority();
 	const clearCompleted = useClearCompletedQueue();
 	const clearFailed = useClearFailedQueue();
@@ -318,6 +321,16 @@ export function QueuePage() {
 			} catch (error) {
 				console.error("Failed to cancel selected items:", error);
 			}
+		}
+	};
+
+	const handleBulkSetPriority = async (priority: 1 | 2 | 3) => {
+		if (selectedItems.size === 0) return;
+		try {
+			await bulkUpdatePriority.mutateAsync({ ids: Array.from(selectedItems), priority });
+			setSelectedItems(new Set());
+		} catch (error) {
+			console.error("Failed to update priority for selected items:", error);
 		}
 	};
 
@@ -592,6 +605,38 @@ export function QueuePage() {
 													)}
 													Restart
 												</button>
+												<div className="dropdown dropdown-bottom">
+													<button
+														type="button"
+														tabIndex={0}
+														className="btn btn-outline btn-sm px-4"
+														disabled={bulkUpdatePriority.isPending}
+													>
+														<ArrowUpDown className="h-3 w-3" />
+														Priority
+														<ChevronDown className="h-3 w-3" />
+													</button>
+													<ul
+														tabIndex={0}
+														className="dropdown-content menu z-10 w-40 rounded-box bg-base-100 p-2 shadow-md"
+													>
+														<li>
+															<button type="button" onClick={() => handleBulkSetPriority(1)}>
+																High
+															</button>
+														</li>
+														<li>
+															<button type="button" onClick={() => handleBulkSetPriority(2)}>
+																Normal
+															</button>
+														</li>
+														<li>
+															<button type="button" onClick={() => handleBulkSetPriority(3)}>
+																Low
+															</button>
+														</li>
+													</ul>
+												</div>
 												<button
 													type="button"
 													className="btn btn-outline btn-warning btn-sm px-4"

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -1246,6 +1246,53 @@ func (s *Server) handleUpdateQueueItemPriority(c *fiber.Ctx) error {
 	return RespondSuccess(c, ToQueueItemResponse(updated))
 }
 
+// handleBulkUpdateQueuePriority handles PATCH /api/queue/bulk/priority
+//
+//	@Summary		Bulk update queue item priorities
+//	@Description	Updates the priority for multiple queue items at once. Items currently being processed are skipped.
+//	@Tags			Queue
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		object{ids=[]int64,priority=int}	true	"IDs and priority: 1=high, 2=normal, 3=low"
+//	@Success		200		{object}	APIResponse{data=object{updated_count=int,skipped_count=int,message=string}}
+//	@Failure		400		{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/queue/bulk/priority [patch]
+func (s *Server) handleBulkUpdateQueuePriority(c *fiber.Ctx) error {
+	var req struct {
+		IDs      []int64 `json:"ids"`
+		Priority int     `json:"priority"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return RespondBadRequest(c, "Invalid request body", err.Error())
+	}
+
+	if len(req.IDs) == 0 {
+		return RespondBadRequest(c, "No queue item IDs provided", "")
+	}
+
+	if req.Priority < 1 || req.Priority > 3 {
+		return RespondValidationError(c, "Invalid priority value", "Valid values: 1 (high), 2 (normal), 3 (low)")
+	}
+
+	updated, skipped, err := s.queueRepo.UpdateQueueItemsPriorityBulk(c.Context(), req.IDs, database.QueuePriority(req.Priority))
+	if err != nil {
+		return RespondInternalError(c, "Failed to update priorities", err.Error())
+	}
+
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
+
+	priorityLabels := map[int]string{1: "high", 2: "normal", 3: "low"}
+	return RespondSuccess(c, fiber.Map{
+		"updated_count": updated,
+		"skipped_count": skipped,
+		"message":       fmt.Sprintf("Successfully set %d items to %s priority (%d skipped — currently processing)", updated, priorityLabels[req.Priority], skipped),
+	})
+}
+
 // handleDownloadNZB handles GET /api/queue/{id}/download
 //
 //	@Summary		Download NZB file

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -235,6 +235,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Delete("/queue/bulk", s.handleDeleteQueueBulk)
 	api.Post("/queue/bulk/restart", s.handleRestartQueueBulk)
 	api.Post("/queue/bulk/cancel", s.handleCancelQueueBulk)
+	api.Patch("/queue/bulk/priority", s.handleBulkUpdateQueuePriority)
 	api.Post("/queue/upload", s.handleUploadToQueue)
 	api.Post("/queue/upload-nzblnk", s.handleUploadNZBLnk)
 	api.Post("/queue/upload-by-name", s.handleSearchNZBByName)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1005,6 +1005,31 @@ func (r *Repository) UpdateQueueItemPriority(ctx context.Context, id int64, prio
 	return nil
 }
 
+// UpdateQueueItemsPriorityBulk updates the priority of multiple queue items, skipping any that are currently processing.
+// Returns the number of items updated and the number skipped.
+func (r *Repository) UpdateQueueItemsPriorityBulk(ctx context.Context, ids []int64, priority QueuePriority) (updated int, skipped int, err error) {
+	for _, id := range ids {
+		var status string
+		scanErr := r.db.QueryRowContext(ctx, `SELECT status FROM import_queue WHERE id = ?`, id).Scan(&status)
+		if scanErr == sql.ErrNoRows {
+			continue
+		}
+		if scanErr != nil {
+			return updated, skipped, fmt.Errorf("failed to check queue item status: %w", scanErr)
+		}
+		if status == string(QueueStatusProcessing) {
+			skipped++
+			continue
+		}
+		_, err = r.db.ExecContext(ctx, `UPDATE import_queue SET priority = ?, updated_at = datetime('now') WHERE id = ?`, priority, id)
+		if err != nil {
+			return updated, skipped, fmt.Errorf("failed to update queue item priority: %w", err)
+		}
+		updated++
+	}
+	return updated, skipped, nil
+}
+
 // AddImportHistory records a successful file import in the persistent history table
 func (r *Repository) AddImportHistory(ctx context.Context, history *ImportHistory) error {
 	query := `


### PR DESCRIPTION
## Summary

- Adds a **Priority** dropdown to the bulk actions toolbar in the Queue page, letting users set High / Normal / Low priority for all selected items at once
- Processing items are automatically skipped (not errored) and a count is returned
- Mirrors the existing bulk cancel / delete / restart pattern throughout the stack
- Optimize arm build

## Changes

| Layer | Change |
|-------|--------|
| Backend DB | `UpdateQueueItemsPriorityBulk` on `Repository` — iterates IDs, skips processing items |
| Backend API | `PATCH /queue/bulk/priority` handler + route registration |
| Frontend client | `bulkUpdateQueueItemPriority(ids, priority)` method |
| Frontend hook | `useBulkUpdateQueueItemPriority()` mutation hook |
| Frontend UI | Priority dropdown in bulk actions toolbar (`QueuePage.tsx`) |

Closes #479