### PR TITLE
fix: enqueue retried items instead of processing immediately

### DIFF
--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -259,7 +259,7 @@ func (s *Server) handleDeleteQueue(c *fiber.Ctx) error {
 // handleRetryQueue handles POST /api/queue/{id}/retry
 //
 //	@Summary		Retry queue item
-//	@Description	Resets a failed, pending, or completed queue item to pending and triggers processing.
+//	@Description	Resets a failed, pending, or completed queue item to pending so it is picked up by the worker pool.
 //	@Tags			Queue
 //	@Produce		json
 //	@Param			id	path		int	true	"Queue item ID"
@@ -301,11 +301,6 @@ func (s *Server) handleRetryQueue(c *fiber.Ctx) error {
 	err = s.queueRepo.UpdateQueueItemStatus(c.Context(), id, database.QueueStatusPending, nil)
 	if err != nil {
 		return RespondInternalError(c, "Failed to retry queue item", err.Error())
-	}
-
-	// Trigger background processing immediately
-	if s.importerService != nil {
-		s.importerService.ProcessItemInBackground(c.Context(), id)
 	}
 
 	if s.progressBroadcaster != nil {


### PR DESCRIPTION
## Summary

- Removes the `ProcessItemInBackground()` call from `handleRetryQueue()` so that retried items re-enter the normal worker-pool queue instead of being dispatched in an unbounded standalone goroutine.
- The item status is reset to `pending`; the existing worker pool polls for pending items and picks it up within the next processing interval, respecting the `MaxProcessorWorkers` concurrency limit.

## Problem

Calling `POST /api/queue/{id}/retry` (or the equivalent UI action) immediately spawned a goroutine via `ProcessItemInBackground()` that ran **outside** the worker pool. Retrying N items at once created N concurrent downloads, bypassing the configured simultaneous-import limit and causing most of them to fail.

Reported in: #549

## What changed

`internal/api/queue_handlers.go` — removed 5 lines (the `ProcessItemInBackground` guard + call + comment). No other files changed.

## Test plan

- [ ] Single retry: retried item transitions `failed` → `pending` → `processing` → `completed` via the normal worker loop
- [ ] Bulk retry: retrying multiple failed items simultaneously processes them up to `MaxProcessorWorkers` at a time, not all at once
- [ ] `make` passes (full build + lint)