### PR TITLE
refactor(utils): merge internal/pathutil into internal/utils

### DIFF
--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
-	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/utils"
 )
 
 // handleListHealth handles GET /api/health
@@ -419,20 +419,20 @@ func (s *Server) handleRepairHealth(c *fiber.Ctx) error {
 	// Determine final path for ARR rescan
 	pathForRescan := libraryPath
 	if pathForRescan == "" && cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "" {
-		pathForRescan = pathutil.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
+		pathForRescan = utils.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
 		slog.InfoContext(ctx, "Using library dir for manual repair",
 			"file_path", item.FilePath,
 			"library_path", pathForRescan)
 	}
 	if pathForRescan == "" && cfg.Import.ImportStrategy == config.ImportStrategySYMLINK && cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
-		pathForRescan = pathutil.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
+		pathForRescan = utils.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
 		slog.InfoContext(ctx, "Using symlink import path for manual repair",
 			"file_path", item.FilePath,
 			"symlink_path", pathForRescan)
 	}
 	if pathForRescan == "" {
 		// Fallback to mount path if no library path found
-		pathForRescan = pathutil.JoinAbsPath(cfg.MountPath, item.FilePath)
+		pathForRescan = utils.JoinAbsPath(cfg.MountPath, item.FilePath)
 		slog.InfoContext(ctx, "Using mount path fallback for manual repair",
 			"file_path", item.FilePath,
 			"mount_path", pathForRescan)
@@ -536,13 +536,13 @@ func (s *Server) handleRepairHealthBulk(c *fiber.Ctx) error {
 
 		pathForRescan := libraryPath
 		if pathForRescan == "" && cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "" {
-			pathForRescan = pathutil.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
+			pathForRescan = utils.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
 		}
 		if pathForRescan == "" && cfg.Import.ImportStrategy == config.ImportStrategySYMLINK && cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
-			pathForRescan = pathutil.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
+			pathForRescan = utils.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
 		}
 		if pathForRescan == "" {
-			pathForRescan = pathutil.JoinAbsPath(cfg.MountPath, item.FilePath)
+			pathForRescan = utils.JoinAbsPath(cfg.MountPath, item.FilePath)
 		}
 
 		// Trigger rescan
@@ -785,7 +785,7 @@ func (s *Server) cleanupHealthRecords(ctx context.Context, olderThan time.Time, 
 				pathToDelete = *item.LibraryPath
 			} else {
 				// Fallback to mount path
-				pathToDelete = pathutil.JoinAbsPath(mountPath, item.FilePath)
+				pathToDelete = utils.JoinAbsPath(mountPath, item.FilePath)
 			}
 
 			// Attempt to delete the physical file using os.Remove
@@ -810,7 +810,7 @@ func (s *Server) cleanupHealthRecords(ctx context.Context, olderThan time.Time, 
 				}
 
 				if rootPath != "" {
-					pathutil.RemoveEmptyDirs(rootPath, filepath.Dir(pathToDelete))
+					utils.RemoveEmptyDirs(rootPath, filepath.Dir(pathToDelete))
 				}
 			}
 		}
@@ -1456,7 +1456,7 @@ func (s *Server) handleRegenerateLibraryFiles(c *fiber.Ctx) error {
 		}
 
 		// Build the actual file path in the mount
-		actualPath := pathutil.JoinAbsPath(cfg.MountPath, file.FilePath)
+		actualPath := utils.JoinAbsPath(cfg.MountPath, file.FilePath)
 
 		// Create directory if needed
 		baseDir := filepath.Dir(libraryPath)
