### PR TITLE
fix(sabnzbd): widen history window + direct nzo_id lookup for *arr (#543)

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -746,17 +746,35 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 		}
 	}
 
+	// When *arr asks for specific nzo_ids, look them up directly so the response
+	// is independent of the bulk retention window. This is the path Sonarr/Radarr
+	// use to confirm a known download by id, and it must succeed regardless of
+	// how old the entry is — see issue #543.
+	if len(nzoIDs) > 0 {
+		return s.respondSABnzbdHistoryByIDs(c, ctx, nzoIDs, categoryFilter, start, limit)
+	}
+
+	// Determine how far back to look in persistent history. Default to 7 days
+	// (10080 minutes) and allow operators to widen further via config. Clients
+	// rebuilding large libraries with multiple *arrs can otherwise outrun the
+	// previous 24h window and lose visibility of completed imports.
+	historyMinutes := 10080
+	if s.configManager != nil {
+		if v := s.configManager.GetConfig().SABnzbd.HistoryRetentionMinutes; v > 0 {
+			historyMinutes = v
+		}
+	}
+
 	// Fetch items from active queue
 	// We use a larger set here to ensure we get everything for deduplication and combined history
 	completedStatus := database.QueueStatusCompleted
-	completedQueueItems, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, "", categoryFilter, 500, 0, "updated_at", "desc")
+	completedQueueItems, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, "", categoryFilter, 2000, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get completed items from queue")
 	}
 
 	// Get recent items from persistent history (buffer for Sonarr)
-	// We look back 24 hours to be safe
-	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, 1440, categoryFilter)
+	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, historyMinutes, categoryFilter)
 	if err != nil {
 		recentHistory = []*database.ImportHistory{} // Fallback
 	}
@@ -889,6 +907,128 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	}
 
 	return s.writeSABnzbdResponseFiber(c, response)
