### PR TITLE
Add support for gzip-compressed NZB files (.nzb.gz)

### DIFF
--- a/frontend/src/components/queue/ImportMethods.tsx
+++ b/frontend/src/components/queue/ImportMethods.tsx
@@ -180,7 +180,9 @@ function EnhancedUploadSection() {
 	const categories = config?.sabnzbd?.categories ?? [];
 
 	const validateFile = useCallback((file: File): string | null => {
-		if (!file.name.toLowerCase().endsWith(".nzb")) return "Only .nzb files are allowed";
+		const name = file.name.toLowerCase();
+		if (!name.endsWith(".nzb") && !name.endsWith(".nzb.gz"))
+			return "Only .nzb or .nzb.gz files are allowed";
 		if (file.size > 100 * 1024 * 1024) return "File size must be less than 100MB";
 		return null;
 	}, []);
@@ -482,7 +484,7 @@ function EnhancedUploadSection() {
 						<input
 							type="file"
 							multiple
-							accept=".nzb"
+							accept=".nzb,.nzb.gz"
 							onChange={handleFileInput}
 							className="hidden"
 						/>

--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -97,8 +97,8 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		return RespondBadRequest(c, "No file provided", "A .nzb file must be uploaded")
 	}
 
-	if !strings.HasSuffix(strings.ToLower(file.Filename), ".nzb") {
-		return RespondValidationError(c, "Invalid file type", "Only .nzb files are allowed")
+	if !nzbtrim.HasNzbExtension(file.Filename) {
+		return RespondValidationError(c, "Invalid file type", "Only .nzb or .nzb.gz files are allowed")
 	}
 
 	const maxUploadSize = 100 * 1024 * 1024 // 100 MB

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/database"
 	internalerrors "github.com/javi11/altmount/internal/errors"
+	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/nzblnk"
 )
 
@@ -576,8 +577,8 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 	}
 
 	// Validate file extension
-	if !strings.HasSuffix(strings.ToLower(file.Filename), ".nzb") {
-		return RespondValidationError(c, "Invalid file type", "Only .nzb files are allowed")
+	if !nzbtrim.HasNzbExtension(file.Filename) {
+		return RespondValidationError(c, "Invalid file type", "Only .nzb or .nzb.gz files are allowed")
 	}
 
 	// Validate file size (100MB limit)

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/importer/utils"
+	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/pathutil"
 )
 
@@ -319,8 +320,8 @@ func (s *Server) handleSABnzbdAddFile(c *fiber.Ctx) error {
 	}
 
 	// Validate file extension
-	if !strings.HasSuffix(strings.ToLower(file.Filename), ".nzb") {
-		return s.writeSABnzbdErrorFiber(c, "Invalid file type, must be .nzb")
+	if !nzbtrim.HasNzbExtension(file.Filename) {
+		return s.writeSABnzbdErrorFiber(c, "Invalid file type, must be .nzb or .nzb.gz")
 	}
 
 	// Get and validate category from form first
@@ -475,8 +476,8 @@ func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 		filename = "downloaded.nzb"
 	}
 
-	// Ensure .nzb extension
-	if !strings.HasSuffix(strings.ToLower(filename), ".nzb") {
+	// Ensure .nzb or .nzb.gz extension
+	if !nzbtrim.HasNzbExtension(filename) {
 		filename += ".nzb"
 	}
 

--- a/internal/importer/scanner/directory.go
+++ b/internal/importer/scanner/directory.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 )
 
 // QueueAdder defines the interface for adding items to the queue
@@ -176,8 +178,7 @@ func (d *DirectoryScanner) performScan(ctx context.Context, scanPath string) {
 		d.info.FilesFound++
 		d.mu.Unlock()
 
-		ext := strings.ToLower(path)
-		if !strings.HasSuffix(ext, ".nzb") && !strings.HasSuffix(ext, ".strm") {
+		if !nzbtrim.HasNzbExtension(path) && !strings.HasSuffix(strings.ToLower(path), ".strm") {
 			return nil
 		}
 

--- a/internal/importer/scanner/watcher.go
+++ b/internal/importer/scanner/watcher.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 )
 
 // WatchQueueAdder interface for adding items to the import queue from directory watcher
@@ -113,7 +114,7 @@ func (w *Watcher) scanDirectory(ctx context.Context, watchDir string) {
 		}
 
 		// Check extension
-		if !strings.HasSuffix(strings.ToLower(d.Name()), ".nzb") {
+		if !nzbtrim.HasNzbExtension(d.Name()) {
 			return nil
 		}
 

--- a/internal/importer/utils/nzbtrim/nzb_trim.go
+++ b/internal/importer/utils/nzbtrim/nzb_trim.go
@@ -17,3 +17,9 @@ func TrimNzbExtension(filename string) string {
 	// Fallback to standard extension removal if it's not a known NZB extension
 	return strings.TrimSuffix(filename, filepath.Ext(filename))
 }
+
+// HasNzbExtension returns true when filename ends with .nzb or .nzb.gz (case-insensitive).
+func HasNzbExtension(filename string) bool {
+	lower := strings.ToLower(filename)
+	return strings.HasSuffix(lower, ".nzb") || strings.HasSuffix(lower, ".nzb.gz")
+}


### PR DESCRIPTION
## Summary
This PR extends NZB file support to include gzip-compressed files (.nzb.gz) in addition to standard .nzb files across the application. A new utility function `HasNzbExtension()` was introduced to centralize and standardize NZB file extension validation.

## Key Changes
- **New utility function**: Added `HasNzbExtension()` in `internal/importer/utils/nzbtrim/nzb_trim.go` to check for both `.nzb` and `.nzb.gz` extensions (case-insensitive)
- **Backend validation updates**: Replaced inline extension checks with the new utility function in:
  - `internal/api/sabnzbd_handlers.go` (file upload and URL download handlers)
  - `internal/api/queue_handlers.go` (queue upload handler)
  - `internal/api/nzb_stremio_handlers.go` (Stremio NZB handler)
  - `internal/importer/scanner/directory.go` (directory scanner)
  - `internal/importer/scanner/watcher.go` (directory watcher)
- **Frontend updates**: 
  - Updated file validation logic in `frontend/src/components/queue/ImportMethods.tsx` to accept both `.nzb` and `.nzb.gz` files
  - Updated file input `accept` attribute to include `.nzb.gz`
  - Updated user-facing error messages to reflect support for both formats

## Implementation Details
- The `HasNzbExtension()` function performs case-insensitive matching by converting filenames to lowercase before checking suffixes
- All error messages have been updated to indicate support for both `.nzb` and `.nzb.gz` formats
- The change is backward compatible and doesn't affect existing `.nzb` file handling

https://claude.ai/code/session_01JrGP2iwN5ekVfdjpbfRJja