### PR TITLE
fix(api): wire user_agent through provider create/update handlers

### DIFF
--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -502,6 +502,7 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 		SkipPing                bool   `json:"skip_ping"`
 		KeepaliveIntervalSeconds int   `json:"keepalive_interval_seconds"`
 		KeepaliveCommand        string `json:"keepalive_command"`
+		UserAgent               string `json:"user_agent"`
 		QuotaBytes              int64  `json:"quota_bytes"`
 		QuotaPeriodHours        int    `json:"quota_period_hours"`
 	}
@@ -544,6 +545,7 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 		SkipPing:                 createReq.SkipPing,
 		KeepaliveIntervalSeconds: createReq.KeepaliveIntervalSeconds,
 		KeepaliveCommand:         createReq.KeepaliveCommand,
+		UserAgent:                createReq.UserAgent,
 		QuotaBytes:               createReq.QuotaBytes,
 		QuotaPeriodHours:         createReq.QuotaPeriodHours,
 	}
@@ -586,6 +588,7 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 		SkipPing:                 newProvider.SkipPing,
 		KeepaliveIntervalSeconds: newProvider.KeepaliveIntervalSeconds,
 		KeepaliveCommand:         newProvider.KeepaliveCommand,
+		UserAgent:                newProvider.UserAgent,
 		QuotaBytes:               newProvider.QuotaBytes,
 		QuotaPeriodHours:         newProvider.QuotaPeriodHours,
 	}
@@ -654,6 +657,7 @@ func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 		SkipPing                 *bool   `json:"skip_ping,omitempty"`
 		KeepaliveIntervalSeconds *int    `json:"keepalive_interval_seconds,omitempty"`
 		KeepaliveCommand         *string `json:"keepalive_command,omitempty"`
+		UserAgent                *string `json:"user_agent,omitempty"`
 		QuotaBytes               *int64  `json:"quota_bytes,omitempty"`
 		QuotaPeriodHours         *int    `json:"quota_period_hours,omitempty"`
 	}
@@ -729,6 +733,9 @@ func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 	if updateReq.QuotaPeriodHours != nil {
 		provider.QuotaPeriodHours = *updateReq.QuotaPeriodHours
 	}
+	if updateReq.UserAgent != nil {
+		provider.UserAgent = *updateReq.UserAgent
+	}
 
 	// Assign the updated provider back to the slice
 	newConfig.Providers[providerIndex] = provider
@@ -767,6 +774,7 @@ func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 		SkipPing:                 provider.SkipPing,
 		KeepaliveIntervalSeconds: provider.KeepaliveIntervalSeconds,
 		KeepaliveCommand:         provider.KeepaliveCommand,
+		UserAgent:                provider.UserAgent,
 		QuotaBytes:               provider.QuotaBytes,
 		QuotaPeriodHours:         provider.QuotaPeriodHours,
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -116,6 +116,7 @@ type ProviderAPIResponse struct {
 	SkipPing                 bool       `json:"skip_ping"`
 	KeepaliveIntervalSeconds int        `json:"keepalive_interval_seconds"`
 	KeepaliveCommand         string     `json:"keepalive_command,omitempty"`
+	UserAgent                string     `json:"user_agent,omitempty"`
 	QuotaBytes               int64      `json:"quota_bytes"`
 	QuotaPeriodHours         int        `json:"quota_period_hours"`
 }


### PR DESCRIPTION
## Summary

- `user_agent` was present in the frontend form and TypeScript request types but silently dropped on the backend
- Both `handleCreateProvider` and `handleUpdateProvider` inline request structs were missing the field, so the JSON value was discarded on parse
- `ProviderAPIResponse` also lacked the field, so any manually-set value could never round-trip back to the UI

## Changes

- `internal/api/types.go`: add `UserAgent string` to `ProviderAPIResponse`
- `internal/api/config_handlers.go` (create handler): add field to request struct, mapping to `config.ProviderConfig`, and response build
- `internal/api/config_handlers.go` (update handler): add field to request struct, apply-patch `if updateReq.UserAgent != nil` block, and response build

`config.ProviderConfig` already had `UserAgent` with correct YAML/JSON tags — no storage changes needed.

## Test plan

- [ ] Create a provider with a User-Agent value → verify it is persisted (check config file or reload UI)
- [ ] Edit an existing provider, set a User-Agent → save → reload edit modal → value is pre-filled
- [ ] Edit an existing provider, clear User-Agent → save → value is gone
- [ ] `go build ./internal/api/...` passes (no compile errors)