### PR TITLE
fix(streaming): coalesce ARR-repair triggers and force-unmount FUSE on recovery exhaustion

### DIFF
--- a/internal/api/fuse_handlers.go
+++ b/internal/api/fuse_handlers.go
@@ -123,9 +123,27 @@ func (m *FuseManager) recoverMount(ctx context.Context) {
 	m.mu.Unlock()
 
 	if attempt > fuseMaxRecoveryAttempts {
-		slog.ErrorContext(ctx, "FUSE recovery exhausted, staying in error state",
+		// Recovery has failed. Detach the kernel-side FUSE mount so consumers
+		// (Sonarr/Radarr/Plex/ffprobe etc.) stop blocking indefinitely on dead
+		// reads — leaving a "ghost" mount accumulates D-state processes and can
+		// take down the host (see issue #539). ForceUnmount runs
+		// `fusermount(3) -uz` / `umount -lf` under the hood.
+		slog.ErrorContext(ctx, "FUSE recovery exhausted, force-unmounting to release kernel mount",
 			"attempts", attempt-1,
 			"path", path)
+
+		if server != nil {
+			if err := server.ForceUnmount(); err != nil {
+				slog.ErrorContext(ctx, "Force unmount on recovery exhaustion failed",
+					"path", path,
+					"error", err)
+			}
+		}
+
+		m.mu.Lock()
+		m.server = nil
+		m.status = "failed"
+		m.mu.Unlock()
 		return
 	}
 

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -41,6 +41,7 @@ type MetadataRemoteFile struct {
 	aesCipher        *aes.AesCipher           // For AES encryption/decryption
 	streamTracker    StreamTracker            // Stream tracker for monitoring active streams
 	cacheSource      *segcache.Source         // Segment cache source (nil = no cache configured)
+	repairCoalescer  *RepairCoalescer         // Throttles streaming-failure repair triggers and rclone VFS refreshes
 	renameMu         sync.Mutex               // Mutex to protect rename operations from race conditions
 }
 
@@ -81,6 +82,7 @@ func NewMetadataRemoteFile(
 		aesCipher:        aesCipher,
 		streamTracker:    streamTracker,
 		cacheSource:      cacheSource,
+		repairCoalescer:  NewRepairCoalescer(rcloneClient, configGetter),
 	}
 }
 
@@ -263,6 +265,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		healthRepository: mrf.healthRepository,
 		arrsService:      mrf.arrsService,
 		rcloneClient:     mrf.rcloneClient,
+		repairCoalescer:  mrf.repairCoalescer,
 		configGetter:     mrf.configGetter,
 		poolManager:      mrf.poolManager,
 		ctx:              ctx,
@@ -773,6 +776,7 @@ type MetadataVirtualFile struct {
 	healthRepository *database.HealthRepository
 	arrsService      ARRsRepairService
 	rcloneClient     rclonecli.RcloneRcClient // RClone RC client for VFS notifications
+	repairCoalescer  *RepairCoalescer         // Throttles repair triggers; may be nil in tests
 	configGetter     config.ConfigGetter
 	poolManager      pool.Manager // Pool manager for dynamic pool access
 	ctx              context.Context
@@ -1688,7 +1692,21 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 
 // updateFileHealthOnError updates both metadata and database health status when corruption is detected.
 // Uses synchronous operations with timeout to prevent goroutine leaks.
+//
+// A streaming-failure repair trigger for the same path is debounced through the
+// shared RepairCoalescer so that repeated corrupt reads of one file (or a batch
+// of corrupt files) cannot fan out into one DB write + one rclone VFS refresh
+// per call. See issue #539 for the failure mode this guards against.
 func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usenet.DataCorruptionError, noRetry bool) {
+	// Per-path debounce: short-circuit if this file already triggered a repair
+	// inside the debounce window. ShouldTrigger handles a nil coalescer
+	// (test harness) by returning true.
+	if !mvf.repairCoalescer.ShouldTrigger(mvf.name) {
+		slog.DebugContext(mvf.ctx, "Streaming failure repair already triggered recently, debouncing",
+			"file", mvf.name)
+		return
+	}
+
 	// Use a short timeout context to prevent blocking indefinitely
 	ctx, cancel := context.WithTimeout(mvf.ctx, 5*time.Second)
 	defer cancel()
@@ -1727,22 +1745,12 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 			relativePath = strings.TrimPrefix(relativePath, "/")
 			slog.InfoContext(ctx, "Moving metadata file for corrupted item to safety folder to trigger replacement", "file_path", mvf.name)
 			if moveErr := mvf.metadataService.MoveToCorrupted(ctx, relativePath); moveErr == nil {
-				// Successfully moved metadata, notify rclone VFS refresh
-				if mvf.rcloneClient != nil {
-					go func() {
-						virtualDir := filepath.Dir(mvf.name)
-						vfsName := cfg.RClone.VFSName
-						if vfsName == "" {
-							vfsName = config.MountProvider
-						}
-						// Increased timeout to 60 seconds as vfs/refresh can be slow
-						vfsCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-						defer cancel()
-						if refreshErr := mvf.rcloneClient.RefreshDir(vfsCtx, vfsName, []string{virtualDir}); refreshErr != nil {
-							slog.ErrorContext(vfsCtx, "Failed to notify rclone VFS about file status change after streaming failure", "file", mvf.name, "err", refreshErr)
-						}
-					}()
-				}
+				// Successfully moved metadata, enqueue a coalesced rclone VFS
+				// refresh. Multiple files in the same directory collapse into a
+				// single RC call; concurrent failures across directories are
+				// batched into one call as well. EnqueueRefresh is a no-op on a
+				// nil coalescer (test harness).
+				mvf.repairCoalescer.EnqueueRefresh(filepath.Dir(mvf.name))
 			} else {
 				slog.WarnContext(ctx, "Failed to move corrupted metadata file, proceeding with repair trigger status", "error", moveErr)
 			}

--- a/internal/nzbfilesystem/repair_coalescer.go
+++ b/internal/nzbfilesystem/repair_coalescer.go
@@ -1,0 +1,181 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/pkg/rclonecli"
+)
+
+// RepairCoalescer throttles per-file streaming-failure repair triggers and
+// coalesces rclone VFS refresh calls so that a batch of corrupted reads cannot
+// fan out into one RC POST per file.
+//
+// Two mechanisms:
+//
+//  1. Per-path debounce — ShouldTrigger returns false if the same file path
+//     was triggered within the debounce window. This prevents repeated reads
+//     of the same corrupted file from re-firing the repair pipeline.
+//
+//  2. Directory-level VFS refresh coalescing — EnqueueRefresh adds a virtual
+//     directory to a pending set; a single worker goroutine drains the set,
+//     deduplicates, and issues at most one RefreshDir RC call at a time with
+//     a minimum interval between calls.
+type RepairCoalescer struct {
+	rclone       rclonecli.RcloneRcClient
+	configGetter config.ConfigGetter
+
+	debounceTTL  time.Duration
+	flushDelay   time.Duration
+	refreshTO    time.Duration
+
+	mu      sync.Mutex
+	seen    map[string]time.Time
+	pending map[string]struct{}
+
+	wakeCh chan struct{}
+	stopCh chan struct{}
+	stopWg sync.WaitGroup
+}
+
+const (
+	defaultRepairDebounceTTL = 30 * time.Second
+	defaultRefreshFlushDelay = 1 * time.Second
+	defaultRefreshTimeout    = 60 * time.Second
+)
+
+// NewRepairCoalescer constructs a coalescer and starts its background worker.
+// The worker runs for the lifetime of the process; call Close to stop it in
+// tests or during graceful shutdown.
+func NewRepairCoalescer(rclone rclonecli.RcloneRcClient, configGetter config.ConfigGetter) *RepairCoalescer {
+	c := &RepairCoalescer{
+		rclone:       rclone,
+		configGetter: configGetter,
+		debounceTTL:  defaultRepairDebounceTTL,
+		flushDelay:   defaultRefreshFlushDelay,
+		refreshTO:    defaultRefreshTimeout,
+		seen:         make(map[string]time.Time),
+		pending:      make(map[string]struct{}),
+		wakeCh:       make(chan struct{}, 1),
+		stopCh:       make(chan struct{}),
+	}
+	c.stopWg.Add(1)
+	go c.run()
+	return c
+}
+
+// ShouldTrigger reports whether a streaming-failure repair should be fired for
+// path. It returns true at most once per debounce window per path. Stale
+// entries are pruned opportunistically on each call.
+func (c *RepairCoalescer) ShouldTrigger(path string) bool {
+	if c == nil {
+		return true
+	}
+	now := time.Now()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if last, ok := c.seen[path]; ok && now.Sub(last) < c.debounceTTL {
+		return false
+	}
+	c.seen[path] = now
+
+	// Opportunistic prune: cap the map growth on long-running processes.
+	if len(c.seen) > 1024 {
+		cutoff := now.Add(-c.debounceTTL)
+		for k, t := range c.seen {
+			if t.Before(cutoff) {
+				delete(c.seen, k)
+			}
+		}
+	}
+	return true
+}
+
+// EnqueueRefresh adds virtualDir to the set of directories that will be sent
+// to rclone in the next batched vfs/refresh call. Duplicate directories within
+// the same flush window collapse to a single entry.
+func (c *RepairCoalescer) EnqueueRefresh(virtualDir string) {
+	if c == nil || c.rclone == nil || virtualDir == "" {
+		return
+	}
+	c.mu.Lock()
+	c.pending[virtualDir] = struct{}{}
+	c.mu.Unlock()
+
+	select {
+	case c.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+// Close stops the background worker. Pending refreshes are dropped.
+func (c *RepairCoalescer) Close() {
+	if c == nil {
+		return
+	}
+	select {
+	case <-c.stopCh:
+		return
+	default:
+	}
+	close(c.stopCh)
+	c.stopWg.Wait()
+}
+
+func (c *RepairCoalescer) run() {
+	defer c.stopWg.Done()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-c.wakeCh:
+		}
+
+		// Coalescing window: let a burst accumulate before flushing so that
+		// 12 concurrent streaming failures collapse into one RC call.
+		select {
+		case <-c.stopCh:
+			return
+		case <-time.After(c.flushDelay):
+		}
+
+		c.flush()
+	}
+}
+
+func (c *RepairCoalescer) flush() {
+	c.mu.Lock()
+	if len(c.pending) == 0 {
+		c.mu.Unlock()
+		return
+	}
+	dirs := make([]string, 0, len(c.pending))
+	for d := range c.pending {
+		dirs = append(dirs, d)
+	}
+	c.pending = make(map[string]struct{})
+	c.mu.Unlock()
+
+	cfg := c.configGetter()
+	vfsName := cfg.RClone.VFSName
+	if vfsName == "" {
+		vfsName = config.MountProvider
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.refreshTO)
+	defer cancel()
+
+	if err := c.rclone.RefreshDir(ctx, vfsName, dirs); err != nil {
+		slog.ErrorContext(ctx, "Failed to notify rclone VFS about file status changes after streaming failure",
+			"dir_count", len(dirs),
+			"err", err)
+		return
+	}
+	slog.DebugContext(ctx, "Coalesced rclone VFS refresh dispatched",
+		"dir_count", len(dirs))
+}

--- a/internal/nzbfilesystem/repair_coalescer_test.go
+++ b/internal/nzbfilesystem/repair_coalescer_test.go
@@ -1,0 +1,159 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// fakeRcloneClient counts RefreshDir calls and records every directory list it
+// receives, with safe concurrent access.
+type fakeRcloneClient struct {
+	mu    sync.Mutex
+	calls int32
+	dirs  []string
+}
+
+func (f *fakeRcloneClient) RefreshDir(_ context.Context, _ string, dirs []string) error {
+	atomic.AddInt32(&f.calls, 1)
+	f.mu.Lock()
+	f.dirs = append(f.dirs, dirs...)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeRcloneClient) callCount() int {
+	return int(atomic.LoadInt32(&f.calls))
+}
+
+func (f *fakeRcloneClient) collectedDirs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.dirs))
+	copy(out, f.dirs)
+	return out
+}
+
+func newTestCoalescer(t *testing.T, client *fakeRcloneClient) *RepairCoalescer {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.RClone.VFSName = "test"
+	c := NewRepairCoalescer(client, func() *config.Config { return cfg })
+	// Tighten the flush window for tests so they stay snappy.
+	c.flushDelay = 20 * time.Millisecond
+	c.debounceTTL = 100 * time.Millisecond
+	t.Cleanup(c.Close)
+	return c
+}
+
+func TestRepairCoalescer_ShouldTrigger_DebouncesByPath(t *testing.T) {
+	c := newTestCoalescer(t, &fakeRcloneClient{})
+
+	if !c.ShouldTrigger("/movies/a.mkv") {
+		t.Fatal("first call must return true")
+	}
+	if c.ShouldTrigger("/movies/a.mkv") {
+		t.Fatal("repeat call within debounce window must return false")
+	}
+	if !c.ShouldTrigger("/movies/b.mkv") {
+		t.Fatal("different path must return true")
+	}
+
+	// After the debounce TTL elapses, the path becomes triggerable again.
+	time.Sleep(c.debounceTTL + 50*time.Millisecond)
+	if !c.ShouldTrigger("/movies/a.mkv") {
+		t.Fatal("path must be triggerable again after debounce TTL")
+	}
+}
+
+func TestRepairCoalescer_ShouldTrigger_NilReceiverIsSafe(t *testing.T) {
+	var c *RepairCoalescer
+	if !c.ShouldTrigger("/foo") {
+		t.Fatal("nil coalescer must allow trigger (no-op fallback)")
+	}
+}
+
+func TestRepairCoalescer_BurstCoalescesIntoSingleRefresh(t *testing.T) {
+	client := &fakeRcloneClient{}
+	c := newTestCoalescer(t, client)
+
+	// Simulate the issue #539 scenario: 12 concurrent corrupted files in the
+	// same directory all fire EnqueueRefresh in rapid succession. Without
+	// coalescing this would produce 12 RC POSTs.
+	const burst = 12
+	var wg sync.WaitGroup
+	for i := 0; i < burst; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.EnqueueRefresh("/movies/sonarr")
+		}()
+	}
+	wg.Wait()
+
+	// Wait for the worker to flush.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if client.callCount() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := client.callCount(); got != 1 {
+		t.Fatalf("expected exactly 1 coalesced RefreshDir call, got %d", got)
+	}
+	dirs := client.collectedDirs()
+	if len(dirs) != 1 || dirs[0] != "/movies/sonarr" {
+		t.Fatalf("expected single dir entry [/movies/sonarr], got %v", dirs)
+	}
+}
+
+func TestRepairCoalescer_DistinctDirsBatchTogether(t *testing.T) {
+	client := &fakeRcloneClient{}
+	c := newTestCoalescer(t, client)
+
+	c.EnqueueRefresh("/a")
+	c.EnqueueRefresh("/b")
+	c.EnqueueRefresh("/c")
+	c.EnqueueRefresh("/a") // duplicate inside window
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if client.callCount() >= 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := client.callCount(); got != 1 {
+		t.Fatalf("expected 1 batched call, got %d", got)
+	}
+	dirs := client.collectedDirs()
+	if len(dirs) != 3 {
+		t.Fatalf("expected 3 deduped dirs, got %d (%v)", len(dirs), dirs)
+	}
+	seen := map[string]bool{}
+	for _, d := range dirs {
+		seen[d] = true
+	}
+	for _, want := range []string{"/a", "/b", "/c"} {
+		if !seen[want] {
+			t.Errorf("missing dir %q in batch (got %v)", want, dirs)
+		}
+	}
+}
+
+func TestRepairCoalescer_NilClient_NoPanic(t *testing.T) {
+	cfg := &config.Config{}
+	c := NewRepairCoalescer(nil, func() *config.Config { return cfg })
+	t.Cleanup(c.Close)
+
+	// Must not panic, and must not enqueue anything.
+	c.EnqueueRefresh("/foo")
+	time.Sleep(50 * time.Millisecond)
+}


