### PR TITLE
fix(importer): route imports to normal folder, deduplicate with _1 suffix

### DIFF
--- a/internal/importer/filesystem/utils.go
+++ b/internal/importer/filesystem/utils.go
@@ -9,6 +9,7 @@ import (
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
 )
 
 // CalculateVirtualDirectory determines the virtual directory path based on NZB file location
@@ -219,4 +220,28 @@ func DetermineFileLocation(file parser.ParsedFile, baseDir string) (parentPath, 
 	virtualPath := filepath.Join(baseDir, dir)
 	virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
 	return virtualPath, name
+}
+
+// EnsureUniqueVirtualPath returns a path that is safe to write to.
+// If a healthy metadata file already exists at virtualPath, appends _1, _2, …
+// to the stem (before the extension) until an unused slot is found.
+// Non-healthy metadata is treated as available to overwrite, so the original
+// path is returned unchanged.
+func EnsureUniqueVirtualPath(virtualPath string, ms *metadata.MetadataService) string {
+	if !isHealthyMetadata(virtualPath, ms) {
+		return virtualPath
+	}
+	ext := filepath.Ext(virtualPath)
+	stem := strings.TrimSuffix(virtualPath, ext)
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s_%d%s", stem, i, ext)
+		if !isHealthyMetadata(candidate, ms) {
+			return candidate
+		}
+	}
+}
+
+func isHealthyMetadata(virtualPath string, ms *metadata.MetadataService) bool {
+	meta, err := ms.ReadFileMetadata(virtualPath)
+	return err == nil && meta != nil && meta.Status == metapb.FileStatus_FILE_STATUS_HEALTHY
 }

--- a/internal/importer/filesystem/utils_test.go
+++ b/internal/importer/filesystem/utils_test.go
@@ -1,9 +1,15 @@
 package filesystem
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/javi11/altmount/internal/importer/parser"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -168,4 +174,62 @@ func TestSeparateFiles_MultiFile(t *testing.T) {
 	if len(par2) != 1 {
 		t.Errorf("expected 1 par2, got %d", len(par2))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// EnsureUniqueVirtualPath
+// ---------------------------------------------------------------------------
+
+func newTestMetadataService(t *testing.T) *metadata.MetadataService {
+	t.Helper()
+	return metadata.NewMetadataService(t.TempDir())
+}
+
+func writeHealthyMeta(t *testing.T, ms *metadata.MetadataService, virtualPath string) {
+	t.Helper()
+	dir := filepath.Dir(virtualPath)
+	if dir != "" && dir != "/" && dir != "." {
+		require.NoError(t, os.MkdirAll(ms.GetMetadataDirectoryPath(dir), 0755))
+	}
+	fileMeta := ms.CreateFileMetadata(
+		1000, "/fake/nzb.nzb.gz",
+		metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, fileMeta))
+}
+
+func TestEnsureUniqueVirtualPath_NoConflict(t *testing.T) {
+	ms := newTestMetadataService(t)
+	result := EnsureUniqueVirtualPath("/complete/tv/show.S01E01.mkv", ms)
+	assert.Equal(t, "/complete/tv/show.S01E01.mkv", result)
+}
+
+func TestEnsureUniqueVirtualPath_OneConflict(t *testing.T) {
+	ms := newTestMetadataService(t)
+	writeHealthyMeta(t, ms, "/complete/tv/show.S01E01.mkv")
+	result := EnsureUniqueVirtualPath("/complete/tv/show.S01E01.mkv", ms)
+	assert.Equal(t, "/complete/tv/show.S01E01_1.mkv", result)
+}
+
+func TestEnsureUniqueVirtualPath_TwoConflicts(t *testing.T) {
+	ms := newTestMetadataService(t)
+	writeHealthyMeta(t, ms, "/complete/tv/show.S01E01.mkv")
+	writeHealthyMeta(t, ms, "/complete/tv/show.S01E01_1.mkv")
+	result := EnsureUniqueVirtualPath("/complete/tv/show.S01E01.mkv", ms)
+	assert.Equal(t, "/complete/tv/show.S01E01_2.mkv", result)
+}
+
+func TestEnsureUniqueVirtualPath_UnhealthyNotDeduplicated(t *testing.T) {
+	ms := newTestMetadataService(t)
+	dir := "/complete/tv"
+	require.NoError(t, os.MkdirAll(ms.GetMetadataDirectoryPath(dir), 0755))
+	fileMeta := ms.CreateFileMetadata(
+		1000, "/fake/nzb.nzb.gz",
+		metapb.FileStatus_FILE_STATUS_CORRUPTED,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata("/complete/tv/show.S01E01.mkv", fileMeta))
+	result := EnsureUniqueVirtualPath("/complete/tv/show.S01E01.mkv", ms)
+	assert.Equal(t, "/complete/tv/show.S01E01.mkv", result)
 }

