### PR TITLE
perf(metadata): drop full-proto cache; extract-and-release FileMetadata

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -69,6 +69,18 @@ func NewHealthChecker(
 	}
 }
 
+// healthCheckInput holds the fields extracted from FileMetadata that the
+// health check path actually needs. Passing this lean struct — instead of the
+// full *metapb.FileMetadata — lets the proto wrapper be GC'd while
+// ValidateSegmentAvailabilityDetailed performs long-running NNTP stat
+// round-trips. Only SegmentData must remain referenced for the validation
+// window (it holds the message IDs being checked); everything else is scalar.
+type healthCheckInput struct {
+	fileSize      int64
+	sourceNzbPath string
+	segments      []*metapb.SegmentData
+}
+
 // CheckFile checks the health of a specific file
 func (hc *HealthChecker) CheckFile(ctx context.Context, filePath string, opts ...CheckOptions) HealthEvent {
 	// Get file metadata
@@ -100,19 +112,34 @@ func (hc *HealthChecker) CheckFile(ctx context.Context, filePath string, opts ..
 		}
 	}
 
+	// Extract only the fields needed for validation. The local fileMeta pointer
+	// then falls out of scope and becomes eligible for GC — its proto wrapper
+	// (MessageState, unknownFields, sizeCache, Par2Files, NestedSources, etc.)
+	// is freed before NNTP stat round-trips begin.
+	input := healthCheckInput{
+		fileSize:      fileMeta.FileSize,
+		sourceNzbPath: fileMeta.SourceNzbPath,
+		segments:      fileMeta.SegmentData,
+	}
+	fileMeta = nil //nolint:ineffassign // explicit drop so the proto can be collected
+
 	// Perform the health check
-	return hc.checkSingleFile(ctx, filePath, fileMeta, opts...)
+	return hc.checkSingleFile(ctx, filePath, input, opts...)
 }
 
 // checkSingleFile performs a health check on a single file
