### PR TITLE
fix(importer): filter sample files with underscore suffix

### DIFF
--- a/internal/importer/utils/file_validation.go
+++ b/internal/importer/utils/file_validation.go
@@ -9,10 +9,11 @@ import (
 )
 
 // sampleProofPattern matches filenames containing "sample" or "proof" as a standalone word.
-// Uses leading non-alphanumeric boundary (including underscore) and trailing word boundary.
-// Examples matched: "movie.sample.mkv", "_sample.mkv", "movie_sample.mkv"
+// Uses symmetric non-alphanumeric boundaries (underscore, digits, punctuation, end-of-string)
+// on both sides. Letters prevent matching, so "samplemovie.mkv" is allowed.
+// Examples matched: "movie.sample.mkv", "_sample.mkv", "movie_sample.mkv", "_sample_clip.mkv"
 // Examples not matched: "samplemovie.mkv", "Free.Samples.mkv" (plural)
-var sampleProofPattern = regexp.MustCompile(`(?i)(^|[^a-zA-Z0-9])(sample|proof)\b`)
+var sampleProofPattern = regexp.MustCompile(`(?i)(^|[^a-zA-Z0-9])(sample|proof)(?:[^a-zA-Z0-9]|$)`)
 
 // isSampleOrProof checks if a filename looks like a sample or proof file
 func isSampleOrProof(filename string, size int64) bool {

--- a/internal/importer/utils/file_validation_test.go
+++ b/internal/importer/utils/file_validation_test.go
@@ -281,9 +281,9 @@ func TestIsAllowedFile_SampleProofPatterns(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "proof at start of filename with underscore is allowed (word char)",
+			name:     "proof at start of filename with underscore is rejected",
 			filename: "proof_test.mkv",
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "sample merged with word is allowed",
@@ -336,9 +336,29 @@ func TestIsAllowedFile_SampleProofPatterns(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "sample followed by underscore is allowed",
+			name:     "sample followed by underscore is rejected",
 			filename: "sample_test.mkv",
-			expected: true,
+			expected: false,
+		},
+		{
+			name:     "underscore-sandwiched sample is rejected",
+			filename: "_sample_clip.mkv",
+			expected: false,
+		},
+		{
+			name:     "sample before digit is rejected",
+			filename: "sample_720p.mkv",
+			expected: false,
+		},
+		{
+			name:     "proof before digit is rejected",
+			filename: "proof_720p.mkv",
+			expected: false,
+		},
+		{
+			name:     "sample embedded with underscores is rejected",
+			filename: "movie._sample_hd.mkv",
+			expected: false,
 		},
 		{
 			name:     "sample in directory path is rejected",


### PR DESCRIPTION
## Summary

- Fixed `sampleProofPattern` regex in `internal/importer/utils/file_validation.go` — replaced the trailing `\b` word boundary with `(?:[^a-zA-Z0-9]|$)`
- Updated 2 tests that documented the old (buggy) behaviour
- Added 5 new test cases covering the previously-missed patterns

## Problem

Go's RE2 engine treats `_` as a word character (`\w = [0-9A-Za-z_]`), so `\b` does **not** fire between `e` and `_`. The old pattern:

```
(?i)(^|[^a-zA-Z0-9])(sample|proof)\b
```

left these filenames unfiltered:

| Filename | Expected | Old result |
|---|---|---|
| `_sample_clip.mkv` | filtered | **allowed** |
| `sample_720p.mkv` | filtered | **allowed** |
| `movie._sample_hd.mkv` | filtered | **allowed** |

## Fix

```
(?i)(^|[^a-zA-Z0-9])(sample|proof)(?:[^a-zA-Z0-9]|$)
```

Both boundaries now behave symmetrically: underscore, digits, punctuation, and end-of-string act as separators on both sides. Letters still prevent matching, so `samplemovie.mkv` remains allowed.

## Test plan

- [ ] `go test -race -cover ./internal/importer/utils/... -run TestIsAllowedFile` — all 23 pattern tests pass
- [ ] `_sample_clip.mkv`, `sample_720p.mkv`, `proof_720p.mkv`, `movie._sample_hd.mkv` are now correctly filtered
- [ ] `samplemovie.mkv`, `SpongeBob.Free.Samples.mkv` remain allowed