### PR TITLE
feat(fuse): async read-ahead buffer for smoother FUSE throughput

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -948,6 +948,7 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 		entry_timeout_seconds: 1,
 		max_cache_size_mb: 128,
 		max_read_ahead_mb: 128,
+		async_buffer_size: 8 * 1024 * 1024,
 	});
 
 	useEffect(() => {
@@ -1056,6 +1057,29 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 								MB
 							</span>
 						</div>
+					</fieldset>
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend">Async Read-Ahead Buffer (per file)</legend>
+						<div className="join w-full">
+							<input
+								type="number"
+								className="input input-bordered join-item w-full bg-base-100 font-mono text-sm"
+								value={Math.round((formData.async_buffer_size ?? 8 * 1024 * 1024) / (1024 * 1024))}
+								onChange={(e) =>
+									updateField({
+										async_buffer_size: (Number.parseInt(e.target.value, 10) || 0) * 1024 * 1024,
+									})
+								}
+								min={0}
+								disabled={isRunning}
+							/>
+							<span className="btn btn-ghost join-item pointer-events-none border-base-300 text-xs">
+								MB
+							</span>
+						</div>
+						<p className="label text-base-content/50 text-xs">
+							0 to disable. Buffers reads ahead to smooth FUSE throughput.
+						</p>
 					</fieldset>
 					<fieldset className="fieldset">
 						<legend className="fieldset-legend">Permissions</legend>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -205,6 +205,7 @@ export interface FuseConfig {
 	entry_timeout_seconds: number;
 	max_cache_size_mb: number;
 	max_read_ahead_mb: number;
+	async_buffer_size: number;
 }
 
 // Import strategy type

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -94,7 +94,8 @@ type FuseConfig struct {
 	EntryTimeoutSeconds int    `yaml:"entry_timeout_seconds" mapstructure:"entry_timeout_seconds" json:"entry_timeout_seconds"`
 	MaxCacheSizeMB      int    `yaml:"max_cache_size_mb" mapstructure:"max_cache_size_mb" json:"max_cache_size_mb"`
 	MaxReadAheadMB      int    `yaml:"max_read_ahead_mb" mapstructure:"max_read_ahead_mb" json:"max_read_ahead_mb"`
-	Backend             string `yaml:"backend" mapstructure:"backend" json:"backend"` // "hanwen" or "cgo" (empty = platform default)
+	Backend             string `yaml:"backend" mapstructure:"backend" json:"backend"`             // "hanwen" or "cgo" (empty = platform default)
+	AsyncBufferSize     int    `yaml:"async_buffer_size" mapstructure:"async_buffer_size" json:"async_buffer_size"` // read-ahead buffer per open file (bytes), 0 = disabled
 }
 
 // APIConfig represents REST API configuration
@@ -1448,6 +1449,7 @@ func DefaultConfig(configDir ...string) *Config {
 			EntryTimeoutSeconds: 1,
 			MaxCacheSizeMB:      128,
 			MaxReadAheadMB:      128,
+			AsyncBufferSize:     8 * 1024 * 1024, // 8MB read-ahead buffer per open file
 		},
 		MountPath: "",            // Empty by default - required when ARRs is enabled
 		MountType: MountTypeNone, // No mount system active by default

--- a/internal/fuse/backend/asyncbuffer.go
+++ b/internal/fuse/backend/asyncbuffer.go
@@ -1,0 +1,253 @@
+package backend
+
+import (
+	"context"
+	"io"
+	"sync"
+)
+
+const (
+	// defaultAsyncBufSize is the default read-ahead buffer size (8MB).
+	defaultAsyncBufSize = 8 * 1024 * 1024
+	// fillChunkSize is how much the background goroutine reads per iteration.
+	// Larger chunks reduce mutex acquisition overhead in ReadAtContext.
+	// Segments are ~750KB, so 1MB reads ~1 ReadAtContext call per segment.
+	fillChunkSize = 1024 * 1024 // 1MB
+)
+
+// readAtContexter matches nzbfilesystem.MetadataVirtualFile.ReadAtContext.
+type readAtContexter interface {
+	ReadAtContext(ctx context.Context, p []byte, off int64) (n int, err error)
+}
+
+// AsyncReadBuffer wraps a readAtContexter and continuously reads ahead
+// into a ring buffer. FUSE reads pull from the pre-filled buffer instead
+// of blocking on the underlying (network-backed) reader.
+type AsyncReadBuffer struct {
+	src      readAtContexter
+	ctx      context.Context
+	cancel   context.CancelFunc
+	fileSize int64
+
+	mu   sync.Mutex
+	cond *sync.Cond
+
+	buf     []byte
+	bufSize int
+	readPos int // read cursor in ring buffer
+	filled  int // bytes currently in buffer
+
+	baseOff int64 // absolute file offset corresponding to readPos
+	fillOff int64 // absolute file offset of next fill read
+
+	srcErr  error // terminal error from source
+	srcDone bool  // fill goroutine finished
+	started bool  // fill goroutine has been launched
+
+	closeOnce sync.Once
+	wg        sync.WaitGroup
+}
+
+// NewAsyncReadBuffer creates an async read-ahead buffer wrapping src.
+// The fill goroutine is started lazily on the first ReadAtContext call
+// to avoid allocating memory for files that are opened but never read.
+func NewAsyncReadBuffer(ctx context.Context, src readAtContexter, bufSize int, fileSize int64) *AsyncReadBuffer {
+	if bufSize <= 0 {
+		bufSize = defaultAsyncBufSize
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	a := &AsyncReadBuffer{
+		src:      src,
+		ctx:      ctx,
+		cancel:   cancel,
+		fileSize: fileSize,
+		bufSize:  bufSize,
+	}
+	a.cond = sync.NewCond(&a.mu)
+	return a
+}
+
+// startFill launches the background fill goroutine. Must be called with a.mu held.
+func (a *AsyncReadBuffer) startFill() {
+	if a.started {
+		return
+	}
+	a.started = true
+	a.buf = make([]byte, a.bufSize)
+	a.wg.Add(1)
+	go a.fill()
+}
+
+// fill continuously reads from the source into the ring buffer.
+func (a *AsyncReadBuffer) fill() {
+	defer a.wg.Done()
+	tmp := make([]byte, fillChunkSize)
+
+	for {
+		if a.ctx.Err() != nil {
+			a.mu.Lock()
+			a.srcErr = a.ctx.Err()
+			a.srcDone = true
+			a.cond.Broadcast()
+			a.mu.Unlock()
+			return
+		}
+
+		// Wait if buffer is full.
+		a.mu.Lock()
+		for a.filled >= a.bufSize && a.ctx.Err() == nil {
+			a.cond.Wait()
+		}
+		if a.ctx.Err() != nil {
+			a.srcErr = a.ctx.Err()
+			a.srcDone = true
+			a.cond.Broadcast()
+			a.mu.Unlock()
+			return
+		}
+		space := a.bufSize - a.filled
+		fillOff := a.fillOff
+		a.mu.Unlock()
+
+		// Check if we've reached the end of the file.
+		if a.fileSize > 0 && fillOff >= a.fileSize {
+			a.mu.Lock()
+			a.srcErr = io.EOF
+			a.srcDone = true
+			a.cond.Broadcast()
+			a.mu.Unlock()
+			return
+		}
+
+		// Read from source outside the lock — this is the potentially blocking call.
+		toRead := min(len(tmp), space)
+		if a.fileSize > 0 && fillOff+int64(toRead) > a.fileSize {
+			toRead = int(a.fileSize - fillOff)
+		}
+		n, err := a.src.ReadAtContext(a.ctx, tmp[:toRead], fillOff)
+
+		// Copy into ring buffer.
+		a.mu.Lock()
+		if n > 0 {
+			writePos := (a.readPos + a.filled) % a.bufSize
+			// Handle wrap-around: may need two copies.
+			first := min(n, a.bufSize-writePos)
+			copy(a.buf[writePos:writePos+first], tmp[:first])
+			if first < n {
+				copy(a.buf[:n-first], tmp[first:n])
+			}
+			a.filled += n
+			a.fillOff += int64(n)
+		}
+		if err != nil {
+			a.srcErr = err
+			a.srcDone = true
+		}
+		a.cond.Broadcast()
+		a.mu.Unlock()
+
+		if err != nil {
+			return
+		}
+	}
+}
+
+// ReadAtContext reads from the async buffer at the given offset.
+// Sequential reads are served from the buffer. Non-sequential reads
+// that fall outside the buffer window pass through to the source directly.
+func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	a.mu.Lock()
+	a.startFill()
+
+	// Check if the offset is within our buffer window.
+	bufEnd := a.baseOff + int64(a.filled)
+	if off >= a.baseOff && off < bufEnd {
+		// Data is already in the buffer — serve it.
+		n := a.copyFromBuffer(p, off)
+		a.mu.Unlock()
+		return n, nil
+	}
+
+	// If sequential (offset matches buffer frontier), wait for data.
+	if off == bufEnd && !a.srcDone {
+		for a.baseOff+int64(a.filled) <= off && !a.srcDone && ctx.Err() == nil {
+			a.cond.Wait()
+		}
+		if ctx.Err() != nil {
+			a.mu.Unlock()
+			return 0, ctx.Err()
+		}
+		if a.filled > 0 && off >= a.baseOff && off < a.baseOff+int64(a.filled) {
+			n := a.copyFromBuffer(p, off)
+			a.mu.Unlock()
+			return n, nil
+		}
+		// Buffer is empty and source is done.
+		if a.srcDone {
+			err := a.srcErr
+			a.mu.Unlock()
+			return 0, err
+		}
+	}
+
+	// Source done and offset matches frontier — return the error.
+	if off == bufEnd && a.srcDone {
+		err := a.srcErr
+		a.mu.Unlock()
+		return 0, err
+	}
+
+	a.mu.Unlock()
+
+	// Non-sequential or out-of-range: pass through directly to source.
+	return a.src.ReadAtContext(ctx, p, off)
+}
+
+// copyFromBuffer copies data from the ring buffer into p starting at file offset off.
+// Caller must hold a.mu. Advances readPos and baseOff, draining consumed data.
+func (a *AsyncReadBuffer) copyFromBuffer(p []byte, off int64) int {
+	// Skip any bytes between baseOff and off (data we don't need).
+	skip := int(off - a.baseOff)
+	if skip > 0 {
+		a.readPos = (a.readPos + skip) % a.bufSize
+		a.filled -= skip
+		a.baseOff += int64(skip)
+	}
+
+	n := min(len(p), a.filled)
+	// Handle wrap-around.
+	first := min(n, a.bufSize-a.readPos)
+	copy(p[:first], a.buf[a.readPos:a.readPos+first])
+	if first < n {
+		copy(p[first:n], a.buf[:n-first])
+	}
+	a.readPos = (a.readPos + n) % a.bufSize
+	a.filled -= n
+	a.baseOff += int64(n)
+	a.cond.Signal() // wake fill goroutine — room available
+	return n
+}
+
+// GetBufferedOffset returns the file offset up to which data is buffered.
+func (a *AsyncReadBuffer) GetBufferedOffset() int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.baseOff + int64(a.filled)
+}
+
+// Close stops the fill goroutine and releases resources.
+// It does NOT close the underlying source — the FUSE handle owns that lifecycle.
+func (a *AsyncReadBuffer) Close() {
+	a.closeOnce.Do(func() {
+		a.cancel()
+		a.mu.Lock()
+		a.srcDone = true
+		a.cond.Broadcast()
+		a.mu.Unlock()
+		a.wg.Wait()
+	})
+}

--- a/internal/fuse/backend/asyncbuffer_test.go
+++ b/internal/fuse/backend/asyncbuffer_test.go
@@ -1,0 +1,241 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockSource implements readAtContexter for testing.
+type mockSource struct {
+	data    []byte
+	mu      sync.Mutex
+	delay   time.Duration // per-read delay to simulate slow source
+	readErr error         // error to return after all data consumed
+}
+
+func (m *mockSource) ReadAtContext(_ context.Context, p []byte, off int64) (int, error) {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if off >= int64(len(m.data)) {
+		if m.readErr != nil {
+			return 0, m.readErr
+		}
+		return 0, io.EOF
+	}
+	n := copy(p, m.data[off:])
+	return n, nil
+}
+
+func TestAsyncReadBuffer_BasicSequentialRead(t *testing.T) {
+	data := bytes.Repeat([]byte("abcdefghijklmnop"), 1024) // 16KB
+	src := &mockSource{data: data}
+	buf := NewAsyncReadBuffer(context.Background(), src, 4096, int64(len(data)))
+	defer buf.Close()
+
+	got := make([]byte, 0, len(data))
+	p := make([]byte, 256)
+	off := int64(0)
+	for off < int64(len(data)) {
+		n, err := buf.ReadAtContext(context.Background(), p, off)
+		if n > 0 {
+			got = append(got, p[:n]...)
+			off += int64(n)
+		}
+		if err != nil {
+			if err == io.EOF && off >= int64(len(data)) {
+				break
+			}
+			t.Fatalf("unexpected error at offset %d: %v", off, err)
+		}
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatalf("data mismatch: got %d bytes, want %d bytes", len(got), len(data))
+	}
+}
+
+func TestAsyncReadBuffer_SlowSource(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 8192)
+	src := &mockSource{data: data, delay: 5 * time.Millisecond}
+	// Large buffer relative to data — should fill ahead.
+	buf := NewAsyncReadBuffer(context.Background(), src, 16384, int64(len(data)))
+	defer buf.Close()
+
+	// Wait briefly for buffer to fill.
+	time.Sleep(200 * time.Millisecond)
+
+	// Reads should now be instant.
+	p := make([]byte, 4096)
+	start := time.Now()
+	n, err := buf.ReadAtContext(context.Background(), p, 0)
+	dur := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 4096 {
+		t.Fatalf("got %d bytes, want 4096", n)
+	}
+	if dur > 10*time.Millisecond {
+		t.Fatalf("read took %v, expected instant (data should be buffered)", dur)
+	}
+}
+
+func TestAsyncReadBuffer_ErrorPropagation(t *testing.T) {
+	data := []byte("hello")
+	src := &mockSource{data: data}
+	buf := NewAsyncReadBuffer(context.Background(), src, 1024, int64(len(data)))
+	defer buf.Close()
+
+	// Read all data.
+	p := make([]byte, 10)
+	n, _ := buf.ReadAtContext(context.Background(), p, 0)
+	if n != 5 {
+		t.Fatalf("got %d bytes, want 5", n)
+	}
+
+	// Next read should return EOF.
+	n, err := buf.ReadAtContext(context.Background(), p, 5)
+	if err != io.EOF {
+		t.Fatalf("expected io.EOF, got n=%d err=%v", n, err)
+	}
+}
+
+func TestAsyncReadBuffer_CloseDuringFill(t *testing.T) {
+	// Very slow source — fill goroutine will be blocked.
+	data := bytes.Repeat([]byte("x"), 1024*1024)
+	src := &mockSource{data: data, delay: 100 * time.Millisecond}
+	buf := NewAsyncReadBuffer(context.Background(), src, 4096, int64(len(data)))
+
+	// Close immediately — should not hang.
+	done := make(chan struct{})
+	go func() {
+		buf.Close()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() hung")
+	}
+}
+
+func TestAsyncReadBuffer_OutOfRangePassthrough(t *testing.T) {
+	data := bytes.Repeat([]byte("abcdefgh"), 1024) // 8KB
+	src := &mockSource{data: data}
+	buf := NewAsyncReadBuffer(context.Background(), src, 2048, int64(len(data)))
+	defer buf.Close()
+
+	// Read the first 1024 bytes to advance the buffer.
+	p := make([]byte, 1024)
+	n, err := buf.ReadAtContext(context.Background(), p, 0)
+	if err != nil || n != 1024 {
+		t.Fatalf("first read: n=%d err=%v", n, err)
+	}
+
+	// Read at offset 6000 — far outside the buffer window.
+	// Should pass through to source directly.
+	p2 := make([]byte, 100)
+	n, err = buf.ReadAtContext(context.Background(), p2, 6000)
+	if err != nil {
+		t.Fatalf("passthrough read: err=%v", err)
+	}
+	if n != 100 {
+		t.Fatalf("passthrough read: n=%d, want 100", n)
+	}
+	if !bytes.Equal(p2[:n], data[6000:6100]) {
+		t.Fatal("passthrough read: data mismatch")
+	}
+}
+
+func TestAsyncReadBuffer_GetBufferedOffset(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 4096)
+	src := &mockSource{data: data}
+	buf := NewAsyncReadBuffer(context.Background(), src, 8192, int64(len(data)))
+	defer buf.Close()
+
+	// Trigger fill by doing a small read (fill is lazy).
+	p := make([]byte, 1)
+	buf.ReadAtContext(context.Background(), p, 0)
+
+	// Wait for fill to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	off := buf.GetBufferedOffset()
+	// After reading 1 byte, baseOff=1, fill should have read all 4096 bytes.
+	// So buffered offset = 4096 (baseOff=1 + filled=4095).
+	if off != int64(len(data)) {
+		t.Fatalf("GetBufferedOffset() = %d, want %d", off, len(data))
+	}
+
+	// Consume some data.
+	p = make([]byte, 1024)
+	buf.ReadAtContext(context.Background(), p, 1)
+	off = buf.GetBufferedOffset()
+	// baseOff advanced by 1024, filled reduced by 1024, but fillOff didn't change.
+	if off != int64(len(data)) {
+		t.Fatalf("after read: GetBufferedOffset() = %d, want %d", off, len(data))
+	}
+}
+
+func TestAsyncReadBuffer_ZeroLengthRead(t *testing.T) {
+	src := &mockSource{data: []byte("hello")}
+	buf := NewAsyncReadBuffer(context.Background(), src, 1024, 5)
+	defer buf.Close()
+
+	n, err := buf.ReadAtContext(context.Background(), nil, 0)
+	if n != 0 || err != nil {
+		t.Fatalf("zero-length read: n=%d err=%v", n, err)
+	}
+}
+
+func TestAsyncReadBuffer_ConcurrentReadClose(t *testing.T) {
+	data := bytes.Repeat([]byte("x"), 1024*1024)
+	src := &mockSource{data: data, delay: time.Millisecond}
+	buf := NewAsyncReadBuffer(context.Background(), src, 4096, int64(len(data)))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Reader goroutine.
+	go func() {
+		defer wg.Done()
+		p := make([]byte, 512)
+		off := int64(0)
+		for i := 0; i < 100; i++ {
+			n, err := buf.ReadAtContext(context.Background(), p, off)
+			if err != nil {
+				return
+			}
+			off += int64(n)
+		}
+	}()
+
+	// Close after a short delay.
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+		buf.Close()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent read+close hung")
+	}
+}

