### PR TITLE
fix(stremio): expire cleanup actually deletes meta files and folders

### DIFF
--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -13,11 +13,16 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
 	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/prowlarr"
 )
+
+// stremioDownloadIDPrefix marks queue items originating from the Stremio addon.
+// Used by the cleanup service to identify and expire those items.
+const stremioDownloadIDPrefix = "stremio:"
 
 // stremioManifest is the Stremio addon manifest response.
 type stremioManifest struct {
@@ -402,7 +407,8 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 	case "series":
 		category = "TV"
 	}
-	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &category, &priority, nil, nil)
+	stremioDownloadID := stremioDownloadIDPrefix + uuid.NewString()
+	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &category, &priority, nil, &stremioDownloadID)
 	if err != nil {
 		os.Remove(tempPath)
 		slog.ErrorContext(ctx, "Failed to add Prowlarr NZB to queue", "error", err, "title", safeTitle)

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1878,9 +1878,9 @@ func (r *Repository) ClearHourlyStatsSince(ctx context.Context, since time.Time)
 }
 
 // GetExpiredStremioQueueItems returns completed Stremio queue items whose completed_at
-// is older than ttlHours. Items are identified as Stremio-originated by their nzb_path
-// containing tempUploadDir (typically os.TempDir()+"/altmount-uploads").
-func (r *Repository) GetExpiredStremioQueueItems(ctx context.Context, ttlHours int, tempUploadDir string) ([]*ImportQueueItem, error) {
+// is older than ttlHours. Items are identified as Stremio-originated by their download_id
+// having the "stremio:" prefix set when the addon enqueues an import.
+func (r *Repository) GetExpiredStremioQueueItems(ctx context.Context, ttlHours int) ([]*ImportQueueItem, error) {
 	var cutoffExpr string
 	if r.dialect.IsPostgres() {
 		cutoffExpr = fmt.Sprintf("NOW() - INTERVAL '%d hours'", ttlHours)
@@ -1894,12 +1894,12 @@ func (r *Repository) GetExpiredStremioQueueItems(ctx context.Context, ttlHours i
 		FROM import_queue
 		WHERE status = 'completed'
 		  AND completed_at < %s
-		  AND nzb_path LIKE ?
+		  AND download_id LIKE 'stremio:%%'
 		ORDER BY completed_at ASC
 		LIMIT 100
 	`, cutoffExpr)
 
-	rows, err := r.db.QueryContext(ctx, query, "%"+tempUploadDir+"%")
+	rows, err := r.db.QueryContext(ctx, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query expired stremio queue items: %w", err)
 	}

--- a/internal/stremio/cleanup.go
+++ b/internal/stremio/cleanup.go
@@ -13,7 +13,7 @@ import (
 )
 
 // StremioCleanupService periodically removes expired Stremio-originated queue items
-// along with their associated .meta files and temp NZB files.
+// along with their associated .meta files, storage directory, and persistent NZB files.
 type StremioCleanupService struct {
 	queueRepo       *database.Repository
 	metadataService *metadata.MetadataService
@@ -50,9 +50,6 @@ func (s *StremioCleanupService) StartCleanup(ctx context.Context) {
 	}()
 }
 
-// tempUploadDir is the directory where Stremio-originated NZB files are stored.
-var tempUploadDir = filepath.Join(os.TempDir(), "altmount-uploads")
-
 func (s *StremioCleanupService) cleanupExpired(ctx context.Context) {
 	cfg := s.configGetter()
 	ttlHours := cfg.Stremio.NzbTTLHours
@@ -60,7 +57,7 @@ func (s *StremioCleanupService) cleanupExpired(ctx context.Context) {
 		return
 	}
 
-	items, err := s.queueRepo.GetExpiredStremioQueueItems(ctx, ttlHours, tempUploadDir)
+	items, err := s.queueRepo.GetExpiredStremioQueueItems(ctx, ttlHours)
 	if err != nil {
 		slog.ErrorContext(ctx, "StremioCleanup: failed to query expired items", "error", err)
 		return
@@ -79,33 +76,35 @@ func (s *StremioCleanupService) deleteItem(ctx context.Context, item *database.I
 	if item.StoragePath != nil && *item.StoragePath != "" {
 		storagePath := *item.StoragePath
 		if s.metadataService.DirectoryExists(storagePath) {
-			// Directory: delete each .meta file inside
-			files, err := s.metadataService.ListDirectory(storagePath)
-			if err != nil {
-				slog.ErrorContext(ctx, "StremioCleanup: failed to list directory", "path", storagePath, "error", err)
-			} else {
-				for _, filename := range files {
-					virtualPath := filepath.Join(storagePath, filename)
-					if err := s.metadataService.DeleteFileMetadataWithSourceNzb(ctx, virtualPath, false); err != nil {
-						slog.ErrorContext(ctx, "StremioCleanup: failed to delete meta", "path", virtualPath, "error", err)
-					}
-				}
+			// Multi-file: remove the entire metadata subtree (including nested .meta files)
+			if err := s.metadataService.DeleteDirectory(storagePath); err != nil {
+				slog.ErrorContext(ctx, "StremioCleanup: failed to delete storage directory",
+					"path", storagePath, "error", err)
 			}
-			// Delete the temp NZB manually (source NZB not tracked per-file in directory case)
+			// Remove the persistent NZB file (one source NZB shared by all files in the dir)
 			if err := os.Remove(item.NzbPath); err != nil && !os.IsNotExist(err) {
-				slog.ErrorContext(ctx, "StremioCleanup: failed to delete temp NZB", "path", item.NzbPath, "error", err)
+				slog.ErrorContext(ctx, "StremioCleanup: failed to delete persistent NZB",
+					"path", item.NzbPath, "error", err)
 			}
 		} else {
 			// Single file: delete .meta + source NZB together
 			if err := s.metadataService.DeleteFileMetadataWithSourceNzb(ctx, storagePath, true); err != nil {
-				slog.ErrorContext(ctx, "StremioCleanup: failed to delete meta+nzb", "path", storagePath, "error", err)
+				slog.ErrorContext(ctx, "StremioCleanup: failed to delete meta+nzb",
+					"path", storagePath, "error", err)
 			}
 		}
 	} else {
-		// No storage path recorded — just delete the temp NZB if it still exists
+		// No storage path recorded — just delete the persistent NZB if it still exists
 		if err := os.Remove(item.NzbPath); err != nil && !os.IsNotExist(err) {
-			slog.ErrorContext(ctx, "StremioCleanup: failed to delete temp NZB", "path", item.NzbPath, "error", err)
+			slog.ErrorContext(ctx, "StremioCleanup: failed to delete persistent NZB",
+				"path", item.NzbPath, "error", err)
 		}
+	}
+
+	// Best-effort: prune the per-id parent folder under .nzbs (e.g. /config/.nzbs/Movies/123/)
+	// once it is empty. os.Remove only succeeds on empty directories, so this is safe.
+	if parent := filepath.Dir(item.NzbPath); parent != "" && parent != "." && parent != "/" {
+		_ = os.Remove(parent)
 	}
 
 	// Remove queue DB entry regardless of file deletion outcome


### PR DESCRIPTION
## Summary

The Stremio NZB expiration cleanup wasn't deleting `.meta` files or the storage folder when items aged past `Stremio.NzbTTLHours`. Three bugs contributed:

1. **Detection query never matched.** `GetExpiredStremioQueueItems` filtered Stremio rows via `nzb_path LIKE '%altmount-uploads%'`, but `ensurePersistentNzb` rewrites `nzb_path` to `<configDir>/.nzbs/{category}/{id}/file.nzb.gz` (and persists it to DB) before the item completes. By the time `status = 'completed'`, the filter could never match — cleanup ran zero deletions.
2. **Directory walk was shallow.** The directory branch in `deleteItem` used `metadataService.ListDirectory`, which only returns top-level `.meta` files. Nested `.meta` files (e.g. `Season 02/Episode.mkv.meta`) survived, so the storage folder was never empty and `RemoveEmptyDirs` couldn't prune it.
3. **`.nzbs/{cat}/{id}/` parent leaked.** Cleanup only `os.Remove`d the NZB file, leaving the empty per-id subfolder behind forever.

## Changes

- `internal/api/stremio_addon_handlers.go` — tag every Stremio enqueue with `download_id = "stremio:<uuid>"` so items remain identifiable after the NZB path is rewritten.
- `internal/database/repository.go` — `GetExpiredStremioQueueItems` now filters by `download_id LIKE 'stremio:%'` and drops the `tempUploadDir` parameter.
- `internal/stremio/cleanup.go` — directory branch uses `metadataService.DeleteDirectory` (backed by `os.RemoveAll`, with the existing root-safety guard) so nested `.meta` files and the folder itself are wiped in one call. Best-effort `os.Remove` on the `.nzbs/{cat}/{id}/` parent — only succeeds when empty, so it's safe.

No schema migration required. `download_id` was previously `nil` for Stremio items, so existing rows won't match the new filter (acceptable: they predate the fix and either already aged out or won't be cleaned automatically).

fix https://github.com/javi11/altmount/issues/564