### PR TITLE
fix(sabnzbd): fix history endpoint timeout and add path-existence diagnostic

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -717,6 +718,9 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 		return s.writeSABnzbdErrorFiber(c, "Importer service not available")
 	}
 
+	ctx, cancel := context.WithTimeout(c.Context(), 10*time.Second)
+	defer cancel()
+
 	// Get category filter from query parameter
 	categoryFilter := s.normalizeCategoryFilter(c)
 
@@ -745,14 +749,14 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	// Fetch items from active queue
 	// We use a larger set here to ensure we get everything for deduplication and combined history
 	completedStatus := database.QueueStatusCompleted
-	completedQueueItems, err := s.queueRepo.ListQueueItems(c.Context(), &completedStatus, "", categoryFilter, 10000, 0, "updated_at", "desc")
+	completedQueueItems, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, "", categoryFilter, 500, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get completed items from queue")
 	}
 
 	// Get recent items from persistent history (buffer for Sonarr)
 	// We look back 24 hours to be safe
-	recentHistory, err := s.queueRepo.ListRecentImportHistory(c.Context(), 1440, categoryFilter)
+	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, 1440, categoryFilter)
 	if err != nil {
 		recentHistory = []*database.ImportHistory{} // Fallback
 	}
@@ -818,7 +822,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 
 	// Get failed items from active queue
 	failedStatus := database.QueueStatusFailed
-	failed, err := s.queueRepo.ListQueueItems(c.Context(), &failedStatus, "", categoryFilter, 1000, 0, "updated_at", "desc")
+	failed, err := s.queueRepo.ListQueueItems(ctx, &failedStatus, "", categoryFilter, 1000, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get failed items")
 	}
@@ -1319,6 +1323,14 @@ func (s *Server) calculateHistoryStoragePath(item *database.ImportQueueItem, bas
 
 	fullStoragePath := filepath.Join(pathParts...)
 	fullStoragePath = filepath.ToSlash(filepath.Clean(fullStoragePath))
+
+	if _, err := os.Stat(fullStoragePath); os.IsNotExist(err) {
+		slog.WarnContext(context.Background(), "sabnzbd history: reported path does not exist on disk",
+			"item_id", item.ID,
+			"storage_path", *item.StoragePath,
+			"reported_path", fullStoragePath,
+		)
+	}
 
 	// Return the full file path for SYMLINK/STRM to help Arrs find it immediately.
 	// Otherwise return directory.

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1083,9 +1083,8 @@ func (r *Repository) ListRecentImportHistory(ctx context.Context, minutes int, c
 	}
 
 	query := fmt.Sprintf(`
-		SELECT h.id, h.download_id, h.nzb_id, h.nzb_name, h.file_name, h.file_size, h.virtual_path, f.library_path, h.category, h.completed_at
+		SELECT h.id, h.download_id, h.nzb_id, h.nzb_name, h.file_name, h.file_size, h.virtual_path, '' AS library_path, h.category, h.completed_at
 		FROM import_history h
-		LEFT JOIN file_health f ON TRIM(h.virtual_path, '/') = TRIM(f.file_path, '/')
 		WHERE h.completed_at >= %s
 		  AND (? = '' OR LOWER(h.category) = LOWER(?))
 		ORDER BY h.completed_at DESC


### PR DESCRIPTION
## Summary

- **Remove TRIM() cross-join** from `ListRecentImportHistory` in `internal/database/repository.go`: the `LEFT JOIN file_health` used `TRIM()` on both join sides, preventing any index from being used on `file_health` and causing a full cross-scan as the table grew. The `library_path` column was scanned but never consumed downstream, so it's replaced with `'' AS library_path`.
- **Add 10 s context timeout** in `handleSABnzbdHistory`: all three DB calls now share a bounded context so a slow query can no longer stall Sonarr/Radarr indefinitely.
- **Reduce completed-item fetch limit** from 10 000 → 500: the persistent `import_history` table already covers older items; the queue only needs recent ones for deduplication.
- **Add `slog.WarnContext` diagnostic** in `calculateHistoryStoragePath` when the computed path does not exist on disk, logging `item_id`, `storage_path`, and `reported_path` to surface the root cause of the Whisparr file-not-found errors (path structure mismatch vs. FUSE eviction).

## Why

Sonarr/Radarr (and Whisparr) were logging:

```
DownloadClientUnavailableException: Unable to connect to SABnzbd, Http request timed out
```

on `GetHistory`. As `import_history` and `file_health` grew the TRIM-join degraded silently from ms → seconds → past Sonarr's ≈10–15 s HTTP timeout.

A separate set of 30+ errors showed files under `/mnt/downloads/altmount/adult/…` not found at import time. The new warn log will identify whether this is a path mismatch (wrong `CompleteDir` config) or FUSE eviction.

## Test plan

- [ ] `go test ./internal/database/... ./internal/api/...` passes
- [ ] `EXPLAIN QUERY PLAN` on `ListRecentImportHistory` shows `SEARCH import_history USING INDEX idx_import_history_completed` (no `SCAN file_health`)
- [ ] `/sabnzbd?mode=history` responds in < 2 s with a populated history table
- [ ] AltMount logs show `WarnContext` entries if path mismatch is present