### PR TITLE
feat(ui): merge import providers into NNTP providers config page

### DIFF
--- a/frontend/src/components/config/ProvidersConfigSection.tsx
+++ b/frontend/src/components/config/ProvidersConfigSection.tsx
@@ -25,6 +25,8 @@ interface ProvidersConfigSectionProps {
 	onUpdate?: (section: string, data: ProviderConfig[]) => Promise<void>;
 	isUpdating?: boolean;
 	variant?: "providers" | "import_providers";
+	title?: string;
+	description?: string;
 }
 
 export function ProvidersConfigSection({
@@ -32,6 +34,8 @@ export function ProvidersConfigSection({
 	onUpdate,
 	isUpdating = false,
 	variant = "providers",
+	title,
+	description,
 }: ProvidersConfigSectionProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [editingProvider, setEditingProvider] = useState<ProviderConfig | null>(null);
@@ -294,8 +298,12 @@ export function ProvidersConfigSection({
 			{/* Header */}
 			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 				<div>
-					<h3 className="font-bold text-base-content text-xl tracking-tight">NNTP Providers</h3>
-					<p className="mt-1 text-base-content/50 text-xs">Drag cards to adjust priority order.</p>
+					<h3 className="font-bold text-base-content text-xl tracking-tight">
+						{title ?? "NNTP Providers"}
+					</h3>
+					<p className="mt-1 text-base-content/50 text-xs">
+						{description ?? "Drag cards to adjust priority order."}
+					</p>
 				</div>
 				<button
 					type="button"
@@ -313,7 +321,9 @@ export function ProvidersConfigSection({
 					<Wifi className="mx-auto mb-4 h-12 w-12 text-base-content/20" />
 					<h4 className="font-bold text-base-content/80 text-lg">No Providers Configured</h4>
 					<p className="mb-6 text-base-content/60 text-sm">
-						Add a Usenet provider to enable downloading.
+						{variant === "import_providers"
+							? "Add a provider to use for imports and health checks."
+							: "Add a Usenet provider to enable downloading."}
 					</p>
 					<button type="button" className="btn btn-primary px-8" onClick={handleCreate}>
 						Add First Provider

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -118,8 +118,9 @@ export function ConfigurationPage() {
 	// Get active section from URL parameter, default to webdav
 	const activeSection = (() => {
 		if (!section) return "webdav";
-		// Redirect legacy rclone/fuse paths to mount
+		// Redirect legacy paths
 		if (section === "rclone" || section === "fuse") return "mount" as ConfigSection;
+		if (section === "import_providers") return "providers" as ConfigSection;
 		const validSections = Object.keys(CONFIG_SECTIONS) as (ConfigSection | "system")[];
 		return validSections.includes(section as ConfigSection | "system")
 			? (section as ConfigSection | "system")
@@ -132,6 +133,8 @@ export function ConfigurationPage() {
 			navigate("/config/webdav", { replace: true });
 		} else if (section === "rclone" || section === "fuse") {
 			navigate("/config/mount", { replace: true });
+		} else if (section === "import_providers") {
+			navigate("/config/providers", { replace: true });
 		}
 	}, [section, navigate]);
 
@@ -524,19 +527,24 @@ export function ConfigurationPage() {
 									/>
 								)}
 								{activeSection === "providers" && (
-									<ProvidersConfigSection
-										config={config}
-										onUpdate={handleConfigUpdate}
-										isUpdating={updateConfigSection.isPending}
-									/>
-								)}
-								{activeSection === "import_providers" && (
-									<ProvidersConfigSection
-										config={config}
-										onUpdate={handleConfigUpdate}
-										isUpdating={updateConfigSection.isPending}
-										variant="import_providers"
-									/>
+									<div className="space-y-10">
+										<ProvidersConfigSection
+											config={config}
+											onUpdate={handleConfigUpdate}
+											isUpdating={updateConfigSection.isPending}
+											title="Download Providers"
+											description="Primary pool used for all downloads. Drag cards to adjust priority order."
+										/>
+										<div className="divider" />
+										<ProvidersConfigSection
+											config={config}
+											onUpdate={handleConfigUpdate}
+											isUpdating={updateConfigSection.isPending}
+											variant="import_providers"
+											title="Import & Health-Check Providers"
+											description="Secondary pool used exclusively for imports and health checks. Drag cards to adjust priority order."
+										/>
+									</div>
 								)}
 								{activeSection === "mount" && (
 									<MountConfigSection
@@ -588,7 +596,6 @@ export function ConfigurationPage() {
 									"streaming",
 									"system",
 									"providers",
-									"import_providers",
 									"mount",
 									"sabnzbd",
 									"arrs",


### PR DESCRIPTION
## Summary

- The import/health-check provider pool was previously a separate sidebar nav entry (`/config/import_providers`). This moves it onto the same page as the download providers, separated by a divider with distinct headings.
- Adds optional `title` and `description` props to `ProvidersConfigSection` so each pool can be labelled independently without changing existing behaviour.
- `/config/import_providers` now redirects to `/config/providers` for backward compatibility with any bookmarked URLs.

## What changed

| File | Change |
|------|--------|
| `ProvidersConfigSection.tsx` | Add `title` / `description` props; context-aware empty-state copy for import variant |
| `ConfigurationPage.tsx` | Render both pools under `activeSection === "providers"`; remove `import_providers` from sidebar groups and exclusion list; add redirect |

## Test plan

- [ ] Navigate to `/config/providers` — confirm two sections appear: **Download Providers** and **Import & Health-Check Providers**
- [ ] Verify CRUD (add / edit / delete / reorder) works independently for each pool
- [ ] Navigate to `/config/import_providers` — confirm redirect to `/config/providers`
- [ ] Confirm sidebar no longer shows a separate "Import Providers" entry
- [ ] Run `bun run check` — no new errors