### PR TITLE
fix(database): periodic WAL checkpoint to prevent unbounded SQLite WAL growth

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -77,6 +77,8 @@ func runServe(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
+	db.StartCheckpointLoop(ctx, 5*time.Minute)
+
 	repos := setupRepositories(ctx, db)
 	poolManager := pool.NewManager(ctx, repos.MainRepo)
 

--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -1,9 +1,11 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
+	"log/slog"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -219,6 +221,32 @@ func (db *DB) Close() error {
 // Connection returns the underlying database connection.
 func (db *DB) Connection() *sql.DB {
 	return db.conn
+}
+
+// StartCheckpointLoop starts a background goroutine that periodically forces a WAL checkpoint
+// (SQLite only). Call once after opening the DB; stops when ctx is cancelled.
+func (db *DB) StartCheckpointLoop(ctx context.Context, interval time.Duration) {
+	if db.dialect.d != DialectSQLite {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				var busy, log, checkpointed int
+				row := db.conn.QueryRowContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)")
+				if err := row.Scan(&busy, &log, &checkpointed); err != nil {
+					slog.WarnContext(ctx, "WAL checkpoint failed", "err", err)
+				} else {
+					slog.DebugContext(ctx, "WAL checkpoint complete", "busy", busy, "log", log, "checkpointed", checkpointed)
+				}
+			}
+		}
+	}()
 }
 
 // UpdateConnectionPool adjusts the database connection pool settings based on worker count.


### PR DESCRIPTION
## Summary

- Adds a `StartCheckpointLoop` method on `*DB` that runs `PRAGMA wal_checkpoint(TRUNCATE)` every 5 minutes in a background goroutine
- Calls it in `serve.go` immediately after the database is initialised

## Why

SQLite's built-in auto-checkpoint (`wal_autocheckpoint=500`, already set) is **passive** — it only runs when no readers are active. In a 24/7 read-heavy app there is nearly always an active reader, so checkpoints get skipped and the WAL file grows without bound (reports of 284 MB WAL files in the wild).

`PRAGMA wal_checkpoint(TRUNCATE)` waits for active readers to finish, performs a full checkpoint, then truncates the WAL file back to zero. Running it on a fixed 5-minute interval ensures the WAL is reclaimed regardless of sustained read load.

## Notes for reviewers

- **Postgres**: `StartCheckpointLoop` is a no-op — it returns immediately if the dialect is not SQLite
- **Shutdown**: the goroutine exits cleanly when the server context is cancelled
- The 5-minute interval is a conservative choice; the checkpoint typically completes in milliseconds