### PR TITLE
fix: allow rclone rc_pass to be saved via the External RClone form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ go.work.sum
 example/
 
 ./altmount
+altmount
 *.db*
 *node_modules*
 .git

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -226,6 +226,12 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 		err = c.BodyParser(newConfig)
 		// BodyParser will map fields like "profiler_enabled" from JSON to the root of newConfig
 		// because Config struct has it with `json:"profiler_enabled"`.
+		// Preserve existing rc_pass when the request omits or sends an empty value.
+		// The frontend sends rc_pass: "" when the user hasn't entered a new password,
+		// so an empty value means "keep the existing password", not "clear it".
+		if err == nil && newConfig.RClone.RCPass == "" {
+			newConfig.RClone.RCPass = currentConfig.RClone.RCPass
+		}
 	default:
 		return RespondValidationError(c, fmt.Sprintf("Unknown configuration section: %s", section), "INVALID_SECTION")
 	}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -203,7 +203,7 @@ type RCloneConfig struct {
 	RCUrl     string            `yaml:"rc_url" mapstructure:"rc_url" json:"rc_url"`
 	RCPort    int               `yaml:"rc_port" mapstructure:"rc_port" json:"rc_port"`
 	RCUser    string            `yaml:"rc_user" mapstructure:"rc_user" json:"rc_user"`
-	RCPass    string            `yaml:"rc_pass" mapstructure:"rc_pass" json:"-"`
+	RCPass    string            `yaml:"rc_pass" mapstructure:"rc_pass" json:"rc_pass,omitempty"`
 	RCOptions map[string]string `yaml:"rc_options" mapstructure:"rc_options" json:"rc_options"`
 
 	// Mount Configuration


### PR DESCRIPTION
RCloneConfig.RCPass had json:"-" which prevented encoding/json from
parsing the incoming rc_pass value during BodyParser, so any password
entered in the UI was silently discarded.

Changed the tag to json:"rc_pass,omitempty" so the field is accepted
on input. All API responses already mask the actual password via
ToConfigAPIResponse (which returns rc_pass_set:bool), so output
security is unchanged.

Added a preservation guard in handlePatchConfigSection: when the
parsed rc_pass is empty (meaning the user didn't type a new one),
restore the old value from currentConfig so existing passwords are
never cleared by unrelated saves.

https://claude.ai/code/session_01JQytCBtV2o1ykkzgmt3zfv