--- a/internal/importer/multifile/processor.go
+++ b/internal/importer/multifile/processor.go
@@ -93,14 +93,9 @@ func ProcessRegularFiles(
 			virtualPath := filepath.Join(parentPath, filename)
 			virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
 
-			if existingMeta, err := metadataService.ReadFileMetadata(virtualPath); err == nil && existingMeta != nil {
-				if existingMeta.Status == metapb.FileStatus_FILE_STATUS_HEALTHY {
-					slog.InfoContext(ctx, "Skipping re-import of healthy file",
-						"file", filename,
-						"virtual_path", virtualPath)
-					return nil
-				}
-			}
+			// If a healthy file already exists, generate a unique path (_1, _2, …)
+			// so the new import lands alongside the existing one.
+			virtualPath = filesystem.EnsureUniqueVirtualPath(virtualPath, metadataService)
 
 			if !utils.IsAllowedFile(filename, file.Size, allowedFileExtensions, filterSamples) {
 				return nil

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -770,6 +770,18 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 					cleanRel = ""
 				}
 
+				// Strip the queue_id subfolder added by ensurePersistentNzb.
+				// Storage structure: .nzbs/{category}/{queue_id}/filename.nzb.gz
+				// The numeric ID must not leak into the virtual destination path.
+				if item.ID != 0 {
+					queueIDStr := strconv.FormatInt(item.ID, 10)
+					if cleanRel == queueIDStr {
+						cleanRel = ""
+					} else if after, ok := strings.CutSuffix(cleanRel, "/"+queueIDStr); ok {
+						cleanRel = after
+					}
+				}
+
 				cleanBase := filepath.ToSlash(*basePath)
 				// Avoid duplication if basePath already starts with relDir (common with Watcher or manual imports)
 				// We only apply this reconstruction if basePath is empty or root, otherwise we trust basePath

--- a/internal/importer/service_path_test.go
+++ b/internal/importer/service_path_test.go
@@ -29,6 +29,7 @@ func TestCalculateProcessVirtualDir_FailedPath(t *testing.T) {
 		nzbPath      string
 		basePath     string
 		category     string
+		itemID       int64
 		expectedPath string
 	}{
 		{
@@ -63,12 +64,44 @@ func TestCalculateProcessVirtualDir_FailedPath(t *testing.T) {
 			basePath:     "Plex_Media/Series/Show (2026)/Season 01",
 			expectedPath: "/mnt/remotes/altmount/Plex_Media/Series/Show (2026)/Season 01",
 		},
+		{
+			name:         "nzb in queue_id subfolder (no basePath)",
+			nzbPath:      "/config/.nzbs/tv/22/Show.S01E01.nzb.gz",
+			basePath:     "",
+			category:     "tv",
+			itemID:       22,
+			expectedPath: "/mnt/remotes/altmount/tv",
+		},
+		{
+			name:         "nzb in queue_id subfolder with basePath",
+			nzbPath:      "/config/.nzbs/tv/22/Show.S01E01.nzb.gz",
+			basePath:     "media",
+			category:     "tv",
+			itemID:       22,
+			expectedPath: "/mnt/remotes/altmount/media/tv",
+		},
+		{
+			name:         "failed nzb in queue_id subfolder",
+			nzbPath:      "/config/.nzbs/failed/tv/22/Show.S01E01.nzb.gz",
+			basePath:     "",
+			category:     "tv",
+			itemID:       22,
+			expectedPath: "/mnt/remotes/altmount/tv",
+		},
+		{
+			name:         "nzb in queue_id subfolder no category",
+			nzbPath:      "/config/.nzbs/22/Show.S01E01.nzb.gz",
+			basePath:     "",
+			itemID:       22,
+			expectedPath: "/mnt/remotes/altmount",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			item := &database.ImportQueueItem{
 				NzbPath: filepath.FromSlash(tt.nzbPath),
+				ID:      tt.itemID,
 			}
 			if tt.category != "" {
 				item.Category = &tt.category

--- a/internal/importer/singlefile/processor.go
+++ b/internal/importer/singlefile/processor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/utils"
 	"github.com/javi11/altmount/internal/importer/validation"
@@ -43,19 +44,13 @@ func ProcessSingleFile(
 		return "", "", fmt.Errorf("file '%s' does not match allowed extensions (allowed: %v)", file.Filename, allowedFileExtensions)
 	}
 
-	// Create virtual file path
+	// Create virtual file path, then ensure it is unique.
+	// If a healthy file already exists at this path, a _1, _2, … suffix is
+	// appended to the stem so the new import lands alongside the existing one
+	// rather than being silently skipped.
 	virtualFilePath := filepath.Join(virtualDir, file.Filename)
 	virtualFilePath = strings.ReplaceAll(virtualFilePath, string(filepath.Separator), "/")
-
-	// Check if file already exists and is healthy
-	if existingMeta, err := metadataService.ReadFileMetadata(virtualFilePath); err == nil && existingMeta != nil {
-		if existingMeta.Status == metapb.FileStatus_FILE_STATUS_HEALTHY {
-			slog.InfoContext(ctx, "Skipping re-import of healthy file",
-				"file", file.Filename,
-				"virtual_path", virtualFilePath)
-			return virtualDir, "", nil
-		}
-	}
+	virtualFilePath = filesystem.EnsureUniqueVirtualPath(virtualFilePath, metadataService)
 
 	// Double check if this specific file is allowed
 	if !utils.IsAllowedFile(file.Filename, file.Size, allowedFileExtensions, filterSamples) {


### PR DESCRIPTION
## Summary

- **Fix destination path**: Files imported via the web UI (no `relativePath`) were landing in `/complete/{category}/{queue_id}/` because `calculateProcessVirtualDir` computed `cleanRel` as `{category}/{item.ID}` when reading the persistent `.nzbs` path, and only stripped `failed/` — not the trailing numeric ID. Now the queue_id component is explicitly stripped so files land in `/complete/{category}/` (single-file) or `/complete/{category}/ReleaseName/` (multi-file). The NZB itself remains safely in `.nzbs/{category}/{id}/`.
- **Duplicate handling**: Both single-file and multi-file processors previously skipped re-imports of healthy files with an early `return nil`. They now call `filesystem.EnsureUniqueVirtualPath` which appends `_1`, `_2`, … to the stem (before extension) until an unused virtual path is found. Non-healthy (corrupted/unspecified) metadata is still overwritten as before.

## Changes

| File | What changed |
|------|-------------|
| `internal/importer/service.go` | Strip `/{item.ID}` from `.nzbs`-relative path in `calculateProcessVirtualDir` |
| `internal/importer/service_path_test.go` | 4 new test cases covering queue_id subfolder scenarios |
| `internal/importer/filesystem/utils.go` | Add `EnsureUniqueVirtualPath` + `isHealthyMetadata` helpers |
| `internal/importer/filesystem/utils_test.go` | 4 tests: no-conflict, one-conflict, two-conflicts, unhealthy-no-dedup |
| `internal/importer/singlefile/processor.go` | Replace healthy-file skip with `EnsureUniqueVirtualPath` call |
| `internal/importer/multifile/processor.go` | Replace healthy-file skip with `EnsureUniqueVirtualPath` call |

## Test plan

- [ ] All importer unit tests pass: `go test ./internal/importer/... -race`
- [ ] Add NZB via web UI with a category → confirm virtual path is `/complete/{category}/…` (no numeric subfolder)
- [ ] Add the same NZB a second time → confirm a `_1`-suffixed entry appears instead of a silent skip