@@ -1546,7 +1546,7 @@ func deleteLibraryFile(ctx context.Context, cfg *config.Config, item *database.F
 	if item.LibraryPath != nil && *item.LibraryPath != "" {
 		pathToDelete = *item.LibraryPath
 	} else {
-		pathToDelete = pathutil.JoinAbsPath(cfg.MountPath, item.FilePath)
+		pathToDelete = utils.JoinAbsPath(cfg.MountPath, item.FilePath)
 	}
 
 	if err := os.Remove(pathToDelete); err != nil {
@@ -1566,7 +1566,7 @@ func deleteLibraryFile(ctx context.Context, cfg *config.Config, item *database.F
 		rootPath = cfg.MountPath
 	}
 	if rootPath != "" {
-		pathutil.RemoveEmptyDirs(rootPath, filepath.Dir(pathToDelete))
+		utils.RemoveEmptyDirs(rootPath, filepath.Dir(pathToDelete))
 	}
 
 	return true

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -24,7 +24,7 @@ import (
 	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/importer/utils"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
-	"github.com/javi11/altmount/internal/pathutil"
+	apputils "github.com/javi11/altmount/internal/utils"
 )
 
 // getDefaultCategory returns the Default category from config or a fallback
@@ -1165,7 +1165,7 @@ func (s *Server) handleSABnzbdGetConfig(c *fiber.Ctx) error {
 		// Build misc configuration
 		itemBasePath := s.calculateItemBasePath()
 		sabnzbdConfig.Misc = SABnzbdMiscConfig{
-			CompleteDir:            pathutil.JoinAbsPath(itemBasePath, cfg.SABnzbd.CompleteDir),
+			CompleteDir:            apputils.JoinAbsPath(itemBasePath, cfg.SABnzbd.CompleteDir),
 			PreCheck:               0,
 			HistoryRetention:       "",
 			HistoryRetentionOption: "all",

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/nntppool/v4"
 	"github.com/jinzhu/copier"
 	"github.com/robfig/cron/v3"
@@ -764,17 +764,17 @@ func (c *Config) Validate() error {
 // This performs actual filesystem checks and may create directories if needed
 func (c *Config) ValidateDirectories() error {
 	// Check metadata directory
-	if err := pathutil.CheckDirectoryWritable(c.Metadata.RootPath); err != nil {
+	if err := utils.CheckDirectoryWritable(c.Metadata.RootPath); err != nil {
 		return fmt.Errorf("metadata directory validation failed: %w", err)
 	}
 
 	// Check database directory
-	if err := pathutil.CheckFileDirectoryWritable(c.Database.Path, "database"); err != nil {
+	if err := utils.CheckFileDirectoryWritable(c.Database.Path, "database"); err != nil {
 		return err
 	}
 
 	// Check log file directory (only if log file is configured)
-	if err := pathutil.CheckFileDirectoryWritable(c.Log.File, "log"); err != nil {
+	if err := utils.CheckFileDirectoryWritable(c.Log.File, "log"); err != nil {
 		return err
 	}
 

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -19,7 +19,7 @@ import (
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/metadata"
-	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/altmount/pkg/rclonecli"
 	"github.com/sourcegraph/conc/pool"
 )
@@ -699,7 +699,7 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 
 				if needsRecovery {
 					// Use the configured mount path to build an absolute expected path
-					expectedPath := pathutil.JoinAbsPath(cfg.MountPath, path)
+					expectedPath := utils.JoinAbsPath(cfg.MountPath, path)
 					if _, err := os.Stat(expectedPath); err == nil {
 						// Found it! Use this recovered path ONLY if it is absolute and NOT equal to the local mount path
 						// (since repairs MUST use the library path Sonarr/Radarr expects).
@@ -1506,7 +1506,7 @@ func (lsw *LibrarySyncWorker) getAllImportDirFiles(ctx context.Context, oldMount
 // It checks both the full mount path and the relative path (for STRM files)
 func (lsw *LibrarySyncWorker) getLibraryPath(metaPath string, filesInUse map[string]string) *string {
 	cfg := lsw.configGetter()
-	mountPath := pathutil.JoinAbsPath(cfg.MountPath, metaPath)
+	mountPath := utils.JoinAbsPath(cfg.MountPath, metaPath)
 
 	if libPath, ok := filesInUse[mountPath]; ok {
 		return &libPath

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -19,7 +19,7 @@ import (
 	"github.com/javi11/altmount/internal/importer"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
-	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/sourcegraph/conc/pool"
 )
@@ -914,12 +914,12 @@ func (hw *HealthWorker) resolvePathForRescan(item *database.FileHealth) string {
 	}
 	cfg := hw.configGetter()
 	if cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "" {
-		return pathutil.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
+		return utils.JoinAbsPath(*cfg.Health.LibraryDir, item.FilePath)
 	}
 	if cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
-		return pathutil.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
+		return utils.JoinAbsPath(*cfg.Import.ImportDir, item.FilePath)
 	}
-	return pathutil.JoinAbsPath(cfg.MountPath, item.FilePath)
+	return utils.JoinAbsPath(cfg.MountPath, item.FilePath)
 }
 
 // cleanupZombieRecord deletes the health record and associated metadata for a file that is

--- a/internal/library/library.go
+++ b/internal/library/library.go
@@ -1,4 +1,4 @@
-package utils
+package library
 
 import (
 	"context"

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -13,7 +13,7 @@ import (
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
-	"github.com/javi11/altmount/internal/pathutil"
+	"github.com/javi11/altmount/internal/utils"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -395,7 +395,7 @@ func (ms *MetadataService) DeleteFileMetadataWithSourceNzb(ctx context.Context, 
 	}
 
 	// Clean up empty parent directories in metadata path
-	pathutil.RemoveEmptyDirs(ms.rootPath, metadataDir)
+	utils.RemoveEmptyDirs(ms.rootPath, metadataDir)
 
 	// Optionally delete the source NZB file (error-tolerant)
 	if deleteSourceNzb && sourceNzbPath != "" {
@@ -765,7 +765,7 @@ func (ms *MetadataService) CleanupOrphanedIDSymlinks(ctx context.Context) (int, 
 	}
 
 	// Clean empty shard directories bottom-up
-	pathutil.RemoveEmptyDirs(ms.rootPath, idsRoot)
+	utils.RemoveEmptyDirs(ms.rootPath, idsRoot)
 
 	return removed, nil
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -21,7 +21,7 @@ import (
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/nzbfilesystem/segcache"
-	"github.com/javi11/altmount/internal/pathutil"
+
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/usenet"
 	"github.com/javi11/altmount/internal/utils"
@@ -343,7 +343,7 @@ func (mrf *MetadataRemoteFile) RemoveFile(ctx context.Context, fileName string) 
 		}
 
 		if rootPath != "" {
-			pathutil.RemoveEmptyDirs(rootPath, filepath.Dir(physicalPath))
+			utils.RemoveEmptyDirs(rootPath, filepath.Dir(physicalPath))
 		}
 	}
 

--- a/internal/utils/path.go
+++ b/internal/utils/path.go
@@ -1,5 +1,4 @@
-// Package pathutil provides path validation utilities.
-package pathutil
+package utils
 
 import (
 	"fmt"

--- a/internal/utils/path_test.go
+++ b/internal/utils/path_test.go
@@ -1,4 +1,4 @@
-package pathutil
+package utils
 
 import (
 	"os"


### PR DESCRIPTION
## Summary

- Moves all path utility functions (`CheckDirectoryWritable`, `CheckFileDirectoryWritable`, `JoinAbsPath`, `NormalizeLibraryPath`, `RemoveEmptyDirs`) from `internal/pathutil` into `internal/utils/path.go`
- Ports the `pathutil` tests into `internal/utils/path_test.go`
- Moves `internal/utils/library.go` (which imported `internal/config`) into a new `internal/library` package to prevent the import cycle that would arise from `config` importing `utils`
- Updates all 7 importers (`config/manager.go`, `health/worker.go`, `health/library_sync.go`, `api/health_handlers.go`, `api/sabnzbd_handlers.go`, `metadata/service.go`, `nzbfilesystem/metadata_remote_file.go`) to reference `internal/utils` instead of `internal/pathutil`
- Deletes the `internal/pathutil` directory

## Why

Two overlapping utility packages existed with no clear boundary. This consolidates them into a single canonical `internal/utils` package.

## Reviewer notes

- `sabnzbd_handlers.go` already imported `internal/importer/utils` under the name `utils`, so `internal/utils` is aliased as `apputils` in that file only
- The `internal/library` package is a straight move of the old `utils/library.go` — no logic changed
- `go build ./...` and `go test ./internal/utils/...` both pass