### PR DESCRIPTION
Closes #539.

## Problem

When a batch of NZBs has expired Usenet articles (`nntp: 430 no such article`), every streaming failure synchronously fired an "immediate ARR repair" plus an async `vfs/refresh` POST to the rclone RC daemon — one per file, with no debounce. With ~12 corrupted files this storms the RC daemon at `localhost:5573`. The FUSE health monitor then tries to recover and fails after 3 attempts on `Post /config/create: context deadline exceeded`. After exhaustion, `recoverMount` simply `return`s — the kernel still holds the mount, every read on `/mnt/altmount` blocks indefinitely, consumer processes (Sonarr/Radarr/Plex/ffprobe) pile up in D-state, and the container keeps reporting healthy. In the reporter's environment the host load average reached 600 after ~16h.

## Changes

### 1. Storm throttling — `internal/nzbfilesystem/repair_coalescer.go` (new)

`RepairCoalescer` provides two mechanisms shared across all `MetadataVirtualFile` instances:

- **Per-path debounce (30s window).** `ShouldTrigger(path)` returns `true` at most once per debounce window per path; repeat reads of the same corrupted file no longer re-fire the repair pipeline.
- **Directory-level VFS-refresh coalescing.** `EnqueueRefresh(virtualDir)` adds the directory to a pending set; a single worker goroutine drains the set after a 1s flush window, dedupes, and issues at most one `RefreshDir` RC call at a time with all affected dirs batched into one request.

