### PR TITLE
refactor(stremio): move StremioCleanupService out of internal/api

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/javi11/altmount/frontend"
 	"github.com/javi11/altmount/internal/api"
 	"github.com/javi11/altmount/internal/arrs"
+	"github.com/javi11/altmount/internal/stremio"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/health"
 	"github.com/javi11/altmount/internal/metadata"
@@ -147,7 +148,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 
 	streamTracker.StartCleanup(ctx) // Periodic cleanup of stale streams
 
-	stremioCleanup := api.NewStremioCleanupService(repos.MainRepo, metadataService, configManager.GetConfigGetter())
+	stremioCleanup := stremio.NewStremioCleanupService(repos.MainRepo, metadataService, configManager.GetConfigGetter())
 	stremioCleanup.StartCleanup(ctx)
 
 	apiServer := setupAPIServer(app, repos, authService, configManager, metadataReader, metadataService, fs, poolManager, importerService, arrsService, mountService, progressBroadcaster, streamTracker, cacheSource)

--- a/internal/stremio/cleanup.go
+++ b/internal/stremio/cleanup.go
@@ -1,4 +1,4 @@
-package api
+package stremio
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

- Moves `StremioCleanupService` from `internal/api/stremio_cleanup.go` to a new `internal/stremio/cleanup.go` package
- Updates `cmd/altmount/cmd/serve.go` to import and use `stremio.NewStremioCleanupService`
- No logic changes — pure package reorganisation

## Why

`StremioCleanupService` is a background maintenance service with zero HTTP/fiber dependencies. Placing it in `internal/api` violated that package's responsibility (HTTP routing and request handling). The new `internal/stremio` package is the correct home for stremio-specific non-HTTP logic.

## Reviewer notes

- `internal/api/stremio_addon_handlers.go` and `internal/api/nzb_stremio_handlers.go` remain in `internal/api` — they are HTTP handlers and belong there.
- `go build ./...` passes cleanly.