--- a/internal/fuse/backend/cgofuse/fs.go
+++ b/internal/fuse/backend/cgofuse/fs.go
@@ -37,10 +37,11 @@ type readAtContexter interface {
 }
 
 type openHandle struct {
-	file   afero.File
-	stream *nzbfilesystem.ActiveStream
-	path   string
-	closed atomic.Bool
+	file     afero.File
+	stream   *nzbfilesystem.ActiveStream
+	path     string
+	closed   atomic.Bool
+	asyncBuf *backend.AsyncReadBuffer // nil when async buffering is disabled
 }
 
 // FS implements cgofuse.FileSystemInterface using NzbFilesystem.
@@ -130,6 +131,9 @@ func (f *FS) Destroy() {
 func (f *FS) closeHandle(h *openHandle) {
 	if !h.closed.CompareAndSwap(false, true) {
 		return
+	}
+	if h.asyncBuf != nil {
+		h.asyncBuf.Close()
 	}
 	if h.stream != nil && f.cfg.StreamTracker != nil {
 		f.cfg.StreamTracker.Remove(h.stream.ID)
@@ -290,6 +294,15 @@ func (f *FS) OpenEx(path string, fi *cgofuse.FileInfo_t) int {
 		path:   clean,
 	}
 
+	// Wrap with async read-ahead buffer for smoother FUSE reads.
+	// Only for files larger than the buffer itself — skip small metadata reads
+	// that Finder/Spotlight trigger to avoid excessive memory usage.
+	if asyncBufSize := f.cfg.FuseConfig.AsyncBufferSize; asyncBufSize > 0 && info.Size() > int64(asyncBufSize) {
+		if rac, ok := file.(readAtContexter); ok {
+			h.asyncBuf = backend.NewAsyncReadBuffer(ctx, rac, asyncBufSize, info.Size())
+		}
+	}
+
 	fi.Fh = f.allocHandle(h)
 
 	// Use DIRECT_IO when file size is unknown/zero to prevent the kernel
@@ -322,7 +335,9 @@ func (f *FS) Read(path string, buff []byte, ofst int64, fh uint64) int {
 	var err error
 	ctx := context.Background()
 
-	if rac, ok := h.file.(readAtContexter); ok {
+	if h.asyncBuf != nil {
+		n, err = h.asyncBuf.ReadAtContext(ctx, buff, ofst)
+	} else if rac, ok := h.file.(readAtContexter); ok {
 		n, err = rac.ReadAtContext(ctx, buff, ofst)
 	} else if ra, ok := h.file.(io.ReaderAt); ok {
 		n, err = ra.ReadAt(buff, ofst)

--- a/internal/fuse/backend/hanwen/backend.go
+++ b/internal/fuse/backend/hanwen/backend.go
@@ -50,7 +50,7 @@ func (b *Backend) Type() backend.Type {
 func (b *Backend) Mount(ctx context.Context, onReady func()) error {
 	b.cleanup()
 
-	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker)
+	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker, b.cfg.FuseConfig.AsyncBufferSize)
 
 	attrTimeout := time.Duration(b.cfg.FuseConfig.AttrTimeoutSeconds) * time.Second
 	entryTimeout := time.Duration(b.cfg.FuseConfig.EntryTimeoutSeconds) * time.Second

--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -37,6 +37,7 @@ type Dir struct {
 	isRootDir     bool
 	uid           uint32
 	gid           uint32
+	asyncBufSize  int
 }
 
 // NewDir creates a new directory node for the FUSE filesystem.
@@ -46,6 +47,7 @@ func NewDir(
 	logger *slog.Logger,
 	uid, gid uint32,
 	st backend.StreamTracker,
+	asyncBufSize int,
 ) *Dir {
 	return &Dir{
 		nzbfs:         nzbfs,
@@ -55,6 +57,7 @@ func NewDir(
 		isRootDir:     path == "" || path == "/",
 		uid:           uid,
 		gid:           gid,
+		asyncBufSize:  asyncBufSize,
 	}
 }
 
@@ -155,6 +158,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 			logger:        d.logger,
 			uid:           d.uid,
 			gid:           d.gid,
+			asyncBufSize:  d.asyncBufSize,
 		}
 		return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
 	}
@@ -167,6 +171,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		size:          info.Size(),
 		uid:           d.uid,
 		gid:           d.gid,
+		asyncBufSize:  d.asyncBufSize,
 	}
 	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG}), 0
 }

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -32,6 +32,7 @@ type File struct {
 	size          int64
 	uid           uint32
 	gid           uint32
+	asyncBufSize  int
 }
 
 // Getattr implements fs.NodeGetattrer.
@@ -90,7 +91,17 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 		warmable.WarmUp()
 	}
 