+}
+
+// respondSABnzbdHistoryByIDs returns a SABnzbd history response containing only
+// the rows that match the supplied nzo_ids. It looks each id up directly in the
+// queue and persistent history tables, bypassing the bulk retention window so
+// *arr clients can always reconcile a download they previously saw — even days
+// or weeks later. See issue #543.
+func (s *Server) respondSABnzbdHistoryByIDs(
+	c *fiber.Ctx,
+	ctx context.Context,
+	nzoIDs map[string]bool,
+	categoryFilter string,
+	start, limit int,
+) error {
+	finalItems := make([]*database.ImportQueueItem, 0, len(nzoIDs))
+	seen := make(map[int64]bool, len(nzoIDs))
+
+	categoryMatches := func(cat *string) bool {
+		if categoryFilter == "" {
+			return true
+		}
+		if cat == nil {
+			return false
+		}
+		return strings.EqualFold(*cat, categoryFilter)
+	}
+
+	for raw := range nzoIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+
+		// 1. Numeric id → queue first, then history.nzb_id.
+		if numericID, err := strconv.ParseInt(id, 10, 64); err == nil {
+			if item, err := s.queueRepo.GetQueueItem(ctx, numericID); err == nil && item != nil {
+				if !item.SkipArrNotification && categoryMatches(item.Category) && !seen[item.ID] {
+					finalItems = append(finalItems, item)
+					seen[item.ID] = true
+				}
+				continue
+			}
+			if h, err := s.queueRepo.GetImportHistoryByNzbID(ctx, numericID); err == nil && h != nil {
+				if categoryMatches(h.Category) && !seen[h.ID] {
+					finalItems = append(finalItems, importHistoryToQueueItem(h))
+					seen[h.ID] = true
+				}
+				continue
+			}
+		}
+
+		// 2. String id → queue.download_id, then history.download_id.
+		if item, err := s.queueRepo.GetQueueItemByDownloadID(ctx, id); err == nil && item != nil {
+			if !item.SkipArrNotification && categoryMatches(item.Category) && !seen[item.ID] {
+				finalItems = append(finalItems, item)
+				seen[item.ID] = true
+			}
+			continue
+		}
+		if h, err := s.queueRepo.GetImportHistoryByDownloadID(ctx, id); err == nil && h != nil {
+			if categoryMatches(h.Category) && !seen[h.ID] {
+				finalItems = append(finalItems, importHistoryToQueueItem(h))
+				seen[h.ID] = true
+			}
+		}
+	}
+
+	totalAvailableCount := len(finalItems)
+
+	if start < len(finalItems) {
+		finalItems = finalItems[start:]
+	} else {
+		finalItems = []*database.ImportQueueItem{}
+	}
+	if limit > 0 && len(finalItems) > limit {
+		finalItems = finalItems[:limit]
+	}
+
+	slots := make([]SABnzbdHistorySlot, 0, len(finalItems))
+	var totalBytes int64
+	itemBasePath := s.calculateItemBasePath()
+	for i, item := range finalItems {
+		finalPath := s.calculateHistoryStoragePath(item, itemBasePath)
+		slot := ToSABnzbdHistorySlot(item, start+i, finalPath)
+		slots = append(slots, slot)
+		totalBytes += slot.Bytes
+	}
+
+	response := SABnzbdCompleteHistoryResponse{
+		History: SABnzbdHistoryObject{
+			Slots:     slots,
+			TotalSize: formatHumanSize(totalBytes),
+			MonthSize: "0 B",
+			WeekSize:  "0 B",
+			Version:   "4.5.0",
+			DaySize:   "0 B",
+			Noofslots: totalAvailableCount,
+		},
+	}
+	return s.writeSABnzbdResponseFiber(c, response)
+}
+
+// importHistoryToQueueItem adapts a persistent ImportHistory row into the
+// ImportQueueItem shape used by ToSABnzbdHistorySlot.
+func importHistoryToQueueItem(h *database.ImportHistory) *database.ImportQueueItem {
+	id := h.ID
+	if h.NzbID != nil {
+		id = *h.NzbID
+	}
+	completedAt := h.CompletedAt
+	fileSize := h.FileSize
+	virtualPath := h.VirtualPath
+	return &database.ImportQueueItem{
+		ID:          id,
+		DownloadID:  h.DownloadID,
+		NzbPath:     h.NzbName,
+		Status:      database.QueueStatusCompleted,
+		FileSize:    &fileSize,
+		CompletedAt: &completedAt,
+		Category:    h.Category,
+		StoragePath: &virtualPath,
+	}
 }
 
 // handleSABnzbdHistoryDelete handles deleting items from history

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -372,6 +372,11 @@ type SABnzbdConfig struct {
 	CompleteDir           string            `yaml:"complete_dir" mapstructure:"complete_dir" json:"complete_dir"`
 	DownloadClientBaseURL string            `yaml:"download_client_base_url" mapstructure:"download_client_base_url" json:"download_client_base_url,omitempty"`
 	Categories            []SABnzbdCategory `yaml:"categories" mapstructure:"categories" json:"categories"`
+	// HistoryRetentionMinutes controls how far back the SABnzbd-emulating history
+	// endpoint looks into import_history when *arr clients poll without a specific
+	// nzo_id filter. Older entries are still returned when *arr asks for them by
+	// nzo_id. Defaults to 10080 (7 days).
+	HistoryRetentionMinutes int `yaml:"history_retention_minutes" mapstructure:"history_retention_minutes" json:"history_retention_minutes,omitempty"`
 	// Fallback configuration for sending failed imports to external SABnzbd
 	FallbackHost   string `yaml:"fallback_host" mapstructure:"fallback_host" json:"fallback_host"`
 	FallbackAPIKey string `yaml:"fallback_api_key" mapstructure:"fallback_api_key" json:"fallback_api_key"` // Masked in API responses
@@ -663,6 +668,11 @@ func (c *Config) Validate() error {
 		c.Fuse.Enabled = &falseVal
 	default:
 		return fmt.Errorf("invalid mount_type: %s (must be none, rclone, fuse, or rclone_external)", c.MountType)
+	}
+
+	// Apply default history retention for older configs that pre-date the field.
+	if c.SABnzbd.HistoryRetentionMinutes <= 0 {
+		c.SABnzbd.HistoryRetentionMinutes = 10080
 	}
 
 	// Validate SABnzbd configuration
@@ -1428,8 +1438,9 @@ func DefaultConfig(configDir ...string) *Config {
 					Priority: 4,
 				},
 			},
