### PR TITLE
fix(pwa): handle Authelia auth-proxy redirects correctly

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,15 @@ export class APIClient {
 		try {
 			const response = await fetch(url, config);
 
+			// Auth proxy (e.g. Authelia) issues a 302 to the login page. With
+			// redirect: "manual" in the service worker the SW returns an opaque
+			// redirect here instead of following it cross-origin (which would
+			// CORS-fail). Reload so the browser navigates through Authelia.
+			if (response.type === "opaqueredirect") {
+				window.location.reload();
+				throw new APIError(302, "Session expired, redirecting to login", "");
+			}
+
 			if (!response.ok) {
 				if (response.status === 401) {
 					window.dispatchEvent(new CustomEvent("api:unauthorized"));
@@ -145,6 +154,15 @@ export class APIClient {
 
 		try {
 			const response = await fetch(url, config);
+
+			// Auth proxy (e.g. Authelia) issues a 302 to the login page. With
+			// redirect: "manual" in the service worker the SW returns an opaque
+			// redirect here instead of following it cross-origin (which would
+			// CORS-fail). Reload so the browser navigates through Authelia.
+			if (response.type === "opaqueredirect") {
+				window.location.reload();
+				throw new APIError(302, "Session expired, redirecting to login", "");
+			}
 
 			if (!response.ok) {
 				if (response.status === 401) {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -63,26 +63,39 @@ export default defineConfig({
 				],
 			},
 			workbox: {
-				globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+				// Exclude html: index.html must NOT be precached so every navigation
+				// reaches the network (and Authelia can check the session).
+				globPatterns: ["**/*.{js,css,ico,png,svg,woff2}"],
 				runtimeCaching: [
-					// NetworkFirst for navigation so auth proxies (e.g. Authelia) can
-					// redirect unauthenticated requests before the SW serves cached HTML.
+					// redirect: "manual" prevents the SW from following Authelia's 302
+					// cross-origin to login.kipsi.top. The opaque redirect is passed back
+					// to the browser which follows it as a normal navigation to the login page.
+					// When the session is valid, the 200 HTML response is cached as usual.
 					{
 						urlPattern: ({ request }) => request.mode === "navigate",
 						handler: "NetworkFirst",
 						options: {
 							cacheName: "navigation-cache",
 							networkTimeoutSeconds: 10,
+							fetchOptions: {
+								redirect: "manual",
+							},
 							cacheableResponse: {
 								statuses: [200],
 							},
 						},
 					},
+					// redirect: "manual" prevents the SW from following auth-proxy 302s
+					// cross-origin (which would CORS-fail). The opaque redirect is passed
+					// to the page; client.ts detects it and reloads through Authelia.
 					{
 						urlPattern: /^\/api\/.*/i,
 						handler: "NetworkFirst",
 						options: {
 							cacheName: "api-cache",
+							fetchOptions: {
+								redirect: "manual",
+							},
 							expiration: {
 								maxEntries: 50,
 								maxAgeSeconds: 60 * 5,


### PR DESCRIPTION
## Summary

- Remove `html` from workbox `globPatterns` so `index.html` is never precached — every navigation now hits the network and Authelia can check the session
- Add `fetchOptions: { redirect: "manual" }` to both workbox `NetworkFirst` handlers (navigation and `/api/*`) so the service worker returns opaque redirects instead of following Authelia's 302 cross-origin (which CORS-fails)
- Detect `response.type === "opaqueredirect"` in `APIClient.request()` and `requestWithMeta()` — calls `window.location.reload()` to navigate through Authelia when the session has expired

## Root cause (confirmed from HAR)

When the Authelia session expires the app's HTML loads from browser disk cache, bypassing Authelia entirely. The app then makes API calls which Authelia 302-redirects to `login.kipsi.top`. `fetch()` with `credentials: "include"` tries to follow the cross-origin redirect, hits CORS (no `Access-Control-Allow-*` headers on `login.kipsi.top`), and every API call returns **status 0**. The app silently showed the built-in login form instead of redirecting through Authelia.

HAR evidence:
| Entry | Status | URL |
|-------|--------|-----|
| 0 | 200 | `/` — served from **disk cache**, Authelia never sees it |
| 7 | **302** | `/api/auth/config` → Authelia redirects to `login.kipsi.top` |
| 8 | **0** | `login.kipsi.top/?rd=…` — **CORS failure** |
| 9 | 200 | OPTIONS `login.kipsi.top` — preflight, no Allow-Credentials |
| 11, 14 | **302** | `/api/user`, `/api/auth/registration-status` — same pattern |
| 12, 15 | **0** | Same CORS failures |

## Test plan

- [ ] Build succeeds: `cd frontend && bun run build`
- [ ] With Authelia session expired (clear cookies for `altmount.kipsi.top`), opening the app redirects to `login.kipsi.top` instead of showing CORS errors or the built-in login form
- [ ] After logging in at Authelia, the app loads correctly and all API calls succeed
- [ ] Normal authenticated flow is unaffected