### PR TITLE
feat(import): configurable import history retention with 90-day default

### DIFF
--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -555,6 +555,27 @@ export function ImportConfigSection({
 							disable.
 						</p>
 					</fieldset>
+
+					<fieldset className="fieldset min-w-0">
+						<legend className="fieldset-legend font-semibold">History Retention (Days)</legend>
+						<input
+							type="number"
+							className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
+							value={formData.history_retention_days ?? 90}
+							readOnly={isReadOnly}
+							min={0}
+							onChange={(e) =>
+								handleInputChange(
+									"history_retention_days",
+									Number.parseInt(e.target.value, 10) || 0,
+								)
+							}
+						/>
+						<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
+							Auto-remove completed import history records older than this many days. Set to 0 to
+							keep forever. Default: 90 days (3 months).
+						</p>
+					</fieldset>
 				</div>
 			</div>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -228,6 +228,7 @@ export interface ImportConfig {
 	rename_to_nzb_name?: boolean;
 	filter_sample_files?: boolean;
 	failed_item_retention_hours?: number | null;
+	history_retention_days?: number | null;
 	delete_completed_nzb?: boolean;
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -275,6 +275,7 @@ type ImportConfig struct {
 	RenameToNzbName                *bool          `yaml:"rename_to_nzb_name" mapstructure:"rename_to_nzb_name" json:"rename_to_nzb_name,omitempty"`
 	FilterSampleFiles              *bool          `yaml:"filter_sample_files" mapstructure:"filter_sample_files" json:"filter_sample_files,omitempty"`
 	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
+	HistoryRetentionDays           *int           `yaml:"history_retention_days" mapstructure:"history_retention_days" json:"history_retention_days,omitempty"`
 	DeleteCompletedNzb             *bool          `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
 }
 
@@ -1245,6 +1246,7 @@ func DefaultConfig(configDir ...string) *Config {
 	prowlarrEnabled := false   // Prowlarr integration disabled by default
 	watchIntervalSeconds := 10        // Default watch interval
 	failedItemRetentionHours := 24    // Default: auto-remove failed items after 24 hours
+	historyRetentionDays := 90        // Default: auto-remove import history after 90 days (3 months)
 	cleanupAutomaticImportFailure := false
 	metadataBackupEnabled := false
 	failureMaskingEnabled := true
@@ -1381,6 +1383,7 @@ func DefaultConfig(configDir ...string) *Config {
 			WatchDir:                nil,
 			WatchIntervalSeconds:    &watchIntervalSeconds,
 			FailedItemRetentionHours: &failedItemRetentionHours,
+			HistoryRetentionDays:     &historyRetentionDays,
 		},
 		Log: LogConfig{
 			File:       logPath, // Default log file path

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -791,6 +791,16 @@ func (r *QueueRepository) DeleteFailedItemsOlderThan(ctx context.Context, olderT
 	return deletedItems, nil
 }
 
+// DeleteImportHistoryOlderThan deletes import_history records completed before olderThan.
+func (r *QueueRepository) DeleteImportHistoryOlderThan(ctx context.Context, olderThan time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM import_history WHERE completed_at < ?`, olderThan)
+	if err != nil {
+		return fmt.Errorf("failed to delete old import history: %w", err)
+	}
+	return nil
+}
+
 // ResetStaleItems resets processing items back to pending on service startup
 func (r *QueueRepository) ResetStaleItems(ctx context.Context) error {
 	// Reset all items that are in 'processing' status

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1165,6 +1165,7 @@ func (s *Service) handleProcessingFailure(ctx context.Context, item *database.Im
 func (s *Service) runFailedItemCleanup(ctx context.Context) {
 	// Run once at startup
 	s.cleanupFailedItems(ctx)
+	s.cleanupOldHistory(ctx)
 
 	ticker := time.NewTicker(1 * time.Hour)
 	defer ticker.Stop()
@@ -1175,6 +1176,7 @@ func (s *Service) runFailedItemCleanup(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.cleanupFailedItems(ctx)
+			s.cleanupOldHistory(ctx)
 		}
 	}
 }
@@ -1218,6 +1220,19 @@ func (s *Service) cleanupFailedItems(ctx context.Context) {
 	s.log.InfoContext(ctx, "Cleaned up stale failed queue items",
 		"count", len(deletedItems),
 		"retention_hours", retentionHours)
+}
+
+// cleanupOldHistory deletes import_history records older than the configured retention period.
+func (s *Service) cleanupOldHistory(ctx context.Context) {
+	cfg := s.configGetter()
+	if cfg.Import.HistoryRetentionDays == nil || *cfg.Import.HistoryRetentionDays <= 0 {
+		return // disabled
+	}
+
+	cutoff := time.Now().Add(-time.Duration(*cfg.Import.HistoryRetentionDays) * 24 * time.Hour)
+	if err := s.database.Repository.DeleteImportHistoryOlderThan(ctx, cutoff); err != nil {
+		s.log.ErrorContext(ctx, "Failed to clean up old import history", "error", err)
+	}
 }
 
 // CancelProcessing cancels a processing queue item by cancelling its context


### PR DESCRIPTION
## Summary

- Adds `HistoryRetentionDays *int` to `ImportConfig` (default **90 days / 3 months**)
- New `DeleteImportHistoryOlderThan` method on `QueueRepository` deletes `import_history` rows where `completed_at < cutoff`
- The existing hourly cleanup goroutine (`runFailedItemCleanup`) now calls `cleanupOldHistory` alongside `cleanupFailedItems` — no new goroutine needed
- Setting the value to **0** disables automatic cleanup (records kept forever)
- Frontend: new **History Retention (Days)** number input in the Queue Maintenance section of the Import config page, matching the style of the existing Failed Item Retention field

## What changed

| File | Change |
|------|--------|
| `internal/config/manager.go` | `HistoryRetentionDays *int` field + default 90 |
| `internal/database/queue_repository.go` | `DeleteImportHistoryOlderThan` method |
| `internal/importer/service.go` | `cleanupOldHistory` method + wired into hourly goroutine |
| `frontend/src/types/config.ts` | `history_retention_days?: number \| null` |
| `frontend/src/components/config/WorkersConfigSection.tsx` | History Retention UI field |

## Test plan

- [ ] Build passes (`make`)
- [ ] Config page → Import section shows "History Retention (Days)" field with value 90
- [ ] Saving a new value persists and is returned by the config API
- [ ] With retention set to a positive value, the hourly cleanup removes `import_history` rows older than the threshold
- [ ] With retention set to 0, no rows are deleted (cleanup is skipped)