-			FallbackHost:   "",
-			FallbackAPIKey: "",
+			FallbackHost:            "",
+			FallbackAPIKey:          "",
+			HistoryRetentionMinutes: 10080,
 		},
 		Providers: []ProviderConfig{},
 		Nzblnk: NzblnkConfig{

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1019,6 +1019,30 @@ func (r *Repository) GetImportHistoryByDownloadID(ctx context.Context, downloadI
 	return &h, nil
 }
 
+// GetImportHistoryByNzbID retrieves an import history item by its original NZB ID
+// (the integer ID of the queue row that produced this history entry). Returns
+// (nil, nil) when no matching row exists.
+func (r *Repository) GetImportHistoryByNzbID(ctx context.Context, nzbID int64) (*ImportHistory, error) {
+	query := `
+		SELECT h.id, h.download_id, h.nzb_id, h.nzb_name, h.file_name, h.file_size, h.virtual_path, f.library_path, h.category, h.completed_at
+		FROM import_history h
+		LEFT JOIN file_health f ON TRIM(h.virtual_path, '/') = TRIM(f.file_path, '/')
+		WHERE h.nzb_id = ?
+		LIMIT 1
+	`
+
+	var h ImportHistory
+	err := r.db.QueryRowContext(ctx, query, nzbID).Scan(&h.ID, &h.DownloadID, &h.NzbID, &h.NzbName, &h.FileName, &h.FileSize, &h.VirtualPath, &h.LibraryPath, &h.Category, &h.CompletedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get import history by nzb_id: %w", err)
+	}
+
+	return &h, nil
+}
+
 // GetImportHistoryByPath retrieves an import history item by its virtual path
 func (r *Repository) GetImportHistoryByPath(ctx context.Context, virtualPath string) (*ImportHistory, error) {
 	query := `


### PR DESCRIPTION
## Summary

Fixes intermittent *"path does not exist / no files eligible for import"* errors reported in [#543](https://github.com/javi11/altmount/issues/543) when rebuilding large libraries with multiple *arr instances.

Sonarr/Radarr poll AltMount's SABnzbd-emulating `/sabnzbd/api?mode=history` endpoint to reconcile completed downloads. The previous implementation capped the response at:

- top **500** most recent completed queue rows
- last **1440 minutes (24h)** of `import_history`
- and applied the `nzo_ids` filter *after* those caps

During heavy import bursts, an entry that completed >24h ago and was pushed past the top-500 rows silently disappeared from history. The next *arr poll for that nzo_id returned nothing → reported as failed.

## Changes

- **Direct lookup when `nzo_ids` is supplied** — bypasses the bulk window entirely. Looks each id up in queue (by integer id and `download_id`) and `import_history` (by `nzb_id` and `download_id`). A known download is always reconcilable regardless of age.
- **Wider default window** — unfiltered polls now look back **7 days** (10080 minutes). Configurable via the new `SABnzbd.HistoryRetentionMinutes` field (with a validate-time fallback so existing configs get the new default automatically).
- **Higher completed-queue cap** — 500 → 2000 (pagination still applied later, so the wire payload doesn't grow unless requested).
- **New repository method** `GetImportHistoryByNzbID` mirroring the existing `GetImportHistoryByDownloadID`.

Out of scope: the symlink/path generation in `calculateHistoryStoragePath` could also contribute to the reporter's symptoms in some cases — that warrants a separate look.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race -count=1 ./...` all green
- [ ] Manual: with `import_history` rows aged past 24h, poll `/sabnzbd/api?mode=history&nzo_ids=<id>` and confirm the row appears in `slots`
- [ ] Manual: poll without `nzo_ids` and confirm rows up to 7 days old appear
- [ ] Manual: refresh download client in Sonarr after seeding aged history → no "path does not exist" error

Fixes #543