### PR TITLE
fix(rclonecli): kill+respawn wedged rcd during mount recovery

### DIFF
--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -65,6 +65,24 @@ func (m *Manager) RecoverMount(ctx context.Context, provider string) error {
 
 	m.logger.WarnContext(ctx, "Attempting to recover mount", "provider", provider)
 
+	// Pre-recovery rcd liveness probe. If the rcd subprocess has wedged,
+	// every subsequent RPC (mount/unmount, config/create, mount/mount) will
+	// hang on context deadline exceeded. Kill+respawn rcd before issuing
+	// recovery RPCs to break out of that wedge.
+	if !m.pingServerWithTimeout(ctx, 5*time.Second) {
+		m.logger.WarnContext(ctx, "rcd unresponsive during recovery, restarting subprocess", "provider", provider)
+		if err := m.restartServer(ctx); err != nil {
+			return fmt.Errorf("failed to restart wedged rcd: %w", err)
+		}
+		// After restart there is nothing to RC-unmount; skip straight to Mount,
+		// which will recreate the rclone config and FUSE mount on the fresh rcd.
+		if err := m.Mount(ctx, provider, mountInfo.LocalPath, mountInfo.WebDAVURL); err != nil {
+			return fmt.Errorf("failed to recover mount for %s after rcd restart: %w", provider, err)
+		}
+		m.logger.InfoContext(ctx, "Successfully recovered mount after rcd restart", "provider", provider)
+		return nil
+	}
+
 	// First try to unmount cleanly
 	if err := m.unmount(ctx, provider); err != nil {
 		m.logger.ErrorContext(ctx, "Failed to unmount during recovery", "err", err, "provider", provider)
@@ -105,6 +123,37 @@ func (m *Manager) MonitorMounts(ctx context.Context) {
 // performMountHealthCheck checks and attempts to recover unhealthy mounts
 func (m *Manager) performMountHealthCheck() {
 	if !m.IsReady() {
+		return
+	}
+
+	// IsReady() only reflects startup state. Probe the rcd subprocess with a
+	// bounded timeout so a wedged rcd is detected even when no individual
+	// mount has failed yet.
+	if !m.pingServerWithTimeout(m.ctx, 5*time.Second) {
+		m.logger.WarnContext(m.ctx, "rcd unresponsive during health check, restarting subprocess")
+		if err := m.restartServer(m.ctx); err != nil {
+			m.logger.ErrorContext(m.ctx, "Failed to restart wedged rcd", "err", err)
+			return
+		}
+		// restartServer marked all mounts as unmounted. Re-establish each one
+		// against the fresh rcd; each Mount call is independent.
+		m.mountsMutex.RLock()
+		toRemount := make([]*MountInfo, 0, len(m.mounts))
+		for _, mount := range m.mounts {
+			toRemount = append(toRemount, mount)
+		}
+		m.mountsMutex.RUnlock()
+
+		for _, mount := range toRemount {
+			info := mount
+			go func() {
+				if err := m.Mount(m.ctx, info.Provider, info.LocalPath, info.WebDAVURL); err != nil {
+					m.logger.ErrorContext(m.ctx, "Failed to remount after rcd restart", "err", err, "provider", info.Provider)
+				}
+			}()
+		}
+		// Don't fall through to per-mount recovery on this tick; remounts are
+		// in flight and the next tick will assess health.
 		return
 	}
 

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -29,11 +29,12 @@ type Manager struct {
 	logger        *slog.Logger
 	ctx           context.Context
 	cancel        context.CancelFunc
-	httpClient    *http.Client
-	serverReady   chan struct{}
-	serverStarted bool
-	mu            sync.RWMutex
-	cfg           *config.Manager
+	httpClient     *http.Client
+	serverReady    chan struct{}
+	processExited  chan struct{}
+	serverStarted  bool
+	mu             sync.RWMutex
+	cfg            *config.Manager
 }
 
 type MountInfo struct {
@@ -79,8 +80,9 @@ func NewManager(cfm *config.Manager) *Manager {
 		logger:      logger,
 		ctx:         ctx,
 		cancel:      cancel,
-		httpClient:  httpclient.NewDefault(),
-		serverReady: make(chan struct{}),
+		httpClient:    httpclient.NewDefault(),
+		serverReady:   make(chan struct{}),
+		processExited: make(chan struct{}),
 	}
 }
 
@@ -151,6 +153,12 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 	m.serverStarted = true
 
+	// Capture references owned by this lifecycle so a future restart that
+	// swaps these channels under m.mu cannot race with the goroutine below.
+	cmd := m.cmd
+	serverReady := m.serverReady
+	processExited := m.processExited
+
 	// Wait for server to be ready in a goroutine
 	go func() {
 		defer func() {
@@ -160,7 +168,7 @@ func (m *Manager) Start(ctx context.Context) error {
 		}()
 
 		m.waitForServer()
-		close(m.serverReady)
+		close(serverReady)
 
 		// Start mount monitoring once server is ready
 		go func() {
@@ -173,7 +181,14 @@ func (m *Manager) Start(ctx context.Context) error {
 		}()
 
 		// Wait for command to finish and log output
-		err := m.cmd.Wait()
+		err := cmd.Wait()
+		// Signal that the subprocess has exited so restartServer can proceed.
+		select {
+		case <-processExited:
+			// already closed (defensive)
+		default:
+			close(processExited)
+		}
 		switch {
 		case err == nil:
 			m.logger.InfoContext(m.ctx, "Rclone RC server exited normally")
@@ -406,4 +421,96 @@ func (m *Manager) WaitForReady(timeout time.Duration) error {
 
 func (m *Manager) GetLogger() *slog.Logger {
 	return m.logger
+}
+
+// pingServerWithTimeout probes the rcd server with a bounded timeout so a
+// wedged subprocess fails fast instead of hanging the recovery path.
+// Returns true if rcd answers core/version within the timeout.
+func (m *Manager) pingServerWithTimeout(ctx context.Context, timeout time.Duration) bool {
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	body, err := json.Marshal(map[string]any{})
+	if err != nil {
+		return false
+	}
+
+	url := fmt.Sprintf("http://localhost:%s/core/version", m.rcPort)
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodPost, url, bytes.NewBuffer(body))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			m.logger.DebugContext(probeCtx, "Failed to close ping response body", "err", cerr)
+		}
+	}()
+	return resp.StatusCode == http.StatusOK
+}
+
+// restartServer force-kills the rcd subprocess and starts a fresh one.
+// Used by recovery paths when the rcd has wedged and is not responding to RPCs.
+// The mount map is preserved; callers are expected to re-establish mounts
+// against the fresh rcd via Mount(...).
+func (m *Manager) restartServer(ctx context.Context) error {
+	m.mu.Lock()
+	cmd := m.cmd
+	exited := m.processExited
+	wasStarted := m.serverStarted
+	m.mu.Unlock()
+
+	if !wasStarted || cmd == nil || cmd.Process == nil {
+		return fmt.Errorf("rcd subprocess not running, cannot restart")
+	}
+
+	m.logger.WarnContext(ctx, "Killing wedged rcd subprocess", "pid", cmd.Process.Pid)
+	if err := cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		m.logger.ErrorContext(ctx, "Failed to kill rcd process", "err", err)
+		// Continue anyway — the Wait goroutine may still close processExited
+		// if the process eventually dies on its own.
+	}
+
+	// Wait for the existing Start goroutine to observe the exit, with a hard
+	// cap so a stuck Wait doesn't block recovery indefinitely.
+	select {
+	case <-exited:
+	case <-time.After(10 * time.Second):
+		m.logger.WarnContext(ctx, "Timed out waiting for rcd subprocess to exit; proceeding with restart")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Reset lifecycle state so Start() will spawn a new subprocess.
+	m.mu.Lock()
+	m.serverStarted = false
+	m.cmd = nil
+	m.serverReady = make(chan struct{})
+	m.processExited = make(chan struct{})
+	m.mu.Unlock()
+
+	if err := m.Start(ctx); err != nil {
+		return fmt.Errorf("failed to restart rcd: %w", err)
+	}
+
+	if err := m.WaitForReady(30 * time.Second); err != nil {
+		return fmt.Errorf("rcd did not become ready after restart: %w", err)
+	}
+
+	// Mark all known mounts as unmounted so the next health-check tick
+	// re-establishes them against the fresh rcd.
+	m.mountsMutex.Lock()
+	for _, mount := range m.mounts {
+		mount.Mounted = false
+		mount.Error = "rcd subprocess restarted; awaiting remount"
+	}
+	m.mountsMutex.Unlock()
+
+	m.logger.InfoContext(ctx, "rcd subprocess restarted successfully")
+	return nil
 }


### PR DESCRIPTION
## Summary

Fixes [#551](https://github.com/javi11/altmount/issues/551) — follow-up to PR #541.

PR #541 fixed the OS-level FUSE unmount during recovery, but the next step (`POST /config/create` against the rcd subprocess) can hang indefinitely when rcd itself has wedged. The recovery loop then retries the same wedged endpoint until exhausted, leaving the mount permanently dead until the container is restarted.

This change adds rcd subprocess liveness detection and kill+respawn:

- **`pingServerWithTimeout`** — bounded `core/version` probe that fails fast instead of hanging the recovery path.
- **`restartServer`** — force-kills the rcd subprocess, waits for the existing `Start` goroutine to observe exit (via a new `processExited` channel), resets lifecycle state, respawns, and waits for the new rcd to become ready.
- **`RecoverMount`** — probes rcd before issuing recovery RPCs; on probe failure, restarts rcd and remounts on the fresh subprocess.
- **`performMountHealthCheck`** — same probe each tick, so a wedged rcd is caught even before any individual mount fails. After restart, all known mounts are re-established in parallel.

### Race-safety

The `Start` goroutine captures `cmd`, `serverReady`, and `processExited` locally so a future `restartServer` that swaps these channels under `m.mu` cannot race with the in-flight `cmd.Wait()` / `close(serverReady)` calls. `restartServer` waits on the captured `processExited` channel rather than calling `cmd.Wait()` a second time.

### Out of scope

- No changes to `makeRequest`'s default behavior — long-running ops like `vfs/refresh` should not get bounded timeouts.
- Metrics/counters for rcd restarts (worth a follow-up).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./pkg/rclonecli/...` passes
- [ ] Manual smoke test on Linux: start altmount, `kill -STOP` the rcd PID, wait 30s, confirm logs show liveness probe fail → `restartServer` → new rcd PID → mounts re-established
- [ ] Field validation by issue reporter against original `4d4cf985` reproduction