### PR TITLE
Set inflight_requests default to 10 in config Validate()

### DIFF
--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -551,6 +551,9 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 		return RespondValidationError(c, "Configuration validation failed", err.Error())
 	}
 
+	// Refresh from normalized config (Validate may have applied defaults)
+	newProvider = newConfig.Providers[len(newConfig.Providers)-1]
+
 	if err := s.configManager.UpdateConfig(newConfig); err != nil {
 		return RespondInternalError(c, "Failed to update configuration", err.Error())
 	}
@@ -728,6 +731,9 @@ func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 	if err := s.configManager.ValidateConfigUpdate(newConfig); err != nil {
 		return RespondValidationError(c, "Configuration validation failed", err.Error())
 	}
+
+	// Refresh from normalized config (Validate may have applied defaults)
+	provider = newConfig.Providers[providerIndex]
 
 	if err := s.configManager.UpdateConfig(newConfig); err != nil {
 		return RespondInternalError(c, "Failed to update configuration", err.Error())

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -720,6 +720,9 @@ func (c *Config) Validate() error {
 		if provider.MaxConnections <= 0 {
 			return fmt.Errorf("provider %d: max_connections must be greater than 0", i)
 		}
+		if provider.InflightRequests <= 0 {
+			c.Providers[i].InflightRequests = 10
+		}
 	}
 
 	// Validate Fuse configuration


### PR DESCRIPTION
Providers with missing or zero inflight_requests now get normalized to
10 during config validation, covering YAML loading, API create, and API
update paths. Both API handlers also refresh their local provider copy
from newConfig after validation so responses reflect the normalized value.

https://claude.ai/code/session_01PRtsz2p6CNBiUC6Fti9LiP