### PR TITLE
fix(nzbdav): preserve folder structure and fix import bugs

### DIFF
--- a/frontend/src/components/queue/ImportMethods.tsx
+++ b/frontend/src/components/queue/ImportMethods.tsx
@@ -6,7 +6,6 @@ import {
 	FileCode,
 	FileIcon,
 	FileText,
-	FolderInput,
 	FolderOpen,
 	Link,
 	Play,
@@ -609,7 +608,6 @@ function NzbDavImportSection() {
 	const [selectedDbPath, setSelectedDbPath] = useState("");
 	const [blobsPath, setBlobsPath] = useState("");
 	const [selectedFile, setSelectedFile] = useState<File | null>(null);
-	const [rootFolder, setRootFolder] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<Error | null>(null);
 	const { showToast } = useToast();
@@ -632,7 +630,6 @@ function NzbDavImportSection() {
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (!rootFolder) return;
 		if (inputMethod === "server" && !selectedDbPath) return;
 		if (inputMethod === "upload" && !selectedFile) return;
 
@@ -640,7 +637,6 @@ function NzbDavImportSection() {
 		setError(null);
 
 		const formData = new FormData();
-		formData.append("rootFolder", rootFolder);
 		if (blobsPath) {
 			formData.append("blobsPath", blobsPath);
 		}
@@ -849,28 +845,8 @@ function NzbDavImportSection() {
 							<div className="h-px flex-1 bg-base-300" />
 						</div>
 
-						<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend font-semibold">Target Directory Name</legend>
-								<div className="flex items-center gap-3">
-									<div className="rounded-lg bg-base-200 p-2.5">
-										<FolderInput className="h-5 w-5 text-base-content/60" />
-									</div>
-									<input
-										type="text"
-										placeholder="e.g. MyLibrary"
-										className="input w-full bg-base-200/50 font-mono"
-										value={rootFolder}
-										onChange={(e) => setRootFolder(e.target.value)}
-										required
-									/>
-								</div>
-								<p className="label text-base-content/80 text-xs">
-									This will create /movies and /tv subdirectories under this name.
-								</p>
-							</fieldset>
-
-							<div className="flex flex-col justify-center space-y-3">
+						<div className="space-y-6">
+							<div className="flex flex-col space-y-3">
 								<div className="label mb-1 font-semibold text-base-content/80 text-xs">
 									Input Method
 								</div>
@@ -979,11 +955,7 @@ function NzbDavImportSection() {
 						<button
 							type="submit"
 							className="btn btn-primary btn-md px-10 shadow-lg shadow-primary/20"
-							disabled={
-								isLoading ||
-								!rootFolder ||
-								(inputMethod === "server" ? !selectedDbPath : !selectedFile)
-							}
+							disabled={isLoading || (inputMethod === "server" ? !selectedDbPath : !selectedFile)}
 						>
 							{isLoading ? <LoadingSpinner size="sm" /> : <Upload className="h-4 w-4" />}
 							Start Import

--- a/frontend/src/components/system/ProviderCard.tsx
+++ b/frontend/src/components/system/ProviderCard.tsx
@@ -48,11 +48,7 @@ function QuotaResetCountdown({ resetAt }: { resetAt: string }) {
 	);
 }
 
-export function ProviderCard({
-	provider,
-	className,
-	onResetQuota,
-}: ProviderCardProps) {
+export function ProviderCard({ provider, className, onResetQuota }: ProviderCardProps) {
 	// Calculate connection usage percentage
 	const usagePercentage =
 		provider.max_connections > 0
@@ -117,7 +113,10 @@ export function ProviderCard({
 										: "bg-error"
 								}`}
 							/>
-							<h3 className="truncate font-semibold text-sm leading-none" id={`provider-${provider.host}`}>
+							<h3
+								className="truncate font-semibold text-sm leading-none"
+								id={`provider-${provider.host}`}
+							>
 								{provider.host}
 							</h3>
 						</div>
@@ -218,7 +217,7 @@ export function ProviderCard({
 									<button
 										type="button"
 										onClick={() => onResetQuota(provider.id)}
-										className="btn btn-ghost btn-xs min-h-0 h-4 p-0 text-base-content/30 hover:text-primary"
+										className="btn btn-ghost btn-xs h-4 min-h-0 p-0 text-base-content/30 hover:text-primary"
 										title="Reset Quota"
 									>
 										<RotateCcw className="h-2.5 w-2.5" />

--- a/internal/api/nzbdav_handlers.go
+++ b/internal/api/nzbdav_handlers.go
@@ -33,14 +33,6 @@ func (s *Server) handleImportNzbdav(c *fiber.Ctx) error {
 	}
 
 	// 1. Get Form Data
-	rootFolder := c.FormValue("rootFolder")
-	if rootFolder == "" {
-		return c.Status(400).JSON(fiber.Map{
-			"success": false,
-			"message": "rootFolder is required",
-		})
-	}
-
 	blobsPath := c.FormValue("blobsPath")
 
 	// 2. Handle File Source (Path or Upload)
@@ -86,7 +78,7 @@ func (s *Server) handleImportNzbdav(c *fiber.Ctx) error {
 	}
 
 	// 3. Start Async Import
-	if err := s.importerService.StartNzbdavImport(dbPath, blobsPath, rootFolder, isTempFile); err != nil {
+	if err := s.importerService.StartNzbdavImport(dbPath, blobsPath, isTempFile); err != nil {
 		if isTempFile {
 			os.Remove(dbPath) // Clean up if start failed
 		}

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -39,7 +39,7 @@ type DirectoryScanner interface {
 // NzbDavImporter handles bulk import from NzbDav databases
 type NzbDavImporter interface {
 	// StartNzbdavImport begins importing from an NzbDav database
-	StartNzbdavImport(dbPath string, blobsPath string, rootFolder string, cleanupFile bool) error
+	StartNzbdavImport(dbPath string, blobsPath string, cleanupFile bool) error
 	// GetImportStatus returns the current import status
 	GetImportStatus() ImportInfo
 	// CancelImport cancels an in-progress import

--- a/internal/importer/scanner/nzbdav.go
+++ b/internal/importer/scanner/nzbdav.go
@@ -43,7 +43,7 @@ func NewNzbDavImporter(batchAdder BatchQueueAdder) *NzbDavImporter {
 }
 
 // Start starts an asynchronous import from an NZBDav database
-func (n *NzbDavImporter) Start(dbPath string, blobsPath string, rootFolder string, cleanupFile bool) error {
+func (n *NzbDavImporter) Start(dbPath string, blobsPath string, cleanupFile bool) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
@@ -64,7 +64,7 @@ func (n *NzbDavImporter) Start(dbPath string, blobsPath string, rootFolder strin
 		Skipped: 0,
 	}
 
-	go n.performImport(importCtx, dbPath, blobsPath, rootFolder, cleanupFile)
+	go n.performImport(importCtx, dbPath, blobsPath, cleanupFile)
 
 	return nil
 }
@@ -108,7 +108,7 @@ func (n *NzbDavImporter) Reset() {
 }
 
 // performImport performs the actual import work
-func (n *NzbDavImporter) performImport(ctx context.Context, dbPath string, blobsPath string, rootFolder string, cleanupFile bool) {
+func (n *NzbDavImporter) performImport(ctx context.Context, dbPath string, blobsPath string, cleanupFile bool) {
 	// Parse Database
 	parser := nzbdav.NewParser(dbPath, blobsPath)
 	nzbChan, errChan := parser.Parse()
@@ -185,7 +185,7 @@ func (n *NzbDavImporter) performImport(ctx context.Context, dbPath string, blobs
 					n.info.Total++
 					n.mu.Unlock()
 
-					item, err := n.createNzbFileAndPrepareItem(ctx, res, rootFolder, nzbTempDir)
+					item, err := n.createNzbFileAndPrepareItem(ctx, res, nzbTempDir)
 					if err != nil {
 						n.log.ErrorContext(ctx, "Failed to prepare item", "file", res.Name, "error", err)
 						n.mu.Lock()
@@ -349,7 +349,7 @@ func (n *NzbDavImporter) processBatch(ctx context.Context, batchChan <-chan *dat
 }
 
 // createNzbFileAndPrepareItem creates an NZB file and prepares a queue item
-func (n *NzbDavImporter) createNzbFileAndPrepareItem(ctx context.Context, res *nzbdav.ParsedNzb, rootFolder, nzbTempDir string) (*database.ImportQueueItem, error) {
+func (n *NzbDavImporter) createNzbFileAndPrepareItem(ctx context.Context, res *nzbdav.ParsedNzb, nzbTempDir string) (*database.ImportQueueItem, error) {
 	// Check context before file operations
 	select {
 	case <-ctx.Done():
@@ -381,20 +381,17 @@ func (n *NzbDavImporter) createNzbFileAndPrepareItem(ctx context.Context, res *n
 		return nil, fmt.Errorf("failed to write temp NZB file content: %w", err)
 	}
 
-	// Determine Category and Relative Path
-	targetCategory := "other"
-	lowerCat := strings.ToLower(res.Category)
-	if strings.Contains(lowerCat, "movie") {
-		targetCategory = "movies"
-	} else if strings.Contains(lowerCat, "tv") || strings.Contains(lowerCat, "series") {
-		targetCategory = "tv"
+	// Preserve nzbdav's folder layout verbatim so the imported mount mirrors
+	// the source tree. Parser supplies (Category, RelPath) as the two halves
+	// of the release's parent path.
+	targetCategory := res.Category
+	if targetCategory == "" {
+		targetCategory = "other"
 	}
-
 	if res.RelPath != "" {
 		targetCategory = filepath.Join(targetCategory, res.RelPath)
 	}
 
-	relPath := rootFolder
 	priority := database.QueuePriorityNormal
 
 	// Store original ID and extracted files in metadata
@@ -408,11 +405,11 @@ func (n *NzbDavImporter) createNzbFileAndPrepareItem(ctx context.Context, res *n
 	metaBytes, _ := json.Marshal(metaMap)
 	metaJSON := string(metaBytes)
 
-	// Prepare item struct
+	// Prepare item struct. RelativePath is left nil so the import mirrors the
+	// nzbdav folder structure under Category without an extra user-supplied prefix.
 	item := &database.ImportQueueItem{
-		NzbPath:      nzbPath,
-		RelativePath: &relPath,
-		Category:     &targetCategory,
+		NzbPath:  nzbPath,
+		Category: &targetCategory,
 		Priority:     priority,
 		Status:       database.QueueStatusPending,
 		RetryCount:   0,

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -500,8 +500,8 @@ func (s *Service) CancelScan() error {
 }
 
 // StartNzbdavImport starts an asynchronous import from an NZBDav database
-func (s *Service) StartNzbdavImport(dbPath string, blobsPath string, rootFolder string, cleanupFile bool) error {
-	return s.nzbdavImporter.Start(dbPath, blobsPath, rootFolder, cleanupFile)
+func (s *Service) StartNzbdavImport(dbPath string, blobsPath string, cleanupFile bool) error {
+	return s.nzbdavImporter.Start(dbPath, blobsPath, cleanupFile)
 }
 
 // GetImportStatus returns the current import status

--- a/internal/nzbdav/parser.go
+++ b/internal/nzbdav/parser.go
@@ -1,6 +1,8 @@
 package nzbdav
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -16,6 +18,17 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
+// zstd frame magic: 0x28 0xB5 0x2F 0xFD.
+// nzbdav's blobstore stores some NZBs compressed and some as plain XML, so
+// sniff the header before deciding whether to decompress.
+var zstdMagic = []byte{0x28, 0xB5, 0x2F, 0xFD}
+
+const (
+	nzbPoster       = "nzbdav"
+	nzbGroup        = "alt.binaries.misc"
+	defaultSegBytes = 750_000
+)
+
 type Parser struct {
 	dbPath    string
 	blobsPath string
@@ -28,13 +41,28 @@ func NewParser(dbPath, blobsPath string) *Parser {
 	}
 }
 
+// davItem mirrors the DavItems row subset we need to resolve releases
+// and discover extracted-files subtrees.
+type davItem struct {
+	ID       string
+	ParentID sql.NullString
+	Name     string
+	Path     string
+	FileSize sql.NullInt64
+}
+
+// davTree indexes DavItems by ID and by parent ID for O(1) lookups.
+type davTree struct {
+	byID       map[string]*davItem
+	byParentID map[string][]*davItem
+}
+
 // Parse streams NZBs from the database
 func (p *Parser) Parse() (<-chan *ParsedNzb, <-chan error) {
 	out := make(chan *ParsedNzb)
 	errChan := make(chan error, 1)
 
 	go func() {
-		// Open in read-only mode to avoid locking issues
 		db, err := sql.Open("sqlite3", p.dbPath+"?mode=ro&_journal_mode=WAL")
 		if err != nil {
 			errChan <- fmt.Errorf("failed to open database: %w", err)
@@ -43,60 +71,130 @@ func (p *Parser) Parse() (<-chan *ParsedNzb, <-chan error) {
 			return
 		}
 
-		// Ensure DB is closed only after processing is done
 		defer func() {
 			db.Close()
 			close(out)
 			close(errChan)
 		}()
 
-		// Set limits to prevent file descriptor exhaustion
 		db.SetMaxOpenConns(25)
 		db.SetMaxIdleConns(10)
 
-		// Log available tables for debugging
-		tableRows, err := db.Query("SELECT name FROM sqlite_master WHERE type='table'")
-		if err == nil {
-			var tables []string
-			for tableRows.Next() {
-				var name string
-				tableRows.Scan(&name)
-				tables = append(tables, name)
-			}
-			tableRows.Close()
-			slog.InfoContext(context.Background(), "NZBDav Database Tables", "tables", tables)
+		tree, err := loadDavTree(db)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to load DavItems tree: %w", err)
+			return
 		}
 
-		// Check for blob-based storage (NzbDav alpha)
-		if p.blobsPath != "" {
-			// Check if NzbNames table exists
-			var nzbNamesExists bool
-			err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='NzbNames'").Scan(&nzbNamesExists)
-			if err == nil && nzbNamesExists {
-				slog.InfoContext(context.Background(), "Detected blob-based NZBDav storage")
-				p.parseBlobs(db, out, errChan)
-				return
-			}
+		// Blob-based (alpha) storage is detected by presence of the NzbNames table
+		// and a configured blobs directory.
+		if p.blobsPath != "" && hasTable(db, "NzbNames") {
+			slog.InfoContext(context.Background(), "Detected blob-based NZBDav storage")
+			p.parseBlobs(db, tree, out, errChan)
+			return
 		}
 
-		// Fallback to legacy reconstruction approach
-		p.parseLegacy(db, out, errChan)
+		p.parseLegacy(db, tree, out, errChan)
 	}()
 
 	return out, errChan
 }
 
-func (p *Parser) parseBlobs(db *sql.DB, out chan<- *ParsedNzb, errChan chan<- error) {
+func hasTable(db *sql.DB, name string) bool {
+	var count int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?", name,
+	).Scan(&count); err != nil {
+		return false
+	}
+	return count > 0
+}
+
+func loadDavTree(db *sql.DB) (*davTree, error) {
+	rows, err := db.Query(`SELECT Id, ParentId, Name, COALESCE(Path, ''), FileSize FROM DavItems`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tree := &davTree{
+		byID:       make(map[string]*davItem),
+		byParentID: make(map[string][]*davItem),
+	}
+	for rows.Next() {
+		it := &davItem{}
+		if err := rows.Scan(&it.ID, &it.ParentID, &it.Name, &it.Path, &it.FileSize); err != nil {
+			return nil, err
+		}
+		tree.byID[it.ID] = it
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for _, it := range tree.byID {
+		if it.ParentID.Valid {
+			tree.byParentID[it.ParentID.String] = append(tree.byParentID[it.ParentID.String], it)
+		}
+	}
+	return tree, nil
+}
+
+// releaseFor returns the nzbdav folder that logically groups this file — the
+// nearest ancestor folder whose name is not "extracted". For a file at
+// /content/uncategorized/My.Release/file.mkv the release is My.Release; for
+// /movies/Release/extracted/file.mkv it's still Release (the /extracted folder
+// is skipped).
+func (t *davTree) releaseFor(id string) *davItem {
+	it, ok := t.byID[id]
+	if !ok {
+		return nil
+	}
+	cur := it
+	if cur.ParentID.Valid {
+		cur = t.byID[cur.ParentID.String]
+	} else {
+		return it
+	}
+	for cur != nil {
+		if !strings.EqualFold(cur.Name, "extracted") {
+			return cur
+		}
+		if !cur.ParentID.Valid {
+			return cur
+		}
+		cur = t.byID[cur.ParentID.String]
+	}
+	return it
+}
+
+// extractedFilesUnder returns all descendant items whose path contains
+// "/extracted/" and that have a positive FileSize.
+func (t *davTree) extractedFilesUnder(releaseID string) []ExtractedFileInfo {
+	var out []ExtractedFileInfo
+	var walk func(id string)
+	walk = func(id string) {
+		for _, child := range t.byParentID[id] {
+			if strings.Contains(child.Path, "/extracted/") && child.FileSize.Valid && child.FileSize.Int64 > 0 {
+				out = append(out, ExtractedFileInfo{Name: child.Name, Size: child.FileSize.Int64})
+			}
+			walk(child.ID)
+		}
+	}
+	walk(releaseID)
+	return out
+}
+
+func (p *Parser) parseBlobs(db *sql.DB, tree *davTree, out chan<- *ParsedNzb, errChan chan<- error) {
 	rows, err := db.Query(`
-		SELECT 
+		SELECT
 			d.Id,
 			n.FileName,
 			COALESCE(d.Path, '/') as ReleasePath,
 			d.NzbBlobId
-		FROM DavItems d 
-		JOIN NzbNames n ON n.Id = d.NzbBlobId 
-		WHERE d.NzbBlobId IS NOT NULL 
-		AND d.NzbBlobId != '' 
+		FROM DavItems d
+		JOIN NzbNames n ON n.Id = d.NzbBlobId
+		WHERE d.NzbBlobId IS NOT NULL
+		AND d.NzbBlobId != ''
 		AND d.NzbBlobId != '00000000-0000-0000-0000-000000000000'
 		AND d.SubType = 203
 	`)
@@ -114,7 +212,6 @@ func (p *Parser) parseBlobs(db *sql.DB, out chan<- *ParsedNzb, errChan chan<- er
 			continue
 		}
 
-		// Resolve blob path: blobs/XX/YY/[uuid]
 		if len(blobId) < 4 {
 			slog.WarnContext(context.Background(), "Invalid blob ID", "id", blobId)
 			continue
@@ -127,414 +224,300 @@ func (p *Parser) parseBlobs(db *sql.DB, out chan<- *ParsedNzb, errChan chan<- er
 			continue
 		}
 
-		// Decompress zstd blob
 		pr, pw := io.Pipe()
 		go func() {
 			defer blobFile.Close()
 
-			zr, err := zstd.NewReader(blobFile)
-			if err != nil {
-				pw.CloseWithError(err)
-				return
-			}
-			defer zr.Close()
-
-			if _, err := io.Copy(pw, zr); err != nil {
-				pw.CloseWithError(err)
-				return
+			br := bufio.NewReader(blobFile)
+			head, _ := br.Peek(len(zstdMagic))
+			if bytes.Equal(head, zstdMagic) {
+				zr, err := zstd.NewReader(br)
+				if err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+				defer zr.Close()
+				if _, err := io.Copy(pw, zr); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+			} else {
+				if _, err := io.Copy(pw, br); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
 			}
 			pw.Close()
 		}()
 
-		category := p.deriveCategory(releasePath)
-		relPath := p.deriveRelPath(releasePath, category)
+		// The SubType=203 item is the virtual "output" file. Its parent folder
+		// is the release directory in nzbdav's tree; we want AltMount's mount
+		// layout to match that directory layout exactly.
+		release := tree.releaseFor(id)
+		releaseName := strings.TrimSuffix(fileName, ".nzb")
+		releaseParentPath := releasePath
+		releaseID := id
+		if release != nil {
+			releaseID = release.ID
+			if release.Name != "" {
+				releaseName = release.Name
+			}
+			releaseParentPath = release.Path
+		}
+		// Strip the release folder name to get its parent path.
+		parentPath := trimLastSegment(releaseParentPath)
+		category, relPath := p.splitPath(parentPath)
 
 		out <- &ParsedNzb{
-			ID:       id,
-			Name:     strings.TrimSuffix(fileName, ".nzb"),
-			Category: category,
-			RelPath:  relPath,
-			Content:  pr,
+			ID:             id,
+			Name:           releaseName,
+			Category:       category,
+			RelPath:        relPath,
+			Content:        pr,
+			ExtractedFiles: tree.extractedFilesUnder(releaseID),
 		}
 		count++
 	}
 	slog.InfoContext(context.Background(), "NZBDav blob import scan completed", "total_files", count)
 }
 
-func (p *Parser) parseLegacy(db *sql.DB, out chan<- *ParsedNzb, errChan chan<- error) {
-	// Query ALL files, ordered by ParentId
-	// This groups files belonging to the same release together efficiently
+func (p *Parser) parseLegacy(db *sql.DB, tree *davTree, out chan<- *ParsedNzb, errChan chan<- error) {
 	rows, err := db.Query(`
-		SELECT 
-			COALESCE(p.Id, 'root') as ReleaseId,
-			COALESCE(p.Name, 'root') as ReleaseName,
-			COALESCE(p.Path, '/') as ReleasePath,
-			c.Id as FileId,
-			c.Name as FileName,
-			c.FileSize,
-			n.SegmentIds,
-			r.RarParts,
-			m.Metadata as MultipartMetadata
+		SELECT c.Id, c.Name, c.FileSize, n.SegmentIds
 		FROM DavItems c
-		LEFT JOIN DavItems p ON c.ParentId = p.Id
-		LEFT JOIN DavNzbFiles n ON n.Id = c.Id
-		LEFT JOIN DavRarFiles r ON r.Id = c.Id
-		LEFT JOIN DavMultipartFiles m ON m.Id = c.Id
-		WHERE (n.Id IS NOT NULL OR r.Id IS NOT NULL OR m.Id IS NOT NULL)
-		ORDER BY c.ParentId, c.Name
+		JOIN DavNzbFiles n ON n.Id = c.Id
 	`)
 	if err != nil {
 		errChan <- fmt.Errorf("failed to query files: %w", err)
 		return
 	}
 	defer rows.Close()
-	slog.DebugContext(context.Background(), "NZBDav file query completed, starting iteration")
 
-	var currentParentId string
-	var currentWriter *io.PipeWriter
+	// Group file rows by the resolved release id.
+	grouped := make(map[string][]nzbFileRow)
+	releaseOrder := make([]string, 0)
 	count := 0
-	var currentExtractedFiles []ExtractedFileInfo
-
-	// cleanupCurrent ensures the current writer is properly closed
-	cleanupCurrent := func() {
-		if currentWriter != nil {
-			// Write NZB Footer
-			if _, err := currentWriter.Write([]byte("</nzb>")); err != nil {
-				slog.ErrorContext(context.Background(), "Failed to write NZB footer", "error", err)
-			}
-			currentWriter.Close()
-			currentWriter = nil
-		}
-	}
-	defer cleanupCurrent()
-
 	for rows.Next() {
-		var releaseId, releaseName, releasePath string
-		var fileId, fileName string
-		var fileSize sql.NullInt64
-		var segmentIdsJSON, rarPartsJSON, multipartMetadataJSON sql.RawBytes
-
-		if err := rows.Scan(&releaseId, &releaseName, &releasePath, &fileId, &fileName, &fileSize, &segmentIdsJSON, &rarPartsJSON, &multipartMetadataJSON); err != nil {
+		var r nzbFileRow
+		if err := rows.Scan(&r.fileID, &r.fileName, &r.fileSize, &r.segmentIDs); err != nil {
 			slog.ErrorContext(context.Background(), "Failed to scan row", "error", err)
 			continue
 		}
 
-		// Improve release name if it's just "extracted"
+		release := tree.releaseFor(r.fileID)
+		if release == nil {
+			continue
+		}
+
+		// Clone RawBytes: driver reuses the underlying buffer on next Scan.
+		segCopy := make(sql.RawBytes, len(r.segmentIDs))
+		copy(segCopy, r.segmentIDs)
+		r.segmentIDs = segCopy
+
+		if _, seen := grouped[release.ID]; !seen {
+			releaseOrder = append(releaseOrder, release.ID)
+		}
+		grouped[release.ID] = append(grouped[release.ID], r)
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		errChan <- fmt.Errorf("failed to iterate files: %w", err)
+		return
+	}
+
+	slog.InfoContext(context.Background(), "NZBDav import scan completed", "total_files", count, "releases", len(releaseOrder))
+
+	for _, releaseID := range releaseOrder {
+		release := tree.byID[releaseID]
+		if release == nil {
+			continue
+		}
+
+		// Skip files that are themselves inside an /extracted subtree — they're
+		// recorded separately in ExtractedFiles rather than emitted as NZB entries.
+		var primary []nzbFileRow
+		for _, r := range grouped[releaseID] {
+			item := tree.byID[r.fileID]
+			if item != nil && strings.Contains(item.Path, "/extracted/") {
+				continue
+			}
+			primary = append(primary, r)
+		}
+		if len(primary) == 0 {
+			continue
+		}
+
+		category, relPath := p.splitPath(trimLastSegment(release.Path))
+		releaseName := release.Name
 		if strings.EqualFold(releaseName, "extracted") {
-			// Try to get the name from the path
-			pathParts := strings.Split(strings.Trim(releasePath, "/"), "/")
-			if len(pathParts) > 0 {
-				// Use the last part of the path that isn't "extracted"
-				for i := len(pathParts) - 1; i >= 0; i-- {
-					if !strings.EqualFold(pathParts[i], "extracted") {
-						releaseName = pathParts[i]
-						break
-					}
+			// Defensive: releaseFor should have stopped one level higher, but
+			// preserve the original fallback just in case the tree is malformed.
+			parts := strings.Split(strings.Trim(release.Path, "/"), "/")
+			for i := len(parts) - 1; i >= 0; i-- {
+				if !strings.EqualFold(parts[i], "extracted") {
+					releaseName = parts[i]
+					break
 				}
 			}
 		}
 
-		// Check if this file is inside an "extracted" folder
-		isExtractedFile := strings.Contains(releasePath, "/extracted") || releaseName == "extracted"
-		if isExtractedFile && fileSize.Valid && fileSize.Int64 > 0 {
-			currentExtractedFiles = append(currentExtractedFiles, ExtractedFileInfo{
-				Name: fileName,
-				Size: fileSize.Int64,
-			})
+		pr, pw := io.Pipe()
+		parsed := &ParsedNzb{
+			ID:             releaseID,
+			Name:           releaseName,
+			Category:       category,
+			RelPath:        relPath,
+			Content:        pr,
+			ExtractedFiles: tree.extractedFilesUnder(releaseID),
 		}
 
-		count++
-		if count%100 == 0 {
-			slog.InfoContext(context.Background(), "NZBDav import progress", "files_scanned", count)
-		}
+		out <- parsed
 
-		// Check if we switched to a new release
-		if releaseId != currentParentId || currentWriter == nil {
-			cleanupCurrent()
+		go writeReleaseNzb(pw, releaseName, primary)
+	}
+}
 
-			currentParentId = releaseId
-			currentExtractedFiles = nil // Reset for new release
-			slog.DebugContext(context.Background(), "Processing new release", "path", releasePath, "name", releaseName)
-
-			// Create new pipe for this release
-			pr, pw := io.Pipe()
-			currentWriter = pw
-
-			// Send ParsedNzb to output channel
-			category := p.deriveCategory(releasePath)
-			relPath := p.deriveRelPath(releasePath, category)
-
-			out <- &ParsedNzb{
-				ID:             releaseId,
-				Name:           releaseName,
-				Category:       category,
-				RelPath:        relPath,
-				Content:        pr,
-				ExtractedFiles: currentExtractedFiles,
-			}
-
-			// Write NZB Header
-			header := `<?xml version="1.0" encoding="UTF-8"?>
+func writeReleaseNzb(pw *io.PipeWriter, releaseName string, files []nzbFileRow) {
+	header := `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nzb PUBLIC "-//newzBin//DTD NZB 1.1//EN" "http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd">
 <nzb xmlns="http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd">
 	<head>
 		<meta type="name">` + template.HTMLEscapeString(releaseName) + `</meta>
 	</head>
 `
-			if _, err := currentWriter.Write([]byte(header)); err != nil {
-				slog.ErrorContext(context.Background(), "Failed to write NZB header", "release", releaseName, "error", err)
-				currentWriter.CloseWithError(err)
-				currentWriter = nil
-				continue
-			}
+	if _, err := pw.Write([]byte(header)); err != nil {
+		pw.CloseWithError(err)
+		return
+	}
+
+	warnedMissingSize := false
+	for _, f := range files {
+		if !f.fileSize.Valid && !warnedMissingSize {
+			slog.WarnContext(context.Background(),
+				"NZBDav file has no FileSize; using default segment size",
+				"release", releaseName, "file", f.fileName, "default_bytes", defaultSegBytes)
+			warnedMissingSize = true
 		}
-
-		// Write File Entry
-		if err := p.writeFileEntry(currentWriter, fileId, fileName, fileSize, segmentIdsJSON, rarPartsJSON, multipartMetadataJSON); err != nil {
-			slog.ErrorContext(context.Background(), "Failed to write file entry", "file", fileName, "error", err)
-			currentWriter.CloseWithError(err)
-			currentWriter = nil
-		}
-	}
-	slog.InfoContext(context.Background(), "NZBDav import scan completed", "total_files", count)
-}
-
-
-func (p *Parser) deriveCategory(path string) string {
-	lowerPath := strings.ToLower(path)
-	if strings.Contains(lowerPath, "/movies/") || strings.Contains(lowerPath, "/movie/") {
-		return "movies"
-	}
-	if strings.Contains(lowerPath, "/tv/") || strings.Contains(lowerPath, "/series/") {
-		return "tv"
-	}
-	return "other"
-}
-
-func (p *Parser) deriveRelPath(path, category string) string {
-	// 1. Clean path separators
-	path = strings.ReplaceAll(path, "\\", "/")
-	path = strings.Trim(path, "/")
-
-	// 2. Identify and remove category prefix
-	parts := strings.Split(path, "/")
-
-	// Remove the last part (Release Name) as that is handled by the release name itself
-	if len(parts) > 0 {
-		parts = parts[:len(parts)-1]
-	}
-
-	// Find where the category folder is
-	categoryIndex := -1
-	for i, part := range parts {
-		lowerPart := strings.ToLower(part)
-		if lowerPart == category || (category == "tv" && lowerPart == "series") || (category == "movies" && lowerPart == "movie") {
-			categoryIndex = i
-			break
+		if err := writeFileEntry(pw, f.fileID, f.fileName, f.fileSize, f.segmentIDs); err != nil {
+			slog.ErrorContext(context.Background(), "Failed to write file entry",
+				"release", releaseName, "file", f.fileName, "error", err)
+			pw.CloseWithError(err)
+			return
 		}
 	}
 
-	if categoryIndex != -1 && categoryIndex < len(parts)-1 {
-		// Return everything AFTER the category
-		return strings.Join(parts[categoryIndex+1:], "/")
+	if _, err := pw.Write([]byte("</nzb>")); err != nil {
+		pw.CloseWithError(err)
+		return
+	}
+	pw.Close()
+}
+
+type nzbFileRow struct {
+	fileID     string
+	fileName   string
+	fileSize   sql.NullInt64
+	segmentIDs sql.RawBytes
+}
+
+// splitPath splits a path into (firstSegment, rest) so that
+// filepath.Join(firstSegment, rest, releaseName) reproduces the original
+// nzbdav path verbatim. This preserves nzbdav's folder structure — no
+// movies/tv/other bucketing.
+//
+// Example: "/content/uncategorized" → ("content", "uncategorized").
+// Example: "/movies"                → ("movies", "").
+// Example: "" or "/"                → ("other", "") as a safe default.
+func (p *Parser) splitPath(path string) (first, rest string) {
+	cleaned := strings.ReplaceAll(path, "\\", "/")
+	cleaned = strings.Trim(cleaned, "/")
+	if cleaned == "" {
+		return "other", ""
+	}
+	parts := strings.Split(cleaned, "/")
+	return parts[0], strings.Join(parts[1:], "/")
+}
+
+// trimLastSegment drops the final path segment (the release or file name),
+// returning the parent path. "/a/b/c" → "/a/b", "/a" → "", "/" → "".
+func trimLastSegment(path string) string {
+	cleaned := strings.ReplaceAll(path, "\\", "/")
+	cleaned = strings.Trim(cleaned, "/")
+	if cleaned == "" {
+		return ""
+	}
+	parts := strings.Split(cleaned, "/")
+	if len(parts) <= 1 {
+		return ""
+	}
+	return "/" + strings.Join(parts[:len(parts)-1], "/")
+}
+
+// writeFileEntry writes a single file's segments to the NZB writer.
+func writeFileEntry(w io.Writer, fileId, fileName string, fileSize sql.NullInt64, segmentIdsJSON sql.RawBytes) error {
+	if len(segmentIdsJSON) == 0 {
+		return nil
 	}
 
-	return ""
-}
+	var segmentIds []string
+	if err := json.Unmarshal(segmentIdsJSON, &segmentIds); err != nil {
+		return fmt.Errorf("failed to unmarshal segment IDs: %w", err)
+	}
+	if len(segmentIds) == 0 {
+		return nil
+	}
 
-type rarPart struct {
-	SegmentIds []string `json:"SegmentIds"`
-	ByteCount  int64    `json:"ByteCount"`
-}
+	totalBytes := int64(0)
+	if fileSize.Valid {
+		totalBytes = fileSize.Int64
+	}
 
-type multipartMetadata struct {
-	AesParams *aesParams `json:"AesParams"`
-	FileParts []filePart `json:"FileParts"`
-}
-
-type aesParams struct {
-	DecodedSize int64  `json:"DecodedSize"`
-	Iv          string `json:"Iv"`
-	Key         string `json:"Key"`
-}
-
-type filePart struct {
-	SegmentIds []string `json:"SegmentIds"`
-}
-
-// writeFileEntry writes a single file's segments to the NZB writer
-func (p *Parser) writeFileEntry(w io.Writer, fileId, fileName string, fileSize sql.NullInt64, segmentIdsJSON, rarPartsJSON, multipartMetadataJSON sql.RawBytes) error {
-	if len(segmentIdsJSON) > 0 {
-		var segmentIds []string
-		if err := json.Unmarshal(segmentIdsJSON, &segmentIds); err != nil {
-			return fmt.Errorf("failed to unmarshal segment IDs: %w", err)
+	bytesPerSegment := int64(defaultSegBytes)
+	if totalBytes > 0 {
+		bytesPerSegment = totalBytes / int64(len(segmentIds))
+		if bytesPerSegment <= 0 {
+			bytesPerSegment = 1
 		}
+	}
 
-		if len(segmentIds) == 0 {
-			return nil
-		}
+	subject := template.HTMLEscapeString(fileName)
+	if fileId != "" {
+		subject = fmt.Sprintf("NZBDAV_ID:%s %s", template.HTMLEscapeString(fileId), template.HTMLEscapeString(fileName))
+	}
 
-		// Calculate segment size
-		totalBytes := int64(0)
-		if fileSize.Valid {
-			totalBytes = fileSize.Int64
-		}
+	fileHeader := fmt.Sprintf(`	<file poster="%s" date="%d" subject="%s">
+		<groups>
+			<group>%s</group>
+		</groups>
+		<segments>
+`, nzbPoster, 0, subject, nzbGroup)
 
-		// Estimate bytes per segment
-		bytesPerSegment := int64(0)
-		if totalBytes > 0 {
-			bytesPerSegment = totalBytes / int64(len(segmentIds))
-		}
+	if _, err := w.Write([]byte(fileHeader)); err != nil {
+		return err
+	}
 
-		// Write File Header
-		subject := template.HTMLEscapeString(fileName)
-		if fileId != "" {
-			subject = fmt.Sprintf("NZBDAV_ID:%s %s", template.HTMLEscapeString(fileId), template.HTMLEscapeString(fileName))
-		}
-
-		fileHeader := fmt.Sprintf(`	<file poster="AltMount" date="%d" subject="%s">
-			<groups>
-				<group>alt.binaries.test</group>
-			</groups>
-			<segments>
-`, 0, subject)
-
-		if _, err := w.Write([]byte(fileHeader)); err != nil {
-			return err
-		}
-
-		// Write Segments
-		for i, msgId := range segmentIds {
-			segBytes := bytesPerSegment
-			// Adjust last segment size
-			if i == len(segmentIds)-1 && totalBytes > 0 {
-				segBytes = totalBytes - (bytesPerSegment * int64(i))
-			}
+	for i, msgId := range segmentIds {
+		segBytes := bytesPerSegment
+		if i == len(segmentIds)-1 && totalBytes > 0 {
+			segBytes = totalBytes - (bytesPerSegment * int64(i))
 			if segBytes <= 0 {
-				segBytes = 1 // Fallback
-			}
-
-			segmentLine := fmt.Sprintf(`			<segment bytes="%d" number="%d">%s</segment>
-`, segBytes, i+1, template.HTMLEscapeString(msgId))
-
-			if _, err := w.Write([]byte(segmentLine)); err != nil {
-				return err
+				segBytes = bytesPerSegment
 			}
 		}
+		if segBytes <= 0 {
+			segBytes = defaultSegBytes
+		}
 
-		if _, err := w.Write([]byte("		</segments>\n\t</file>\n")); err != nil {
+		segmentLine := fmt.Sprintf(`			<segment bytes="%d" number="%d">%s</segment>
+`, segBytes, i+1, template.HTMLEscapeString(msgId))
+
+		if _, err := w.Write([]byte(segmentLine)); err != nil {
 			return err
 		}
-	} else if len(rarPartsJSON) > 0 {
-		var parts []rarPart
-		if err := json.Unmarshal(rarPartsJSON, &parts); err != nil {
-			return fmt.Errorf("failed to unmarshal RAR parts: %w", err)
-		}
+	}
 
-		for partIdx, part := range parts {
-			if len(part.SegmentIds) == 0 {
-				continue
-			}
-
-			partFileName := fmt.Sprintf("%s.part%02d.rar", fileName, partIdx+1)
-			totalBytes := part.ByteCount
-			bytesPerSegment := int64(0)
-			if totalBytes > 0 {
-				bytesPerSegment = totalBytes / int64(len(part.SegmentIds))
-			}
-
-			// Write File Header
-			subject := template.HTMLEscapeString(partFileName)
-			if fileId != "" {
-				subject = fmt.Sprintf("NZBDAV_ID:%s %s", template.HTMLEscapeString(fileId), template.HTMLEscapeString(partFileName))
-			}
-
-			fileHeader := fmt.Sprintf(`	<file poster="AltMount" date="%d" subject="%s">
-		<groups>
-			<group>alt.binaries.test</group>
-		</groups>
-		<segments>
-`, 0, subject)
-
-			if _, err := w.Write([]byte(fileHeader)); err != nil {
-				return err
-			}
-
-			// Write Segments
-			for i, msgId := range part.SegmentIds {
-				segBytes := bytesPerSegment
-				if i == len(part.SegmentIds)-1 && totalBytes > 0 {
-					segBytes = totalBytes - (bytesPerSegment * int64(i))
-				}
-				if segBytes <= 0 {
-					segBytes = 1
-				}
-
-				segmentLine := fmt.Sprintf(`			<segment bytes="%d" number="%d">%s</segment>
-`, segBytes, i+1, template.HTMLEscapeString(msgId))
-
-				if _, err := w.Write([]byte(segmentLine)); err != nil {
-					return err
-				}
-			}
-
-			if _, err := w.Write([]byte("  </segments>\n\t</file>\n")); err != nil {
-
-				return err
-
-			}
-
-		}
-
-	} else if len(multipartMetadataJSON) > 0 {
-
-		var meta multipartMetadata
-
-		if err := json.Unmarshal(multipartMetadataJSON, &meta); err != nil {
-
-			return fmt.Errorf("failed to unmarshal multipart metadata: %w", err)
-
-		}
-
-		for partIdx, part := range meta.FileParts {
-			if len(part.SegmentIds) == 0 {
-				continue
-			}
-
-			partFileName := fmt.Sprintf("%s.part%02d", fileName, partIdx+1)
-			extraMeta := ""
-			if meta.AesParams != nil {
-				extraMeta = fmt.Sprintf("AES_KEY:%s AES_IV:%s DECODED_SIZE:%d ",
-					meta.AesParams.Key, meta.AesParams.Iv, meta.AesParams.DecodedSize)
-			}
-
-			subject := fmt.Sprintf("NZBDAV_ID:%s %s%s",
-				template.HTMLEscapeString(fileId), extraMeta, template.HTMLEscapeString(partFileName))
-
-			fileHeader := fmt.Sprintf(`	<file poster="AltMount" date="%d" subject="%s">
-		<groups>
-			<group>alt.binaries.test</group>
-		</groups>
-		<segments>
-`, 0, subject)
-
-			if _, err := w.Write([]byte(fileHeader)); err != nil {
-				return err
-			}
-
-			for i, msgId := range part.SegmentIds {
-				segmentLine := fmt.Sprintf(`			<segment bytes="%d" number="%d">%s</segment>
-`, 750000, i+1, template.HTMLEscapeString(msgId))
-
-				if _, err := w.Write([]byte(segmentLine)); err != nil {
-					return err
-				}
-			}
-
-			if _, err := w.Write([]byte("		</segments>\n\t</file>\n")); err != nil {
-				return err
-			}
-		}
+	if _, err := w.Write([]byte("		</segments>\n\t</file>\n")); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/nzbdav/parser_test.go
+++ b/internal/nzbdav/parser_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
@@ -13,15 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParser_Parse(t *testing.T) {
-	// Create temp DB
-	tmpDir := t.TempDir()
-	dbPath := filepath.Join(tmpDir, "test.db")
+// openLegacyDB creates an in-memory-ish temp DB with the minimal schema used
+// by the legacy reconstruction path.
+func openLegacyDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
-	// Init Schema
 	_, err = db.Exec(`
 		CREATE TABLE DavItems (
 			Id TEXT PRIMARY KEY,
@@ -35,107 +36,162 @@ func TestParser_Parse(t *testing.T) {
 			Id TEXT PRIMARY KEY,
 			SegmentIds TEXT
 		);
-		CREATE TABLE DavRarFiles (
-			Id TEXT PRIMARY KEY,
-			RarParts TEXT
-		);
-		CREATE TABLE DavMultipartFiles (
-			Id TEXT PRIMARY KEY,
-			Metadata TEXT
-		);
+	`)
+	require.NoError(t, err)
+	return db, dbPath
+}
+
+func collect(t *testing.T, out <-chan *ParsedNzb, errChan <-chan error) []*ParsedNzb {
+	t.Helper()
+	var got []*ParsedNzb
+	for {
+		select {
+		case res, ok := <-out:
+			if !ok {
+				return got
+			}
+			got = append(got, res)
+		case err, ok := <-errChan:
+			if ok && err != nil {
+				t.Fatalf("parser error: %v", err)
+			}
+		}
+	}
+}
+
+func TestParser_Parse_MergesExtractedIntoRelease(t *testing.T) {
+	db, dbPath := openLegacyDB(t)
+
+	_, err := db.Exec(`
+		INSERT INTO DavItems (Id, ParentId, Name, FileSize, Type, Path) VALUES
+		('root',    NULL,     '/',                  NULL,      1, '/'),
+		('movies',  'root',   'movies',             NULL,      1, '/movies'),
+		('rel1',    'movies', 'My.Release.1080p',   NULL,      1, '/movies/My.Release.1080p'),
+		('file1',   'rel1',   'movie.mkv',          1048576,   0, '/movies/My.Release.1080p/movie.mkv'),
+		('rel2',    'movies', 'Actual.Movie.Name',  NULL,      1, '/movies/Actual.Movie.Name'),
+		('ext',     'rel2',   'extracted',          NULL,      1, '/movies/Actual.Movie.Name/extracted'),
+		('fileMain','rel2',   'movie2.nzb',         2097152,   0, '/movies/Actual.Movie.Name/movie2.nzb'),
+		('fileExt', 'ext',    'movie2.mkv',         2097152,   0, '/movies/Actual.Movie.Name/extracted/movie2.mkv');
+
+		INSERT INTO DavNzbFiles (Id, SegmentIds) VALUES
+		('file1',    '["msg1@test","msg2@test"]'),
+		('fileMain', '["msg3@test"]'),
+		('fileExt',  '["msg4@test"]');
 	`)
 	require.NoError(t, err)
 
-	// Insert Data
-	// Root -> Movies -> Release -> File
-	_, err = db.Exec(`
-		INSERT INTO DavItems (Id, ParentId, Name, Type, Path) VALUES 
-		('root', NULL, '/', 1, '/'),
-		('movies', 'root', 'movies', 1, '/movies'),
-		('rel1', 'movies', 'My.Release.1080p', 1, '/movies/My.Release.1080p'),
-		('file1', 'rel1', 'movie.mkv', 0, '/movies/My.Release.1080p/movie.mkv'),
-		('rel2', 'movies', 'Actual.Movie.Name', 1, '/movies/Actual.Movie.Name'),
-		('ext', 'rel2', 'extracted', 1, '/movies/Actual.Movie.Name/extracted'),
-		('file2', 'ext', 'movie2.mkv', 0, '/movies/Actual.Movie.Name/extracted/movie2.mkv');
+	out, errChan := NewParser(dbPath, "").Parse()
+	got := collect(t, out, errChan)
 
-		INSERT INTO DavNzbFiles (Id, SegmentIds) VALUES 
-		('file1', '["msg1@test", "msg2@test"]'),
-		('file2', '["msg3@test"]');
+	require.Len(t, got, 2)
+
+	byName := map[string]*ParsedNzb{}
+	for _, r := range got {
+		byName[r.Name] = r
+	}
+
+	rel1 := byName["My.Release.1080p"]
+	require.NotNil(t, rel1)
+	assert.Equal(t, "movies", rel1.Category)
+	assert.Empty(t, rel1.ExtractedFiles)
+	rel1Body, _ := io.ReadAll(rel1.Content)
+	assert.Contains(t, string(rel1Body), `<meta type="name">My.Release.1080p</meta>`)
+	assert.Contains(t, string(rel1Body), "NZBDAV_ID:file1")
+	assert.Contains(t, string(rel1Body), `poster="nzbdav"`)
+	assert.NotContains(t, string(rel1Body), "alt.binaries.test")
+
+	rel2 := byName["Actual.Movie.Name"]
+	require.NotNil(t, rel2)
+	assert.Equal(t, "movies", rel2.Category)
+	rel2Body, _ := io.ReadAll(rel2.Content)
+	assert.Contains(t, string(rel2Body), `<meta type="name">Actual.Movie.Name</meta>`)
+	// Primary file (not in /extracted) must be in the NZB body.
+	assert.Contains(t, string(rel2Body), "NZBDAV_ID:fileMain")
+	// File inside /extracted/ must NOT appear as a <file> entry — it's metadata only.
+	assert.NotContains(t, string(rel2Body), "NZBDAV_ID:fileExt")
+
+	// Extracted files list is populated from the /extracted subtree.
+	require.Len(t, rel2.ExtractedFiles, 1)
+	assert.Equal(t, "movie2.mkv", rel2.ExtractedFiles[0].Name)
+	assert.Equal(t, int64(2097152), rel2.ExtractedFiles[0].Size)
+}
+
+func TestParser_Parse_TVCategory(t *testing.T) {
+	db, dbPath := openLegacyDB(t)
+
+	_, err := db.Exec(`
+		INSERT INTO DavItems (Id, ParentId, Name, FileSize, Type, Path) VALUES
+		('root', NULL,   '/',                   NULL,    1, '/'),
+		('tv',   'root', 'tv',                  NULL,    1, '/tv'),
+		('show', 'tv',   'Show.S01.1080p',      NULL,    1, '/tv/Show.S01.1080p'),
+		('ep1',  'show', 'Show.S01E01.mkv',     1048576, 0, '/tv/Show.S01.1080p/Show.S01E01.mkv');
+
+		INSERT INTO DavNzbFiles (Id, SegmentIds) VALUES
+		('ep1', '["seg1@test"]');
 	`)
 	require.NoError(t, err)
 
-	// Run Parser
-	parser := NewParser(dbPath, "")
-	out, errChan := parser.Parse()
+	out, errChan := NewParser(dbPath, "").Parse()
+	got := collect(t, out, errChan)
 
-	// Verify
-	// Note: ORDER BY c.ParentId, c.Name
-	// file1 parent is rel1
-	// file2 parent is ext
+	require.Len(t, got, 1)
+	assert.Equal(t, "tv", got[0].Category)
+	assert.Equal(t, "Show.S01.1080p", got[0].Name)
+}
 
-	// Item 1
-	select {
-	case res, ok := <-out:
-		require.True(t, ok)
-		// file2 (parent 'ext') might come first depending on sorting, but let's see.
-		// Actually, since we order by ParentId, and IDs are likely UUIDs or sequential.
-		// In our insert, 'ext' comes after 'rel1' alphabetically? maybe.
+func TestParser_Parse_MissingFileSize(t *testing.T) {
+	db, dbPath := openLegacyDB(t)
 
-		if res.Name == "Actual.Movie.Name" {
-			assert.Equal(t, "movies", res.Category)
-			content, _ := io.ReadAll(res.Content)
-			assert.Contains(t, string(content), `<meta type="name">Actual.Movie.Name</meta>`)
-		} else {
-			assert.Equal(t, "My.Release.1080p", res.Name)
-			assert.Equal(t, "movies", res.Category)
-			content, _ := io.ReadAll(res.Content)
-			assert.Contains(t, string(content), `<meta type="name">My.Release.1080p</meta>`)
-			assert.Contains(t, string(content), "subject=\"NZBDAV_ID:file1 &#34;movie.mkv&#34;\">")
-		}
+	_, err := db.Exec(`
+		INSERT INTO DavItems (Id, ParentId, Name, FileSize, Type, Path) VALUES
+		('root',   NULL,     '/',                 NULL, 1, '/'),
+		('movies', 'root',   'movies',            NULL, 1, '/movies'),
+		('rel',    'movies', 'NoSize.Release',    NULL, 1, '/movies/NoSize.Release'),
+		('file',   'rel',    'thing.mkv',         NULL, 0, '/movies/NoSize.Release/thing.mkv');
 
-	case err := <-errChan:
-		require.NoError(t, err)
-	}
+		INSERT INTO DavNzbFiles (Id, SegmentIds) VALUES
+		('file', '["m1@t","m2@t"]');
+	`)
+	require.NoError(t, err)
 
-	// Item 2
-	select {
-	case res, ok := <-out:
-		require.True(t, ok)
-		if res.Name == "Actual.Movie.Name" {
-			assert.Equal(t, "movies", res.Category)
-			content, _ := io.ReadAll(res.Content)
-			assert.Contains(t, string(content), `<meta type="name">Actual.Movie.Name</meta>`)
-		} else {
-			assert.Equal(t, "My.Release.1080p", res.Name)
-			assert.Equal(t, "movies", res.Category)
-			content, _ := io.ReadAll(res.Content)
-			assert.Contains(t, string(content), `<meta type="name">My.Release.1080p</meta>`)
-		}
-	case err := <-errChan:
-		require.NoError(t, err)
-	}
+	out, errChan := NewParser(dbPath, "").Parse()
+	got := collect(t, out, errChan)
 
-	// Should be no more items
-	_, ok := <-out
-	assert.False(t, ok)
+	require.Len(t, got, 1)
+	body, _ := io.ReadAll(got[0].Content)
+	s := string(body)
+	// Both segments should use the 750_000-byte default, never 1.
+	assert.Equal(t, 2, strings.Count(s, `bytes="750000"`), "expected both segments to fall back to default size: %s", s)
+	assert.NotContains(t, s, `bytes="1"`)
+}
+
+func writeZstdBlob(t *testing.T, path string, content []byte) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	zw, err := zstd.NewWriter(f)
+	require.NoError(t, err)
+	_, err = zw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
 }
 
 func TestParser_Parse_Blobs(t *testing.T) {
-	// Create temp dir and blobs folder
 	tmpDir := t.TempDir()
 	blobsDir := filepath.Join(tmpDir, "blobs")
-	require.NoError(t, os.MkdirAll(blobsDir, 0755))
-
-	dbPath := filepath.Join(tmpDir, "test_blobs.db")
+	dbPath := filepath.Join(tmpDir, "blobs.db")
 	db, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
 	defer db.Close()
 
-	// Init Schema (alpha version)
 	_, err = db.Exec(`
 		CREATE TABLE DavItems (
 			Id TEXT PRIMARY KEY,
+			ParentId TEXT,
 			Name TEXT,
+			FileSize INTEGER,
 			Path TEXT,
 			NzbBlobId TEXT,
 			SubType INTEGER
@@ -147,11 +203,8 @@ func TestParser_Parse_Blobs(t *testing.T) {
 	`)
 	require.NoError(t, err)
 
-	// Create a compressed blob
 	blobId := "a1b2c3d4e5f6g7h8"
-	shardedDir := filepath.Join(blobsDir, blobId[0:2], blobId[2:4])
-	require.NoError(t, os.MkdirAll(shardedDir, 0755))
-
+	blobPath := filepath.Join(blobsDir, blobId[0:2], blobId[2:4], blobId)
 	nzbContent := `<?xml version="1.0" encoding="UTF-8"?>
 <nzb xmlns="http://www.newzbin.com/DTD/nzb/nzb-1.1.dtd">
 	<file poster="poster" date="12345" subject="subject">
@@ -159,44 +212,159 @@ func TestParser_Parse_Blobs(t *testing.T) {
 		<segments><segment bytes="100" number="1">msgid@test</segment></segments>
 	</file>
 </nzb>`
+	writeZstdBlob(t, blobPath, []byte(nzbContent))
 
-	blobPath := filepath.Join(shardedDir, blobId)
-	f, err := os.Create(blobPath)
-	require.NoError(t, err)
-
-	zw, err := zstd.NewWriter(f)
-	require.NoError(t, err)
-	_, err = zw.Write([]byte(nzbContent))
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
-	require.NoError(t, f.Close())
-
-	// Insert Data
 	_, err = db.Exec(`
 		INSERT INTO NzbNames (Id, FileName) VALUES ('a1b2c3d4e5f6g7h8', 'My Movie.nzb');
-		INSERT INTO DavItems (Id, Name, Path, NzbBlobId, SubType) VALUES 
-		('item1', 'My Movie', '/movies/My Movie', 'a1b2c3d4e5f6g7h8', 203);
+		INSERT INTO DavItems (Id, ParentId, Name, Path, NzbBlobId, SubType) VALUES
+		('root',   NULL,      '/',                      '/',                              NULL,               1),
+		('movies', 'root',    'movies',                 '/movies',                        NULL,               1),
+		('folder', 'movies',  'My Movie',               '/movies/My Movie',               NULL,               1),
+		('item1',  'folder',  'My Movie.mkv',           '/movies/My Movie/My Movie.mkv',  'a1b2c3d4e5f6g7h8', 203);
 	`)
 	require.NoError(t, err)
 
-	// Run Parser
-	parser := NewParser(dbPath, blobsDir)
-	out, errChan := parser.Parse()
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+	got := collect(t, out, errChan)
 
-	// Verify
-	select {
-	case res, ok := <-out:
-		require.True(t, ok)
-		assert.Equal(t, "item1", res.ID)
-		assert.Equal(t, "My Movie", res.Name)
-		assert.Equal(t, "movies", res.Category)
-		content, _ := io.ReadAll(res.Content)
-		assert.Equal(t, nzbContent, string(content))
-	case err := <-errChan:
-		require.NoError(t, err)
-	}
+	require.Len(t, got, 1)
+	assert.Equal(t, "item1", got[0].ID)
+	assert.Equal(t, "My Movie", got[0].Name)
+	assert.Equal(t, "movies", got[0].Category)
+	body, _ := io.ReadAll(got[0].Content)
+	assert.Equal(t, nzbContent, string(body))
+}
 
-	// Should be no more items
-	_, ok := <-out
-	assert.False(t, ok)
+func TestParser_Parse_Blobs_Uncompressed(t *testing.T) {
+	tmpDir := t.TempDir()
+	blobsDir := filepath.Join(tmpDir, "blobs")
+	dbPath := filepath.Join(tmpDir, "blobs_plain.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE DavItems (
+			Id TEXT PRIMARY KEY, ParentId TEXT, Name TEXT, FileSize INTEGER,
+			Path TEXT, NzbBlobId TEXT, SubType INTEGER
+		);
+		CREATE TABLE NzbNames (Id TEXT PRIMARY KEY, FileName TEXT);
+	`)
+	require.NoError(t, err)
+
+	blobId := "ff00ff00ff00ff00"
+	plain := `<?xml version="1.0" encoding="UTF-8"?><nzb><file subject="x"/></nzb>`
+	blobPath := filepath.Join(blobsDir, blobId[0:2], blobId[2:4], blobId)
+	require.NoError(t, os.MkdirAll(filepath.Dir(blobPath), 0o755))
+	require.NoError(t, os.WriteFile(blobPath, []byte(plain), 0o644))
+
+	_, err = db.Exec(`
+		INSERT INTO NzbNames (Id, FileName) VALUES ('ff00ff00ff00ff00', 'Thing.nzb');
+		INSERT INTO DavItems (Id, ParentId, Name, Path, NzbBlobId, SubType) VALUES
+		('root',   NULL,     '/',              '/',                       NULL, 1),
+		('movies', 'root',   'movies',         '/movies',                 NULL, 1),
+		('folder', 'movies', 'Thing',          '/movies/Thing',           NULL, 1),
+		('item',   'folder', 'Thing.mkv',      '/movies/Thing/Thing.mkv', 'ff00ff00ff00ff00', 203);
+	`)
+	require.NoError(t, err)
+
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+	got := collect(t, out, errChan)
+
+	require.Len(t, got, 1)
+	body, err := io.ReadAll(got[0].Content)
+	require.NoError(t, err)
+	assert.Equal(t, plain, string(body))
+}
+
+func TestParser_Parse_Blobs_PreservesArbitraryFolderStructure(t *testing.T) {
+	// Mirrors the real-world nzbdav layout /content/uncategorized/<release>/<file>
+	// reported by users. The parser must preserve this tree verbatim instead of
+	// forcing /movies/, /tv/, or /other/.
+	tmpDir := t.TempDir()
+	blobsDir := filepath.Join(tmpDir, "blobs")
+	dbPath := filepath.Join(tmpDir, "content.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE DavItems (
+			Id TEXT PRIMARY KEY, ParentId TEXT, Name TEXT, FileSize INTEGER,
+			Path TEXT, NzbBlobId TEXT, SubType INTEGER
+		);
+		CREATE TABLE NzbNames (Id TEXT PRIMARY KEY, FileName TEXT);
+	`)
+	require.NoError(t, err)
+
+	blobId := "1234567890abcdef"
+	writeZstdBlob(t, filepath.Join(blobsDir, "12", "34", blobId), []byte("<nzb/>"))
+
+	_, err = db.Exec(`
+		INSERT INTO NzbNames (Id, FileName) VALUES ('1234567890abcdef', 'Fresh.Off.The.Boat.nzb');
+		INSERT INTO DavItems (Id, ParentId, Name, Path, NzbBlobId, SubType) VALUES
+		('root',    NULL,    '/',                     '/',                                                      NULL, 1),
+		('content', 'root',  'content',               '/content',                                               NULL, 1),
+		('uncat',   'content','uncategorized',        '/content/uncategorized',                                 NULL, 1),
+		('folder',  'uncat', 'Fresh.Off.The.Boat',    '/content/uncategorized/Fresh.Off.The.Boat',              NULL, 1),
+		('item',    'folder','Fresh.Off.The.Boat.mkv','/content/uncategorized/Fresh.Off.The.Boat/Fresh.Off.The.Boat.mkv', '1234567890abcdef', 203);
+	`)
+	require.NoError(t, err)
+
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+	got := collect(t, out, errChan)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "Fresh.Off.The.Boat", got[0].Name)
+	assert.Equal(t, "content", got[0].Category)
+	assert.Equal(t, "uncategorized", got[0].RelPath)
+}
+
+func TestParser_Parse_Blobs_WithExtracted(t *testing.T) {
+	tmpDir := t.TempDir()
+	blobsDir := filepath.Join(tmpDir, "blobs")
+	dbPath := filepath.Join(tmpDir, "blobs_ext.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`
+		CREATE TABLE DavItems (
+			Id TEXT PRIMARY KEY,
+			ParentId TEXT,
+			Name TEXT,
+			FileSize INTEGER,
+			Path TEXT,
+			NzbBlobId TEXT,
+			SubType INTEGER
+		);
+		CREATE TABLE NzbNames (
+			Id TEXT PRIMARY KEY,
+			FileName TEXT
+		);
+	`)
+	require.NoError(t, err)
+
+	blobId := "0011223344556677"
+	writeZstdBlob(t, filepath.Join(blobsDir, "00", "11", blobId), []byte("<nzb/>"))
+
+	_, err = db.Exec(`
+		INSERT INTO NzbNames (Id, FileName) VALUES ('0011223344556677', 'Movie.nzb');
+		INSERT INTO DavItems (Id, ParentId, Name, FileSize, Path, NzbBlobId, SubType) VALUES
+		('root',    NULL,     '/',              NULL,    '/',                                       NULL,               1),
+		('movies',  'root',   'movies',         NULL,    '/movies',                                 NULL,               1),
+		('folder',  'movies', 'Movie',          NULL,    '/movies/Movie',                           NULL,               1),
+		('item',    'folder', 'Movie.mkv',      NULL,    '/movies/Movie/Movie.mkv',                 '0011223344556677', 203),
+		('ext',     'folder', 'extracted',      NULL,    '/movies/Movie/extracted',                 NULL,               1),
+		('inner',   'ext',    'feature.mkv',    5242880, '/movies/Movie/extracted/feature.mkv',     NULL,               0);
+	`)
+	require.NoError(t, err)
+
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+	got := collect(t, out, errChan)
+
+	require.Len(t, got, 1)
+	require.Len(t, got[0].ExtractedFiles, 1)
+	assert.Equal(t, "feature.mkv", got[0].ExtractedFiles[0].Name)
+	assert.Equal(t, int64(5242880), got[0].ExtractedFiles[0].Size)
 }


### PR DESCRIPTION
## Summary

- Preserve nzbdav's folder layout verbatim — imports mirror the source tree instead of being forced into `/movies`, `/tv`, or `/other`
- Sniff zstd magic before decompressing blobs — plain-XML blobs no longer fail with `invalid input: magic number mismatch`
- Fix release grouping (files under `/<release>/extracted/` now group under `<release>`) and finally populate `ExtractedFiles` in both blob and legacy schemas
- Remove the **Target Directory Name** form field — imports are seamless, no user-supplied prefix needed
- Drop ~140 lines of dead `DavRarFiles` / `DavMultipartFiles` / AES code that no upstream nzbdav schema ever produced

## Why

Triggered by two concrete failures against a real user DB (`/Users/javi/mio/nzbdav/nzbdav/db.sqlite` + `blobs/`):

1. Import errored out on `Fresh.Off.the.Boat.S01E12…` with `failed to write temp NZB file content: invalid input: magic number mismatch`. Inspection showed the blob is plain XML (`<?xml…`) — nzbdav's blobstore mixes zstd-compressed and uncompressed NZBs and we only handled the compressed path.
2. The user's library lives at `/content/uncategorized/<release>/…`; the old parser rebucketed everything into `other` (or `movies`/`tv` via path sniffing), so the imported mount tree didn't match the source.

## Key changes

**Parser (`internal/nzbdav/parser.go`)**
- `bufio.Peek` + zstd magic check; plain pass-through otherwise.
- `releaseFor` now walks up skipping `extracted`, so a file in `/movies/Release/extracted/file.mkv` groups under `Release` (not the `extracted` folder).
- New `splitPath` + `trimLastSegment` helpers return `(firstSegment, rest)` of the release's parent path, feeding `Category` + `RelPath` without any bucketing.
- `ExtractedFiles` collected via a tree walk **before** `ParsedNzb` is emitted (was always an empty slice before).
- Segment-size fallback: `750_000` bytes instead of `1`; warn once per release on missing `FileSize`.
- `poster="nzbdav"`, `group="alt.binaries.misc"` constants; removed `AltMount` / `alt.binaries.test`.
- Removed RAR/Multipart/AES code paths — not present upstream.

**Scanner / API / UI**
- `NzbDavImporter.Start` / `StartNzbdavImport` / `createNzbFileAndPrepareItem` lose `rootFolder`.
- `ImportQueueItem.RelativePath` left `nil`; `processNzbItem` already defaults `basePath = ""` when nil (service.go:676).
- API no longer reads/validates `rootFolder`.
- Frontend drops the **Target Directory Name** fieldset, its state, and validation; cleans up unused `FolderInput` import.

**Note:** `ProviderCard.tsx` is an incidental biome auto-format only — no logic change.

## Migration / compatibility

- Breaking change to `POST /api/import/nzbdav`: `rootFolder` form field is gone. Not a documented/public API; internal-only.
- Previous imports that relied on the forced `movies`/`tv`/`other` layout will continue working since nothing rewrites already-queued items.

## Test plan

- [x] `go build ./...`
- [x] `go test -race ./internal/nzbdav/... ./internal/importer/... ./internal/api/...`
- [x] `bun run check` (biome) + `bunx tsc --noEmit`
- [x] Manual: imported the user's real nzbdav DB — no more magic-number error, release paths preserved as `/content/uncategorized/<release>`, `ExtractedFiles` populated.
- [ ] Reviewer: smoke-test an import from a v0.6.0+ nzbdav (blob schema) and an older legacy DB to confirm both paths still work.