### PR TITLE
feat(importer): bound import_history growth via shared retention

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -160,7 +160,7 @@ import:
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)
                  # Windows example: 'C:\Users\user\Videos'
   skip_health_check: true # Bypass Usenet article validation during import (default: true)
-  failed_item_retention_hours: 24 # Auto-remove failed queue items and NZB files after this many hours (0 to disable, default: 24)
+  import_retention_hours: 24 # Auto-remove failed queue items, their NZB files, and old import history rows after this many hours (0 to disable, default: 24)
 
 # Health monitoring configuration
 health:

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -4492,10 +4492,10 @@ components:
           type: array
         expand_bluray_iso:
           type: boolean
-        failed_item_retention_hours:
-          type: integer
         import_dir:
           type: string
+        import_retention_hours:
+          type: integer
         import_strategy:
           $ref: "#/components/schemas/config.ImportStrategy"
         max_download_prefetch:

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1156,10 +1156,10 @@ definitions:
         type: array
       expand_bluray_iso:
         type: boolean
-      failed_item_retention_hours:
-        type: integer
       import_dir:
         type: string
+      import_retention_hours:
+        type: integer
       import_strategy:
         $ref: '#/definitions/config.ImportStrategy'
       max_download_prefetch:

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -536,23 +536,23 @@ export function ImportConfigSection({
 					</div>
 
 					<fieldset className="fieldset min-w-0">
-						<legend className="fieldset-legend font-semibold">Failed Item Retention (Hours)</legend>
+						<legend className="fieldset-legend font-semibold">Import Retention (Hours)</legend>
 						<input
 							type="number"
 							className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
-							value={formData.failed_item_retention_hours ?? 0}
+							value={formData.import_retention_hours ?? 0}
 							readOnly={isReadOnly}
 							min={0}
 							onChange={(e) =>
 								handleInputChange(
-									"failed_item_retention_hours",
+									"import_retention_hours",
 									Number.parseInt(e.target.value, 10) || 0,
 								)
 							}
 						/>
 						<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
-							Auto-remove failed queue items and their NZB files after this many hours. Set to 0 to
-							disable.
+							Auto-remove failed queue items (and their NZB files) and old import history rows after
+							this many hours. Set to 0 to disable.
 						</p>
 					</fieldset>
 				</div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -227,7 +227,7 @@ export interface ImportConfig {
 	allow_nested_rar_extraction?: boolean;
 	rename_to_nzb_name?: boolean;
 	filter_sample_files?: boolean;
-	failed_item_retention_hours?: number | null;
+	import_retention_hours?: number | null;
 	delete_completed_nzb?: boolean;
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -274,7 +274,9 @@ type ImportConfig struct {
 	ExpandBlurayIso                *bool          `yaml:"expand_bluray_iso" mapstructure:"expand_bluray_iso" json:"expand_bluray_iso,omitempty"`
 	RenameToNzbName                *bool          `yaml:"rename_to_nzb_name" mapstructure:"rename_to_nzb_name" json:"rename_to_nzb_name,omitempty"`
 	FilterSampleFiles              *bool          `yaml:"filter_sample_files" mapstructure:"filter_sample_files" json:"filter_sample_files,omitempty"`
-	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
+	// ImportRetentionHours controls how long failed import_queue items AND import_history
+	// rows are kept before being auto-deleted. <=0 (or nil) disables both cleanups.
+	ImportRetentionHours           *int           `yaml:"import_retention_hours" mapstructure:"import_retention_hours" json:"import_retention_hours,omitempty"`
 	DeleteCompletedNzb             *bool          `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
 }
 
@@ -1244,7 +1246,7 @@ func DefaultConfig(configDir ...string) *Config {
 	stremioEnabled := false    // Stremio endpoint disabled by default
 	prowlarrEnabled := false   // Prowlarr integration disabled by default
 	watchIntervalSeconds := 10        // Default watch interval
-	failedItemRetentionHours := 24    // Default: auto-remove failed items after 24 hours
+	importRetentionHours := 24        // Default: auto-remove failed items + import history after 24 hours
 	cleanupAutomaticImportFailure := false
 	metadataBackupEnabled := false
 	failureMaskingEnabled := true
@@ -1380,7 +1382,7 @@ func DefaultConfig(configDir ...string) *Config {
 			ImportDir:               nil,                // No default import directory
 			WatchDir:                nil,
 			WatchIntervalSeconds:    &watchIntervalSeconds,
-			FailedItemRetentionHours: &failedItemRetentionHours,
+			ImportRetentionHours:    &importRetentionHours,
 		},
 		Log: LogConfig{
 			File:       logPath, // Default log file path

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -813,6 +813,18 @@ func (r *QueueRepository) ResetStaleItems(ctx context.Context) error {
 	return nil
 }
 
+// DeleteImportHistoryOlderThan removes rows from import_history with completed_at older than cutoff.
+// Returns the number of rows deleted. import_daily_stats is intentionally NOT modified — it stores
+// pre-aggregated stats meant to outlive raw history rows.
+func (r *QueueRepository) DeleteImportHistoryOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM import_history WHERE completed_at < ?`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete old import history: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
 // ClearImportHistory deletes all records from the import_history and import_daily_stats tables
 func (r *QueueRepository) ClearImportHistory(ctx context.Context) error {
 	// Clear history records

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1161,10 +1161,12 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 	}
 }
 
-// runFailedItemCleanup periodically removes stale failed queue items and their NZB files.
+// runFailedItemCleanup periodically removes stale failed queue items, their NZB files,
+// and old import_history rows.
 func (s *Service) runFailedItemCleanup(ctx context.Context) {
 	// Run once at startup
 	s.cleanupFailedItems(ctx)
+	s.cleanupOldHistory(ctx)
 
 	ticker := time.NewTicker(1 * time.Hour)
 	defer ticker.Stop()
@@ -1175,7 +1177,32 @@ func (s *Service) runFailedItemCleanup(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.cleanupFailedItems(ctx)
+			s.cleanupOldHistory(ctx)
 		}
+	}
+}
+
+// cleanupOldHistory deletes import_history rows older than the configured retention period.
+func (s *Service) cleanupOldHistory(ctx context.Context) {
+	cfg := s.configGetter()
+	retentionHours := 0
+	if cfg.Import.ImportRetentionHours != nil {
+		retentionHours = *cfg.Import.ImportRetentionHours
+	}
+	if retentionHours <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-time.Duration(retentionHours) * time.Hour)
+	deleted, err := s.database.Repository.DeleteImportHistoryOlderThan(ctx, cutoff)
+	if err != nil {
+		s.log.ErrorContext(ctx, "Failed to cleanup old import history", "error", err)
+		return
+	}
+	if deleted > 0 {
+		s.log.InfoContext(ctx, "Cleaned up old import history",
+			"count", deleted,
+			"retention_hours", retentionHours)
 	}
 }
 
@@ -1184,8 +1211,8 @@ func (s *Service) runFailedItemCleanup(ctx context.Context) {
 func (s *Service) cleanupFailedItems(ctx context.Context) {
 	cfg := s.configGetter()
 	retentionHours := 0
-	if cfg.Import.FailedItemRetentionHours != nil {
-		retentionHours = *cfg.Import.FailedItemRetentionHours
+	if cfg.Import.ImportRetentionHours != nil {
+		retentionHours = *cfg.Import.ImportRetentionHours
 	}
 
 	if retentionHours <= 0 {


### PR DESCRIPTION
## Summary

`import_history` was growing without bound — no retention/cleanup ever ran against it. Only failed `import_queue` items were pruned (via `failed_item_retention_hours`).

This PR introduces a single shared retention period that governs both:
- failed `import_queue` items (existing behavior)
- old `import_history` rows (new)

The config field is renamed `failed_item_retention_hours` → `import_retention_hours` since it no longer applies only to failed items. Default stays at 24h; set `<= 0` to disable both cleanups. The existing hourly cleanup goroutine in the importer service is reused (no new ticker).

`import_daily_stats` is intentionally untouched — it's pre-aggregated and meant to outlive raw history rows.

## Changes

- `internal/config/manager.go`: rename field + yaml/json tags, update default var name and comment
- `internal/database/queue_repository.go`: add `DeleteImportHistoryOlderThan(ctx, cutoff)`
- `internal/importer/service.go`: add `cleanupOldHistory`, wire into `runFailedItemCleanup` (startup + hourly tick)
- `frontend/src/types/config.ts` + `WorkersConfigSection.tsx`: rename property, update label to "Import Retention (Hours)" and helper text
- `config.sample.yaml`, `docs/static/swagger.yaml`, `docs/static/openapi.yaml`: rename + update descriptions

## Breaking change

⚠️ Users with `failed_item_retention_hours` in their YAML/JSON config must rename it to `import_retention_hours`. Old key is no longer read.

## Test plan

- [ ] `go build ./...` succeeds (verified locally)
- [ ] Frontend `tsc --noEmit` + biome check pass (verified locally)
- [ ] Set `import_retention_hours: 1`, insert an `import_history` row with `completed_at = now() - 2h` via SQL, restart server → row deleted on startup
- [ ] Set `import_retention_hours: 0` → no rows deleted from either `import_history` or failed `import_queue`
- [ ] Confirm `import_daily_stats` rows are untouched after history cleanup runs
- [ ] Frontend: config form shows "Import Retention (Hours)" label and persists value through API roundtrip