### PR TITLE
fix(importer): keep original NZB filename in persistent storage

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -863,11 +863,6 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 		nzbDir = filepath.Join(nzbDir, *item.Category)
 	}
 
-	// Create .nzbs directory if not exists
-	if err := os.MkdirAll(nzbDir, 0755); err != nil {
-		return fmt.Errorf("failed to create persistent NZB directory: %w", err)
-	}
-
 	// Check if current path is already in the persistent directory
 	absNzbPath, _ := filepath.Abs(item.NzbPath)
 	absNzbDir, _ := filepath.Abs(nzbDir)
@@ -877,13 +872,19 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 		return nil
 	}
 
-	// Persistent filename uses the queue ID as a suffix to guarantee uniqueness
-	// across concurrent imports without filesystem collision checks.
+	// Store each NZB in a per-ID subfolder to guarantee uniqueness without
+	// polluting the user-visible filename (which is exposed via the SABnzbd
+	// history API and parsed by Sonarr/Radarr — a trailing `_<id>` would
+	// break their release-group parser).
 	if item.ID == 0 {
 		return fmt.Errorf("cannot persist NZB without queue ID (row must be inserted first)")
 	}
+	nzbDir = filepath.Join(nzbDir, strconv.FormatInt(item.ID, 10))
+	if err := os.MkdirAll(nzbDir, 0755); err != nil {
+		return fmt.Errorf("failed to create persistent NZB directory: %w", err)
+	}
 	base := nzbtrim.TrimNzbExtension(sanitizeFilename(filepath.Base(item.NzbPath)))
-	newPath := filepath.Join(nzbDir, fmt.Sprintf("%s_%d%s", base, item.ID, nzbfile.GzExtension))
+	newPath := filepath.Join(nzbDir, base+nzbfile.GzExtension)
 
 	s.log.DebugContext(ctx, "Moving and compressing NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath)
 


### PR DESCRIPTION
## Summary

NZB downloads were arriving in Sonarr/Radarr with a trailing `_<id>` token in the filename (e.g. `Show.S01E01-GROUP_42.nzb`), which breaks the ARRs' release-group parser (they expect the release group to be the last token).

The suffix comes from `ensurePersistentNzb` in `internal/importer/service.go`, which appended the queue-row ID to the persistent NZB filename to guarantee uniqueness across concurrent imports. The persistent path is stored as `item.NzbPath` and leaks back to ARRs through the SABnzbd-compat history endpoint, which exposes `filepath.Base(item.NzbPath)` in the `name`, `nzb_name`, and `download` fields.

This PR moves the uniqueness guarantee into a per-ID subfolder so the file keeps its original base name:

- before: `<config>/.nzbs/[<cat>/]<base>_<id>.nzb.gz`
- after:  `<config>/.nzbs/[<cat>/]<id>/<base>.nzb.gz`

`filepath.Base(item.NzbPath)` now returns the clean original filename, so the SABnzbd history payload no longer carries the `_<id>` suffix.

## Notes for reviewers

- Existing queue rows from before this change keep their old suffixed paths and are **not** migrated. Only newly-added NZBs benefit. If a one-shot rename is desired for already-persisted entries we can do it as a follow-up.
- The early-return short-circuit (`strings.HasPrefix(absNzbPath, absNzbDir)`) still works — files already in `.nzbs/` are untouched.
- `MkdirAll` was relocated so it covers the new per-ID subfolder.

## Test plan

- [x] `go build ./internal/importer/...`
- [x] `go test -race ./internal/importer/...`
- [ ] Manual: queue a fresh NZB through the SABnzbd-compat endpoint, hit `GET /api/history`, confirm `name` / `nzb_name` / `download` no longer carry `_<id>`
- [ ] Manual: confirm Sonarr/Radarr correctly parses the release group on a new download