Result: a burst of 12 concurrent NNTP 430s in the same dir → 1 RC POST instead of 12.

Wired into `MetadataRemoteFile` via `NewRepairCoalescer` (no public signature change) and propagated to each `MetadataVirtualFile` on `OpenFile`. `updateFileHealthOnError` short-circuits via the debounce and replaces the per-file `RefreshDir` goroutine with a coalescer enqueue.

### 2. Force-unmount on FUSE recovery exhaustion — `internal/api/fuse_handlers.go`

`FuseManager.recoverMount` previously logged and `return`ed on the exhaustion path, leaving a kernel-side ghost mount. It now calls `server.ForceUnmount()` (which runs `fusermount(3) -uz` / `umount -lf` under the hood) before returning, and transitions to a new `"failed"` terminal state so future status calls reflect the dead mount.

## Tests

`internal/nzbfilesystem/repair_coalescer_test.go` — 5 race-clean tests:

- `ShouldTrigger_DebouncesByPath` — same path debounced; different paths independent; TTL expiry works.
- `ShouldTrigger_NilReceiverIsSafe` — nil-receiver no-op fallback for tests.
- `BurstCoalescesIntoSingleRefresh` — 12 concurrent enqueues for one dir collapse to exactly 1 RC call.
- `DistinctDirsBatchTogether` — 3 distinct dirs + 1 duplicate → 1 batched call with 3 deduped entries.
- `NilClient_NoPanic` — coalescer with nil client doesn't panic.

`go test -race -count=1 ./internal/nzbfilesystem ./internal/api` — pass.
`go vet ./...` — clean. Full `go build ./...` — clean.

## Reviewer notes

- This PR addresses the two highest-blast-radius items in the issue (the storm trigger and the host-killing ghost mount). Two follow-ups remain from the report and can ship in subsequent PRs:
  - Kill+respawn the rclone process during recovery if its RC has wedged (fix #3 in the plan).
  - Add an RC liveness probe to `/api/health` so Docker `HEALTHCHECK` reflects a wedged daemon (fix #4).
- Backwards compatibility: `MetadataVirtualFile.repairCoalescer` is nil-safe, so existing test fixtures that build the struct directly continue to compile and run.
- Lifecycle: the coalescer's worker goroutine has process lifetime; `Close()` is provided for test cleanup.

## Test plan

- [x] Unit tests pass with `-race`.
- [x] `go vet` and `go build` clean.
- [ ] E2E reproduction in reporter's scenario (queue ~12 NZBs with missing articles, confirm logs show coalesced refreshes and no ghost mount on simulated RC wedge — see plan's verification section).