### PR TITLE
feat(frontend): remove provider missing-articles toast notification

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown, Network, RotateCcw } from "lucide-react";
-import { useEffect, useRef } from "react";
 import { QueueHistoricalStatsCard } from "../components/queue/QueueHistoricalStatsCard";
 import { ActivityHub } from "../components/system/ActivityHub";
 import { HealthStatusCard } from "../components/system/HealthStatusCard";
@@ -23,7 +22,6 @@ export function Dashboard() {
 	const { showToast } = useToast();
 	const resetStats = useResetSystemStats();
 	const { resetProviderQuota } = useProviders();
-	const warnedProvidersRef = useRef<Set<string>>(new Set());
 
 	const hasError = queueError || healthError;
 
@@ -89,26 +87,6 @@ export function Dashboard() {
 			});
 		}
 	};
-
-	// Fire warning toast when server reports missing_warning for a provider
-	useEffect(() => {
-		if (!poolMetrics?.providers) return;
-		const warned = warnedProvidersRef.current;
-
-		for (const provider of poolMetrics.providers) {
-			if (provider.missing_warning && !warned.has(provider.id)) {
-				warned.add(provider.id);
-				showToast({
-					type: "warning",
-					title: "High Missing Article Rate",
-					message: `${provider.host} has ~${Math.round(provider.missing_rate_per_minute)}/min missing articles. Consider using a backup provider.`,
-					duration: 10000,
-				});
-			} else if (!provider.missing_warning && warned.has(provider.id)) {
-				warned.delete(provider.id);
-			}
-		}
-	}, [poolMetrics?.providers, showToast]);
 
 	if (hasError) {
 		return (
@@ -242,11 +220,7 @@ export function Dashboard() {
 					</h2>
 					<div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 						{poolMetrics.providers.map((provider) => (
-							<ProviderCard
-								key={provider.id}
-								provider={provider}
-								onResetQuota={handleResetQuota}
-							/>
+							<ProviderCard key={provider.id} provider={provider} onResetQuota={handleResetQuota} />
 						))}
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- Removes the "High Missing Article Rate" warning toast from the Dashboard
- Deletes the `warnedProvidersRef` ref and the `useEffect` that fired the toast whenever `provider.missing_warning` was true
- Cleans up now-unused `useRef` and `useEffect` imports

## Why

The toast was disruptive — it fired repeatedly as pool metrics polled, creating noise whenever a provider had elevated missing-article rates. The same information is already surfaced passively in the ProviderCard and ProviderHealth table, so the popup adds no value.

## What's unchanged

- Per-card missing article count and rate display (`ProviderCard.tsx`)
- ProviderHealth table missing-article column (`ProviderHealth.tsx`)
- `ProviderStatus` type fields (`missing_count`, `missing_rate_per_minute`, `missing_warning`)

## Test plan

- [ ] Open Dashboard — no toast appears even when providers report `missing_warning: true`
- [ ] ProviderCard still shows missing article count/rate when present
- [ ] `bun run build` passes cleanly