### PR TITLE
fix(webdav): preserve password on config save instead of overwriting with mask

### DIFF
--- a/frontend/src/components/config/WebDAVConfigSection.tsx
+++ b/frontend/src/components/config/WebDAVConfigSection.tsx
@@ -23,6 +23,7 @@ export function WebDAVConfigSection({
 }: WebDAVConfigSectionProps) {
 	const [formData, setFormData] = useState<WebDAVFormData>({
 		...config.webdav,
+		password: "",
 		mount_path: config.mount_path,
 	});
 	const [hasChanges, setHasChanges] = useState(false);
@@ -30,6 +31,7 @@ export function WebDAVConfigSection({
 	useEffect(() => {
 		setFormData({
 			...config.webdav,
+			password: "",
 			mount_path: config.mount_path,
 		});
 		setHasChanges(false);
@@ -40,6 +42,7 @@ export function WebDAVConfigSection({
 		setFormData(newData);
 		const currentConfig = {
 			...config.webdav,
+			password: "",
 			mount_path: config.mount_path,
 		};
 		setHasChanges(JSON.stringify(newData) !== JSON.stringify(currentConfig));
@@ -144,6 +147,7 @@ export function WebDAVConfigSection({
 								value={formData.password}
 								readOnly={isReadOnly}
 								onChange={(e) => handleInputChange("password", e.target.value)}
+								placeholder="Leave blank to keep current password"
 							/>
 						</fieldset>
 					</div>

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -232,6 +232,11 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 		if err == nil && newConfig.RClone.RCPass == "" {
 			newConfig.RClone.RCPass = currentConfig.RClone.RCPass
 		}
+		// Preserve existing WebDAV password when the request omits or sends an empty value.
+		// The frontend sends password: "" when the user hasn't entered a new password.
+		if err == nil && newConfig.WebDAV.Password == "" {
+			newConfig.WebDAV.Password = currentConfig.WebDAV.Password
+		}
 	default:
 		return RespondValidationError(c, fmt.Sprintf("Unknown configuration section: %s", section), "INVALID_SECTION")
 	}


### PR DESCRIPTION
## Summary

- **Bug**: Opening WebDAV settings and saving (even without touching the password field) overwrote `config.yaml` with `"********"` as the literal password, breaking WebDAV authentication on restart.
- **Root cause**: `GET /api/config` masks the password as `"********"` in the response. The frontend initialised the form with that value, so every save sent `password: "********"` to the backend, which stored it verbatim.
- **Fix**: Two-part change mirroring the existing `RClone.RCPass` preservation pattern already in the codebase.

### Backend (`internal/api/config_handlers.go`)
Added WebDAV password preservation in `handlePatchConfigSection`: when the PATCH body sends an empty password, the handler restores the current stored password instead of overwriting it.

### Frontend (`frontend/src/components/config/WebDAVConfigSection.tsx`)
- Password field now initialises as `""` (not `"********"` from the API response)
- Change-detection baseline also uses `""` for password so saving other fields without touching the password doesn't trigger a spurious diff
- Added placeholder `"Leave blank to keep current password"` for UX clarity

## Test plan

- [ ] Open WebDAV settings → password field shows empty (not `"********"`)
- [ ] Save without changing password → `config.yaml` retains the real password
- [ ] Type a new password and save → `config.yaml` updates to the new value
- [ ] Save again without touching password → new password is preserved