### PR TITLE
fix: nil pointer dereference in ToNNTPProviders when Enabled is unset

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -980,7 +980,7 @@ func (c *Config) ProvidersEqual(other *Config) bool {
 func (c *Config) ToNNTPProviders() []nntppool.Provider {
 	var providers []nntppool.Provider
 	for _, p := range c.Providers {
-		if *p.Enabled {
+		if p.Enabled != nil && *p.Enabled {
 			providers = append(providers, p.ToNNTPProvider())
 		}
 	}


### PR DESCRIPTION
ProviderConfig.Enabled is a *bool and can be nil when the field is
omitted from config. Add a nil check before dereferencing, consistent
with every other *bool read in the codebase (e.g. manager.go:556,
pool/config.go:65).

https://claude.ai/code/session_01EeYNcxh5Fz94R4DRmaeu2o