### PR TITLE
fix(sabnzbd): correct priority mapping and switch command handling

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -144,16 +144,32 @@ func (s *Server) handleSABnzbdResume(c *fiber.Ctx) error {
 	return s.writeSABnzbdResponseFiber(c, SABnzbdResponse{Status: true})
 }
 
-// handleSABnzbdSwitch handles priority switching
+// handleSABnzbdSwitch handles queue position switching.
+// value2 is a 0-based queue position (0 = top) per the SABnzbd API spec.
+// Some clients also send text-based priority tokens ("high", "force", etc.).
+// Position 0 (move to top) maps to High priority; any other numeric position maps to Normal.
 func (s *Server) handleSABnzbdSwitch(c *fiber.Ctx) error {
 	value := c.Query("value")
-	value2 := c.Query("value2") // Priority (0, 1, 2)
+	value2 := c.Query("value2")
 
 	if value == "" || value2 == "" {
 		return s.writeSABnzbdErrorFiber(c, "Missing parameters")
 	}
 
-	priority := s.parseSABnzbdPriority(value2)
+	// Map queue position or legacy priority token to AltMount priority.
+	var priority database.QueuePriority
+	switch strings.ToLower(value2) {
+	case "force", "2", "high", "1":
+		priority = database.QueuePriorityHigh
+	case "low", "-1", "paused", "-2":
+		priority = database.QueuePriorityLow
+	case "0":
+		// Position 0 = move to top of queue → highest priority.
+		priority = database.QueuePriorityHigh
+	default:
+		// Any other numeric position → normal priority.
+		priority = database.QueuePriorityNormal
+	}
 
 	// Attempt to parse as database ID first
 	id, err := strconv.ParseInt(value, 10, 64)
@@ -1247,14 +1263,15 @@ func (s *Server) handleSABnzbdVersion(c *fiber.Ctx) error {
 	return s.writeSABnzbdResponseFiber(c, response)
 }
 
-// parseSABnzbdPriority converts SABnzbd priority string to AltMount priority
+// parseSABnzbdPriority converts SABnzbd priority string to AltMount priority.
+// SABnzbd numeric values: 2=Force, 1=High, 0=Normal, -1=Low, -2=Paused.
 func (s *Server) parseSABnzbdPriority(priority string) database.QueuePriority {
 	switch strings.ToLower(priority) {
-	case "high", "2":
+	case "force", "2", "high", "1":
 		return database.QueuePriorityHigh
-	case "low", "0":
+	case "low", "-1", "paused", "-2":
 		return database.QueuePriorityLow
-	default:
+	default: // "normal", "0", or unrecognized
 		return database.QueuePriorityNormal
 	}
 }

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -145,9 +145,8 @@ func (s *Server) handleSABnzbdResume(c *fiber.Ctx) error {
 }
 
 // handleSABnzbdSwitch handles queue position switching.
-// value2 is a 0-based queue position (0 = top) per the SABnzbd API spec.
-// Some clients also send text-based priority tokens ("high", "force", etc.).
-// Position 0 (move to top) maps to High priority; any other numeric position maps to Normal.
+// value2 is a 0-based queue position (0 = top) per the SABnzbd API spec,
+// but some clients send text-based priority tokens instead.
 func (s *Server) handleSABnzbdSwitch(c *fiber.Ctx) error {
 	value := c.Query("value")
 	value2 := c.Query("value2")
@@ -156,19 +155,10 @@ func (s *Server) handleSABnzbdSwitch(c *fiber.Ctx) error {
 		return s.writeSABnzbdErrorFiber(c, "Missing parameters")
 	}
 
-	// Map queue position or legacy priority token to AltMount priority.
-	var priority database.QueuePriority
-	switch strings.ToLower(value2) {
-	case "force", "2", "high", "1":
+	priority := s.parseSABnzbdPriority(value2)
+	// Position 0 = "move to top of queue" — override to High regardless of token mapping.
+	if value2 == "0" {
 		priority = database.QueuePriorityHigh
-	case "low", "-1", "paused", "-2":
-		priority = database.QueuePriorityLow
-	case "0":
-		// Position 0 = move to top of queue → highest priority.
-		priority = database.QueuePriorityHigh
-	default:
-		// Any other numeric position → normal priority.
-		priority = database.QueuePriorityNormal
 	}
 
 	// Attempt to parse as database ID first


### PR DESCRIPTION
## Summary

- **Wrong SABnzbd → AltMount priority mapping**: `parseSABnzbdPriority` had the numeric values shifted by one. SABnzbd sends `1` for High and `0` for Normal, but the old code mapped `"0"` → Low and `"1"` (via default) → Normal. Sonarr/Radarr sending `priority=1` (High) resulted in items queued as Normal; `priority=0` (Normal) resulted in Low.
- **`switch` command treated queue position as priority**: The SABnzbd `switch` command uses `value2` as a 0-based queue position (`0` = top). The old code passed it directly to `parseSABnzbdPriority`, so "move to top" (`value2=0`) set the item to **Low** priority — the exact opposite of intended. Position `0` now correctly maps to High priority.

## What changed

`internal/api/sabnzbd_handlers.go`
- `parseSABnzbdPriority`: fixed mapping — `"force"/"2"/"high"/"1"` → High, `"low"/"-1"/"paused"/"-2"` → Low, `"normal"/"0"` (default) → Normal
- `handleSABnzbdSwitch`: replaced single `parseSABnzbdPriority(value2)` call with an explicit switch that handles position `0` as "move to top" (High) and any other numeric position as Normal, while still accepting text tokens for backward compat

## Test plan

- [ ] `go build ./internal/api/...` passes (verified)
- [ ] Sonarr/Radarr: trigger a force grab — confirm the queue item gets priority=1 (High) in the DB
- [ ] SABnzbd client Move to Top — confirm the item gets High priority, not Low
- [ ] Normal-priority add (priority=0) — confirm item is queued as Normal, not Low