-func (hc *HealthChecker) checkSingleFile(ctx context.Context, filePath string, fileMeta *metapb.FileMetadata, opts ...CheckOptions) HealthEvent {
+func (hc *HealthChecker) checkSingleFile(ctx context.Context, filePath string, input healthCheckInput, opts ...CheckOptions) HealthEvent {
+	// Copy SourceNzbPath to an independent string so HealthEvent does not
+	// retain a pointer into the original proto (which would keep the whole
+	// message alive through any downstream consumer of the event).
+	sourceNzb := input.sourceNzbPath
 	event := HealthEvent{
 		FilePath:  filePath,
 		Timestamp: time.Now(),
-		SourceNzb: &fileMeta.SourceNzbPath,
+		SourceNzb: &sourceNzb,
 	}
 
-	if len(fileMeta.SegmentData) == 0 {
+	if len(input.segments) == 0 {
 		event.Type = EventTypeCheckFailed
 		event.Status = database.HealthStatusCorrupted
 		event.Error = fmt.Errorf("no segment data available")
@@ -134,12 +161,12 @@ func (hc *HealthChecker) checkSingleFile(ctx context.Context, filePath string, f
 
 	slog.InfoContext(ctx, "Checking segment availability",
 		"file_path", filePath,
-		"total_segments", len(fileMeta.SegmentData),
+		"total_segments", len(input.segments),
 		"sample_percentage", samplePercentage)
 
 	// 1. Metadata integrity check - Verify the entire file map is complete
-	loader := &metadataSegmentLoader{segments: fileMeta.SegmentData}
-	if err := usenet.CheckMetadataIntegrity(fileMeta.FileSize, loader); err != nil {
+	loader := &metadataSegmentLoader{segments: input.segments}
+	if err := usenet.CheckMetadataIntegrity(input.fileSize, loader); err != nil {
 		event.Type = EventTypeFileCorrupted
 		event.Status = database.HealthStatusCorrupted
 		event.Error = fmt.Errorf("metadata corruption: %w", err)
@@ -151,7 +178,7 @@ func (hc *HealthChecker) checkSingleFile(ctx context.Context, filePath string, f
 	// 2. Network availability check - Validate segment availability using detailed validation logic
 	result, err := usenet.ValidateSegmentAvailabilityDetailed(
 		ctx,
-		fileMeta.SegmentData,
+		input.segments,
 		hc.poolManager,
 		cfg.GetMaxConnectionsForHealthChecks(),
 		samplePercentage,

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -32,24 +32,28 @@ type FileMetadataLite struct {
 	Status     metapb.FileStatus
 }
 
-// MetadataService provides low-level read/write operations for metadata files
+// MetadataService provides low-level read/write operations for metadata files.
+//
+// Only a lightweight metadata projection (liteCache) is kept in memory. The
+// full FileMetadata proto — dominated by SegmentData/NestedSources slices
+// holding thousands of message-ID strings — is never cached. Callers that need
+// segments (Open, HealthChecker) re-read from disk each time; the proto then
+// lives only for the duration of the open handle or the health check. This
+// bounds steady-state memory at ~liteCache_entries × 40 bytes instead of the
+// previous unbounded segment retention.
 type MetadataService struct {
 	rootPath string
-	// fileCache caches parsed FileMetadata keyed by virtual path.
-	// Entries are evicted on LRU basis and invalidated on any write/delete/rename.
-	fileCache *lru.Cache[string, *metapb.FileMetadata]
-	// liteCache caches lightweight metadata for Readdir. Avoids deserializing
-	// full protos (with SegmentData, etc.) just to list a directory.
+	// liteCache caches lightweight metadata (size, modtime, status) used by
+	// Readdir/Stat/Getattr, and populated as a side effect of ReadFileMetadata
+	// so info-only callers still benefit.
 	liteCache *lru.Cache[string, *FileMetadataLite]
 }
 
 // NewMetadataService creates a new metadata service
 func NewMetadataService(rootPath string) *MetadataService {
-	cache, _ := lru.New[string, *metapb.FileMetadata](defaultMetadataCacheSize)
 	liteCache, _ := lru.New[string, *FileMetadataLite](defaultMetadataCacheSize)
 	return &MetadataService{
 		rootPath:  rootPath,
-		fileCache: cache,
 		liteCache: liteCache,
 	}
 }
@@ -123,8 +127,8 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 
 	metadata.NzbdavId = nzbdavId // Restore for in-memory use
 
-	// Update cache with the written metadata
-	ms.fileCache.Add(virtualPath, metadata)
+	// Update only the lightweight cache; the full proto (with SegmentData) is
+	// never cached to avoid long-term retention of segment strings.
 	ms.liteCache.Add(virtualPath, &FileMetadataLite{
 		FileSize:   metadata.FileSize,
 		ModifiedAt: metadata.ModifiedAt,
@@ -134,14 +138,12 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 	return nil
 }
 
-// ReadFileMetadata reads file metadata from disk, using an in-memory LRU cache
-// to avoid repeated disk I/O and protobuf deserialization on hot FUSE paths.
+// ReadFileMetadata reads file metadata from disk. The full proto (including
+// SegmentData and NestedSources) is returned to the caller but NOT cached —
+// those slices dominate heap usage and must not be retained beyond the
+// caller's handle. As a side effect, the lightweight projection is cached so
+// subsequent Readdir/Stat calls are fast without a disk read.
 func (ms *MetadataService) ReadFileMetadata(virtualPath string) (*metapb.FileMetadata, error) {
-	// Check cache first
-	if cached, ok := ms.fileCache.Get(virtualPath); ok {
-		return cached, nil
-	}
-
 	// Create metadata file path
 	filename := filepath.Base(virtualPath)
 	metadataDir := filepath.Join(ms.rootPath, filepath.Dir(virtualPath))
@@ -168,8 +170,7 @@ func (ms *MetadataService) ReadFileMetadata(virtualPath string) (*metapb.FileMet
 		metadata.NzbdavId = string(idData)
 	}
 
-	// Store in cache
-	ms.fileCache.Add(virtualPath, metadata)
+	// Populate only the lightweight cache — the full proto is never cached.
 	ms.liteCache.Add(virtualPath, &FileMetadataLite{
 		FileSize:   metadata.FileSize,
 		ModifiedAt: metadata.ModifiedAt,
@@ -186,17 +187,6 @@ func (ms *MetadataService) ReadFileMetadataLite(virtualPath string) (*FileMetada
 	// Check lite cache first
 	if cached, ok := ms.liteCache.Get(virtualPath); ok {
 		return cached, nil
-	}
-
-	// If the full metadata is already cached, extract from it
-	if full, ok := ms.fileCache.Get(virtualPath); ok {
-		lite := &FileMetadataLite{
-			FileSize:   full.FileSize,
-			ModifiedAt: full.ModifiedAt,
-			Status:     full.Status,
-		}
-		ms.liteCache.Add(virtualPath, lite)
-		return lite, nil
 	}
 
 	// Cache miss — read from disk and deserialize
@@ -390,7 +380,6 @@ func (ms *MetadataService) DeleteFileMetadata(virtualPath string) error {
 
 // DeleteFileMetadataWithSourceNzb deletes a metadata file and optionally its source NZB
 func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, virtualPath string, deleteSourceNzb bool) error {
-	ms.fileCache.Remove(virtualPath)
 	ms.liteCache.Remove(virtualPath)
 
 	filename := filepath.Base(virtualPath)
@@ -448,11 +437,6 @@ func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, 
 func (ms *MetadataService) DeleteDirectory(virtualPath string) error {
 	// Purge all cached entries under this directory
 	prefix := virtualPath + string(filepath.Separator)
-	for _, key := range ms.fileCache.Keys() {
-		if key == virtualPath || strings.HasPrefix(key, prefix) {
-			ms.fileCache.Remove(key)
-		}
-	}
 	for _, key := range ms.liteCache.Keys() {
 		if key == virtualPath || strings.HasPrefix(key, prefix) {
 			ms.liteCache.Remove(key)
@@ -472,8 +456,6 @@ func (ms *MetadataService) DeleteDirectory(virtualPath string) error {
 // RenameFileMetadata atomically renames a metadata file (and its .id sidecar) from oldVirtualPath to newVirtualPath.
 // Uses os.Rename for atomicity on the same filesystem, falling back to read-write-delete for cross-device moves.
 func (ms *MetadataService) RenameFileMetadata(oldVirtualPath, newVirtualPath string) error {
-	ms.fileCache.Remove(oldVirtualPath)
-	ms.fileCache.Remove(newVirtualPath)
 	ms.liteCache.Remove(oldVirtualPath)
 	ms.liteCache.Remove(newVirtualPath)
 
@@ -745,7 +727,6 @@ func (ms *MetadataService) cleanupEmptyDirsRecursive(path string, protected []st
 
 // MoveToCorrupted moves a metadata file to a special corrupted directory for safety
 func (ms *MetadataService) MoveToCorrupted(ctx context.Context, virtualPath string) error {
-	ms.fileCache.Remove(virtualPath)
 	ms.liteCache.Remove(virtualPath)
 
 	// Normalize path and remove leading slashes to ensure it joins correctly

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -237,10 +237,28 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		}
 	}
 
+	// Extract only the fields the handle needs from the proto. The full
+	// *FileMetadata then falls out of scope and becomes eligible for GC,
+	// freeing the proto wrapper overhead (~protoimpl.MessageState +
+	// unknownFields + sizeCache + unused fields like NzbdavId). Slices are
+	// carried by reference; they stay alive only while the handle is open.
+	handleMeta := &fileHandleMeta{
+		FileSize:      fileMeta.FileSize,
+		ModifiedAt:    fileMeta.ModifiedAt,
+		SourceNzbPath: fileMeta.SourceNzbPath,
+		Encryption:    fileMeta.Encryption,
+		Password:      fileMeta.Password,
+		Salt:          fileMeta.Salt,
+		AesKey:        fileMeta.AesKey,
+		AesIv:         fileMeta.AesIv,
+		SegmentData:   fileMeta.SegmentData,
+		NestedSources: fileMeta.NestedSources,
+	}
+
 	// Create a metadata-based virtual file handle
 	virtualFile := &MetadataVirtualFile{
 		name:             name,
-		fileMeta:         fileMeta,
+		meta:             handleMeta,
 		metadataService:  mrf.metadataService,
 		healthRepository: mrf.healthRepository,
 		arrsService:      mrf.arrsService,
@@ -751,10 +769,29 @@ func (mvd *MetadataVirtualDirectory) Truncate(size int64) error {
 	return os.ErrPermission
 }
 
+// fileHandleMeta holds the subset of FileMetadata fields that an open
+// MetadataVirtualFile actually needs. Storing this lean struct instead of the
+// full protobuf lets the proto wrapper (protoimpl.MessageState, unknownFields,
+// sizeCache, and unused fields like NzbdavId) be collected immediately after
+// OpenFile returns. Segment and nested-source slices are carried by reference;
+// they remain live only while the handle is open and are released in Close().
+type fileHandleMeta struct {
+	FileSize      int64
+	ModifiedAt    int64
+	SourceNzbPath string
+	Encryption    metapb.Encryption
+	Password      string
+	Salt          string
+	AesKey        []byte
+	AesIv         []byte
+	SegmentData   []*metapb.SegmentData
+	NestedSources []*metapb.NestedSegmentSource
+}
+
 // MetadataVirtualFile implements afero.File for metadata-backed virtual files
 type MetadataVirtualFile struct {
 	name             string
-	fileMeta         *metapb.FileMetadata
+	meta             *fileHandleMeta
 	metadataService  *metadata.MetadataService
 	healthRepository *database.HealthRepository
 	arrsService      ARRsRepairService
@@ -912,7 +949,7 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 			if errors.As(readErr, &dataCorruptionErr) {
 				mvf.updateFileHealthOnError(dataCorruptionErr, dataCorruptionErr.NoRetry)
 				return n, &CorruptedFileError{
-					TotalExpected: mvf.fileMeta.FileSize,
+					TotalExpected: mvf.meta.FileSize,
 					UnderlyingErr: dataCorruptionErr,
 				}
 			}
@@ -947,7 +984,7 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	if off < 0 {
 		return 0, ErrNegativeOffset
 	}
-	if off >= mvf.fileMeta.FileSize {
+	if off >= mvf.meta.FileSize {
 		return 0, io.EOF
 	}
 
@@ -966,8 +1003,8 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 
 		// Read from the shared reader (same logic as Read but bounded to len(p))
 		want := int64(len(p))
-		if off+want > mvf.fileMeta.FileSize {
-			want = mvf.fileMeta.FileSize - off
+		if off+want > mvf.meta.FileSize {
+			want = mvf.meta.FileSize - off
 		}
 		buf := p[:want]
 		for n < int(want) {
@@ -1006,8 +1043,8 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	mvf.closeCurrentReader()
 
 	end := off + int64(len(p)) - 1
-	if end >= mvf.fileMeta.FileSize {
-		end = mvf.fileMeta.FileSize - 1
+	if end >= mvf.meta.FileSize {
+		end = mvf.meta.FileSize - 1
 	}
 
 	reader, err := mvf.createReaderAtOffset(off, end)
@@ -1038,16 +1075,16 @@ func (mvf *MetadataVirtualFile) createReaderAtOffset(start, end int64) (io.ReadC
 	}
 
 	// Nested sources take priority — each source has its own segments and AES credentials
-	if len(mvf.fileMeta.NestedSources) > 0 {
+	if len(mvf.meta.NestedSources) > 0 {
 		return mvf.createNestedReader(start, end)
 	}
 
-	if len(mvf.fileMeta.SegmentData) == 0 {
+	if len(mvf.meta.SegmentData) == 0 {
 		return nil, ErrMissmatchedSegments
 	}
 
 	// Create reader based on encryption type
-	if mvf.fileMeta.Encryption != metapb.Encryption_NONE {
+	if mvf.meta.Encryption != metapb.Encryption_NONE {
 		return mvf.createEncryptedReaderAtOffset(start, end)
 	}
 
@@ -1056,17 +1093,17 @@ func (mvf *MetadataVirtualFile) createReaderAtOffset(start, end int64) (io.ReadC
 
 // createEncryptedReaderAtOffset creates an encrypted reader for a specific offset range
 func (mvf *MetadataVirtualFile) createEncryptedReaderAtOffset(start, end int64) (io.ReadCloser, error) {
-	switch mvf.fileMeta.Encryption {
+	switch mvf.meta.Encryption {
 	case metapb.Encryption_RCLONE:
 		if mvf.rcloneCipher == nil {
 			return nil, ErrNoCipherConfig
 		}
 
-		password := mvf.fileMeta.Password
+		password := mvf.meta.Password
 		if password == "" {
 			password = mvf.globalPassword
 		}
-		salt := mvf.fileMeta.Salt
+		salt := mvf.meta.Salt
 		if salt == "" {
 			salt = mvf.globalSalt
 		}
@@ -1074,7 +1111,7 @@ func (mvf *MetadataVirtualFile) createEncryptedReaderAtOffset(start, end int64) 
 		return mvf.rcloneCipher.Open(
 			mvf.ctx,
 			&utils.RangeHeader{Start: start, End: end},
-			mvf.fileMeta.FileSize,
+			mvf.meta.FileSize,
 			password,
 			salt,
 			func(ctx context.Context, s, e int64) (io.ReadCloser, error) {
@@ -1086,26 +1123,26 @@ func (mvf *MetadataVirtualFile) createEncryptedReaderAtOffset(start, end int64) 
 		if mvf.aesCipher == nil {
 			return nil, ErrNoCipherConfig
 		}
-		if len(mvf.fileMeta.AesKey) == 0 {
+		if len(mvf.meta.AesKey) == 0 {
 			return nil, fmt.Errorf("missing AES key in metadata")
 		}
-		if len(mvf.fileMeta.AesIv) == 0 {
+		if len(mvf.meta.AesIv) == 0 {
 			return nil, fmt.Errorf("missing AES IV in metadata")
 		}
 
 		return mvf.aesCipher.Open(
 			mvf.ctx,
 			&utils.RangeHeader{Start: start, End: end},
-			mvf.fileMeta.FileSize,
-			mvf.fileMeta.AesKey,
-			mvf.fileMeta.AesIv,
+			mvf.meta.FileSize,
+			mvf.meta.AesKey,
+			mvf.meta.AesIv,
 			func(ctx context.Context, s, e int64) (io.ReadCloser, error) {
 				return mvf.createUsenetReader(ctx, s, e)
 			},
 		)
 
 	default:
-		return nil, fmt.Errorf("unsupported encryption type: %v", mvf.fileMeta.Encryption)
+		return nil, fmt.Errorf("unsupported encryption type: %v", mvf.meta.Encryption)
 	}
 }
 
@@ -1122,7 +1159,7 @@ func (mvf *MetadataVirtualFile) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent: // Relative to the current offset
 		abs = mvf.position + offset
 	case io.SeekEnd: // Relative to the end
-		abs = mvf.fileMeta.FileSize + offset
+		abs = mvf.meta.FileSize + offset
 	default:
 		return 0, ErrInvalidWhence
 	}
@@ -1131,7 +1168,7 @@ func (mvf *MetadataVirtualFile) Seek(offset int64, whence int) (int64, error) {
 		return 0, ErrSeekNegative
 	}
 
-	if abs > mvf.fileMeta.FileSize {
+	if abs > mvf.meta.FileSize {
 		return 0, ErrSeekTooFar
 	}
 
@@ -1173,6 +1210,7 @@ func (mvf *MetadataVirtualFile) Close() error {
 		mvf.readerInitialized = false
 	}
 	mvf.segmentIndex = nil // Release segment offset index for GC
+	mvf.meta = nil         // Release segment/nested-source slices for GC
 	mvf.mu.Unlock()
 
 	// Wait for any background reader closes from previous seeks
@@ -1211,9 +1249,9 @@ func (mvf *MetadataVirtualFile) Readdirnames(n int) ([]string, error) {
 func (mvf *MetadataVirtualFile) Stat() (fs.FileInfo, error) {
 	info := &MetadataFileInfo{
 		name:    filepath.Base(mvf.name),
-		size:    mvf.fileMeta.FileSize,
+		size:    mvf.meta.FileSize,
 		mode:    0644,
-		modTime: time.Unix(mvf.fileMeta.ModifiedAt, 0),
+		modTime: time.Unix(mvf.meta.ModifiedAt, 0),
 		isDir:   false, // Files are never directories in simplified schema
 	}
 
@@ -1252,7 +1290,7 @@ func (mvf *MetadataVirtualFile) hasMoreDataToRead() bool {
 		return true
 	}
 	// If original range was unbounded (-1) and we haven't reached file end, there's more to read
-	if mvf.originalRangeEnd == -1 && mvf.position < mvf.fileMeta.FileSize {
+	if mvf.originalRangeEnd == -1 && mvf.position < mvf.meta.FileSize {
 		return true
 	}
 	return false
@@ -1285,14 +1323,14 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 	start, end := mvf.getRequestRange()
 
 	if end == -1 {
-		end = mvf.fileMeta.FileSize - 1
+		end = mvf.meta.FileSize - 1
 	}
 
 	// When ReadAtContext has advanced the shared cursor past mvf.position (which
 	// ReadAt does not move), open the reader at the shared cursor so the next
 	// shared-path read picks up where the last one left off.
 	if mvf.readAtSharedNext > 0 &&
-		mvf.readAtSharedNext < mvf.fileMeta.FileSize &&
+		mvf.readAtSharedNext < mvf.meta.FileSize &&
 		start < mvf.readAtSharedNext &&
 		(end < 0 || mvf.readAtSharedNext <= end) {
 		start = mvf.readAtSharedNext
@@ -1303,14 +1341,14 @@ func (mvf *MetadataVirtualFile) ensureReader() error {
 	mvf.currentRangeEnd = end
 
 	// Create reader for the calculated range using metadata segments
-	if len(mvf.fileMeta.NestedSources) > 0 {
+	if len(mvf.meta.NestedSources) > 0 {
 		// Nested RAR: use multi-source reader
 		reader, err := mvf.createNestedReader(start, end)
 		if err != nil {
 			return fmt.Errorf("failed to create nested reader: %w", err)
 		}
 		mvf.reader = reader
-	} else if mvf.fileMeta.Encryption != metapb.Encryption_NONE {
+	} else if mvf.meta.Encryption != metapb.Encryption_NONE {
 		// Wrap the usenet reader with encryption
 		decryptedReader, err := mvf.wrapWithEncryption(start, end)
 		if err != nil {
@@ -1364,16 +1402,16 @@ func (mvf *MetadataVirtualFile) getRequestRange() (start, end int64) {
 
 // createUsenetReader creates a new usenet reader for the specified range using metadata segments
 func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, end int64) (io.ReadCloser, error) {
-	if len(mvf.fileMeta.SegmentData) == 0 {
+	if len(mvf.meta.SegmentData) == 0 {
 		return nil, ErrMissmatchedSegments
 	}
 
 	// Build segment offset index lazily on first read (thread-safe via sync.Once)
 	mvf.segmentIndexOnce.Do(func() {
-		mvf.segmentIndex = buildSegmentIndex(mvf.fileMeta.SegmentData)
+		mvf.segmentIndex = buildSegmentIndex(mvf.meta.SegmentData)
 	})
 
-	loader := newMetadataSegmentLoader(mvf.fileMeta.SegmentData)
+	loader := newMetadataSegmentLoader(mvf.meta.SegmentData)
 
 	// segmentIndex is always non-nil here (built by segmentIndexOnce.Do above).
 	// Use O(log n) binary search to find segment boundaries, then create a lazy
@@ -1388,7 +1426,7 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 
 	if !rg.HasSegments() {
 		var availableBytes int64
-		for _, seg := range mvf.fileMeta.SegmentData {
+		for _, seg := range mvf.meta.SegmentData {
 			availableBytes += seg.SegmentSize
 		}
 
@@ -1396,7 +1434,7 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 			"start", start,
 			"end", end,
 			"available_bytes", availableBytes,
-			"expected_file_size", mvf.fileMeta.FileSize,
+			"expected_file_size", mvf.meta.FileSize,
 		)
 
 		mvf.updateFileHealthOnError(&usenet.DataCorruptionError{
@@ -1404,7 +1442,7 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 		}, true)
 
 		return nil, &CorruptedFileError{
-			TotalExpected: mvf.fileMeta.FileSize,
+			TotalExpected: mvf.meta.FileSize,
 			UnderlyingErr: ErrMissmatchedSegments,
 		}
 	}
@@ -1428,7 +1466,7 @@ func (mvf *MetadataVirtualFile) createUsenetReader(ctx context.Context, start, e
 // This avoids opening all inner volumes simultaneously, which would cause all their
 // segments to be prefetched concurrently and spike memory usage.
 func (mvf *MetadataVirtualFile) createNestedReader(start, end int64) (io.ReadCloser, error) {
-	sources := mvf.fileMeta.NestedSources
+	sources := mvf.meta.NestedSources
 	if len(sources) == 0 {
 		return nil, fmt.Errorf("no nested sources available")
 	}
@@ -1601,22 +1639,22 @@ func (r *lazyNestedMultiReader) Close() error {
 
 // wrapWithEncryption wraps a usenet reader with encryption using metadata
 func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadCloser, error) {
-	if mvf.fileMeta.Encryption == metapb.Encryption_NONE {
+	if mvf.meta.Encryption == metapb.Encryption_NONE {
 		return nil, ErrNoEncryptionParams
 	}
 
-	switch mvf.fileMeta.Encryption {
+	switch mvf.meta.Encryption {
 	case metapb.Encryption_RCLONE:
 		if mvf.rcloneCipher == nil {
 			return nil, ErrNoCipherConfig
 		}
 
 		// Get password and salt from metadata, with global fallback
-		password := mvf.fileMeta.Password
+		password := mvf.meta.Password
 		if password == "" {
 			password = mvf.globalPassword
 		}
-		salt := mvf.fileMeta.Salt
+		salt := mvf.meta.Salt
 		if salt == "" {
 			salt = mvf.globalSalt
 		}
@@ -1625,7 +1663,7 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 		decryptedReader, err := mvf.rcloneCipher.Open(
 			mvf.ctx,
 			&utils.RangeHeader{Start: start, End: end},
-			mvf.fileMeta.FileSize,
+			mvf.meta.FileSize,
 			password,
 			salt,
 			func(ctx context.Context, start, end int64) (io.ReadCloser, error) {
@@ -1642,10 +1680,10 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 		if mvf.aesCipher == nil {
 			return nil, ErrNoCipherConfig
 		}
-		if len(mvf.fileMeta.AesKey) == 0 {
+		if len(mvf.meta.AesKey) == 0 {
 			return nil, fmt.Errorf("missing AES key in metadata")
 		}
-		if len(mvf.fileMeta.AesIv) == 0 {
+		if len(mvf.meta.AesIv) == 0 {
 			return nil, fmt.Errorf("missing AES IV in metadata")
 		}
 
@@ -1653,9 +1691,9 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 		decryptedReader, err := mvf.aesCipher.Open(
 			mvf.ctx,
 			&utils.RangeHeader{Start: start, End: end},
-			mvf.fileMeta.FileSize,
-			mvf.fileMeta.AesKey,
-			mvf.fileMeta.AesIv,
+			mvf.meta.FileSize,
+			mvf.meta.AesKey,
+			mvf.meta.AesIv,
 			func(ctx context.Context, s, e int64) (io.ReadCloser, error) {
 				// Create usenet reader first for encrypted data
 				return mvf.createUsenetReader(ctx, s, e)
@@ -1667,7 +1705,7 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 		return decryptedReader, nil
 
 	default:
-		return nil, fmt.Errorf("unsupported encryption type: %v", mvf.fileMeta.Encryption)
+		return nil, fmt.Errorf("unsupported encryption type: %v", mvf.meta.Encryption)
 	}
 }
 
@@ -1689,14 +1727,14 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 
 	// Update database health tracking (blocking with timeout)
 	errorMsg := dataCorruptionErr.Error()
-	sourceNzbPath := &mvf.fileMeta.SourceNzbPath
+	sourceNzbPath := &mvf.meta.SourceNzbPath
 	if *sourceNzbPath == "" {
 		sourceNzbPath = nil
 	}
 
 	// Create error details JSON
 	errorDetails := fmt.Sprintf(`{"missing_articles": %d, "total_articles": %d, "error_type": "ArticleNotFound"}`,
-		1, len(mvf.fileMeta.SegmentData))
+		1, len(mvf.meta.SegmentData))
 
 	// Mark as repair_triggered with high priority to trigger the replacement immediately.
 	// We skip the re-verification phase because a streaming failure is a definitive indicator of corruption.

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -14,7 +14,7 @@ import (
 // createTestVirtualFile creates a MetadataVirtualFile with default configuration for testing
 func createTestVirtualFile(fileSize int64) *MetadataVirtualFile {
 	return &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize: fileSize,
 		},
 	}
@@ -24,12 +24,12 @@ func TestCreateTestVirtualFile(t *testing.T) {
 	fileSize := int64(100 * 1024 * 1024) // 100MB
 	mvf := createTestVirtualFile(fileSize)
 
-	if mvf.fileMeta.FileSize != fileSize {
-		t.Errorf("createTestVirtualFile() fileSize = %d, want %d", mvf.fileMeta.FileSize, fileSize)
+	if mvf.meta.FileSize != fileSize {
+		t.Errorf("createTestVirtualFile() fileSize = %d, want %d", mvf.meta.FileSize, fileSize)
 	}
 
-	if mvf.fileMeta == nil {
-		t.Error("createTestVirtualFile() fileMeta should not be nil")
+	if mvf.meta == nil {
+		t.Error("createTestVirtualFile() meta should not be nil")
 	}
 }
 
@@ -259,7 +259,7 @@ func TestSegmentIndexIntegration(t *testing.T) {
 // TestReadAtBoundsValidation tests ReadAt boundary validation
 func TestReadAtBoundsValidation(t *testing.T) {
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize: 1000,
 		},
 	}
@@ -301,7 +301,7 @@ func TestReadAtNoPoolManager(t *testing.T) {
 	}
 
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize:    1000,
 			SegmentData: segments,
 		},
@@ -320,7 +320,7 @@ func TestReadAtNoPoolManager(t *testing.T) {
 // TestReadAtNoSegments tests ReadAt when there are no segments
 func TestReadAtNoSegments(t *testing.T) {
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize:    1000,
 			SegmentData: nil, // No segments
 		},
@@ -390,7 +390,7 @@ func (m *mockPoolManager) ResetProviderQuota(_ context.Context, _ nntppool.Provi
 func TestSeekResetsOriginalRangeEnd(t *testing.T) {
 	fileSize := int64(100 * 1024 * 1024) // 100MB
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize: fileSize,
 		},
 		position:          0,
@@ -418,7 +418,7 @@ func TestSeekResetsOriginalRangeEnd(t *testing.T) {
 func TestSeekSamePositionDoesNotResetRange(t *testing.T) {
 	fileSize := int64(100 * 1024 * 1024) // 100MB
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize: fileSize,
 		},
 		position:          1024,
@@ -442,7 +442,7 @@ func TestSeekSamePositionDoesNotResetRange(t *testing.T) {
 func TestMultipleConsecutiveSeeks(t *testing.T) {
 	fileSize := int64(100 * 1024 * 1024) // 100MB
 	mvf := &MetadataVirtualFile{
-		fileMeta: &metapb.FileMetadata{
+		meta: &fileHandleMeta{
 			FileSize: fileSize,
 		},
 		position:          0,
@@ -508,7 +508,7 @@ func TestSeekWithWhenceModes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mvf := &MetadataVirtualFile{
-				fileMeta: &metapb.FileMetadata{
+				meta: &fileHandleMeta{
 					FileSize: fileSize,
 				},
 				position:          tt.initialPos,
@@ -570,7 +570,7 @@ func TestSeekErrorCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mvf := &MetadataVirtualFile{
-				fileMeta: &metapb.FileMetadata{
+				meta: &fileHandleMeta{
 					FileSize: fileSize,
 				},
 				position:          tt.initialPos,


### PR DESCRIPTION
## Summary

A pprof `inuse_space` snapshot showed **400 MB (82% of 487 MB heap)** retained by `*FileMetadata` protos deserialized via `MetadataService.ReadFileMetadata` — mostly through the FUSE Open path (296 MB, 60.84%) and HealthChecker (102 MB, 21.05%). Top allocators were `reflect.unsafe_New` and `consumeStringValidateUTF8`, both inside `proto.Unmarshal` of large `SegmentData` slices.

Follow-up to 7f4e866 which handled the Readdir/Stat/Getattr side via `FileMetadataLite`.

## Changes

- **`internal/metadata/service.go`** — remove the 4096-entry `fileCache` entirely. Only `liteCache` (40-byte `FileMetadataLite`) remains. `ReadFileMetadata` now always reads from disk; the full proto is never cached. Callers that need segments carry them only for the lifetime of their operation.

- **`internal/nzbfilesystem/metadata_remote_file.go`** — replace `MetadataVirtualFile.fileMeta *metapb.FileMetadata` with a lean `fileHandleMeta` struct holding only the fields the handle uses (`FileSize`, `ModifiedAt`, `SourceNzbPath`, `Encryption`, `Password`, `Salt`, `AesKey`, `AesIv`, `SegmentData`, `NestedSources`). Slices are referenced, not copied. `Close()` nils `mvf.meta` so segment and nested-source slices become GC-eligible immediately when the kernel releases the handle.

- **`internal/health/checker.go`** — `checkSingleFile` now takes `healthCheckInput` (scalar + segment slice) instead of `*metapb.FileMetadata`. `CheckFile` extracts the three needed fields and drops the proto pointer so the wrapper is collected before long NNTP stat round-trips. Also fixes a lifetime bug where `event.SourceNzb = &fileMeta.SourceNzbPath` pinned the whole proto via an interior pointer.

## Expected impact

The 400 MB attributable to `ReadFileMetadata` drops to near-zero steady-state. Segment bytes live only while a handle is open or a health check is in flight; no full proto is ever cached. `reflect.unsafe_New` and `consumeStringValidateUTF8` should leave the top 5 of `inuse_space`.

## Trade-off

Every `Open` / `CheckFile` now does one `os.ReadFile` + `proto.Unmarshal` instead of a cache hit. FUSE `Open` is not a hot path (unlike `Read`), and the OS page cache makes repeat reads near-free. Unmarshal CPU is transient and was already happening on every cache miss.

## Test plan

- [x] `go test -race -count=1 ./internal/metadata/... ./internal/nzbfilesystem/... ./internal/health/...` passes
- [x] `go build ./...` and `go vet ./...` clean
- [ ] Reproduce the workload that produced the 480 MB baseline, capture a fresh `inuse_space` pprof, and confirm `ReadFileMetadata`-attributed allocations drop out of the top 5
- [ ] Smoke: open a large NZB-backed file via FUSE, seek/read/close 50×, watch heap plateau under `GODEBUG=gctrace=1`
- [ ] Smoke: trigger a HealthChecker cycle on a file with many segments; confirm correct result and heap release after the cycle
- [ ] Smoke: Readdir a large directory; confirm lite path unchanged