### PR TITLE
feat: dynamic config changes without server restart + WebDAV debug logging

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/health"
 	"github.com/javi11/altmount/internal/metadata"
+	"github.com/javi11/altmount/internal/nzbfilesystem/segcache"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/rclone"
@@ -125,13 +127,18 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Initialize segment cache (shared between FUSE and WebDAV)
-	segcacheMgr := initializeSegmentCache(ctx, cfg)
-	if segcacheMgr != nil {
-		defer segcacheMgr.Stop()
+	// Initialize segment cache (shared between FUSE and WebDAV) with atomic pointer for dynamic swap
+	var segcachePtr atomic.Pointer[segcache.Manager]
+	if initialCache := initializeSegmentCache(ctx, cfg); initialCache != nil {
+		segcachePtr.Store(initialCache)
+		defer func() {
+			if mgr := segcachePtr.Load(); mgr != nil {
+				mgr.Stop()
+			}
+		}()
 	}
 
-	fs := initializeFilesystem(ctx, metadataService, repos.HealthRepo, arrsService, rcloneRCClient, poolManager, configManager.GetConfigGetter(), streamTracker, segcacheMgr)
+	fs := initializeFilesystem(ctx, metadataService, repos.HealthRepo, arrsService, rcloneRCClient, poolManager, configManager.GetConfigGetter(), streamTracker, &segcachePtr)
 
 	// 6. Setup web services
 	app, debugMode := createFiberApp(ctx, cfg)
@@ -147,7 +154,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	stremioCleanup := api.NewStremioCleanupService(repos.MainRepo, metadataService, configManager.GetConfigGetter())
 	stremioCleanup.StartCleanup(ctx)
 
-	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, metadataService, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker, segcacheMgr)
+	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, metadataService, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker, &segcachePtr)
 	apiServer.SetLogFilePath(slogutil.GetLogFilePath(cfg.Log))
 
 	webdavHandler, err := setupWebDAV(cfg, fs, authService, repos.UserRepo, configManager, streamTracker)
