### PR TITLE
fix(pwa): let auth proxies redirect before service worker serves cached HTML

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,6 +65,19 @@ export default defineConfig({
 			workbox: {
 				globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
 				runtimeCaching: [
+					// NetworkFirst for navigation so auth proxies (e.g. Authelia) can
+					// redirect unauthenticated requests before the SW serves cached HTML.
+					{
+						urlPattern: ({ request }) => request.mode === "navigate",
+						handler: "NetworkFirst",
+						options: {
+							cacheName: "navigation-cache",
+							networkTimeoutSeconds: 10,
+							cacheableResponse: {
+								statuses: [200],
+							},
+						},
+					},
 					{
 						urlPattern: /^\/api\/.*/i,
 						handler: "NetworkFirst",
@@ -78,8 +91,6 @@ export default defineConfig({
 						},
 					},
 				],
-				navigateFallback: "index.html",
-				navigateFallbackDenylist: [/^\/webdav/, /^\/sabnzbd/],
 			},
 		}),
 	],


### PR DESCRIPTION
## What changed

Replaced `navigateFallback: 'index.html'` + `navigateFallbackDenylist` with a dedicated `NetworkFirst` runtime caching rule scoped to navigation requests (`request.mode === 'navigate'`).

## Why

When the app is deployed behind an authentication reverse-proxy (e.g. **Authelia**), the proxy responds to unauthenticated requests with a `302` redirect to the login page. The previous Workbox configuration used `navigateFallback`, which intercepts every navigation request in the service worker and immediately returns the cached `index.html` — **before** the request reaches the network. This meant the auth redirect was silently swallowed and the login page was never shown.

## How it works now

1. The service worker tries the network first for all navigation requests.
2. If the proxy returns a `302`, the browser receives and follows it → Authelia login page is shown.
3. Only HTTP `200` responses are stored in `navigation-cache` (`cacheableResponse: { statuses: [200] }`), so auth redirects are never cached.
4. If the network is unavailable, the service worker falls back to a previously-cached `200` response for offline support.

The `/webdav` and `/sabnzbd` denylist entries are no longer needed since there is no navigation fallback to deny.

## Test plan

- [ ] Build succeeds (`bun run build`)
- [ ] Unauthenticated access behind Authelia redirects to the login page
- [ ] Authenticated access loads the app normally
- [ ] DevTools → Application → Service Workers → offline mode: navigation either loads a cached page or shows the browser offline error (no blank screen)