-	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker)
+	// Create async read-ahead buffer for smoother FUSE reads.
+	// Only for files larger than the buffer itself — skip small metadata reads
+	// that Finder/Spotlight trigger to avoid excessive memory usage.
+	var asyncBuf *backend.AsyncReadBuffer
+	if f.asyncBufSize > 0 && f.size > int64(f.asyncBufSize) {
+		if rac, ok := aferoFile.(readAtContexter); ok {
+			asyncBuf = backend.NewAsyncReadBuffer(ctx, rac, f.asyncBufSize, f.size)
+		}
+	}
+
+	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker, asyncBuf)
 
 	// Use DIRECT_IO when file size is unknown/zero to prevent the kernel
 	// from caching pages with stale size metadata (rclone mount2 pattern).

--- a/internal/fuse/backend/hanwen/handle.go
+++ b/internal/fuse/backend/hanwen/handle.go
@@ -28,10 +28,11 @@ type readAtContexter interface {
 // Handle wraps an afero.File and serves FUSE reads via ReadAtContext (preferred)
 // or io.ReaderAt. No per-handle lock needed: ReadAtContext serializes internally.
 type Handle struct {
-	file   afero.File
-	closed atomic.Bool
-	logger *slog.Logger
-	path   string
+	file     afero.File
+	closed   atomic.Bool
+	logger   *slog.Logger
+	path     string
+	asyncBuf *backend.AsyncReadBuffer // nil when async buffering is disabled
 
 	stream        *nzbfilesystem.ActiveStream
 	streamTracker backend.StreamTracker
@@ -44,6 +45,7 @@ func NewHandle(
 	path string,
 	stream *nzbfilesystem.ActiveStream,
 	st backend.StreamTracker,
+	asyncBuf *backend.AsyncReadBuffer,
 ) *Handle {
 	return &Handle{
 		file:          file,
@@ -51,6 +53,7 @@ func NewHandle(
 		path:          path,
 		stream:        stream,
 		streamTracker: st,
+		asyncBuf:      asyncBuf,
 	}
 }
 
@@ -64,7 +67,9 @@ func (h *Handle) Read(ctx context.Context, dest []byte, off int64) (fuse.ReadRes
 	var n int
 	var err error
 
-	if rac, ok := h.file.(readAtContexter); ok {
+	if h.asyncBuf != nil {
+		n, err = h.asyncBuf.ReadAtContext(ctx, dest, off)
+	} else if rac, ok := h.file.(readAtContexter); ok {
 		n, err = rac.ReadAtContext(ctx, dest, off)
 	} else if ra, ok := h.file.(io.ReaderAt); ok {
 		n, err = ra.ReadAt(dest, off)
@@ -107,6 +112,10 @@ func (h *Handle) Fsync(ctx context.Context, flags uint32) syscall.Errno {
 func (h *Handle) Release(ctx context.Context) syscall.Errno {
 	if !h.closed.CompareAndSwap(false, true) {
 		return 0
+	}
+
+	if h.asyncBuf != nil {
+		h.asyncBuf.Close()
 	}
 
 	if h.stream != nil && h.streamTracker != nil {

--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -67,7 +67,7 @@ func TestHandle_Read_UsesReadAtContext(t *testing.T) {
 	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(4096)).Return(16, nil).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 	ctx := context.Background()
 	dest := make([]byte, 16)
 
@@ -98,7 +98,7 @@ func TestHandle_Read_Concurrency(t *testing.T) {
 	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), mock.AnythingOfType("int64")).Return(10, nil)
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -132,7 +132,7 @@ func TestHandle_Read_ReadError(t *testing.T) {
 	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(0)).Return(0, os.ErrPermission).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -152,7 +152,7 @@ func TestHandle_Read_EOF(t *testing.T) {
 	mockFile.On("ReadAtContext", mock.Anything, mock.AnythingOfType("[]uint8"), int64(0)).Return(5, io.EOF).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -174,7 +174,7 @@ func TestHandle_Read_ContextCanceled(t *testing.T) {
 		Return(0, context.Canceled).Once()
 	mockFile.On("Close").Return(nil)
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 	defer handle.Release(context.Background())
 
 	ctx := context.Background()
@@ -229,7 +229,7 @@ func (f *readAtDepthFile) WriteString(string) (int, error)         { return 0, n
 
 func TestHandle_Read_ConcurrentReadsAllSucceed(t *testing.T) {
 	df := &readAtDepthFile{delay: 5 * time.Millisecond}
-	handle := NewHandle(df, slog.Default(), "testfile", nil, nil)
+	handle := NewHandle(df, slog.Default(), "testfile", nil, nil, nil)
 	defer handle.Release(context.Background())
 
 	var wg sync.WaitGroup
@@ -260,7 +260,7 @@ func TestHandle_Release_Idempotent(t *testing.T) {
 
 	mockFile.On("Close").Return(nil).Once()
 
-	handle := NewHandle(mockFile, logger, "testfile", nil, nil)
+	handle := NewHandle(mockFile, logger, "testfile", nil, nil, nil)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Add `AsyncReadBuffer` at the FUSE layer that wraps `ReadAtContext` with a background goroutine filling a ring buffer
- FUSE reads now pull from pre-filled memory instead of blocking on NNTP segment downloads
- Configurable via `async_buffer_size` in FUSE config (default 8MB, 0 to disable)
- Frontend UI added for the new setting in the Streaming Engine section

## Problem

FUSE reads blocked synchronously on NNTP segment downloads. Profiling showed **66.7% of transfer time was stalling** with 193 gaps >100ms during a 2.3GB file transfer. During active reads throughput was 111 MB/s, but the pipeline stalled whenever reads caught up to the download frontier.

## Solution

Inspired by rclone's `AsyncReader` (which provides smooth reads even without VFS cache), this adds an `AsyncReadBuffer` that:

1. Spawns a background goroutine that continuously reads from the source into a ring buffer
2. FUSE reads serve from pre-filled memory (microseconds) instead of blocking on network (milliseconds)
3. Only activates for files larger than the buffer size (skips Finder/Spotlight metadata reads)
4. Uses lazy initialization — no memory allocated until first read
5. Lives at the FUSE level only — WebDAV path is unaffected

## Results

| Metric | Before | After |
|--------|--------|-------|
| FUSE `cat` speed | ~24 MB/s (94s) | **~41 MB/s (55s)** |
| rclone `cat` speed | ~43 MB/s (53s) | unchanged |
| Gap vs rclone | 75% slower | **~4% slower** |

## Test plan

- [x] 8 unit tests with `-race` for AsyncReadBuffer (sequential reads, slow source, error propagation, concurrent read+close, passthrough, GetBufferedOffset)
- [x] `go build ./...` passes
- [x] Existing handle tests updated and passing
- [ ] Manual: rebuild, restart, `dd if=<fuse-file> of=/dev/null bs=1m` — verify ~40+ MB/s
- [ ] Manual: check pprof heap — verify ~8MB per active file stream
- [ ] Manual: verify Finder browsing doesn't trigger buffer allocation for small files