### PR TITLE
fix(parser): don't propagate IsRarArchive to non-archive sidecars (.txt etc)

### DIFF
--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -235,26 +235,13 @@ func (p *Parser) ParseFile(ctx context.Context, r io.Reader, nzbPath string, pro
 	// Determine NZB type based on content analysis
 	parsed.Type = p.determineNzbType(parsed.Files)
 
-	// Propagate archive type to all non-par2 files.
+	// Propagate archive type to confirmed archive parts only.
 	// For split archives only the first volume contains the magic-byte header, so
 	// Is7zArchive / IsRarArchive may be false on subsequent parts even though they
 	// are archive parts. Correct that now that we know the NZB type.
-	switch parsed.Type {
-	case NzbType7zArchive:
-		for i := range parsed.Files {
-			f := &parsed.Files[i]
-			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) {
-				f.Is7zArchive = true
-			}
-		}
-	case NzbTypeRarArchive:
-		for i := range parsed.Files {
-			f := &parsed.Files[i]
-			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) {
-				f.IsRarArchive = true
-			}
-		}
-	}
+	// Propagation is gated on existing detection (magic bytes or extension) so that
+	// non-archive sidecars (.txt, .nfo, etc.) are never wrongly classified.
+	p.propagateArchiveType(parsed)
 
 	return parsed, nil
 }
@@ -873,6 +860,31 @@ func (p *Parser) determineNzbType(files []ParsedFile) NzbType {
 	}
 
 	return NzbTypeMultiFile
+}
+
+// propagateArchiveType sets the archive-type flag on non-PAR2 files that are
+// confirmed archive parts. Propagation is gated on the file already being
+// detected as an archive (via magic bytes or extension), preventing non-archive
+// sidecars (.txt, .nfo, etc.) from being wrongly classified.
+func (p *Parser) propagateArchiveType(parsed *ParsedNzb) {
+	switch parsed.Type {
+	case NzbType7zArchive:
+		for i := range parsed.Files {
+			f := &parsed.Files[i]
+			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) &&
+				(f.Is7zArchive || fileinfo.Is7zFile(f.Filename)) {
+				f.Is7zArchive = true
+			}
+		}
+	case NzbTypeRarArchive:
+		for i := range parsed.Files {
+			f := &parsed.Files[i]
+			if !f.IsPar2Archive && !fileinfo.IsPar2File(f.Filename) &&
+				(f.IsRarArchive || fileinfo.IsRarFile(f.Filename)) {
+				f.IsRarArchive = true
+			}
+		}
+	}
 }
 
 // GetMetadata extracts metadata from the NZB head section

--- a/internal/importer/parser/parser_test.go
+++ b/internal/importer/parser/parser_test.go
@@ -155,3 +155,38 @@ func TestDetermineNzbType_ExcludesPar2Files(t *testing.T) {
 		})
 	}
 }
+
+// TestPropagateArchiveType_SkipsTxtSidecar is the regression test for
+// Fresh.Off.the.Boat.S01E12 where a .txt sidecar was incorrectly marked
+// IsRarArchive=true by the archive-type propagation loop.
+//
+// Post-PAR2 state modelled here: all RAR volumes already have real names and
+// IsRarArchive=true; the .txt sidecar has IsRarArchive=false and must not be
+// touched by propagation.
+func TestPropagateArchiveType_SkipsTxtSidecar(t *testing.T) {
+	release := "Fresh.Off.the.Boat.S01E12.Dribbling.Tiger.Bounce.Pass.Dragon.1080p.DSNP.WEB-DL.DD5.1.H.264-playWEB"
+	parsed := &ParsedNzb{
+		Type: NzbTypeRarArchive,
+		Files: []ParsedFile{
+			{Filename: release + ".part01.rar", IsRarArchive: true},
+			{Filename: release + ".part02.rar", IsRarArchive: true},
+			{Filename: release + ".part03.rar", IsRarArchive: true},
+			{Filename: "5a3ae665828fe76b0bb904e41d4d2429.txt", IsRarArchive: false},
+			{Filename: "5a3ae665828fe76b0bb904e41d4d2429.par2", IsPar2Archive: true},
+		},
+	}
+
+	p := &Parser{}
+	p.propagateArchiveType(parsed)
+
+	for _, f := range parsed.Files {
+		switch {
+		case strings.HasSuffix(f.Filename, ".rar"):
+			assert.True(t, f.IsRarArchive, "%s must stay IsRarArchive=true", f.Filename)
+		case strings.HasSuffix(f.Filename, ".txt"):
+			assert.False(t, f.IsRarArchive, ".txt sidecar must NOT be marked IsRarArchive=true")
+		case strings.HasSuffix(f.Filename, ".par2"):
+			assert.False(t, f.IsRarArchive, "PAR2 file must NOT be marked IsRarArchive=true")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- The archive-type propagation loop in `ParseFile` was marking every non-PAR2 file as `IsRarArchive=true` when the NZB type was `RarArchive`, including `.txt`/`.nfo` sidecars with no RAR magic bytes and no RAR extension
- These files were then routed to `ProcessArchive` and caused the import to fail
- **Reproducer:** `Fresh.Off.the.Boat.S01E12...playWEB.nzb` — a `.txt` sidecar alongside 34 obfuscated split RAR parts was arriving at `ProcessArchive`

## Fix

- Gate propagation on the file already being detected as an archive via the existing `fileinfo.IsRarFile()` / `Is7zFile()` functions or prior magic-byte detection (`f.IsRarArchive` / `f.Is7zArchive`)
- Extract propagation into `propagateArchiveType` method for testability
- Add regression test `TestPropagateArchiveType_SkipsTxtSidecar`

FIX #514