### PR TITLE
fix(ui): pre-populate sub-section data when switching mount type

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -142,7 +142,27 @@ export function MountConfigSection({ config, onUpdate, isUpdating }: MountConfig
 			}
 		}
 		setMountType(newType);
-		subSectionDataRef.current = {};
+		// Pre-populate sub-section data for the new type (mirrors useEffect([config]) logic)
+		// so that saving immediately after switching includes the correct rclone/fuse config.
+		if (newType === "rclone") {
+			subSectionDataRef.current = buildRCloneMountFormData(config) as unknown as Record<
+				string,
+				unknown
+			>;
+		} else if (newType === "fuse" && config.fuse) {
+			subSectionDataRef.current = config.fuse as unknown as Record<string, unknown>;
+		} else if (newType === "rclone_external") {
+			subSectionDataRef.current = {
+				rc_enabled: true,
+				rc_url: config.rclone.rc_url || "",
+				vfs_name: config.rclone.vfs_name || "altmount",
+				rc_port: config.rclone.rc_port || 5572,
+				rc_user: config.rclone.rc_user || "",
+				rc_pass: "",
+			};
+		} else {
+			subSectionDataRef.current = {};
+		}
 		setHasChanges(true);
 	};
 


### PR DESCRIPTION
When switching from one mount type to another, handleMountTypeChange
was clearing subSectionDataRef.current to {}. The sub-section component
(ExternalRCloneSubSection, RCloneMountSubSection, FuseMountSubSection)
never calls onFormDataChange on mount — only when the user edits a
field. This meant saving immediately after switching would omit the
rclone/fuse config from the PATCH payload, relying solely on the
backend's deep-copy of the previous config.

For rclone_external this caused the RC connection settings not to be
explicitly set on the first save, and any default values shown in the
form were silently discarded.

Fix by mirroring the existing useEffect([config]) initialisation logic
inside handleMountTypeChange, so subSectionDataRef.current is always
populated for the selected type before the user clicks Save.

https://claude.ai/code/session_016NSG2i37y585gco12YLi8q