@@ -165,6 +172,38 @@ func runServe(cmd *cobra.Command, args []string) error {
 	pool.RegisterConfigHandlers(ctx, configManager, poolManager)
 	webdav.RegisterConfigHandlers(ctx, configManager, webdavHandler)
 	api.RegisterLogLevelHandler(ctx, configManager, debugMode)
+	apiServer.RegisterFuseConfigChangeHandler(configManager)
+
+	// Register segment cache config change handler for dynamic enable/disable/resize
+	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
+		oldEnabled := oldConfig.SegmentCache.Enabled != nil && *oldConfig.SegmentCache.Enabled
+		newEnabled := newConfig.SegmentCache.Enabled != nil && *newConfig.SegmentCache.Enabled
+		configChanged := oldEnabled != newEnabled ||
+			oldConfig.SegmentCache.CachePath != newConfig.SegmentCache.CachePath ||
+			oldConfig.SegmentCache.MaxSizeGB != newConfig.SegmentCache.MaxSizeGB ||
+			oldConfig.SegmentCache.ExpiryHours != newConfig.SegmentCache.ExpiryHours
+
+		if !configChanged {
+			return
+		}
+
+		// Stop old cache manager if present
+		if oldMgr := segcachePtr.Load(); oldMgr != nil {
+			oldMgr.Stop()
+			segcachePtr.Store(nil)
+		}
+
+		// Start new cache manager if enabled
+		if newEnabled {
+			newMgr := initializeSegmentCache(context.Background(), newConfig)
+			if newMgr != nil {
+				segcachePtr.Store(newMgr)
+				logger.InfoContext(ctx, "Segment cache reinitialized dynamically")
+			}
+		} else {
+			logger.InfoContext(ctx, "Segment cache disabled dynamically")
+		}
+	})
 
 	healthWorker, librarySyncWorker, err := startHealthWorker(ctx, cfg, repos.HealthRepo, poolManager, configManager, rcloneRCClient, arrsService, importerService, progressBroadcaster)
 	if err != nil {
@@ -207,7 +246,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	// 9. Create HTTP server
-	customServer := createHTTPServer(apiServer, app, webdavHandler, streamHandler, cfg.WebDAV.Port, cfg.ProfilerEnabled)
+	customServer := createHTTPServer(apiServer, app, webdavHandler, streamHandler, cfg.WebDAV.Port, configManager.GetConfigGetter())
 
 	logger.Info("AltMount server started",
 		"port", cfg.WebDAV.Port,

--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -7,7 +7,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -127,18 +126,13 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Initialize segment cache (shared between FUSE and WebDAV) with atomic pointer for dynamic swap
-	var segcachePtr atomic.Pointer[segcache.Manager]
-	if initialCache := initializeSegmentCache(ctx, cfg); initialCache != nil {
-		segcachePtr.Store(initialCache)
-		defer func() {
-			if mgr := segcachePtr.Load(); mgr != nil {
-				mgr.Stop()
-			}
-		}()
+	// Initialize segment cache source — encapsulates atomic manager swap and enabled-flag check.
+	cacheSource := segcache.NewSource(configManager.GetConfigGetter())
+	if initialCache := initializeSegmentCache(ctx, cfg, cacheSource); initialCache != nil {
+		defer initialCache.Stop()
 	}
 
-	fs := initializeFilesystem(ctx, metadataService, repos.HealthRepo, arrsService, rcloneRCClient, poolManager, configManager.GetConfigGetter(), streamTracker, &segcachePtr)
+	fs := initializeFilesystem(ctx, metadataService, repos.HealthRepo, arrsService, rcloneRCClient, poolManager, configManager.GetConfigGetter(), streamTracker, cacheSource)
 
 	// 6. Setup web services
 	app, debugMode := createFiberApp(ctx, cfg)
@@ -154,7 +148,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	stremioCleanup := api.NewStremioCleanupService(repos.MainRepo, metadataService, configManager.GetConfigGetter())
 	stremioCleanup.StartCleanup(ctx)
 
-	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, metadataService, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker, &segcachePtr)
+	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, metadataService, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker, cacheSource)
 	apiServer.SetLogFilePath(slogutil.GetLogFilePath(cfg.Log))
 
 	webdavHandler, err := setupWebDAV(cfg, fs, authService, repos.UserRepo, configManager, streamTracker)
@@ -174,34 +168,26 @@ func runServe(cmd *cobra.Command, args []string) error {
 	api.RegisterLogLevelHandler(ctx, configManager, debugMode)
 	apiServer.RegisterFuseConfigChangeHandler(configManager)
 
-	// Register segment cache config change handler for dynamic enable/disable/resize
+	// Register segment cache config change handler for dynamic path/size/expiry changes.
+	// Enable/disable toggles take effect automatically via cacheSource.Store() at file-open time.
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
-		oldEnabled := oldConfig.SegmentCache.Enabled != nil && *oldConfig.SegmentCache.Enabled
-		newEnabled := newConfig.SegmentCache.Enabled != nil && *newConfig.SegmentCache.Enabled
-		configChanged := oldEnabled != newEnabled ||
-			oldConfig.SegmentCache.CachePath != newConfig.SegmentCache.CachePath ||
+		structuralChange := oldConfig.SegmentCache.CachePath != newConfig.SegmentCache.CachePath ||
 			oldConfig.SegmentCache.MaxSizeGB != newConfig.SegmentCache.MaxSizeGB ||
 			oldConfig.SegmentCache.ExpiryHours != newConfig.SegmentCache.ExpiryHours
 
-		if !configChanged {
+		if !structuralChange {
 			return
 		}
 
-		// Stop old cache manager if present
-		if oldMgr := segcachePtr.Load(); oldMgr != nil {
+		// Stop old manager and swap in a new one for path/size/expiry changes.
+		if oldMgr := cacheSource.Manager(); oldMgr != nil {
 			oldMgr.Stop()
-			segcachePtr.Store(nil)
+			cacheSource.Swap(nil)
 		}
 
-		// Start new cache manager if enabled
-		if newEnabled {
-			newMgr := initializeSegmentCache(context.Background(), newConfig)
-			if newMgr != nil {
-				segcachePtr.Store(newMgr)
-				logger.InfoContext(ctx, "Segment cache reinitialized dynamically")
-			}
-		} else {
-			logger.InfoContext(ctx, "Segment cache disabled dynamically")
+		newMgr := initializeSegmentCache(context.Background(), newConfig, cacheSource)
+		if newMgr != nil {
+			logger.InfoContext(ctx, "Segment cache reinitialized dynamically")
 		}
 	})
 

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-pkgz/auth/v2/token"
@@ -110,17 +111,21 @@ func initializeFilesystem(
 	poolManager pool.Manager,
 	configGetter config.ConfigGetter,
 	streamTracker nzbfilesystem.StreamTracker,
-	segcacheMgr *segcache.Manager,
+	segcachePtr *atomic.Pointer[segcache.Manager],
 ) *nzbfilesystem.NzbFilesystem {
 	// Reset all in-progress file health checks on start up
 	if err := healthRepo.ResetFileAllChecking(ctx); err != nil {
 		slog.ErrorContext(ctx, "failed to reset in progress file health", "err", err)
 	}
 
-	// Build segment store from segment cache manager (nil if disabled)
-	var segmentStore usenet.SegmentStore
-	if segcacheMgr != nil {
-		segmentStore = segcacheMgr.Cache()
+	// Build a dynamic segment store getter so cache changes take effect without restart.
+	// The atomic pointer is swapped by the config change handler when cache settings change.
+	segmentStoreGetter := func() usenet.SegmentStore {
+		mgr := segcachePtr.Load()
+		if mgr == nil {
+			return nil
+		}
+		return mgr.Cache()
 	}
 
 	// Create metadata-based remote file handler
@@ -132,7 +137,7 @@ func initializeFilesystem(
 		poolManager,
 		configGetter,
 		streamTracker,
-		segmentStore,
+		segmentStoreGetter,
 	)
 
 	// Create filesystem backed by metadata
@@ -275,7 +280,7 @@ func setupAPIServer(
 	mountService *rclone.MountService,
 	progressBroadcaster *progress.ProgressBroadcaster,
 	streamTracker *api.StreamTracker,
-	segcacheMgr *segcache.Manager,
+	segcachePtr *atomic.Pointer[segcache.Manager],
 ) *api.Server {
 	apiConfig := &api.Config{
 		Prefix: "/api",
@@ -297,7 +302,7 @@ func setupAPIServer(
 		mountService,
 		progressBroadcaster,
 		streamTracker,
-		segcacheMgr,
+		segcachePtr,
 	)
 
 	apiServer.SetupRoutes(app)
@@ -452,7 +457,7 @@ func startMountService(ctx context.Context, cfg *config.Config, mountService *rc
 }
 
 // createHTTPServer creates the HTTP server with routing
-func createHTTPServer(apiServer *api.Server, app *fiber.App, webdavHandler *webdav.Handler, streamHandler *api.StreamHandler, port int, profilerEnabled bool) *http.Server {
+func createHTTPServer(apiServer *api.Server, app *fiber.App, webdavHandler *webdav.Handler, streamHandler *api.StreamHandler, port int, configGetter config.ConfigGetter) *http.Server {
 	// Mount WebDAV handler directly (no Fiber adapter needed)
 	webdavHTTPHandler := webdavHandler.GetHTTPHandler()
 
@@ -475,7 +480,7 @@ func createHTTPServer(apiServer *api.Server, app *fiber.App, webdavHandler *webd
 		}
 
 		// Route profiler requests if enabled
-		if profilerEnabled && strings.HasPrefix(path, "/debug/pprof") {
+		if configGetter().ProfilerEnabled && strings.HasPrefix(path, "/debug/pprof") {
 			http.DefaultServeMux.ServeHTTP(w, r)
 			return
 		}

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-pkgz/auth/v2/token"
@@ -27,7 +26,6 @@ import (
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/rclone"
-	"github.com/javi11/altmount/internal/usenet"
 	"github.com/javi11/altmount/internal/webdav"
 	"github.com/javi11/altmount/pkg/rclonecli"
 )
@@ -111,21 +109,11 @@ func initializeFilesystem(
 	poolManager pool.Manager,
 	configGetter config.ConfigGetter,
 	streamTracker nzbfilesystem.StreamTracker,
-	segcachePtr *atomic.Pointer[segcache.Manager],
+	cacheSource *segcache.Source,
 ) *nzbfilesystem.NzbFilesystem {
 	// Reset all in-progress file health checks on start up
 	if err := healthRepo.ResetFileAllChecking(ctx); err != nil {
 		slog.ErrorContext(ctx, "failed to reset in progress file health", "err", err)
-	}
-
-	// Build a dynamic segment store getter so cache changes take effect without restart.
-	// The atomic pointer is swapped by the config change handler when cache settings change.
-	segmentStoreGetter := func() usenet.SegmentStore {
-		mgr := segcachePtr.Load()
-		if mgr == nil {
-			return nil
-		}
-		return mgr.Cache()
 	}
 
 	// Create metadata-based remote file handler
@@ -137,7 +125,7 @@ func initializeFilesystem(
 		poolManager,
 		configGetter,
 		streamTracker,
-		segmentStoreGetter,
+		cacheSource,
 	)
 
 	// Create filesystem backed by metadata
@@ -280,7 +268,7 @@ func setupAPIServer(
 	mountService *rclone.MountService,
 	progressBroadcaster *progress.ProgressBroadcaster,
 	streamTracker *api.StreamTracker,
-	segcachePtr *atomic.Pointer[segcache.Manager],
+	cacheSource *segcache.Source,
 ) *api.Server {
 	apiConfig := &api.Config{
 		Prefix: "/api",
@@ -302,7 +290,7 @@ func setupAPIServer(
 		mountService,
 		progressBroadcaster,
 		streamTracker,
-		segcachePtr,
+		cacheSource,
 	)
 
 	apiServer.SetupRoutes(app)
@@ -317,15 +305,16 @@ func setupAPIServer(
 	return apiServer
 }
 
-// initializeSegmentCache creates and starts the segment cache manager if enabled
-func initializeSegmentCache(ctx context.Context, cfg *config.Config) *segcache.Manager {
-	if cfg.SegmentCache.Enabled == nil || !*cfg.SegmentCache.Enabled {
-		slog.InfoContext(ctx, "Segment cache disabled")
+// initializeSegmentCache creates and starts the segment cache manager, loading it into
+// source. Returns the manager so the caller can defer Stop(). Returns nil if CachePath
+// is not configured (enabled/disabled is checked at read-time via source.Store()).
+func initializeSegmentCache(ctx context.Context, cfg *config.Config, source *segcache.Source) *segcache.Manager {
+	if cfg.SegmentCache.CachePath == "" {
+		slog.InfoContext(ctx, "Segment cache not configured (no cache_path set)")
 		return nil
 	}
 
 	mgrCfg := segcache.ManagerConfig{
-		Enabled:        true,
 		CachePath:      cfg.SegmentCache.CachePath,
 		MaxSizeBytes:   int64(cfg.SegmentCache.MaxSizeGB) * 1024 * 1024 * 1024,
 		ExpiryDuration: time.Duration(cfg.SegmentCache.ExpiryHours) * time.Hour,
@@ -338,7 +327,8 @@ func initializeSegmentCache(ctx context.Context, cfg *config.Config) *segcache.M
 	}
 
 	mgr.Start(ctx)
-	slog.InfoContext(ctx, "Segment cache enabled",
+	source.Swap(mgr)
+	slog.InfoContext(ctx, "Segment cache initialized",
 		"cache_path", mgrCfg.CachePath,
 		"max_size_bytes", mgrCfg.MaxSizeBytes,
 		"expiry_duration", mgrCfg.ExpiryDuration)

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -227,15 +227,11 @@ export function ConfigurationPage() {
 					section: "segment_cache",
 					config: { segment_cache: data as unknown as SegmentCacheConfig },
 				});
-			} else if (section === "import" && config) {
-				const importData = data as unknown as ImportConfig;
-				const workersChanged =
-					importData.max_processor_workers !== config.import.max_processor_workers;
+			} else if (section === "import") {
 				await updateConfigSection.mutateAsync({
 					section: "import",
-					config: { import: importData },
+					config: { import: data as unknown as ImportConfig },
 				});
-				if (workersChanged) addRestartRequiredConfig("Import Max Processor Workers");
 			} else if (section === "metadata" && config) {
 				const metadataData = data as unknown as MetadataConfig;
 				const rootPathChanged = metadataData.root_path !== config.metadata.root_path;

--- a/internal/api/fuse_handlers.go
+++ b/internal/api/fuse_handlers.go
@@ -466,3 +466,54 @@ func newMountFactory(nzbfs *nzbfilesystem.NzbFilesystem, configManager ConfigMan
 		return fuse.NewServer(path, nzbfs, logger, cfg.Fuse, st)
 	}
 }
+
+// RegisterFuseConfigChangeHandler registers a config change handler that auto-remounts FUSE
+// when FUSE config options change and the mount is currently running.
+func (s *Server) RegisterFuseConfigChangeHandler(configManager *config.Manager) {
+	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
+		// Only act if FUSE was and still is the mount type
+		if oldConfig.MountType != config.MountTypeFuse && newConfig.MountType != config.MountTypeFuse {
+			return
+		}
+
+		fuseConfigChanged := oldConfig.Fuse.MountPath != newConfig.Fuse.MountPath ||
+			oldConfig.Fuse.Backend != newConfig.Fuse.Backend ||
+			fuseOptionsDiffer(oldConfig.Fuse, newConfig.Fuse)
+
+		mountTypeChanged := oldConfig.MountType != newConfig.MountType
+
+		if !fuseConfigChanged && !mountTypeChanged {
+			return
+		}
+
+		s.fuseManager.mu.Lock()
+		isRunning := s.fuseManager.status == "running"
+		s.fuseManager.mu.Unlock()
+
+		if mountTypeChanged && newConfig.MountType != config.MountTypeFuse {
+			// Mount type changed away from FUSE — stop if running
+			if isRunning {
+				slog.InfoContext(context.Background(), "Mount type changed from FUSE, unmounting")
+				s.fuseManager.Stop()
+			}
+			return
+		}
+
+		if isRunning && fuseConfigChanged {
+			slog.InfoContext(context.Background(), "FUSE config changed, remounting with new settings")
+			s.fuseManager.Stop()
+			// Re-mount with new config (AutoStartFuse reads fresh config)
+			s.AutoStartFuse()
+		}
+	})
+}
+
+// fuseOptionsDiffer compares FUSE config options that require remount.
+func fuseOptionsDiffer(old, new config.FuseConfig) bool {
+	return old.AllowOther != new.AllowOther ||
+		old.Debug != new.Debug ||
+		old.AttrTimeoutSeconds != new.AttrTimeoutSeconds ||
+		old.EntryTimeoutSeconds != new.EntryTimeoutSeconds ||
+		old.MaxCacheSizeMB != new.MaxCacheSizeMB ||
+		old.MaxReadAheadMB != new.MaxReadAheadMB
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -61,7 +61,7 @@ type Server struct {
 	progressBroadcaster *progress.ProgressBroadcaster
 	streamTracker       *StreamTracker
 	fuseManager         *FuseManager
-	segcachePtr         *atomic.Pointer[segcache.Manager] // atomic pointer for dynamic cache swap
+	cacheSource         *segcache.Source
 	logFilePath         string
 	ready               atomic.Bool
 }
@@ -83,7 +83,7 @@ func NewServer(
 	mountService *rclone.MountService,
 	progressBroadcaster *progress.ProgressBroadcaster,
 	streamTracker *StreamTracker,
-	segcachePtr *atomic.Pointer[segcache.Manager],
+	cacheSource *segcache.Source,
 ) *Server {
 	if config == nil {
 		config = DefaultConfig()
@@ -106,7 +106,7 @@ func NewServer(
 		startTime:           time.Now(),
 		progressBroadcaster: progressBroadcaster,
 		streamTracker:       streamTracker,
-		segcachePtr:         segcachePtr,
+		cacheSource:         cacheSource,
 		fuseManager:         NewFuseManager(newMountFactory(nzbFilesystem, configManager, streamTracker)),
 	}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -61,7 +61,7 @@ type Server struct {
 	progressBroadcaster *progress.ProgressBroadcaster
 	streamTracker       *StreamTracker
 	fuseManager         *FuseManager
-	segcacheMgr         *segcache.Manager // nil if segment cache is disabled
+	segcachePtr         *atomic.Pointer[segcache.Manager] // atomic pointer for dynamic cache swap
 	logFilePath         string
 	ready               atomic.Bool
 }
@@ -83,7 +83,7 @@ func NewServer(
 	mountService *rclone.MountService,
 	progressBroadcaster *progress.ProgressBroadcaster,
 	streamTracker *StreamTracker,
-	segcacheMgr *segcache.Manager,
+	segcachePtr *atomic.Pointer[segcache.Manager],
 ) *Server {
 	if config == nil {
 		config = DefaultConfig()
@@ -106,7 +106,7 @@ func NewServer(
 		startTime:           time.Now(),
 		progressBroadcaster: progressBroadcaster,
 		streamTracker:       streamTracker,
-		segcacheMgr:         segcacheMgr,
+		segcachePtr:         segcachePtr,
 		fuseManager:         NewFuseManager(newMountFactory(nzbFilesystem, configManager, streamTracker)),
 	}
 

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -49,6 +50,11 @@ type Manager struct {
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
 
+	// Per-worker loop-control contexts (separate from m.ctx used for item processing).
+	// Cancelling a worker's loopCancel stops its ticker loop without cancelling in-flight items.
+	workerCancels []context.CancelFunc
+	workerCount   int
+
 	// claimMu serialises DB claim transactions to avoid SQLite lock contention.
 	claimMu sync.Mutex
 
@@ -88,11 +94,15 @@ func (m *Manager) Start(ctx context.Context) error {
 		return nil
 	}
 
-	// Start worker pool
+	// Start worker pool with per-worker loop contexts
+	m.workerCancels = make([]context.CancelFunc, 0, m.config.Workers)
 	for i := 0; i < m.config.Workers; i++ {
+		loopCtx, loopCancel := context.WithCancel(m.ctx)
+		m.workerCancels = append(m.workerCancels, loopCancel)
 		m.wg.Add(1)
-		go m.workerLoop(i)
+		go m.workerLoop(i, loopCtx)
 	}
+	m.workerCount = m.config.Workers
 
 	m.running = true
 	m.log.InfoContext(ctx, "Queue manager started", "workers", m.config.Workers)
@@ -111,9 +121,14 @@ func (m *Manager) Stop(ctx context.Context) error {
 
 	m.log.InfoContext(ctx, "Stopping queue manager")
 
-	// Cancel all goroutines
+	// Cancel all worker loop contexts and the manager context
+	for _, cancel := range m.workerCancels {
+		cancel()
+	}
 	m.cancel()
 	m.running = false
+	m.workerCancels = nil
+	m.workerCount = 0
 	m.mu.Unlock()
 
 	// Wait for all goroutines to finish with timeout
@@ -187,8 +202,53 @@ func (m *Manager) CancelProcessing(itemID int64) error {
 	return nil
 }
 
-// workerLoop is the main worker loop
-func (m *Manager) workerLoop(workerID int) {
+// Resize dynamically adjusts the number of queue workers.
+// When scaling down, excess workers finish their current item before stopping.
+func (m *Manager) Resize(ctx context.Context, newCount int) error {
+	if newCount <= 0 {
+		return fmt.Errorf("worker count must be positive, got %d", newCount)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.running {
+		// Not running — just update config for next Start()
+		m.config.Workers = newCount
+		return nil
+	}
+
+	oldCount := m.workerCount
+	if newCount == oldCount {
+		return nil
+	}
+
+	if newCount > oldCount {
+		// Scale up: start additional workers
+		for i := oldCount; i < newCount; i++ {
+			loopCtx, loopCancel := context.WithCancel(m.ctx)
+			m.workerCancels = append(m.workerCancels, loopCancel)
+			m.wg.Add(1)
+			go m.workerLoop(i, loopCtx)
+		}
+	} else {
+		// Scale down: cancel excess worker loop contexts
+		for i := newCount; i < oldCount; i++ {
+			m.workerCancels[i]()
+		}
+		m.workerCancels = m.workerCancels[:newCount]
+	}
+
+	m.workerCount = newCount
+	m.config.Workers = newCount
+	m.log.InfoContext(ctx, "Queue workers resized", "old_count", oldCount, "new_count", newCount)
+	return nil
+}
+
+// workerLoop is the main worker loop.
+// loopCtx controls this worker's lifecycle (cancelled on Resize shrink or Stop).
+// Item processing uses m.ctx so in-flight items are not cancelled when a worker is removed by Resize.
+func (m *Manager) workerLoop(workerID int, loopCtx context.Context) {
 	defer m.wg.Done()
 
 	log := m.log.With("worker_id", workerID)
@@ -208,7 +268,7 @@ func (m *Manager) workerLoop(workerID int) {
 				continue
 			}
 			m.processNextItem(m.ctx, workerID)
-		case <-m.ctx.Done():
+		case <-loopCtx.Done():
 			log.Info("Queue worker stopped")
 			return
 		}

--- a/internal/importer/queue/manager_test.go
+++ b/internal/importer/queue/manager_test.go
@@ -1,0 +1,149 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockProcessor implements ItemProcessor for testing
+type mockProcessor struct{}
+
+func (m *mockProcessor) ProcessItem(_ context.Context, _ *database.ImportQueueItem) (string, error) {
+	return "", nil
+}
+func (m *mockProcessor) HandleSuccess(_ context.Context, _ *database.ImportQueueItem, _ string) error {
+	return nil
+}
+func (m *mockProcessor) HandleFailure(_ context.Context, _ *database.ImportQueueItem, _ error) {}
+
+// testConfigGetter returns a config with a reasonable queue processing interval
+func testConfigGetter() *config.Config {
+	return &config.Config{
+		Import: config.ImportConfig{
+			QueueProcessingIntervalSeconds: 1,
+		},
+	}
+}
+
+func newTestManager(workers int) *Manager {
+	return NewManager(
+		ManagerConfig{
+			Workers:      workers,
+			ConfigGetter: testConfigGetter,
+		},
+		nil, // repository not needed for resize tests
+		&mockProcessor{},
+		nil, // listener
+	)
+}
+
+func TestResize_ScaleUp(t *testing.T) {
+	m := newTestManager(2)
+	ctx := context.Background()
+
+	require.NoError(t, m.Start(ctx))
+	defer func() { _ = m.Stop(ctx) }()
+
+	assert.Equal(t, 2, m.workerCount)
+
+	require.NoError(t, m.Resize(ctx, 4))
+
+	assert.Equal(t, 4, m.workerCount)
+	assert.Equal(t, 4, m.config.Workers)
+	assert.Len(t, m.workerCancels, 4)
+}
+
+func TestResize_ScaleDown(t *testing.T) {
+	m := newTestManager(4)
+	ctx := context.Background()
+
+	require.NoError(t, m.Start(ctx))
+	defer func() { _ = m.Stop(ctx) }()
+
+	assert.Equal(t, 4, m.workerCount)
+
+	require.NoError(t, m.Resize(ctx, 2))
+
+	// Wait briefly for cancelled workers to exit
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 2, m.workerCount)
+	assert.Equal(t, 2, m.config.Workers)
+	assert.Len(t, m.workerCancels, 2)
+}
+
+func TestResize_SameCount(t *testing.T) {
+	m := newTestManager(3)
+	ctx := context.Background()
+
+	require.NoError(t, m.Start(ctx))
+	defer func() { _ = m.Stop(ctx) }()
+
+	require.NoError(t, m.Resize(ctx, 3))
+
+	assert.Equal(t, 3, m.workerCount)
+}
+
+func TestResize_WhenStopped(t *testing.T) {
+	m := newTestManager(2)
+	ctx := context.Background()
+
+	// Resize without starting — should just update config
+	require.NoError(t, m.Resize(ctx, 5))
+
+	assert.Equal(t, 5, m.config.Workers)
+	assert.Equal(t, 0, m.workerCount) // No workers running
+	assert.False(t, m.running)
+}
+
+func TestResize_InvalidCount(t *testing.T) {
+	m := newTestManager(2)
+	ctx := context.Background()
+
+	err := m.Resize(ctx, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "worker count must be positive")
+
+	err = m.Resize(ctx, -1)
+	assert.Error(t, err)
+}
+
+func TestResize_ScaleDownWorkersStop(t *testing.T) {
+	m := newTestManager(4)
+	ctx := context.Background()
+
+	require.NoError(t, m.Start(ctx))
+	defer func() { _ = m.Stop(ctx) }()
+
+	// Scale down from 4 to 1
+	require.NoError(t, m.Resize(ctx, 1))
+
+	// Wait for workers to stop (they exit on loopCtx.Done())
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 1, m.workerCount)
+	assert.Len(t, m.workerCancels, 1)
+}
+
+func TestResize_ScaleUpThenDown(t *testing.T) {
+	m := newTestManager(2)
+	ctx := context.Background()
+
+	require.NoError(t, m.Start(ctx))
+	defer func() { _ = m.Stop(ctx) }()
+
+	// Scale up
+	require.NoError(t, m.Resize(ctx, 6))
+	assert.Equal(t, 6, m.workerCount)
+
+	// Scale back down
+	require.NoError(t, m.Resize(ctx, 3))
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 3, m.workerCount)
+}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -356,11 +356,25 @@ func (s *Service) RegisterConfigChangeHandler(configManager any) {
 		return
 	}
 	mgr.OnConfigChange(func(oldConfig, newConfig *config.Config) {
+		// Update rclone client reference
 		s.mu.Lock()
-		defer s.mu.Unlock()
-
 		if s.postProcessor != nil {
 			s.postProcessor.SetRcloneClient(s.rcloneClient)
+		}
+		s.mu.Unlock()
+
+		// Dynamically resize queue workers if count changed
+		oldWorkers := oldConfig.Import.MaxProcessorWorkers
+		newWorkers := newConfig.Import.MaxProcessorWorkers
+		if newWorkers > 0 && oldWorkers != newWorkers {
+			ctx := context.Background()
+			if err := s.queueManager.Resize(ctx, newWorkers); err != nil {
+				s.log.ErrorContext(ctx, "Failed to resize queue workers", "error", err)
+			} else {
+				s.database.UpdateConnectionPool(newWorkers)
+				s.log.InfoContext(ctx, "Queue workers resized dynamically",
+					"old_workers", oldWorkers, "new_workers", newWorkers)
+			}
 		}
 	})
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -39,8 +39,8 @@ type MetadataRemoteFile struct {
 	rcloneCipher     *rclone.RcloneCrypt      // For rclone encryption/decryption
 	aesCipher        *aes.AesCipher           // For AES encryption/decryption
 	streamTracker    StreamTracker            // Stream tracker for monitoring active streams
-	segmentStore     usenet.SegmentStore      // Optional segment cache (nil = disabled)
-	renameMu         sync.Mutex               // Mutex to protect rename operations from race conditions
+	segmentStoreGetter func() usenet.SegmentStore // Dynamic segment cache getter (returns nil = disabled)
+	renameMu           sync.Mutex                // Mutex to protect rename operations from race conditions
 }
 
 // Configuration is now accessed dynamically through config.ConfigGetter
@@ -55,7 +55,7 @@ func NewMetadataRemoteFile(
 	poolManager pool.Manager,
 	configGetter config.ConfigGetter,
 	streamTracker StreamTracker,
-	segmentStore usenet.SegmentStore,
+	segmentStoreGetter func() usenet.SegmentStore,
 ) *MetadataRemoteFile {
 	// Initialize rclone cipher with global credentials for encrypted files
 	cfg := configGetter()
@@ -79,7 +79,7 @@ func NewMetadataRemoteFile(
 		rcloneCipher:     rcloneCipher,
 		aesCipher:        aesCipher,
 		streamTracker:    streamTracker,
-		segmentStore:     segmentStore,
+		segmentStoreGetter: segmentStoreGetter,
 	}
 }
 
@@ -245,7 +245,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		globalSalt:       mrf.getGlobalSalt(),
 		streamTracker:    mrf.streamTracker,
 		streamID:         streamID,
-		segmentStore:     mrf.segmentStore,
+		segmentStore:     mrf.segmentStoreGetter(),
 	}
 
 	return true, virtualFile, nil

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -20,6 +20,7 @@ import (
 	"github.com/javi11/altmount/internal/encryption/rclone"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/nzbfilesystem/segcache"
 	"github.com/javi11/altmount/internal/pathutil"
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/usenet"
@@ -39,8 +40,8 @@ type MetadataRemoteFile struct {
 	rcloneCipher     *rclone.RcloneCrypt      // For rclone encryption/decryption
 	aesCipher        *aes.AesCipher           // For AES encryption/decryption
 	streamTracker    StreamTracker            // Stream tracker for monitoring active streams
-	segmentStoreGetter func() usenet.SegmentStore // Dynamic segment cache getter (returns nil = disabled)
-	renameMu           sync.Mutex                // Mutex to protect rename operations from race conditions
+	cacheSource *segcache.Source // Segment cache source (nil = no cache configured)
+	renameMu    sync.Mutex      // Mutex to protect rename operations from race conditions
 }
 
 // Configuration is now accessed dynamically through config.ConfigGetter
@@ -55,7 +56,7 @@ func NewMetadataRemoteFile(
 	poolManager pool.Manager,
 	configGetter config.ConfigGetter,
 	streamTracker StreamTracker,
-	segmentStoreGetter func() usenet.SegmentStore,
+	cacheSource *segcache.Source,
 ) *MetadataRemoteFile {
 	// Initialize rclone cipher with global credentials for encrypted files
 	cfg := configGetter()
@@ -78,14 +79,23 @@ func NewMetadataRemoteFile(
 		configGetter:     configGetter,
 		rcloneCipher:     rcloneCipher,
 		aesCipher:        aesCipher,
-		streamTracker:    streamTracker,
-		segmentStoreGetter: segmentStoreGetter,
+		streamTracker: streamTracker,
+		cacheSource:   cacheSource,
 	}
 }
 
 // Helper methods to get dynamic config values
 func (mrf *MetadataRemoteFile) getMaxPrefetch() int {
 	return mrf.configGetter().Streaming.MaxPrefetch
+}
+
+// resolveSegmentStore returns the active SegmentStore for a new reader, or nil if
+// the cache is disabled or not configured. Called once per file-open.
+func (mrf *MetadataRemoteFile) resolveSegmentStore() usenet.SegmentStore {
+	if mrf.cacheSource == nil {
+		return nil
+	}
+	return mrf.cacheSource.Store()
 }
 
 func (mrf *MetadataRemoteFile) getGlobalPassword() string {
@@ -245,7 +255,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		globalSalt:       mrf.getGlobalSalt(),
 		streamTracker:    mrf.streamTracker,
 		streamID:         streamID,
-		segmentStore:     mrf.segmentStoreGetter(),
+		segmentStore:     mrf.resolveSegmentStore(),
 	}
 
 	return true, virtualFile, nil

--- a/internal/nzbfilesystem/segcache/source.go
+++ b/internal/nzbfilesystem/segcache/source.go
@@ -1,0 +1,47 @@
+package segcache
+
+import (
+	"sync/atomic"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/usenet"
+)
+
+// Source is a thin wrapper around an atomic Manager pointer that resolves the
+// active SegmentStore on demand. It is the single value threaded through the
+// application instead of passing raw atomic pointers and getter closures.
+type Source struct {
+	ptr    atomic.Pointer[Manager]
+	getCfg config.ConfigGetter
+}
+
+// NewSource creates a Source. getCfg must not be nil.
+func NewSource(getCfg config.ConfigGetter) *Source {
+	return &Source{getCfg: getCfg}
+}
+
+// Store resolves the current SegmentStore. Returns nil if the cache is
+// disabled in config or no manager has been loaded yet.
+// Call once at file-open time and pass the result to UsenetReader.
+func (s *Source) Store() usenet.SegmentStore {
+	mgr := s.ptr.Load()
+	if mgr == nil {
+		return nil
+	}
+	cfg := s.getCfg()
+	if cfg.SegmentCache.Enabled == nil || !*cfg.SegmentCache.Enabled {
+		return nil
+	}
+	return mgr.Cache()
+}
+
+// Swap replaces the active manager. Pass nil to unload the current manager.
+// The caller is responsible for stopping the old manager before calling Swap.
+func (s *Source) Swap(mgr *Manager) {
+	s.ptr.Store(mgr)
+}
+
+// Manager returns the current manager for stats access. May be nil.
+func (s *Source) Manager() *Manager {
+	return s.ptr.Load()
+}

--- a/internal/webdav/adapter.go
+++ b/internal/webdav/adapter.go
@@ -95,6 +95,7 @@ func (h *webdavMethods) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(ctx, "WebDAV GET", "path", reqPath)
 	fi, err := h.fs.Stat(ctx, reqPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -105,6 +106,7 @@ func (h *webdavMethods) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(ctx, "WebDAV GET stat", "path", reqPath, "is_dir", fi.IsDir(), "size", fi.Size())
 	if fi.IsDir() {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
@@ -135,6 +137,7 @@ func (h *webdavMethods) handleDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(ctx, "WebDAV DELETE", "path", reqPath)
 	if err := h.fs.RemoveAll(ctx, reqPath); err != nil {
 		if os.IsNotExist(err) {
 			http.Error(w, "Not Found", http.StatusNotFound)
@@ -175,6 +178,7 @@ func (h *webdavMethods) handleMove(w http.ResponseWriter, r *http.Request) {
 
 	// Check if destination already exists to determine response code
 	_, statErr := h.fs.Stat(ctx, dst)
+	slog.DebugContext(ctx, "WebDAV MOVE parsed", "src", src, "dst", dst, "dest_exists", !os.IsNotExist(statErr))
 
 	if err := h.fs.Rename(ctx, src, dst); err != nil {
 		if os.IsNotExist(err) {
@@ -200,6 +204,7 @@ func (h *webdavMethods) handleMkcol(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	slog.DebugContext(ctx, "WebDAV MKCOL", "path", reqPath)
 	if r.ContentLength > 0 {
 		// RFC 4918: MKCOL request with a body must return 415 Unsupported Media Type
 		http.Error(w, "Unsupported Media Type", http.StatusUnsupportedMediaType)
@@ -228,6 +233,10 @@ func NewHandler(
 	configGetter config.ConfigGetter, // Dynamic config access
 	streamTracker *api.StreamTracker, // Optional stream tracker
 ) (*Handler, error) {
+	slog.DebugContext(context.Background(), "Creating WebDAV handler",
+		"prefix", config.Prefix,
+		"stream_tracking", streamTracker != nil)
+
 	// Create dynamic auth credentials with initial values
 	authCreds := NewAuthCredentials(config.User, config.Pass)
 
@@ -275,6 +284,7 @@ func NewHandler(
 							} else {
 								effectiveUser = user.UserID
 							}
+							slog.DebugContext(r.Context(), "WebDAV JWT auth succeeded", "user", effectiveUser)
 						}
 					}
 				}
@@ -285,10 +295,12 @@ func NewHandler(
 			if username == currentUser && password == currentPass {
 				authenticated = true
 				effectiveUser = username
+				slog.DebugContext(r.Context(), "WebDAV basic auth succeeded", "user", effectiveUser)
 			}
 		}
 
 		if !authenticated {
+			slog.DebugContext(r.Context(), "WebDAV auth failed", "method", r.Method, "path", r.URL.Path, "has_basic", hasBasicAuth)
 			w.Header().Set("WWW-Authenticate", `Basic realm="BASIC WebDAV REALM"`)
 			w.WriteHeader(http.StatusUnauthorized)
 			_, err := w.Write([]byte("401 Unauthorized"))
@@ -340,6 +352,7 @@ func NewHandler(
 			defer cancel()
 
 			stream := streamTracker.Add(r.URL.Path, "WebDAV", effectiveUser, r.RemoteAddr, r.UserAgent(), 0)
+			slog.DebugContext(r.Context(), "WebDAV stream registered", "path", r.URL.Path, "stream_id", stream)
 			defer streamTracker.Remove(stream)
 
 			streamTracker.SetCancelFunc(stream, cancel)

--- a/internal/webdav/file_system.go
+++ b/internal/webdav/file_system.go
@@ -65,6 +65,7 @@ type customErrorHandler struct {
 }
 
 func (c *customErrorHandler) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (File, error) {
+	slog.DebugContext(ctx, "WebDAV opening file", "name", name)
 	file, err := c.FileSystem.OpenFile(ctx, name, flag, perm)
 	if err != nil {
 		return nil, c.mapError(err)

--- a/internal/webdav/monitored_file_system.go
+++ b/internal/webdav/monitored_file_system.go
@@ -2,6 +2,7 @@ package webdav
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"sync/atomic"
 
@@ -27,13 +28,17 @@ func (m *monitoredFileSystem) OpenFile(ctx context.Context, name string, flag in
 	if streamVal := ctx.Value(utils.ActiveStreamKey); streamVal != nil {
 		if stream, ok := streamVal.(*nzbfilesystem.ActiveStream); ok {
 			// Update total size if available
+			var totalSize int64
 			if stat, err := f.Stat(); err == nil {
-				atomic.StoreInt64(&stream.TotalSize, stat.Size())
+				totalSize = stat.Size()
+				atomic.StoreInt64(&stream.TotalSize, totalSize)
 			}
+			slog.DebugContext(ctx, "WebDAV monitored OpenFile", "name", name, "monitored", true, "total_size", totalSize)
 			return &monitoredFile{File: f, stream: stream, ctx: ctx}, nil
 		}
 	}
 
+	slog.DebugContext(ctx, "WebDAV monitored OpenFile", "name", name, "monitored", false)
 	return f, nil
 }
 

--- a/internal/webdav/propfind/propfind.go
+++ b/internal/webdav/propfind/propfind.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -33,6 +34,7 @@ func HandlePropfind(fs FS, w http.ResponseWriter, r *http.Request, prefix string
 	}
 
 	ctx := r.Context()
+	slog.DebugContext(ctx, "WebDAV PROPFIND", "path", reqPath, "depth", r.Header.Get("Depth"))
 	fi, err := fs.Stat(ctx, reqPath)
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
## Summary

- **FUSE remount on config change**: `RegisterFuseConfigChangeHandler` auto-remounts the FUSE filesystem when mount path, backend, or kernel options (allow_other, debug, timeouts, cache sizes) change — no restart needed
- **Segment cache hot-swap**: cache manager is stored in `atomic.Pointer[segcache.Manager]`; a getter func is passed to `NzbFilesystem` so each `OpenFile` picks up the current cache; config change handler stops the old manager and starts a new one when cache settings change
- **Queue worker dynamic resize**: `queue.Manager.Resize()` scales workers up/down at runtime using per-worker loop contexts; scaling down gracefully lets in-flight items finish; `ImporterService.RegisterConfigChangeHandler` calls `Resize` when `max_processor_workers` changes
- **Frontend**: removed "restart required" toast for import worker count changes (now handled dynamically)
- **WebDAV debug logging**: added `slog.DebugContext` calls in `adapter.go`, `file_system.go`, `monitored_file_system.go`, and `propfind/propfind.go` for request tracing
- **Profiler**: HTTP server reads `profiler_enabled` dynamically from config getter instead of capturing at startup

## Test plan

- [ ] Change FUSE options in config UI — verify FUSE remounts without server restart
- [ ] Enable/disable/resize segment cache in config — verify cache swaps without restart
- [ ] Change `max_processor_workers` in import config — verify workers scale up/down (check logs)
- [ ] Confirm no "restart required" notification for import worker count changes
- [ ] Enable debug log level and make WebDAV requests — verify debug log entries appear for GET, DELETE, MOVE, MKCOL, PROPFIND
- [ ] Run `go test ./internal/importer/queue/...` to verify queue manager tests pass