### PR TITLE
feat: secondary NNTP pool for imports/health checks + UI

### DIFF
--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -144,6 +144,16 @@ func setupNNTPPool(ctx context.Context, cfg *config.Config, poolManager pool.Man
 	} else {
 		slog.InfoContext(ctx, "Starting server without NNTP providers - configure via API to enable downloads")
 	}
+
+	if len(cfg.ImportProviders) > 0 {
+		importProviders := cfg.ToImportNNTPProviders()
+		if err := poolManager.SetImportProviders(importProviders); err != nil {
+			slog.ErrorContext(ctx, "failed to create import NNTP pool", "err", err)
+			return err
+		}
+		slog.InfoContext(ctx, "Import NNTP connection pool initialized", "provider_count", len(cfg.ImportProviders))
+	}
+
 	return nil
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -809,6 +809,41 @@ export class APIClient {
 		});
 	}
 
+	// Import provider endpoints (secondary pool for health checks and imports)
+	async testImportProviderSpeed(id: string) {
+		return this.request<{ speed_mbps: number; duration_seconds: number }>(
+			`/import-providers/${id}/speedtest`,
+			{ method: "POST" },
+		);
+	}
+
+	async createImportProvider(data: ProviderCreateRequest) {
+		return this.request<ProviderConfig>("/import-providers", {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	}
+
+	async updateImportProvider(id: string, data: Partial<ProviderUpdateRequest>) {
+		return this.request<ProviderConfig>(`/import-providers/${id}`, {
+			method: "PUT",
+			body: JSON.stringify(data),
+		});
+	}
+
+	async deleteImportProvider(id: string) {
+		return this.request<{ message: string }>(`/import-providers/${id}`, {
+			method: "DELETE",
+		});
+	}
+
+	async reorderImportProviders(data: ProviderReorderRequest) {
+		return this.request<ProviderConfig[]>("/import-providers/reorder", {
+			method: "PUT",
+			body: JSON.stringify(data),
+		});
+	}
+
 	// Manual Scan endpoints
 	async startManualScan(data: ManualScanRequest) {
 		return this.request<ScanStatusResponse>("/import/scan", {

--- a/frontend/src/components/config/ProviderModal.tsx
+++ b/frontend/src/components/config/ProviderModal.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Check, Loader, Save, Wifi } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useToast } from "../../contexts/ToastContext";
+import { useImportProviders } from "../../hooks/useImportProviders";
 import { useProviders } from "../../hooks/useProviders";
 import type { ProviderConfig, ProviderFormData } from "../../types/config";
 
@@ -9,6 +10,7 @@ interface ProviderModalProps {
 	provider?: ProviderConfig | null;
 	onSuccess: () => void;
 	onCancel: () => void;
+	variant?: "providers" | "import_providers";
 }
 
 const BYTES_PER_GB = 1_073_741_824;
@@ -33,7 +35,13 @@ const defaultFormData: ProviderFormData = {
 	quota_period_hours: 0,
 };
 
-export function ProviderModal({ mode, provider, onSuccess, onCancel }: ProviderModalProps) {
+export function ProviderModal({
+	mode,
+	provider,
+	onSuccess,
+	onCancel,
+	variant = "providers",
+}: ProviderModalProps) {
 	const [formData, setFormData] = useState<ProviderFormData>(defaultFormData);
 	const [isTestingConnection, setIsTestingConnection] = useState(false);
 	const [connectionTestResult, setConnectionTestResult] = useState<{
@@ -45,7 +53,11 @@ export function ProviderModal({ mode, provider, onSuccess, onCancel }: ProviderM
 	const [quotaEnabled, setQuotaEnabled] = useState(false);
 	const [quotaGbInput, setQuotaGbInput] = useState("");
 
-	const { testProvider, createProvider, updateProvider } = useProviders();
+	const regularHooks = useProviders();
+	const importHooks = useImportProviders();
+	const { testProvider } = regularHooks;
+	const { createProvider, updateProvider } =
+		variant === "import_providers" ? importHooks : regularHooks;
 	const { showToast } = useToast();
 
 	// Initialize form data when provider changes

--- a/frontend/src/components/config/ProvidersConfigSection.tsx
+++ b/frontend/src/components/config/ProvidersConfigSection.tsx
@@ -14,6 +14,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { useConfirm } from "../../contexts/ModalContext";
 import { useToast } from "../../contexts/ToastContext";
+import { useImportProviders } from "../../hooks/useImportProviders";
 import { useProviders } from "../../hooks/useProviders";
 import type { ConfigResponse, ProviderConfig } from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
@@ -23,12 +24,14 @@ interface ProvidersConfigSectionProps {
 	config: ConfigResponse;
 	onUpdate?: (section: string, data: ProviderConfig[]) => Promise<void>;
 	isUpdating?: boolean;
+	variant?: "providers" | "import_providers";
 }
 
 export function ProvidersConfigSection({
 	config,
 	onUpdate,
 	isUpdating = false,
+	variant = "providers",
 }: ProvidersConfigSectionProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [editingProvider, setEditingProvider] = useState<ProviderConfig | null>(null);
@@ -42,19 +45,29 @@ export function ProvidersConfigSection({
 	const listRef = useRef<HTMLDivElement>(null);
 	const [testingSpeedProviderId, setTestingSpeedProviderId] = useState<string | null>(null);
 
-	const [formData, setFormData] = useState<ProviderConfig[]>(config.providers);
+	const configProviders =
+		variant === "import_providers" ? config.import_providers : config.providers;
+	const [formData, setFormData] = useState<ProviderConfig[]>(configProviders ?? []);
 	const [hasChanges, setHasChanges] = useState(false);
 
-	const { deleteProvider, testProviderSpeed, resetProviderQuota } = useProviders();
+	const regularHooks = useProviders();
+	const importHooks = useImportProviders();
+	const { deleteProvider, testProviderSpeed, resetProviderQuota } =
+		variant === "import_providers"
+			? {
+					...importHooks,
+					resetProviderQuota: undefined as typeof regularHooks.resetProviderQuota | undefined,
+				}
+			: regularHooks;
 	const [resettingQuotaId, setResettingQuotaId] = useState<string | null>(null);
 	const { confirmDelete } = useConfirm();
 	const { showToast } = useToast();
 
 	// Sync with config when it changes
 	useEffect(() => {
-		setFormData(config.providers);
+		setFormData(configProviders ?? []);
 		setHasChanges(false);
-	}, [config.providers]);
+	}, [configProviders]);
 
 	// Attach non-passive touchmove on the list container so we can call
 	// preventDefault() and prevent page scroll while a touch-drag is active.
@@ -98,7 +111,7 @@ export function ProvidersConfigSection({
 				const [moved] = reordered.splice(draggedIndex, 1);
 				reordered.splice(targetIndex, 0, moved);
 				setFormData(reordered);
-				setHasChanges(JSON.stringify(reordered) !== JSON.stringify(config.providers));
+				setHasChanges(JSON.stringify(reordered) !== JSON.stringify(configProviders));
 			}
 		}
 
@@ -149,6 +162,7 @@ export function ProvidersConfigSection({
 	};
 
 	const handleResetQuota = async (provider: ProviderConfig) => {
+		if (!resetProviderQuota) return;
 		setResettingQuotaId(provider.id);
 		try {
 			await resetProviderQuota.mutateAsync(provider.id);
@@ -204,13 +218,13 @@ export function ProvidersConfigSection({
 			return p;
 		});
 		setFormData(newFormData);
-		setHasChanges(JSON.stringify(newFormData) !== JSON.stringify(config.providers));
+		setHasChanges(JSON.stringify(newFormData) !== JSON.stringify(configProviders));
 	};
 
 	const handleSave = async () => {
 		if (onUpdate && hasChanges) {
 			try {
-				await onUpdate("providers", formData);
+				await onUpdate(variant, formData);
 				setHasChanges(false);
 				showToast({
 					type: "success",
@@ -267,7 +281,7 @@ export function ProvidersConfigSection({
 		const [draggedProviderObj] = reorderedProviders.splice(draggedIndex, 1);
 		reorderedProviders.splice(targetIndex, 0, draggedProviderObj);
 		setFormData(reorderedProviders);
-		setHasChanges(JSON.stringify(reorderedProviders) !== JSON.stringify(config.providers));
+		setHasChanges(JSON.stringify(reorderedProviders) !== JSON.stringify(configProviders));
 	};
 
 	const handleDragEnd = () => {
@@ -560,6 +574,7 @@ export function ProvidersConfigSection({
 					provider={editingProvider}
 					onSuccess={handleModalSuccess}
 					onCancel={() => setIsModalOpen(false)}
+					variant={variant}
 				/>
 			)}
 		</div>

--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -244,7 +244,7 @@ export function ActivityHub() {
 														className={`h-8 w-8 shrink-0 ${progress > 0 ? "text-secondary" : "text-base-content/20"}`}
 													/>
 													{progress > 0 && (
-														<span className="absolute -top-1 -right-1 flex h-3 w-3">
+														<span className="-top-1 -right-1 absolute flex h-3 w-3">
 															<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-secondary opacity-75" />
 															<span className="relative inline-flex h-3 w-3 rounded-full bg-secondary" />
 														</span>

--- a/frontend/src/hooks/useImportProviders.ts
+++ b/frontend/src/hooks/useImportProviders.ts
@@ -1,0 +1,87 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "../api/client";
+import type {
+	ProviderConfig,
+	ProviderCreateRequest,
+	ProviderReorderRequest,
+	ProviderUpdateRequest,
+} from "../types/config";
+import { configKeys } from "./useConfig";
+
+function useTestImportProviderSpeed() {
+	const queryClient = useQueryClient();
+	return useMutation<{ speed_mbps: number; duration_seconds: number }, Error, string>({
+		mutationFn: (id) => apiClient.testImportProviderSpeed(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: configKeys.current() });
+		},
+	});
+}
+
+function useCreateImportProvider() {
+	const queryClient = useQueryClient();
+	return useMutation<ProviderConfig, Error, ProviderCreateRequest>({
+		mutationFn: (data) => apiClient.createImportProvider(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: configKeys.current() });
+		},
+		onError: (error) => {
+			console.error("Failed to create import provider:", error);
+		},
+	});
+}
+
+function useUpdateImportProvider() {
+	const queryClient = useQueryClient();
+	return useMutation<ProviderConfig, Error, { id: string; data: Partial<ProviderUpdateRequest> }>({
+		mutationFn: ({ id, data }) => apiClient.updateImportProvider(id, data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: configKeys.current() });
+		},
+		onError: (error) => {
+			console.error("Failed to update import provider:", error);
+		},
+	});
+}
+
+function useDeleteImportProvider() {
+	const queryClient = useQueryClient();
+	return useMutation<{ message: string }, Error, string>({
+		mutationFn: (id) => apiClient.deleteImportProvider(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: configKeys.current() });
+		},
+		onError: (error) => {
+			console.error("Failed to delete import provider:", error);
+		},
+	});
+}
+
+function useReorderImportProviders() {
+	const queryClient = useQueryClient();
+	return useMutation<ProviderConfig[], Error, ProviderReorderRequest>({
+		mutationFn: (data) => apiClient.reorderImportProviders(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: configKeys.current() });
+		},
+		onError: (error) => {
+			console.error("Failed to reorder import providers:", error);
+		},
+	});
+}
+
+export function useImportProviders() {
+	const testProviderSpeed = useTestImportProviderSpeed();
+	const createProvider = useCreateImportProvider();
+	const updateProvider = useUpdateImportProvider();
+	const deleteProvider = useDeleteImportProvider();
+	const reorderProviders = useReorderImportProviders();
+
+	return {
+		testProviderSpeed,
+		createProvider,
+		updateProvider,
+		deleteProvider,
+		reorderProviders,
+	};
+}

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -270,6 +270,11 @@ export function ConfigurationPage() {
 					section: "providers",
 					config: { providers: data as unknown as ProviderConfig[] },
 				});
+			} else if (section === "import_providers") {
+				await updateConfigSection.mutateAsync({
+					section: "import_providers",
+					config: { import_providers: data as unknown as ProviderConfig[] },
+				});
 			} else if (section === "nzblnk") {
 				await updateConfigSection.mutateAsync({
 					section: "nzblnk",
@@ -525,6 +530,14 @@ export function ConfigurationPage() {
 										isUpdating={updateConfigSection.isPending}
 									/>
 								)}
+								{activeSection === "import_providers" && (
+									<ProvidersConfigSection
+										config={config}
+										onUpdate={handleConfigUpdate}
+										isUpdating={updateConfigSection.isPending}
+										variant="import_providers"
+									/>
+								)}
 								{activeSection === "mount" && (
 									<MountConfigSection
 										config={config}
@@ -575,6 +588,7 @@ export function ConfigurationPage() {
 									"streaming",
 									"system",
 									"providers",
+									"import_providers",
 									"mount",
 									"sabnzbd",
 									"arrs",

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -21,6 +21,7 @@ export interface ConfigResponse {
 	arrs: ArrsConfig;
 	stremio: StremioConfig;
 	providers: ProviderConfig[];
+	import_providers: ProviderConfig[];
 	nzblnk: NzblnkConfig;
 	mount_path: string;
 	mount_type: MountType;
@@ -488,6 +489,7 @@ export type ConfigSection =
 	| "health"
 	| "import"
 	| "providers"
+	| "import_providers"
 	| "mount"
 	| "rclone"
 	| "fuse"
@@ -883,6 +885,12 @@ export const CONFIG_SECTIONS: Record<ConfigSection | "system", ConfigSectionInfo
 	providers: {
 		title: "NNTP Providers",
 		description: "Usenet provider configuration for downloads",
+		icon: "Radio",
+		canEdit: true,
+	},
+	import_providers: {
+		title: "Import Providers",
+		description: "Secondary NNTP providers dedicated to health checks and NZB imports",
 		icon: "Radio",
 		canEdit: true,
 	},

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -309,6 +309,7 @@ export interface ConfigUpdateRequest {
 	arrs?: ArrsConfig;
 	stremio?: Partial<StremioConfig>;
 	providers?: ProviderUpdateRequest[];
+	import_providers?: ProviderUpdateRequest[];
 	nzblnk?: NzblnkConfig;
 	mount_path?: string;
 	mount_type?: MountType;

--- a/internal/api/import_provider_handlers.go
+++ b/internal/api/import_provider_handlers.go
@@ -1,0 +1,569 @@
+package api
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/config"
+	nntppool "github.com/javi11/nntppool/v4"
+)
+
+// handleCreateImportProvider creates a new import NNTP provider
+//
+//	@Summary		Create import NNTP provider
+//	@Description	Adds a new NNTP provider to the import providers list.
+//	@Tags			ImportProviders
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		ProviderCreateRequest	true	"Provider details"
+//	@Success		201		{object}	APIResponse{data=ProviderAPIResponse}
+//	@Failure		400		{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/import-providers [post]
+func (s *Server) handleCreateImportProvider(c *fiber.Ctx) error {
+	if s.configManager == nil {
+		return RespondServiceUnavailable(c, "Configuration management not available", "CONFIG_UNAVAILABLE")
+	}
+
+	currentConfig := s.configManager.GetConfig()
+	if currentConfig == nil {
+		return RespondInternalError(c, "Configuration not available", "CONFIG_NOT_FOUND")
+	}
+
+	var createReq struct {
+		Host                     string `json:"host"`
+		Port                     int    `json:"port"`
+		Username                 string `json:"username"`
+		Password                 string `json:"password"`
+		MaxConnections           int    `json:"max_connections"`
+		InflightRequests         int    `json:"inflight_requests"`
+		TLS                      bool   `json:"tls"`
+		InsecureTLS              bool   `json:"insecure_tls"`
+		ProxyURL                 string `json:"proxy_url"`
+		Enabled                  bool   `json:"enabled"`
+		IsBackupProvider         bool   `json:"is_backup_provider"`
+		SkipPing                 bool   `json:"skip_ping"`
+		KeepaliveIntervalSeconds int    `json:"keepalive_interval_seconds"`
+		KeepaliveCommand         string `json:"keepalive_command"`
+		UserAgent                string `json:"user_agent"`
+		QuotaBytes               int64  `json:"quota_bytes"`
+		QuotaPeriodHours         int    `json:"quota_period_hours"`
+	}
+
+	if err := c.BodyParser(&createReq); err != nil {
+		return RespondValidationError(c, "Invalid JSON in request body", err.Error())
+	}
+
+	if createReq.Host == "" {
+		return RespondValidationError(c, "Host is required", "MISSING_HOST")
+	}
+	if createReq.Port <= 0 || createReq.Port > 65535 {
+		return RespondValidationError(c, "Valid port is required (1-65535)", "INVALID_PORT")
+	}
+	if createReq.Username == "" {
+		return RespondValidationError(c, "Username is required", "MISSING_USERNAME")
+	}
+	if createReq.MaxConnections <= 0 {
+		return RespondValidationError(c, "MaxConnections must be positive", "INVALID_MAX_CONNECTIONS")
+	}
+
+	enabled := createReq.Enabled
+	isBackup := createReq.IsBackupProvider
+	newID := fmt.Sprintf("import_provider_%d", len(currentConfig.ImportProviders)+1)
+
+	newProvider := config.ProviderConfig{
+		ID:                       newID,
+		Host:                     createReq.Host,
+		Port:                     createReq.Port,
+		Username:                 createReq.Username,
+		Password:                 createReq.Password,
+		MaxConnections:           createReq.MaxConnections,
+		InflightRequests:         createReq.InflightRequests,
+		TLS:                      createReq.TLS,
+		InsecureTLS:              createReq.InsecureTLS,
+		ProxyURL:                 createReq.ProxyURL,
+		Enabled:                  &enabled,
+		IsBackupProvider:         &isBackup,
+		SkipPing:                 createReq.SkipPing,
+		KeepaliveIntervalSeconds: createReq.KeepaliveIntervalSeconds,
+		KeepaliveCommand:         createReq.KeepaliveCommand,
+		UserAgent:                createReq.UserAgent,
+		QuotaBytes:               createReq.QuotaBytes,
+		QuotaPeriodHours:         createReq.QuotaPeriodHours,
+	}
+
+	newConfig := currentConfig.DeepCopy()
+	newConfig.ImportProviders = append(newConfig.ImportProviders, newProvider)
+
+	if err := s.configManager.ValidateConfigUpdate(newConfig); err != nil {
+		return RespondValidationError(c, "Configuration validation failed", err.Error())
+	}
+
+	if err := s.configManager.UpdateConfig(newConfig); err != nil {
+		return RespondInternalError(c, "Failed to update configuration", err.Error())
+	}
+
+	if err := s.configManager.SaveConfig(); err != nil {
+		return RespondInternalError(c, "Failed to save configuration", err.Error())
+	}
+
+	newProvider = newConfig.ImportProviders[len(newConfig.ImportProviders)-1]
+
+	response := ProviderAPIResponse{
+		ID:                       newProvider.ID,
+		Host:                     newProvider.Host,
+		Port:                     newProvider.Port,
+		Username:                 newProvider.Username,
+		MaxConnections:           newProvider.MaxConnections,
+		TLS:                      newProvider.TLS,
+		InsecureTLS:              newProvider.InsecureTLS,
+		ProxyURL:                 newProvider.ProxyURL,
+		PasswordSet:              newProvider.Password != "",
+		Enabled:                  newProvider.Enabled != nil && *newProvider.Enabled,
+		IsBackupProvider:         newProvider.IsBackupProvider != nil && *newProvider.IsBackupProvider,
+		InflightRequests:         newProvider.InflightRequests,
+		LastRTTMs:                newProvider.LastRTTMs,
+		SkipPing:                 newProvider.SkipPing,
+		KeepaliveIntervalSeconds: newProvider.KeepaliveIntervalSeconds,
+		KeepaliveCommand:         newProvider.KeepaliveCommand,
+		UserAgent:                newProvider.UserAgent,
+		QuotaBytes:               newProvider.QuotaBytes,
+		QuotaPeriodHours:         newProvider.QuotaPeriodHours,
+	}
+
+	return RespondCreated(c, response)
+}
+
+// handleUpdateImportProvider updates an existing import NNTP provider
+//
+//	@Summary		Update import NNTP provider
+//	@Description	Updates an existing import NNTP provider by ID.
+//	@Tags			ImportProviders
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Provider ID"
+//	@Param			body	body		ProviderUpdateRequest	true	"Fields to update"
+//	@Success		200		{object}	APIResponse{data=ProviderAPIResponse}
+//	@Failure		400		{object}	APIResponse
+//	@Failure		404		{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/import-providers/{id} [put]
+func (s *Server) handleUpdateImportProvider(c *fiber.Ctx) error {
+	if s.configManager == nil {
+		return RespondServiceUnavailable(c, "Configuration management not available", "CONFIG_UNAVAILABLE")
+	}
+
+	providerID := c.Params("id")
+	if providerID == "" {
+		return RespondValidationError(c, "Provider ID is required", "MISSING_PROVIDER_ID")
+	}
+
+	currentConfig := s.configManager.GetConfig()
+	if currentConfig == nil {
+		return RespondInternalError(c, "Configuration not available", "CONFIG_NOT_FOUND")
+	}
+
+	providerIndex := -1
+	for i, p := range currentConfig.ImportProviders {
+		if p.ID == providerID {
+			providerIndex = i
+			break
+		}
+	}
+
+	if providerIndex == -1 {
+		return RespondNotFound(c, "Import provider", "PROVIDER_NOT_FOUND")
+	}
+
+	var updateReq struct {
+		Host                     *string `json:"host,omitempty"`
+		Port                     *int    `json:"port,omitempty"`
+		Username                 *string `json:"username,omitempty"`
+		Password                 *string `json:"password,omitempty"`
+		MaxConnections           *int    `json:"max_connections,omitempty"`
+		InflightRequests         *int    `json:"inflight_requests,omitempty"`
+		TLS                      *bool   `json:"tls,omitempty"`
+		InsecureTLS              *bool   `json:"insecure_tls,omitempty"`
+		ProxyURL                 *string `json:"proxy_url,omitempty"`
+		Enabled                  *bool   `json:"enabled,omitempty"`
+		IsBackupProvider         *bool   `json:"is_backup_provider,omitempty"`
+		SkipPing                 *bool   `json:"skip_ping,omitempty"`
+		KeepaliveIntervalSeconds *int    `json:"keepalive_interval_seconds,omitempty"`
+		KeepaliveCommand         *string `json:"keepalive_command,omitempty"`
+		UserAgent                *string `json:"user_agent,omitempty"`
+		QuotaBytes               *int64  `json:"quota_bytes,omitempty"`
+		QuotaPeriodHours         *int    `json:"quota_period_hours,omitempty"`
+	}
+
+	if err := c.BodyParser(&updateReq); err != nil {
+		return RespondValidationError(c, "Invalid JSON in request body", err.Error())
+	}
+
+	newConfig := currentConfig.DeepCopy()
+	provider := newConfig.ImportProviders[providerIndex]
+
+	if updateReq.Host != nil {
+		if *updateReq.Host == "" {
+			return RespondValidationError(c, "Host cannot be empty", "INVALID_HOST")
+		}
+		provider.Host = *updateReq.Host
+	}
+	if updateReq.Port != nil {
+		if *updateReq.Port <= 0 || *updateReq.Port > 65535 {
+			return RespondValidationError(c, "Valid port is required (1-65535)", "INVALID_PORT")
+		}
+		provider.Port = *updateReq.Port
+	}
+	if updateReq.Username != nil {
+		if *updateReq.Username == "" {
+			return RespondValidationError(c, "Username cannot be empty", "INVALID_USERNAME")
+		}
+		provider.Username = *updateReq.Username
+	}
+	if updateReq.Password != nil {
+		provider.Password = *updateReq.Password
+	}
+	if updateReq.MaxConnections != nil {
+		if *updateReq.MaxConnections <= 0 {
+			return RespondValidationError(c, "MaxConnections must be positive", "INVALID_MAX_CONNECTIONS")
+		}
+		provider.MaxConnections = *updateReq.MaxConnections
+	}
+	if updateReq.InflightRequests != nil {
+		provider.InflightRequests = *updateReq.InflightRequests
+	}
+	if updateReq.TLS != nil {
+		provider.TLS = *updateReq.TLS
+	}
+	if updateReq.InsecureTLS != nil {
+		provider.InsecureTLS = *updateReq.InsecureTLS
+	}
+	if updateReq.ProxyURL != nil {
+		provider.ProxyURL = *updateReq.ProxyURL
+	}
+	if updateReq.Enabled != nil {
+		provider.Enabled = updateReq.Enabled
+	}
+	if updateReq.IsBackupProvider != nil {
+		provider.IsBackupProvider = updateReq.IsBackupProvider
+	}
+	if updateReq.SkipPing != nil {
+		provider.SkipPing = *updateReq.SkipPing
+	}
+	if updateReq.KeepaliveIntervalSeconds != nil {
+		provider.KeepaliveIntervalSeconds = *updateReq.KeepaliveIntervalSeconds
+	}
+	if updateReq.KeepaliveCommand != nil {
+		provider.KeepaliveCommand = *updateReq.KeepaliveCommand
+	}
+	if updateReq.QuotaBytes != nil {
+		provider.QuotaBytes = *updateReq.QuotaBytes
+	}
+	if updateReq.QuotaPeriodHours != nil {
+		provider.QuotaPeriodHours = *updateReq.QuotaPeriodHours
+	}
+	if updateReq.UserAgent != nil {
+		provider.UserAgent = *updateReq.UserAgent
+	}
+
+	newConfig.ImportProviders[providerIndex] = provider
+
+	if err := s.configManager.ValidateConfigUpdate(newConfig); err != nil {
+		return RespondValidationError(c, "Configuration validation failed", err.Error())
+	}
+
+	provider = newConfig.ImportProviders[providerIndex]
+
+	if err := s.configManager.UpdateConfig(newConfig); err != nil {
+		return RespondInternalError(c, "Failed to update configuration", err.Error())
+	}
+
+	if err := s.configManager.SaveConfig(); err != nil {
+		return RespondInternalError(c, "Failed to save configuration", err.Error())
+	}
+
+	response := ProviderAPIResponse{
+		ID:                       provider.ID,
+		Host:                     provider.Host,
+		Port:                     provider.Port,
+		Username:                 provider.Username,
+		MaxConnections:           provider.MaxConnections,
+		TLS:                      provider.TLS,
+		InsecureTLS:              provider.InsecureTLS,
+		ProxyURL:                 provider.ProxyURL,
+		PasswordSet:              provider.Password != "",
+		Enabled:                  provider.Enabled != nil && *provider.Enabled,
+		IsBackupProvider:         provider.IsBackupProvider != nil && *provider.IsBackupProvider,
+		InflightRequests:         provider.InflightRequests,
+		LastRTTMs:                provider.LastRTTMs,
+		SkipPing:                 provider.SkipPing,
+		KeepaliveIntervalSeconds: provider.KeepaliveIntervalSeconds,
+		KeepaliveCommand:         provider.KeepaliveCommand,
+		UserAgent:                provider.UserAgent,
+		QuotaBytes:               provider.QuotaBytes,
+		QuotaPeriodHours:         provider.QuotaPeriodHours,
+	}
+
+	return RespondSuccess(c, response)
+}
+
+// handleDeleteImportProvider removes an import NNTP provider
+//
+//	@Summary		Delete import NNTP provider
+//	@Description	Removes an import NNTP provider by ID from the configuration.
+//	@Tags			ImportProviders
+//	@Produce		json
+//	@Param			id	path	string	true	"Provider ID"
+//	@Success		200	{object}	APIResponse
+//	@Failure		404	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/import-providers/{id} [delete]
+func (s *Server) handleDeleteImportProvider(c *fiber.Ctx) error {
+	if s.configManager == nil {
+		return RespondServiceUnavailable(c, "Configuration management not available", "CONFIG_UNAVAILABLE")
+	}
+
+	providerID := c.Params("id")
+	if providerID == "" {
+		return RespondValidationError(c, "Provider ID is required", "MISSING_PROVIDER_ID")
+	}
+
+	currentConfig := s.configManager.GetConfig()
+	if currentConfig == nil {
+		return RespondInternalError(c, "Configuration not available", "CONFIG_NOT_FOUND")
+	}
+
+	providerIndex := -1
+	for i, p := range currentConfig.ImportProviders {
+		if p.ID == providerID {
+			providerIndex = i
+			break
+		}
+	}
+
+	if providerIndex == -1 {
+		return RespondNotFound(c, "Import provider", "PROVIDER_NOT_FOUND")
+	}
+
+	newConfig := currentConfig.DeepCopy()
+	newConfig.ImportProviders = append(
+		newConfig.ImportProviders[:providerIndex],
+		newConfig.ImportProviders[providerIndex+1:]...,
+	)
+
+	if err := s.configManager.ValidateConfigUpdate(newConfig); err != nil {
+		return RespondValidationError(c, "Configuration validation failed", err.Error())
+	}
+
+	if err := s.configManager.UpdateConfig(newConfig); err != nil {
+		return RespondInternalError(c, "Failed to update configuration", err.Error())
+	}
+
+	if err := s.configManager.SaveConfig(); err != nil {
+		return RespondInternalError(c, "Failed to save configuration", err.Error())
+	}
+
+	return RespondSuccess(c, struct {
+		Message string `json:"message"`
+	}{Message: "Import provider deleted successfully"})
+}
+
+// handleReorderImportProviders reorders the import provider list
+//
+//	@Summary		Reorder import NNTP providers
+//	@Description	Sets the priority order of import NNTP providers.
+//	@Tags			ImportProviders
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		ProviderReorderRequest	true	"Ordered list of provider IDs"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/import-providers/reorder [put]
+func (s *Server) handleReorderImportProviders(c *fiber.Ctx) error {
+	if s.configManager == nil {
+		return RespondServiceUnavailable(c, "Configuration management not available", "CONFIG_UNAVAILABLE")
+	}
+
+	var reorderReq struct {
+		ProviderIDs []string `json:"provider_ids"`
+	}
+
+	if err := c.BodyParser(&reorderReq); err != nil {
+		return RespondValidationError(c, "Invalid JSON in request body", err.Error())
+	}
+
+	if len(reorderReq.ProviderIDs) == 0 {
+		return RespondValidationError(c, "Provider IDs array is required", "MISSING_PROVIDER_IDS")
+	}
+
+	currentConfig := s.configManager.GetConfig()
+	if currentConfig == nil {
+		return RespondInternalError(c, "Configuration not available", "CONFIG_NOT_FOUND")
+	}
+
+	providerMap := make(map[string]config.ProviderConfig)
+	for _, p := range currentConfig.ImportProviders {
+		providerMap[p.ID] = p
+	}
+
+	if len(reorderReq.ProviderIDs) != len(currentConfig.ImportProviders) {
+		return RespondValidationError(c, "Provider IDs count mismatch", "INVALID_PROVIDER_COUNT")
+	}
+
+	newProviders := make([]config.ProviderConfig, 0, len(reorderReq.ProviderIDs))
+	for _, id := range reorderReq.ProviderIDs {
+		provider, exists := providerMap[id]
+		if !exists {
+			return RespondNotFound(c, fmt.Sprintf("Import provider ID '%s'", id), "PROVIDER_NOT_FOUND")
+		}
+		newProviders = append(newProviders, provider)
+	}
+
+	newConfig := currentConfig.DeepCopy()
+	newConfig.ImportProviders = newProviders
+
+	if err := s.configManager.ValidateConfigUpdate(newConfig); err != nil {
+		return RespondValidationError(c, "Configuration validation failed", err.Error())
+	}
+
+	if err := s.configManager.UpdateConfig(newConfig); err != nil {
+		return RespondInternalError(c, "Failed to update configuration", err.Error())
+	}
+
+	if err := s.configManager.SaveConfig(); err != nil {
+		return RespondInternalError(c, "Failed to save configuration", err.Error())
+	}
+
+	providers := make([]ProviderAPIResponse, len(newProviders))
+	for i, p := range newProviders {
+		providers[i] = ProviderAPIResponse{
+			ID:               p.ID,
+			Host:             p.Host,
+			Port:             p.Port,
+			Username:         p.Username,
+			MaxConnections:   p.MaxConnections,
+			TLS:              p.TLS,
+			InsecureTLS:      p.InsecureTLS,
+			ProxyURL:         p.ProxyURL,
+			PasswordSet:      p.Password != "",
+			Enabled:          p.Enabled != nil && *p.Enabled,
+			IsBackupProvider: p.IsBackupProvider != nil && *p.IsBackupProvider,
+			InflightRequests: p.InflightRequests,
+			LastRTTMs:        p.LastRTTMs,
+		}
+	}
+
+	return RespondSuccess(c, providers)
+}
+
+// handleTestImportProviderSpeed tests the download speed of a specific import provider
+//
+//	@Summary		Test import provider download speed
+//	@Description	Runs a speed test against the specified import NNTP provider and saves the result to config.
+//	@Tags			ImportProviders
+//	@Produce		json
+//	@Param			id	path	string	true	"Provider ID"
+//	@Success		200	{object}	APIResponse{data=ProviderSpeedTestResponse}
+//	@Failure		400	{object}	APIResponse
+//	@Failure		404	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Security		ApiKeyAuth
+//	@Router			/import-providers/{id}/speedtest [post]
+func (s *Server) handleTestImportProviderSpeed(c *fiber.Ctx) error {
+	providerID := c.Params("id")
+	if providerID == "" {
+		return RespondBadRequest(c, "Provider ID is required", "")
+	}
+
+	if s.configManager == nil {
+		return RespondInternalError(c, "Configuration management not available", "")
+	}
+
+	cfg := s.configManager.GetConfig()
+	var targetProvider *config.ProviderConfig
+	for _, p := range cfg.ImportProviders {
+		if p.ID == providerID {
+			targetProvider = &p
+			break
+		}
+	}
+
+	if targetProvider == nil {
+		return RespondNotFound(c, "Import provider", "")
+	}
+
+	host := fmt.Sprintf("%s:%d", targetProvider.Host, targetProvider.Port)
+	var tlsCfg *tls.Config
+	if targetProvider.TLS {
+		tlsCfg = &tls.Config{
+			InsecureSkipVerify: targetProvider.InsecureTLS,
+			ServerName:         targetProvider.Host,
+		}
+	}
+
+	pool, err := nntppool.NewClient(c.Context(), []nntppool.Provider{
+		{
+			Host:        host,
+			TLSConfig:   tlsCfg,
+			Auth:        nntppool.Auth{Username: targetProvider.Username, Password: targetProvider.Password},
+			Connections: targetProvider.MaxConnections,
+			IdleTimeout: 60 * time.Second,
+		},
+	})
+	if err != nil {
+		return RespondInternalError(c, "Failed to create connection pool", err.Error())
+	}
+	defer pool.Close()
+
+	providerName := host
+	if targetProvider.Username != "" {
+		providerName = host + "+" + targetProvider.Username
+	}
+
+	testCtx, cancel := context.WithTimeout(c.Context(), 5*time.Minute)
+	defer cancel()
+
+	result, err := pool.SpeedTest(testCtx, nntppool.SpeedTestOptions{
+		ProviderName: providerName,
+	})
+	if err != nil {
+		return RespondInternalError(c, "Speed test failed", err.Error())
+	}
+
+	speed := result.WireSpeedBps / 1024 / 1024
+
+	now := time.Now()
+	currentConfig := s.configManager.GetConfig()
+	newConfig := currentConfig.DeepCopy()
+
+	for i, p := range newConfig.ImportProviders {
+		if p.ID == providerID {
+			newConfig.ImportProviders[i].LastSpeedTestMbps = speed
+			newConfig.ImportProviders[i].LastSpeedTestTime = &now
+			break
+		}
+	}
+
+	if err := s.configManager.UpdateConfig(newConfig); err != nil {
+		slog.ErrorContext(c.Context(), "Failed to update import provider speed test result in config", "provider_id", providerID, "err", err)
+		return RespondInternalError(c, "Failed to save speed test result", err.Error())
+	}
+
+	if err := s.configManager.SaveConfig(); err != nil {
+		slog.ErrorContext(c.Context(), "Failed to persist config after import provider speed test", "err", err)
+	}
+
+	return RespondSuccess(c, ProviderSpeedTestResponse{
+		SpeedMBps: speed,
+		Duration:  result.Elapsed.Seconds(),
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -342,6 +342,13 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/providers/:id/reset-quota", s.handleResetProviderQuota)
 	api.Delete("/providers/:id", s.handleDeleteProvider)
 
+	// Import provider management endpoints (secondary pool for health checks and imports)
+	api.Post("/import-providers/:id/speedtest", s.handleTestImportProviderSpeed)
+	api.Post("/import-providers", s.handleCreateImportProvider)
+	api.Put("/import-providers/reorder", s.handleReorderImportProviders)
+	api.Put("/import-providers/:id", s.handleUpdateImportProvider)
+	api.Delete("/import-providers/:id", s.handleDeleteImportProvider)
+
 	// Configuration-based instance endpoints
 	api.Get("/arrs/instances", s.handleListArrsInstances)
 	api.Get("/arrs/instances/:type/:name", s.handleGetArrsInstance)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -35,6 +35,7 @@ type ConfigAPIResponse struct {
 	RClone          RCloneAPIResponse     `json:"rclone"`
 	SABnzbd         SABnzbdAPIResponse    `json:"sabnzbd"`
 	Providers       []ProviderAPIResponse `json:"providers"`
+	ImportProviders []ProviderAPIResponse `json:"import_providers"`
 	APIKey          string                `json:"api_key,omitempty"`      // User's API key for authentication
 	DownloadKey     string                `json:"download_key,omitempty"` // SHA256 of the API key, used for download/stream URLs
 	ProfilerEnabled bool                  `json:"profiler_enabled"`
@@ -200,6 +201,33 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		}
 	}
 
+	// Convert import providers with password masking
+	importProviders := make([]ProviderAPIResponse, len(cfg.ImportProviders))
+	for i, p := range cfg.ImportProviders {
+		importProviders[i] = ProviderAPIResponse{
+			ID:                       p.ID,
+			Host:                     p.Host,
+			Port:                     p.Port,
+			Username:                 p.Username,
+			MaxConnections:           p.MaxConnections,
+			TLS:                      p.TLS,
+			InsecureTLS:              p.InsecureTLS,
+			ProxyURL:                 p.ProxyURL,
+			PasswordSet:              p.Password != "",
+			Enabled:                  p.Enabled != nil && *p.Enabled,
+			IsBackupProvider:         p.IsBackupProvider != nil && *p.IsBackupProvider,
+			InflightRequests:         p.InflightRequests,
+			LastRTTMs:                p.LastRTTMs,
+			LastSpeedTestMbps:        p.LastSpeedTestMbps,
+			LastSpeedTestTime:        p.LastSpeedTestTime,
+			SkipPing:                 p.SkipPing,
+			KeepaliveIntervalSeconds: p.KeepaliveIntervalSeconds,
+			KeepaliveCommand:         p.KeepaliveCommand,
+			QuotaBytes:               p.QuotaBytes,
+			QuotaPeriodHours:         p.QuotaPeriodHours,
+		}
+	}
+
 	// Create RClone response with all configuration fields
 	rcloneResp := RCloneAPIResponse{
 		PasswordSet:  cfg.RClone.Password != "",
@@ -287,6 +315,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		RClone:          rcloneResp,
 		SABnzbd:         sabnzbdResp,
 		Providers:       providers,
+		ImportProviders: importProviders,
 		APIKey:          apiKey,
 		DownloadKey:     downloadKey,
 		ProfilerEnabled: cfg.ProfilerEnabled,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -53,6 +53,7 @@ type Config struct {
 	Fuse            FuseConfig         `yaml:"fuse" mapstructure:"fuse" json:"fuse"`
 	SegmentCache    SegmentCacheConfig `yaml:"segment_cache" mapstructure:"segment_cache" json:"segment_cache"`
 	Providers       []ProviderConfig   `yaml:"providers" mapstructure:"providers" json:"providers"`
+	ImportProviders []ProviderConfig   `yaml:"import_providers" mapstructure:"import_providers" json:"import_providers"`
 	Nzblnk          NzblnkConfig       `yaml:"nzblnk" mapstructure:"nzblnk" json:"nzblnk"`
 	MountPath       string             `yaml:"mount_path" mapstructure:"mount_path" json:"mount_path"`
 	MountType       MountType          `yaml:"mount_type" mapstructure:"mount_type" json:"mount_type"`
@@ -997,6 +998,17 @@ func (c *Config) ProvidersEqual(other *Config) bool {
 func (c *Config) ToNNTPProviders() []nntppool.Provider {
 	var providers []nntppool.Provider
 	for _, p := range c.Providers {
+		if p.Enabled != nil && *p.Enabled {
+			providers = append(providers, p.ToNNTPProvider())
+		}
+	}
+	return providers
+}
+
+// ToImportNNTPProviders converts ImportProviders to an nntppool.Provider slice (enabled only).
+func (c *Config) ToImportNNTPProviders() []nntppool.Provider {
+	var providers []nntppool.Provider
+	for _, p := range c.ImportProviders {
 		if p.Enabled != nil && *p.Enabled {
 			providers = append(providers, p.ToNNTPProvider())
 		}

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -43,6 +43,10 @@ func (m *mockPoolManager) RemoveProvider(_ string) error                   { ret
 func (m *mockPoolManager) ResetProviderQuota(_ context.Context, _ string) error {
 	return nil
 }
+func (m *mockPoolManager) GetImportPool() (*nntppool.Client, error) {
+	return nil, errors.New("no import pool (test mock)")
+}
+func (m *mockPoolManager) SetImportProviders(_ []nntppool.Provider) error { return nil }
 
 // mockARRsService captures TriggerFileRescan calls and returns a configurable error.
 type mockARRsService struct {

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -474,7 +474,7 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 		return cache, notFoundIDs, nil
 	}
 
-	cp, err := p.poolManager.GetPool()
+	cp, err := p.poolManager.GetImportPool()
 	if err != nil {
 		p.log.DebugContext(context.Background(), "Failed to get connection pool for first segment fetching", "error", err)
 		return cache, notFoundIDs, nil
@@ -531,7 +531,7 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 			defer cancel()
 
 			// Get body for the first segment (v4 returns decoded bytes + YEnc metadata)
-			result, err := cp.BodyPriority(ctx, firstSegment.ID)
+			result, err := cp.Body(ctx, firstSegment.ID)
 			if err != nil {
 				notFound := stderrors.Is(err, nntppool.ErrArticleNotFound)
 				return fetchResult{
@@ -690,7 +690,7 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 	if p.poolManager == nil || !p.poolManager.HasPool() {
 		return
 	}
-	cp, err := p.poolManager.GetPool()
+	cp, err := p.poolManager.GetImportPool()
 	if err != nil {
 		return
 	}
@@ -731,7 +731,7 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 				g.Go(func() error {
 					segCtx, segCancel := context.WithTimeout(gctx, time.Second*30)
 					defer segCancel()
-					sr, err := cp.BodyPriority(segCtx, seg.ID)
+					sr, err := cp.Body(segCtx, seg.ID)
 					if err != nil {
 						return nil // best-effort
 					}
@@ -769,7 +769,7 @@ func (p *Parser) fetchYencHeaders(ctx context.Context, segment nzbparser.NzbSegm
 		return nntppool.YEncMeta{}, errors.NewNonRetryableError("no pool manager available", nil)
 	}
 
-	cp, err := p.poolManager.GetPool()
+	cp, err := p.poolManager.GetImportPool()
 	if err != nil {
 		return nntppool.YEncMeta{}, errors.NewNonRetryableError("no connection pool available", err)
 	}

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -388,6 +388,14 @@ func (m *mockPoolManager) ResetProviderQuota(_ context.Context, _ string) error 
 	return nil
 }
 
+func (m *mockPoolManager) GetImportPool() (*nntppool.Client, error) {
+	return nil, nil
+}
+
+func (m *mockPoolManager) SetImportProviders(_ []nntppool.Provider) error {
+	return nil
+}
+
 // TestSeekResetsOriginalRangeEnd tests that Seek properly resets originalRangeEnd
 // This is critical for video playback - without this fix, seeking causes stale range
 // information to be reused, breaking subsequent reads

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -13,6 +13,7 @@ func RegisterConfigHandlers(ctx context.Context, configManager *config.Manager, 
 		slog.InfoContext(ctx, "Configuration updated")
 
 		handleProviderChanges(ctx, oldConfig, newConfig, poolManager)
+		handleImportProviderChanges(ctx, oldConfig, newConfig, poolManager)
 
 		// Log changes that still require restart
 		if oldConfig.Metadata.RootPath != newConfig.Metadata.RootPath {
@@ -55,6 +56,31 @@ func handleProviderChanges(ctx context.Context, oldConfig, newConfig *config.Con
 		case config.ProviderModified:
 			applyProviderModified(ctx, change, poolManager)
 		}
+	}
+}
+
+// handleImportProviderChanges recreates the import pool whenever the enabled
+// import providers differ from the previous configuration.
+func handleImportProviderChanges(ctx context.Context, oldConfig, newConfig *config.Config, poolManager Manager) {
+	oldImport := oldConfig.ToImportNNTPProviders()
+	newImport := newConfig.ToImportNNTPProviders()
+
+	if len(oldImport) == len(newImport) {
+		same := true
+		for i := range oldImport {
+			if oldImport[i].Host != newImport[i].Host {
+				same = false
+				break
+			}
+		}
+		if same {
+			return
+		}
+	}
+
+	slog.InfoContext(ctx, "Import NNTP providers changed - recreating import pool")
+	if err := poolManager.SetImportProviders(newImport); err != nil {
+		slog.ErrorContext(ctx, "Failed to recreate import NNTP pool", "err", err)
 	}
 }
 

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -16,6 +16,15 @@ type Manager interface {
 	// GetPool returns the current connection pool or error if not available
 	GetPool() (*nntppool.Client, error)
 
+	// GetImportPool returns the import connection pool (for imports and health checks).
+	// Falls back to the main pool if no import providers are configured.
+	GetImportPool() (*nntppool.Client, error)
+
+	// SetImportProviders creates/replaces the import pool with the given providers.
+	// Passing an empty slice clears the import pool and makes GetImportPool fall back
+	// to the main pool.
+	SetImportProviders(providers []nntppool.Provider) error
+
 	// SetProviders creates/recreates the pool with new providers
 	SetProviders(providers []nntppool.Provider) error
 
@@ -74,6 +83,7 @@ type StatsRepository interface {
 type manager struct {
 	mu               sync.RWMutex
 	pool             *nntppool.Client
+	importPool       *nntppool.Client // optional secondary pool for imports/health checks
 	metricsTracker   *MetricsTracker
 	repo             StatsRepository
 	ctx              context.Context
@@ -149,6 +159,49 @@ func (m *manager) GetPool() (*nntppool.Client, error) {
 	}
 
 	return m.pool, nil
+}
+
+// GetImportPool returns the import pool if configured, else falls back to the main pool.
+func (m *manager) GetImportPool() (*nntppool.Client, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.importPool != nil {
+		return m.importPool, nil
+	}
+
+	if m.pool == nil {
+		return nil, fmt.Errorf("NNTP connection pool not available - no providers configured")
+	}
+	return m.pool, nil
+}
+
+// SetImportProviders creates/replaces the secondary NNTP pool used for imports
+// and health checks. An empty slice clears the pool so GetImportPool falls back
+// to the main pool.
+func (m *manager) SetImportProviders(providers []nntppool.Provider) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.importPool != nil {
+		m.importPool.Close()
+		m.importPool = nil
+	}
+
+	if len(providers) == 0 {
+		m.logger.InfoContext(m.ctx, "No import NNTP providers configured - imports/health will use main pool")
+		return nil
+	}
+
+	m.logger.InfoContext(m.ctx, "Creating import NNTP connection pool", "provider_count", len(providers))
+	p, err := nntppool.NewClient(m.ctx, providers)
+	if err != nil {
+		return fmt.Errorf("failed to create import NNTP pool: %w", err)
+	}
+
+	m.importPool = p
+	m.logger.InfoContext(m.ctx, "Import NNTP connection pool created successfully")
+	return nil
 }
 
 // SetProviders creates/recreates the pool with new providers

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -1,7 +1,6 @@
 package usenet
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -350,9 +349,8 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 			attemptCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 
-			buf := bytes.NewBuffer(make([]byte, 0, seg.SegmentSize))
 			fetchStart := time.Now()
-			result, err := cp.BodyStream(attemptCtx, seg.Id, buf)
+			result, err := cp.BodyPriority(attemptCtx, seg.Id)
 			fetchDur := time.Since(fetchStart)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
@@ -377,7 +375,7 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 				return err
 			}
 
-			resultBytes = buf.Bytes()
+			resultBytes = result.Bytes
 			b.metricsTracker.IncArticlesDownloaded()
 			b.metricsTracker.UpdateDownloadProgress(b.streamID, int64(len(resultBytes)))
 

--- a/internal/usenet/validation.go
+++ b/internal/usenet/validation.go
@@ -63,7 +63,7 @@ func ValidateSegmentList(
 		return nil
 	}
 
-	usenetPool, err := poolManager.GetPool()
+	usenetPool, err := poolManager.GetImportPool()
 	if err != nil {
 		return fmt.Errorf("cannot validate segments: usenet connection pool unavailable: %w", err)
 	}
@@ -136,7 +136,7 @@ func ValidateSegmentAvailabilityDetailed(
 		return result, nil
 	}
 
-	usenetPool, err := poolManager.GetPool()
+	usenetPool, err := poolManager.GetImportPool()
 	if err != nil {
 		return result, fmt.Errorf("cannot validate segments: usenet connection pool unavailable: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **`perf(usenet)`**: Switch streaming segment downloads from `BodyStream` to `BodyPriority` so downloads use the priority channel, keeping the connection pool more responsive for interactive streaming
- **`feat(pool)`**: Add optional `import_providers` config key that creates a secondary `*nntppool.Client` dedicated to health checks and NZB imports — falls back transparently to the main pool when not configured; `GetImportPool()` / `SetImportProviders()` added to the `Manager` interface; parser and validation switched to use the import pool
- **`feat(import-providers)`**: Full CRUD backend API at `/api/import-providers/*` with password masking, plus a new "Import Providers" settings section in the UI — reuses `ProvidersConfigSection` and `ProviderModal` via a `variant` prop

## Test plan

- [ ] Configure `import_providers` in `altmount.yaml` — verify a second pool is created on startup and used for imports/health checks
- [ ] Leave `import_providers` empty — verify all behaviour is identical to before (fallback to main pool)
- [ ] Open Settings → Import Providers, add/edit/delete a provider — verify changes persist in config
- [ ] Drag-reorder import providers — verify new order is saved
- [ ] Speed-test an import provider — verify result is saved to config
- [ ] Trigger a health check cycle — verify it uses the import pool when configured
- [ ] Run `go build ./...` and `bun run build` — both should pass clean