### PR TITLE
docs(api): clarify JWT vs API key authentication (#571)

### DIFF
--- a/docs/docs/4. API/endpoints.md
+++ b/docs/docs/4. API/endpoints.md
@@ -10,12 +10,61 @@ AltMount provides a comprehensive REST API for programmatic integration and auto
 
 ## Authentication
 
-AltMount supports two authentication methods:
+Almost every endpoint under `/api/*` requires a **JWT** issued by `POST /api/auth/login`. The `?apikey=...` query parameter is **not** accepted on most endpoints — it only works on the small set of compatibility routes listed below. Requests without a valid JWT receive:
 
-- **Bearer token** (JWT): `Authorization: Bearer <token>` — obtained via `POST /api/auth/login`
-- **API key** (query parameter): `?apikey=YOUR_API_KEY` — found in System → Settings
+```json
+{ "success": false, "message": "Authentication required" }
+```
 
-Most endpoints accept either method.
+### Obtain a JWT
+
+`POST /api/auth/login` accepts a JSON body of `{ "username": "...", "password": "..." }`. On success the server sets an **HTTP-only `JWT` cookie** — the token is **not** included in the response body, so you must either keep the cookie or read the `Set-Cookie` header.
+
+**Option A — use a cookie jar (recommended for scripts):**
+
+```bash
+# 1. Log in and store the cookie
+curl -c cookies.txt -X POST 'http://altmount.local:8585/api/auth/login' \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"yourpassword"}'
+
+# 2. Reuse the cookie on subsequent requests
+curl -b cookies.txt -X POST 'http://altmount.local:8585/api/health/bulk/restart' \
+  -H 'Content-Type: application/json' \
+  -d '{"ids":[0]}'
+```
+
+**Option B — extract the token and send it as a Bearer header:**
+
+```bash
+TOKEN=$(curl -s -i -X POST 'http://altmount.local:8585/api/auth/login' \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"yourpassword"}' \
+  | awk -F'[=;]' '/^[Ss]et-[Cc]ookie: JWT=/ {print $2}')
+
+curl -X POST 'http://altmount.local:8585/api/health/bulk/restart' \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"ids":[0]}'
+```
+
+The JWT can be presented in any of these ways: the `JWT` cookie, an `Authorization: Bearer <token>` header, or the `X-JWT` header.
+
+### Endpoints that accept the API key query parameter
+
+The per-user **API key** (visible in **System → Settings**) is only honoured by routes that read it explicitly. Sending `?apikey=` to any other endpoint will return “Authentication required”. The currently supported endpoints are:
+
+| Endpoint | Accepts |
+|----------|---------|
+| `/api/sabnzbd/*` — SABnzbd-compatible API | `?apikey=` or `ma_username` + `ma_password` |
+| `POST /api/arrs/webhook` — Sonarr/Radarr webhook | `?apikey=` (required) |
+| `POST /api/import/nzbdav` and related `/api/import/nzbdav/*` routes | `?apikey=` |
+
+For everything else (queue, health, files, config, providers, system, FUSE, user, etc.) use the JWT flow above.
+
+### Stremio addon
+
+The Stremio addon is **not** authenticated with the API key. It uses a separate `download_key` (the SHA-256 of your API key) embedded in the URL: `/stremio/:key/manifest.json` and `/stremio/:key/stream/:type/:id.json`. The exact key is shown in the AltMount UI on the Stremio configuration page.
 
 ## Endpoint Categories
 

--- a/docs/docs/4. API/endpoints.md
+++ b/docs/docs/4. API/endpoints.md
@@ -58,7 +58,7 @@ The per-user **API key** (visible in **System → Settings**) is only honoured b
 |----------|---------|
 | `/api/sabnzbd/*` — SABnzbd-compatible API | `?apikey=` or `ma_username` + `ma_password` |
 | `POST /api/arrs/webhook` — Sonarr/Radarr webhook | `?apikey=` (required) |
-| `POST /api/import/nzbdav` and related `/api/import/nzbdav/*` routes | `?apikey=` |
+| `POST /api/import/file` — manual NZB file import | `?apikey=` (required) |
 
 For everything else (queue, health, files, config, providers, system, FUSE, user, etc.) use the JWT flow above.
 

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -30,7 +30,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Register ARR download clients
       tags:
         - ARRs
@@ -47,7 +46,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Test ARR download clients
       tags:
         - ARRs
@@ -63,7 +61,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get ARR health
       tags:
         - ARRs
@@ -79,7 +76,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: List ARR instances
       tags:
         - ARRs
@@ -114,7 +110,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get ARR instance
       tags:
         - ARRs
@@ -143,7 +138,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Test ARR connection
       tags:
         - ARRs
@@ -159,7 +153,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get ARR statistics
       tags:
         - ARRs
@@ -218,7 +211,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Register ARR webhooks
       tags:
         - ARRs
@@ -354,7 +346,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get configuration
       tags:
         - Config
@@ -382,7 +373,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Update configuration
       tags:
         - Config
@@ -419,7 +409,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Patch configuration section
       tags:
         - Config
@@ -466,7 +455,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Test provider download speed
       tags:
         - Providers
@@ -488,7 +476,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Reload configuration
       tags:
         - Config
@@ -517,7 +504,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Validate configuration
       tags:
         - Config
@@ -540,7 +526,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: List active streams
       tags:
         - Files
@@ -569,7 +554,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Kill active stream
       tags:
         - Files
@@ -605,7 +589,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Batch export files as NZBs
       tags:
         - Files
@@ -636,7 +619,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Export file metadata as NZB
       tags:
         - Files
@@ -677,7 +659,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get file metadata
       tags:
         - Files
@@ -693,7 +674,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get stream history
       tags:
         - Files
@@ -710,7 +690,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Force stop FUSE mount
       tags:
         - FUSE
@@ -748,7 +727,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Start FUSE mount
       tags:
         - FUSE
@@ -765,7 +743,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get FUSE status
       tags:
         - FUSE
@@ -787,7 +764,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Stop FUSE mount
       tags:
         - FUSE
@@ -871,7 +847,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: List health records
       tags:
         - Health
@@ -907,7 +882,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Delete health record
       tags:
         - Health
@@ -946,7 +920,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get health record
       tags:
         - Health
@@ -981,7 +954,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cancel health check
       tags:
         - Health
@@ -1021,7 +993,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Trigger immediate health check
       tags:
         - Health
@@ -1071,7 +1042,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Set health check priority
       tags:
         - Health
@@ -1117,7 +1087,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Trigger health repair
       tags:
         - Health
@@ -1158,7 +1127,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Unmask health record
       tags:
         - Health
@@ -1182,7 +1150,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk delete health records
       tags:
         - Health
@@ -1206,7 +1173,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk trigger health repair
       tags:
         - Health
@@ -1230,7 +1196,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk restart health checks
       tags:
         - Health
@@ -1264,7 +1229,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Add file for health check
       tags:
         - Health
@@ -1293,7 +1257,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cleanup health records
       tags:
         - Health
@@ -1335,7 +1298,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: List corrupted files
       tags:
         - Health
@@ -1357,7 +1319,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cancel library sync
       tags:
         - Health
@@ -1385,7 +1346,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Dry-run library sync
       tags:
         - Health
@@ -1402,7 +1362,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Check if library sync is needed
       tags:
         - Health
@@ -1425,7 +1384,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Start library sync
       tags:
         - Health
@@ -1447,7 +1405,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get library sync status
       tags:
         - Health
@@ -1470,7 +1427,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Regenerate library symlinks
       tags:
         - Health
@@ -1492,7 +1448,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Reset all health checks
       tags:
         - Health
@@ -1519,7 +1474,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get health statistics
       tags:
         - Health
@@ -1541,7 +1495,6 @@ paths:
                     type: object
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get health worker status
       tags:
         - Health
@@ -1609,7 +1562,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Clear import history
       tags:
         - Import
@@ -1650,7 +1602,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get import history
       tags:
         - Import
@@ -1666,7 +1617,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cancel NZBDav import
       tags:
         - Import
@@ -1694,7 +1644,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Import from NZBDav source
       tags:
         - Import
@@ -1710,7 +1659,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Reset NZBDav import status
       tags:
         - Import
@@ -1726,7 +1674,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get NZBDav import status
       tags:
         - Import
@@ -1742,7 +1689,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cancel directory scan
       tags:
         - Import
@@ -1770,7 +1716,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Start manual directory scan
       tags:
         - Import
@@ -1791,7 +1736,6 @@ paths:
                     type: object
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get scan status
       tags:
         - Import
@@ -1882,7 +1826,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Create NNTP provider
       tags:
         - Providers
@@ -1907,7 +1850,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Delete NNTP provider
       tags:
         - Providers
@@ -1953,7 +1895,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Update NNTP provider
       tags:
         - Providers
@@ -1982,7 +1923,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Reorder NNTP providers
       tags:
         - Providers
@@ -2017,7 +1957,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Test NNTP provider
       tags:
         - Providers
@@ -2104,7 +2043,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: List queue items
       tags:
         - Queue
@@ -2142,7 +2080,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Delete queue item
       tags:
         - Queue
@@ -2181,7 +2118,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get queue item
       tags:
         - Queue
@@ -2222,7 +2158,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Cancel queue item
       tags:
         - Queue
@@ -2253,7 +2188,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Download NZB file
       tags:
         - Queue
@@ -2309,7 +2243,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Update queue item priority
       tags:
         - Queue
@@ -2356,7 +2289,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Retry queue item
       tags:
         - Queue
@@ -2387,7 +2319,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk delete queue items
       tags:
         - Queue
@@ -2411,7 +2342,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk cancel queue items
       tags:
         - Queue
@@ -2441,7 +2371,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Bulk restart queue items
       tags:
         - Queue
@@ -2463,7 +2392,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Clear completed queue items
       tags:
         - Queue
@@ -2485,7 +2413,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Clear failed queue items
       tags:
         - Queue
@@ -2507,7 +2434,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Clear pending queue items
       tags:
         - Queue
@@ -2535,7 +2461,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get queue statistics
       tags:
         - Queue
@@ -2569,7 +2494,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get historical queue statistics
       tags:
         - Queue
@@ -2613,7 +2537,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Add test download to queue
       tags:
         - Queue
@@ -2668,7 +2591,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Upload NZB file to queue
       tags:
         - Queue
@@ -2721,7 +2643,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Search NZB by name and add to queue
       tags:
         - Queue
@@ -2768,7 +2689,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Add NZBLnk links to queue
       tags:
         - Queue
@@ -2913,7 +2833,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Browse filesystem
       tags:
         - System
@@ -2947,7 +2866,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: System cleanup
       tags:
         - System
@@ -2968,7 +2886,6 @@ paths:
                     type: object
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get system health
       tags:
         - System
@@ -2990,7 +2907,6 @@ paths:
                     type: object
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get NNTP pool metrics
       tags:
         - System
@@ -3018,7 +2934,6 @@ paths:
                     type: object
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Restart system
       tags:
         - System
@@ -3045,7 +2960,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get system statistics
       tags:
         - System
@@ -3062,7 +2976,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Reset system statistics
       tags:
         - System
@@ -3100,7 +3013,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Apply update
       tags:
         - System
@@ -3137,7 +3049,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get update status
       tags:
         - System
@@ -3164,7 +3075,6 @@ paths:
                 $ref: "#/components/schemas/api.APIResponse"
       security:
         - BearerAuth: []
-        - ApiKeyAuth: []
       summary: Get current user
       tags:
         - User

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -21,9 +21,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Automatically registers AltMount as a download client (SABnzbd-compatible) in all configured ARR instances.",
@@ -55,9 +52,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Tests whether AltMount is reachable as a download client from all configured ARR instances.",
@@ -83,9 +77,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns health check results from all configured Sonarr/Radarr instances.",
@@ -111,9 +102,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns all configured Sonarr/Radarr instances.",
@@ -139,9 +127,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Tests connectivity to a Sonarr/Radarr instance with given credentials.",
@@ -187,9 +172,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a specific Sonarr/Radarr instance by type and name.",
@@ -237,9 +219,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns sync statistics for all configured ARR instances.",
@@ -317,9 +296,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Automatically registers AltMount as a webhook connection in all configured Sonarr/Radarr instances.",
@@ -513,9 +489,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current AltMount configuration with sensitive values masked.",
@@ -557,9 +530,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Replaces the entire AltMount configuration. Triggers restart if required.",
@@ -605,9 +575,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Runs a speed test against the specified NNTP provider and saves the result to config.",
@@ -672,9 +639,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Reloads the AltMount configuration from disk without restarting.",
@@ -706,9 +670,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Validates a configuration object without saving it.",
@@ -754,9 +715,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Updates a specific named section of the configuration (e.g. import, sabnzbd, rclone).",
@@ -809,9 +767,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns all currently active NZB file streams. Optionally filter by type=file.",
@@ -845,9 +800,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Terminates an active NZB file stream by ID.",
@@ -888,9 +840,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Exports multiple mounted files as NZBs packed in a single ZIP archive.",
@@ -947,9 +896,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Exports the metadata of a mounted file back to a downloadable NZB file.",
@@ -993,9 +939,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns metadata for a mounted NZB file including segment info, encryption, and status.",
@@ -1054,9 +997,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a history of recently completed NZB file streams.",
@@ -1082,9 +1022,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Force-unmounts the FUSE filesystem using platform-specific commands (fusermount/umount).",
@@ -1110,9 +1047,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Mounts the NZB filesystem at the given path using FUSE.",
@@ -1169,9 +1103,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current status of the FUSE mount (stopped, starting, running, error).",
@@ -1197,9 +1128,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Gracefully unmounts the FUSE filesystem.",
@@ -1231,9 +1159,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a paginated list of file health records with optional status/search filters.",
@@ -1346,9 +1271,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Deletes multiple health records by ID.",
@@ -1402,9 +1324,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Triggers repair attempts for multiple corrupted files.",
@@ -1458,9 +1377,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets multiple health records to pending status for re-checking.",
@@ -1514,9 +1430,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Adds a file to the health monitoring queue for checking.",
@@ -1574,9 +1487,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes old health records based on age, status, or both. Optionally deletes physical files.",
@@ -1621,9 +1531,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a paginated list of health records with corrupted status.",
@@ -1687,9 +1594,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Cancels an in-progress library sync operation.",
@@ -1721,9 +1625,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Simulates a library sync and returns what would be changed without applying it.",
@@ -1767,9 +1668,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns whether a library sync is needed based on current configuration state.",
@@ -1795,9 +1693,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Triggers a library sync operation to reconcile the file system with the database.",
@@ -1829,9 +1724,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current status of the library sync worker.",
@@ -1863,9 +1755,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Regenerates all library symlinks and STRM files for files that already have metadata.",
@@ -1897,9 +1786,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets all health records to pending status for a full re-check cycle.",
@@ -1931,9 +1817,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns counts of health records grouped by status.",
@@ -1977,9 +1860,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current status and statistics of the background health check worker.",
@@ -2017,9 +1897,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a single health record by ID.",
@@ -2076,9 +1953,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Deletes a health record and optionally the associated physical file.",
@@ -2128,9 +2002,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Cancels an in-progress health check for a file.",
@@ -2177,9 +2048,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Triggers an immediate health check for a file, bypassing the queue.",
@@ -2238,9 +2106,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Sets the checking priority for a health record.",
@@ -2316,9 +2181,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Triggers a repair attempt for a corrupted file.",
@@ -2388,9 +2250,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Clears the streaming-failure mask on a health record so it can be checked again.",
@@ -2518,9 +2377,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a paginated list of completed import records.",
@@ -2582,9 +2438,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes all completed import history records.",
@@ -2616,9 +2469,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Starts an import from a WebDAV/NZBDav source, fetching NZBs from the remote.",
@@ -2661,9 +2511,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Cancels the currently running NZBDav import operation.",
@@ -2689,9 +2536,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets the NZBDav import state so a new import can be started.",
@@ -2717,9 +2561,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current status of the NZBDav import operation.",
@@ -2745,9 +2586,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Scans a directory for NZB files and adds them to the import queue.",
@@ -2791,9 +2629,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Cancels the currently running manual directory scan.",
@@ -2819,9 +2654,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns the current status of the manual directory scan operation.",
@@ -2928,9 +2760,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Adds a new NNTP provider to the configuration.",
@@ -2988,9 +2817,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Sets the priority order of NNTP providers.",
@@ -3036,9 +2862,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Tests NNTP provider connectivity with given credentials, returning RTT on success.",
@@ -3096,9 +2919,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Updates an existing NNTP provider by ID.",
@@ -3167,9 +2987,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes an NNTP provider by ID from the configuration.",
@@ -3207,9 +3024,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a paginated list of NZB download queue items with optional filters.",
@@ -3325,9 +3139,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Deletes multiple queue items by ID. Cannot delete items currently being processed.",
@@ -3387,9 +3198,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Requests cancellation of multiple currently-processing queue items.",
@@ -3443,9 +3251,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets multiple queue items to pending status for reprocessing.",
@@ -3505,9 +3310,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes all completed items from the queue.",
@@ -3539,9 +3341,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes all failed items from the queue.",
@@ -3573,9 +3372,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes all pending items from the queue.",
@@ -3607,9 +3403,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns current queue statistics (counts by status, average processing time).",
@@ -3653,9 +3446,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns historical import statistics over a rolling window (last 24h, 7d, 30d, 365d).",
@@ -3707,9 +3497,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Downloads a test NZB from sabnzbd.org and adds it to the queue for connectivity testing.",
@@ -3778,9 +3565,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Uploads an NZB file and adds it to the download queue.",
@@ -3860,9 +3644,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Searches for an NZB by name via the configured indexer and adds the result to the queue.",
@@ -3937,9 +3718,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resolves one or more nzblnk:// links and adds the resulting NZBs to the queue.",
@@ -4008,9 +3786,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns a single queue item by ID.",
@@ -4067,9 +3842,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Deletes a queue item by ID. Cannot delete items currently being processed.",
@@ -4119,9 +3891,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Requests cancellation of a queue item that is currently being processed.",
@@ -4174,9 +3943,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Downloads the original NZB file associated with a queue item.",
@@ -4220,9 +3986,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Changes the priority of a pending or failed queue item.",
@@ -4304,9 +4067,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets a failed, pending, or completed queue item to pending and triggers processing.",
@@ -4515,9 +4275,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Lists filesystem entries at a given path for directory/file picker UIs.",
@@ -4557,9 +4314,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Removes old queue items and health records based on age. Supports dry-run mode.",
@@ -4616,9 +4370,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns health status of all system components (database, workers, etc.).",
@@ -4656,9 +4407,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns download/upload metrics, speed, and per-provider connection statistics.",
@@ -4696,9 +4444,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Schedules a graceful system restart. Use force=true to skip safety checks.",
@@ -4749,9 +4494,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns combined queue, health, and system information statistics.",
@@ -4795,9 +4537,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Resets accumulated system statistics counters (pool metrics, download counters).",
@@ -4823,9 +4562,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Pulls the latest Docker image and restarts the container to apply the update.",
@@ -4881,9 +4617,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Checks Docker Hub for the latest available version and returns whether an update is available.",
@@ -4939,9 +4672,6 @@
                 "security": [
                     {
                         "BearerAuth": []
-                    },
-                    {
-                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Returns information about the currently authenticated user.",

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -1606,7 +1606,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Register ARR download clients
       tags:
       - ARRs
@@ -1623,7 +1622,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Test ARR download clients
       tags:
       - ARRs
@@ -1640,7 +1638,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get ARR health
       tags:
       - ARRs
@@ -1656,7 +1653,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: List ARR instances
       tags:
       - ARRs
@@ -1687,7 +1683,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get ARR instance
       tags:
       - ARRs
@@ -1716,7 +1711,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Test ARR connection
       tags:
       - ARRs
@@ -1732,7 +1726,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get ARR statistics
       tags:
       - ARRs
@@ -1787,7 +1780,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Register ARR webhooks
       tags:
       - ARRs
@@ -1917,7 +1909,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get configuration
       tags:
       - Config
@@ -1946,7 +1937,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Update configuration
       tags:
       - Config
@@ -1981,7 +1971,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Patch configuration section
       tags:
       - Config
@@ -2021,7 +2010,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Test provider download speed
       tags:
       - Providers
@@ -2041,7 +2029,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Reload configuration
       tags:
       - Config
@@ -2070,7 +2057,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Validate configuration
       tags:
       - Config
@@ -2092,7 +2078,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: List active streams
       tags:
       - Files
@@ -2118,7 +2103,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Kill active stream
       tags:
       - Files
@@ -2154,7 +2138,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Batch export files as NZBs
       tags:
       - Files
@@ -2183,7 +2166,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Export file metadata as NZB
       tags:
       - Files
@@ -2219,7 +2201,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get file metadata
       tags:
       - Files
@@ -2235,7 +2216,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get stream history
       tags:
       - Files
@@ -2252,7 +2232,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Force stop FUSE mount
       tags:
       - FUSE
@@ -2288,7 +2267,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Start FUSE mount
       tags:
       - FUSE
@@ -2305,7 +2283,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get FUSE status
       tags:
       - FUSE
@@ -2325,7 +2302,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Stop FUSE mount
       tags:
       - FUSE
@@ -2400,7 +2376,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: List health records
       tags:
       - Health
@@ -2433,7 +2408,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Delete health record
       tags:
       - Health
@@ -2467,7 +2441,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get health record
       tags:
       - Health
@@ -2497,7 +2470,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cancel health check
       tags:
       - Health
@@ -2532,7 +2504,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Trigger immediate health check
       tags:
       - Health
@@ -2578,7 +2549,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Set health check priority
       tags:
       - Health
@@ -2620,7 +2590,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Trigger health repair
       tags:
       - Health
@@ -2656,7 +2625,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Unmask health record
       tags:
       - Health
@@ -2690,7 +2658,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk delete health records
       tags:
       - Health
@@ -2724,7 +2691,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk trigger health repair
       tags:
       - Health
@@ -2758,7 +2724,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk restart health checks
       tags:
       - Health
@@ -2792,7 +2757,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Add file for health check
       tags:
       - Health
@@ -2821,7 +2785,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cleanup health records
       tags:
       - Health
@@ -2859,7 +2822,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: List corrupted files
       tags:
       - Health
@@ -2879,7 +2841,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cancel library sync
       tags:
       - Health
@@ -2905,7 +2866,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Dry-run library sync
       tags:
       - Health
@@ -2922,7 +2882,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Check if library sync is needed
       tags:
       - Health
@@ -2943,7 +2902,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Start library sync
       tags:
       - Health
@@ -2963,7 +2921,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get library sync status
       tags:
       - Health
@@ -2984,7 +2941,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Regenerate library symlinks
       tags:
       - Health
@@ -3005,7 +2961,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Reset all health checks
       tags:
       - Health
@@ -3030,7 +2985,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get health statistics
       tags:
       - Health
@@ -3052,7 +3006,6 @@ paths:
               type: object
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get health worker status
       tags:
       - Health
@@ -3114,7 +3067,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Clear import history
       tags:
       - Import
@@ -3151,7 +3103,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get import history
       tags:
       - Import
@@ -3167,7 +3118,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cancel NZBDav import
       tags:
       - Import
@@ -3195,7 +3145,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Import from NZBDav source
       tags:
       - Import
@@ -3211,7 +3160,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Reset NZBDav import status
       tags:
       - Import
@@ -3227,7 +3175,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get NZBDav import status
       tags:
       - Import
@@ -3243,7 +3190,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cancel directory scan
       tags:
       - Import
@@ -3271,7 +3217,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Start manual directory scan
       tags:
       - Import
@@ -3292,7 +3237,6 @@ paths:
               type: object
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get scan status
       tags:
       - Import
@@ -3375,7 +3319,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Create NNTP provider
       tags:
       - Providers
@@ -3399,7 +3342,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Delete NNTP provider
       tags:
       - Providers
@@ -3441,7 +3383,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Update NNTP provider
       tags:
       - Providers
@@ -3470,7 +3411,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Reorder NNTP providers
       tags:
       - Providers
@@ -3505,7 +3445,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Test NNTP provider
       tags:
       - Providers
@@ -3581,7 +3520,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: List queue items
       tags:
       - Queue
@@ -3614,7 +3552,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Delete queue item
       tags:
       - Queue
@@ -3648,7 +3585,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get queue item
       tags:
       - Queue
@@ -3682,7 +3618,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Cancel queue item
       tags:
       - Queue
@@ -3710,7 +3645,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Download NZB file
       tags:
       - Queue
@@ -3760,7 +3694,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Update queue item priority
       tags:
       - Queue
@@ -3800,7 +3733,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Retry queue item
       tags:
       - Queue
@@ -3839,7 +3771,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk delete queue items
       tags:
       - Queue
@@ -3873,7 +3804,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk cancel queue items
       tags:
       - Queue
@@ -3911,7 +3841,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Bulk restart queue items
       tags:
       - Queue
@@ -3931,7 +3860,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Clear completed queue items
       tags:
       - Queue
@@ -3951,7 +3879,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Clear failed queue items
       tags:
       - Queue
@@ -3971,7 +3898,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Clear pending queue items
       tags:
       - Queue
@@ -3997,7 +3923,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get queue statistics
       tags:
       - Queue
@@ -4028,7 +3953,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get historical queue statistics
       tags:
       - Queue
@@ -4070,7 +3994,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Add test download to queue
       tags:
       - Queue
@@ -4119,7 +4042,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Upload NZB file to queue
       tags:
       - Queue
@@ -4168,7 +4090,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Search NZB by name and add to queue
       tags:
       - Queue
@@ -4213,7 +4134,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Add NZBLnk links to queue
       tags:
       - Queue
@@ -4339,7 +4259,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Browse filesystem
       tags:
       - System
@@ -4373,7 +4292,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: System cleanup
       tags:
       - System
@@ -4395,7 +4313,6 @@ paths:
               type: object
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get system health
       tags:
       - System
@@ -4417,7 +4334,6 @@ paths:
               type: object
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get NNTP pool metrics
       tags:
       - System
@@ -4447,7 +4363,6 @@ paths:
               type: object
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Restart system
       tags:
       - System
@@ -4472,7 +4387,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get system statistics
       tags:
       - System
@@ -4489,7 +4403,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Reset system statistics
       tags:
       - System
@@ -4525,7 +4438,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Apply update
       tags:
       - System
@@ -4559,7 +4471,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get update status
       tags:
       - System
@@ -4584,7 +4495,6 @@ paths:
             $ref: '#/definitions/api.APIResponse'
       security:
       - BearerAuth: []
-      - ApiKeyAuth: []
       summary: Get current user
       tags:
       - User

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -625,7 +625,6 @@ type TestConnectionRequest struct {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/instances [get]
 func (s *Server) handleListArrsInstances(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -665,7 +664,6 @@ func (s *Server) handleListArrsInstances(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		404		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/instances/{type}/{name} [get]
 func (s *Server) handleGetArrsInstance(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -718,7 +716,6 @@ func (s *Server) handleGetArrsInstance(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/instances/test [post]
 func (s *Server) handleTestArrsConnection(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -762,7 +759,6 @@ func (s *Server) handleTestArrsConnection(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/stats [get]
 func (s *Server) handleGetArrsStats(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -835,7 +831,6 @@ func (s *Server) handleGetArrsStats(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/health [get]
 func (s *Server) handleGetArrsHealth(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -866,7 +861,6 @@ func (s *Server) handleGetArrsHealth(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/webhook/register [post]
 func (s *Server) handleRegisterArrsWebhooks(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -903,7 +897,6 @@ func (s *Server) handleRegisterArrsWebhooks(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/download-client/register [post]
 func (s *Server) handleRegisterArrsDownloadClients(c *fiber.Ctx) error {
 	if s.arrsService == nil {
@@ -975,7 +968,6 @@ func (s *Server) handleRegisterArrsDownloadClients(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/arrs/download-client/test [post]
 func (s *Server) handleTestArrsDownloadClients(c *fiber.Ctx) error {
 	if s.arrsService == nil {

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -204,7 +204,6 @@ func (s *Server) handleGetAuthConfig(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse{data=UserResponse}
 //	@Failure		401	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/user [get]
 func (s *Server) handleAuthUser(c *fiber.Ctx) error {
 	user := auth.GetUserFromContext(c)

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -92,7 +92,6 @@ func RegisterLogLevelHandler(ctx context.Context, configManager *config.Manager,
 //	@Success		200	{object}	APIResponse{data=ConfigAPIResponse}
 //	@Failure		503	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config [get]
 func (s *Server) handleGetConfig(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -122,7 +121,6 @@ func (s *Server) handleGetConfig(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config [put]
 func (s *Server) handleUpdateConfig(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -183,7 +181,6 @@ func (s *Server) handleUpdateConfig(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config/{section} [patch]
 func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -292,7 +289,6 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config/reload [post]
 func (s *Server) handleReloadConfig(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -323,7 +319,6 @@ func (s *Server) handleReloadConfig(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config/validate [post]
 func (s *Server) handleValidateConfig(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -377,7 +372,6 @@ func (s *Server) handleValidateConfig(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=TestProviderResponse}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers/test [post]
 func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -478,7 +472,6 @@ func (s *Server) handleTestProvider(c *fiber.Ctx) error {
 //	@Success		201		{object}	APIResponse{data=ProviderAPIResponse}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers [post]
 func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -614,7 +607,6 @@ func (s *Server) handleCreateProvider(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		404		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers/{id} [put]
 func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -797,7 +789,6 @@ func (s *Server) handleUpdateProvider(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers/{id}/reset-quota [post]
 func (s *Server) handleResetProviderQuota(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -852,7 +843,6 @@ func (s *Server) handleResetProviderQuota(c *fiber.Ctx) error {
 //	@Success		204
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers/{id} [delete]
 func (s *Server) handleDeleteProvider(c *fiber.Ctx) error {
 	if s.configManager == nil {
@@ -922,7 +912,6 @@ func (s *Server) handleDeleteProvider(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/providers/reorder [put]
 func (s *Server) handleReorderProviders(c *fiber.Ctx) error {
 	if s.configManager == nil {

--- a/internal/api/file_handlers.go
+++ b/internal/api/file_handlers.go
@@ -30,7 +30,6 @@ import (
 //	@Failure		400		{object}	APIResponse
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/info [get]
 func (s *Server) handleGetFileMetadata(c *fiber.Ctx) error {
 	// Get path from query parameters
@@ -205,7 +204,6 @@ type nzbHead struct {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/export-nzb [get]
 func (s *Server) handleExportMetadataToNZB(c *fiber.Ctx) error {
 	// Get path from query parameters
@@ -395,7 +393,6 @@ func shouldExcludeFile(filename string, excludeArchives bool) bool {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/export-batch [post]
 func (s *Server) handleBatchExportNZB(c *fiber.Ctx) error {
 	ctx := context.Background()

--- a/internal/api/fuse_handlers.go
+++ b/internal/api/fuse_handlers.go
@@ -217,7 +217,6 @@ func (m *FuseManager) recoverMount(ctx context.Context) {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		409		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/fuse/start [post]
 func (s *Server) handleStartFuseMount(c *fiber.Ctx) error {
 	var req struct {
@@ -299,7 +298,6 @@ func (s *Server) handleStartFuseMount(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		409	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/fuse/stop [post]
 func (s *Server) handleStopFuseMount(c *fiber.Ctx) error {
 	s.fuseManager.mu.Lock()
@@ -333,7 +331,6 @@ func (s *Server) handleStopFuseMount(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/fuse/force-stop [post]
 func (s *Server) handleForceStopFuseMount(c *fiber.Ctx) error {
 	s.fuseManager.mu.Lock()
@@ -374,7 +371,6 @@ func (s *Server) handleForceStopFuseMount(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/fuse/status [get]
 func (s *Server) handleGetFuseStatus(c *fiber.Ctx) error {
 	s.fuseManager.mu.Lock()

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -33,7 +33,6 @@ import (
 //	@Success		200			{object}	APIResponse{data=[]HealthItemResponse,meta=APIMeta}
 //	@Failure		400			{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health [get]
 func (s *Server) handleListHealth(c *fiber.Ctx) error {
 	// Parse pagination
@@ -135,7 +134,6 @@ func (s *Server) countHealthItems(ctx context.Context, statusFilter *database.He
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id} [get]
 func (s *Server) handleGetHealth(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -176,7 +174,6 @@ func (s *Server) handleGetHealth(c *fiber.Ctx) error {
 //	@Failure		400				{object}	APIResponse
 //	@Failure		404				{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id} [delete]
 func (s *Server) handleDeleteHealth(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -270,7 +267,6 @@ func (s *Server) handleDeleteHealth(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/bulk/delete [post]
 func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -365,7 +361,6 @@ func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		404		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id}/repair [post]
 func (s *Server) handleRepairHealth(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -481,7 +476,6 @@ func (s *Server) handleRepairHealth(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/bulk/repair [post]
 func (s *Server) handleRepairHealthBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -583,7 +577,6 @@ func (s *Server) handleRepairHealthBulk(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=[]HealthItemResponse,meta=APIMeta}
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/corrupted [get]
 func (s *Server) handleListCorrupted(c *fiber.Ctx) error {
 	// Parse pagination
@@ -642,7 +635,6 @@ func (s *Server) handleListCorrupted(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse{data=HealthStatsResponse}
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/stats [get]
 func (s *Server) handleGetHealthStats(c *fiber.Ctx) error {
 	stats, err := s.healthRepo.GetHealthStats(c.Context())
@@ -665,7 +657,6 @@ func (s *Server) handleGetHealthStats(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/cleanup [delete]
 func (s *Server) handleCleanupHealth(c *fiber.Ctx) error {
 	// Parse request body
@@ -854,7 +845,6 @@ func (s *Server) cleanupHealthRecords(ctx context.Context, olderThan time.Time, 
 //	@Success		201		{object}	APIResponse{data=HealthItemResponse}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/check [post]
 func (s *Server) handleAddHealthCheck(c *fiber.Ctx) error {
 	// Parse request body
@@ -902,7 +892,6 @@ func (s *Server) handleAddHealthCheck(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse{data=HealthWorkerStatusResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/worker/status [get]
 func (s *Server) handleGetHealthWorkerStatus(c *fiber.Ctx) error {
 	if s.healthWorker == nil {
@@ -938,7 +927,6 @@ func (s *Server) handleGetHealthWorkerStatus(c *fiber.Ctx) error {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id}/check-now [post]
 func (s *Server) handleDirectHealthCheck(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -1044,7 +1032,6 @@ type SegmentsInfo struct {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/bulk/restart [post]
 func (s *Server) handleRestartHealthChecksBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -1107,7 +1094,6 @@ func (s *Server) handleRestartHealthChecksBulk(c *fiber.Ctx) error {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id}/cancel [post]
 func (s *Server) handleCancelHealthCheck(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -1178,7 +1164,6 @@ func (s *Server) handleCancelHealthCheck(c *fiber.Ctx) error {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id}/unmask [post]
 func (s *Server) handleUnmaskHealth(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -1239,7 +1224,6 @@ func (s *Server) handleUnmaskHealth(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		404		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/{id}/priority [post]
 func (s *Server) handleSetHealthPriority(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -1306,7 +1290,6 @@ func (s *Server) handleSetHealthPriority(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/reset-all [post]
 func (s *Server) handleResetAllHealthChecks(c *fiber.Ctx) error {
 	// Reset all items to pending status using repository method

--- a/internal/api/import_handlers.go
+++ b/internal/api/import_handlers.go
@@ -23,7 +23,6 @@ import (
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/scan [post]
 func (s *Server) handleStartManualScan(c *fiber.Ctx) error {
 	// Check if importer service is available
@@ -78,7 +77,6 @@ func (s *Server) handleStartManualScan(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse{data=ScanStatusResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/scan/status [get]
 func (s *Server) handleGetScanStatus(c *fiber.Ctx) error {
 	// Check if importer service is available
@@ -106,7 +104,6 @@ func (s *Server) handleGetScanStatus(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/scan [delete]
 func (s *Server) handleCancelScan(c *fiber.Ctx) error {
 	// Check if importer service is available
@@ -311,7 +308,6 @@ func (s *Server) handleManualImportFile(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=[]ImportHistoryResponse,meta=APIMeta}
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/history [get]
 func (s *Server) handleGetImportHistory(c *fiber.Ctx) error {
 	limit := 50
@@ -356,7 +352,6 @@ func toScanStatusResponse(scanInfo importer.ScanInfo) *ScanStatusResponse {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/history [delete]
 func (s *Server) handleClearImportHistory(c *fiber.Ctx) error {
 	if err := s.queueRepo.ClearImportHistory(c.Context()); err != nil {

--- a/internal/api/nzbdav_handlers.go
+++ b/internal/api/nzbdav_handlers.go
@@ -23,7 +23,6 @@ import (
 //	@Success		200		{object}	APIResponse
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav [post]
 func (s *Server) handleImportNzbdav(c *fiber.Ctx) error {
 	// Check if importer service is available
@@ -105,7 +104,6 @@ func (s *Server) handleImportNzbdav(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav/status [get]
 func (s *Server) handleGetNzbdavImportStatus(c *fiber.Ctx) error {
 	if s.importerService == nil {
@@ -149,7 +147,6 @@ func (s *Server) handleGetNzbdavImportStatus(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav/migrate-symlinks [post]
 func (s *Server) handleMigrateNzbdavSymlinks(c *fiber.Ctx) error {
 	var req struct {
@@ -249,7 +246,6 @@ func (s *Server) handleMigrateNzbdavSymlinks(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav [delete]
 func (s *Server) handleCancelNzbdavImport(c *fiber.Ctx) error {
 	if s.importerService == nil {
@@ -281,7 +277,6 @@ func (s *Server) handleCancelNzbdavImport(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav/reset [post]
 func (s *Server) handleResetNzbdavImportStatus(c *fiber.Ctx) error {
 	if s.importerService == nil {
@@ -307,7 +302,6 @@ func (s *Server) handleResetNzbdavImportStatus(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav/pending-migrations [delete]
 func (s *Server) handleClearPendingNzbdavMigrations(c *fiber.Ctx) error {
 	if s.migrationRepo == nil {
@@ -343,7 +337,6 @@ func (s *Server) handleClearPendingNzbdavMigrations(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/import/nzbdav/migrations [delete]
 func (s *Server) handleClearAllNzbdavMigrations(c *fiber.Ctx) error {
 	if s.migrationRepo == nil {

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -29,7 +29,6 @@ type ProviderSpeedTestResponse struct {
 //	@Failure		404	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/config/providers/{id}/speedtest [post]
 func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	providerID := c.Params("id")

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -69,7 +69,6 @@ func transformQueueError(err *string) string {
 //	@Failure		400			{object}	APIResponse
 //	@Failure		401			{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue [get]
 func (s *Server) handleListQueue(c *fiber.Ctx) error {
 	// Parse pagination
@@ -171,7 +170,6 @@ func (s *Server) handleListQueue(c *fiber.Ctx) error {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id} [get]
 func (s *Server) handleGetQueue(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -212,7 +210,6 @@ func (s *Server) handleGetQueue(c *fiber.Ctx) error {
 //	@Failure		404	{object}	APIResponse
 //	@Failure		409	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id} [delete]
 func (s *Server) handleDeleteQueue(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -268,7 +265,6 @@ func (s *Server) handleDeleteQueue(c *fiber.Ctx) error {
 //	@Failure		404	{object}	APIResponse
 //	@Failure		409	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id}/retry [post]
 func (s *Server) handleRetryQueue(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -329,7 +325,6 @@ func (s *Server) handleRetryQueue(c *fiber.Ctx) error {
 //	@Failure		404	{object}	APIResponse
 //	@Failure		409	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id}/cancel [post]
 func (s *Server) handleCancelQueue(c *fiber.Ctx) error {
 	// Extract ID from path parameter
@@ -386,7 +381,6 @@ func (s *Server) handleCancelQueue(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse{data=QueueStatsResponse}
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/stats [get]
 func (s *Server) handleGetQueueStats(c *fiber.Ctx) error {
 	stats, err := s.queueRepo.GetQueueStats(c.Context())
@@ -408,7 +402,6 @@ func (s *Server) handleGetQueueStats(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=QueueHistoricalStatsResponse}
 //	@Failure		500		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/stats/history [get]
 func (s *Server) handleGetQueueHistoricalStats(c *fiber.Ctx) error {
 	// Get optional days parameter, default to 1 (24h)
@@ -448,7 +441,6 @@ func (s *Server) handleGetQueueHistoricalStats(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/completed [delete]
 func (s *Server) handleClearCompletedQueue(c *fiber.Ctx) error {
 	paths, count, err := s.queueRepo.ClearCompletedQueueItems(c.Context())
@@ -474,7 +466,6 @@ func (s *Server) handleClearCompletedQueue(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/failed [delete]
 func (s *Server) handleClearFailedQueue(c *fiber.Ctx) error {
 	paths, count, err := s.queueRepo.ClearFailedQueueItems(c.Context())
@@ -500,7 +491,6 @@ func (s *Server) handleClearFailedQueue(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/pending [delete]
 func (s *Server) handleClearPendingQueue(c *fiber.Ctx) error {
 	paths, count, err := s.queueRepo.ClearPendingQueueItems(c.Context())
@@ -529,7 +519,6 @@ func (s *Server) handleClearPendingQueue(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		409		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/bulk [delete]
 func (s *Server) handleDeleteQueueBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -584,7 +573,6 @@ func (s *Server) handleDeleteQueueBulk(c *fiber.Ctx) error {
 //	@Failure		400				{object}	APIResponse
 //	@Failure		503				{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/upload [post]
 func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 	// Get uploaded file
@@ -690,7 +678,6 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		503		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/upload-nzblnk [post]
 func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 	// Parse request body
@@ -877,7 +864,6 @@ func embedPasswordInNZB(nzbContent []byte, password string) []byte {
 //	@Failure		404		{object}	APIResponse
 //	@Failure		503		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/upload-by-name [post]
 func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 	var req struct {
@@ -967,7 +953,6 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		409		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/bulk/restart [post]
 func (s *Server) handleRestartQueueBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -1038,7 +1023,6 @@ func (s *Server) handleRestartQueueBulk(c *fiber.Ctx) error {
 //	@Success		202		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/bulk/cancel [post]
 func (s *Server) handleCancelQueueBulk(c *fiber.Ctx) error {
 	// Parse request body
@@ -1118,7 +1102,6 @@ func (s *Server) handleCancelQueueBulk(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		502		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/test [post]
 func (s *Server) handleAddTestQueueItem(c *fiber.Ctx) error {
 	// Parse request body
@@ -1213,7 +1196,6 @@ func (s *Server) handleAddTestQueueItem(c *fiber.Ctx) error {
 //	@Failure		404		{object}	APIResponse
 //	@Failure		409		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id}/priority [patch]
 func (s *Server) handleUpdateQueueItemPriority(c *fiber.Ctx) error {
 	idStr := c.Params("id")
@@ -1276,7 +1258,6 @@ func (s *Server) handleUpdateQueueItemPriority(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=object{updated_count=int,skipped_count=int,message=string}}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/bulk/priority [patch]
 func (s *Server) handleBulkUpdateQueuePriority(c *fiber.Ctx) error {
 	var req struct {
@@ -1323,7 +1304,6 @@ func (s *Server) handleBulkUpdateQueuePriority(c *fiber.Ctx) error {
 //	@Failure		400	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/queue/{id}/download [get]
 func (s *Server) handleDownloadNZB(c *fiber.Ctx) error {
 	// Extract ID from path parameter

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -400,7 +400,6 @@ func (s *Server) Shutdown(ctx context.Context) {
 //	@Param			type	query		string	false	"Filter by source type (e.g. file)"
 //	@Success		200		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/active-streams [get]
 func (s *Server) handleGetActiveStreams(c *fiber.Ctx) error {
 	if s.streamTracker == nil {
@@ -499,7 +498,6 @@ func (s *Server) checkSystemHealth(ctx context.Context) SystemHealthResponse {
 //	@Success		200	{object}	APIResponse
 //	@Failure		503	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/library-sync/status [get]
 func (s *Server) handleGetLibrarySyncStatus(c *fiber.Ctx) error {
 	if s.librarySyncWorker == nil {
@@ -521,7 +519,6 @@ func (s *Server) handleGetLibrarySyncStatus(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		503	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/library-sync/start [post]
 func (s *Server) handleStartLibrarySync(c *fiber.Ctx) error {
 	if s.librarySyncWorker == nil {
@@ -543,7 +540,6 @@ func (s *Server) handleStartLibrarySync(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		503	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/library-sync/cancel [post]
 func (s *Server) handleCancelLibrarySync(c *fiber.Ctx) error {
 	if s.librarySyncWorker == nil {
@@ -565,7 +561,6 @@ func (s *Server) handleCancelLibrarySync(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse{data=DryRunSyncResult}
 //	@Failure		503	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/library-sync/dry-run [post]
 func (s *Server) handleDryRunLibrarySync(c *fiber.Ctx) error {
 	if s.librarySyncWorker == nil {
@@ -586,7 +581,6 @@ func (s *Server) handleDryRunLibrarySync(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/health/library-sync/needed [get]
 func (s *Server) handleGetSyncNeeded(c *fiber.Ctx) error {
 	handlers := NewLibrarySyncHandlers(s.librarySyncWorker, s.configManager)
@@ -603,7 +597,6 @@ func (s *Server) handleGetSyncNeeded(c *fiber.Ctx) error {
 //	@Success		200	{object}	APIResponse
 //	@Failure		404	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/active-streams/{id} [delete]
 func (s *Server) handleKillStream(c *fiber.Ctx) error {
 	id := c.Params("id")
@@ -635,7 +628,6 @@ func (s *Server) handleKillStream(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/files/streams/history [get]
 func (s *Server) handleGetStreamHistory(c *fiber.Ctx) error {
 	if s.streamTracker == nil {

--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -27,7 +27,6 @@ var lastMissingWarnTime sync.Map
 //	@Success		200	{object}	APIResponse{data=SystemStatsResponse}
 //	@Failure		500	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/stats [get]
 func (s *Server) handleGetSystemStats(c *fiber.Ctx) error {
 	// Get queue statistics
@@ -71,7 +70,6 @@ func (s *Server) handleGetSystemStats(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse{data=SystemHealthResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/health [get]
 func (s *Server) handleGetSystemHealth(c *fiber.Ctx) error {
 	// Perform health checks
@@ -117,7 +115,6 @@ func (s *Server) handleGetSystemHealth(c *fiber.Ctx) error {
 //	@Success		200		{object}	APIResponse{data=SystemCleanupResponse}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/cleanup [post]
 func (s *Server) handleSystemCleanup(c *fiber.Ctx) error {
 	// Parse request body
@@ -229,7 +226,6 @@ func (s *Server) handleSystemCleanup(c *fiber.Ctx) error {
 //	@Param			body	body		SystemRestartRequest	false	"Restart options"
 //	@Success		200		{object}	APIResponse{data=SystemRestartResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/restart [post]
 func (s *Server) handleSystemRestart(c *fiber.Ctx) error {
 	// Parse request body if present
@@ -272,7 +268,6 @@ func (s *Server) handleSystemRestart(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/stats/reset [post]
 func (s *Server) handleResetSystemStats(c *fiber.Ctx) error {
 	ctx := c.Context()
@@ -407,7 +402,6 @@ func (s *Server) performRestart(ctx context.Context) {
 //	@Param			interval query		string false "Aggregation interval (daily, weekly, monthly, yearly)"
 //	@Success		200		{object}	APIResponse{data=ProviderHistoricalStatsResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/provider-stats [get]
 func (s *Server) handleGetProviderHistoricalStats(c *fiber.Ctx) error {
 	daysStr := c.Query("days", "30")
@@ -468,7 +462,6 @@ func (s *Server) handleGetProviderHistoricalStats(c *fiber.Ctx) error {
 //	@Param			days	query		int	false	"Number of days to fetch data for (default: 30)"
 //	@Success		200		{object}	APIResponse{data=ProviderSpeedTestHistoryResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/provider-speed-history [get]
 func (s *Server) handleGetProviderSpeedHistory(c *fiber.Ctx) error {
 	daysStr := c.Query("days", "30")
@@ -520,7 +513,6 @@ func (s *Server) handleGetProviderSpeedHistory(c *fiber.Ctx) error {
 //	@Produce		json
 //	@Success		200	{object}	APIResponse{data=PoolMetricsResponse}
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/pool/metrics [get]
 func (s *Server) handleGetPoolMetrics(c *fiber.Ctx) error {
 	// Check if pool manager is available
@@ -772,7 +764,6 @@ type FileEntry struct {
 //	@Success		200		{object}	APIResponse
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/browse [get]
 func (s *Server) handleSystemBrowse(c *fiber.Ctx) error {
 	path := c.Query("path")

--- a/internal/api/update_handlers.go
+++ b/internal/api/update_handlers.go
@@ -119,7 +119,6 @@ func fetchLatestGitHubCommit(ctx context.Context) (string, error) {
 //	@Success		200		{object}	APIResponse{data=UpdateStatusResponse}
 //	@Failure		400		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/update/status [get]
 func (s *Server) handleGetUpdateStatus(c *fiber.Ctx) error {
 	channel := UpdateChannel(c.Query("channel", string(UpdateChannelLatest)))
@@ -181,7 +180,6 @@ func (s *Server) handleGetUpdateStatus(c *fiber.Ctx) error {
 //	@Failure		400		{object}	APIResponse
 //	@Failure		503		{object}	APIResponse
 //	@Security		BearerAuth
-//	@Security		ApiKeyAuth
 //	@Router			/system/update/apply [post]
 func (s *Server) handleApplyUpdate(c *fiber.Ctx) error {
 	user := auth.GetUserFromContext(c)


### PR DESCRIPTION
## Summary

Fixes [#571](https://github.com/javi11/altmount/issues/571). The Authentication section of the API docs claimed "Most endpoints accept either method" (Bearer JWT or `?apikey=`), which is wrong and led the reporter to a 401 on `/api/health/bulk/restart?apikey=...`.

In reality (verified against `internal/auth/middleware.go` and the route table in `internal/api/server.go`):

- `/api/*` is guarded by `RequireAuthWithSkip` → `RequireAuth`, which only consults `tokenService.Get` (JWT cookie / `Authorization: Bearer` / `X-JWT`). The `CombinedAuthMiddleware` that would also check the per-user API key is defined but unused.
- The only endpoints that read the API key are those that call `c.Query("apikey")` directly: SABnzbd-compatible API, `POST /api/arrs/webhook`, and the NZBDav import endpoints.
- `POST /api/auth/login` sets the JWT as an **HTTP-only `JWT` cookie** and does **not** return the token in the body, which wasn't documented anywhere.
- The Stremio addon uses a separate `download_key` embedded in the URL, not the API key.

## What changed

`docs/docs/4. API/endpoints.md` — rewrote the **Authentication** section to:

- State up front that `/api/*` requires the JWT.
- Show two working `curl` patterns: cookie-jar (`-c/-b cookies.txt`) and extracting the cookie into an `Authorization: Bearer` header — directly replacing the failing call from the issue.
- Enumerate the exact endpoints that accept `?apikey=`.
- Clarify that the Stremio addon uses `download_key`, not the API key.

`docs/static/openapi.yaml` is already correct (every `/api/*` op declares `BearerAuth`), so no schema changes are needed.

## Test plan

- [ ] `cd docs && bun run build` renders cleanly.
- [ ] Reporter from #571 can reproduce a successful `POST /api/health/bulk/restart` using either of the two documented flows.