### PR TITLE
fix(arrs): guard nested WebhookMetadata pointer fields before dereferencing

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -534,7 +534,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	var err error
 
 	// ID-Based Precision: If we have the exact movie ID and file ID from metadata, use them directly
-	if metadata != nil && metadata.Movie.Id > 0 && metadata.MovieFile.Id > 0 {
+	if metadata != nil && metadata.Movie != nil && metadata.MovieFile != nil && metadata.Movie.Id > 0 && metadata.MovieFile.Id > 0 {
 		slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Radarr repair",
 			"movie_id", metadata.Movie.Id,
 			"movie_file_id", metadata.MovieFile.Id)
@@ -694,7 +694,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	var err error
 
 	// ID-Based Precision: If we have exact IDs from metadata, use them
-	if metadata != nil && metadata.Series.Id > 0 && metadata.EpisodeFile.Id > 0 {
+	if metadata != nil && metadata.Series != nil && metadata.EpisodeFile != nil && metadata.Series.Id > 0 && metadata.EpisodeFile.Id > 0 {
 		slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Sonarr repair",
 			"series_id", metadata.Series.Id,
 			"episode_file_id", metadata.EpisodeFile.Id)


### PR DESCRIPTION
\`WebhookMetadata.Series\`, \`EpisodeFile\`, \`Movie\`, and \`MovieFile\` are all pointer fields (\`omitempty\` in JSON). When a webhook payload omits any of them, the outer \`metadata != nil\` check passes but the inner field access panics with a nil pointer dereference.

Both \`triggerSonarrRescanByPath\` and \`triggerRadarrRescanByPath\` had this pattern:

\`\`\`go
// before
if metadata != nil && metadata.Series.Id > 0 && metadata.EpisodeFile.Id > 0 {

// after
if metadata != nil && metadata.Series != nil && metadata.EpisodeFile != nil && metadata.Series.Id > 0 && metadata.EpisodeFile.Id > 0 {
\`\`\`

Observed in production: 284 panics in 24h at \`manager.go:697 +0x1bf\`, all from the health repair loop calling \`TriggerFileRescan\` for files where the webhook payload omitted the \`series\` field.