### PR TITLE
fix(mount): skip mount dir creation on Windows for rclone and FUSE

### DIFF
--- a/internal/api/fuse_handlers.go
+++ b/internal/api/fuse_handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -241,13 +242,15 @@ func (s *Server) handleStartFuseMount(c *fiber.Ctx) error {
 	s.fuseManager.path = req.Path
 	s.fuseManager.mu.Unlock()
 
-	// Ensure directory exists
-	if _, err := os.Stat(req.Path); os.IsNotExist(err) {
-		if err := os.MkdirAll(req.Path, 0755); err != nil {
-			s.fuseManager.mu.Lock()
-			s.fuseManager.status = "error"
-			s.fuseManager.mu.Unlock()
-			return RespondInternalError(c, "Failed to create mount directory", err.Error())
+	// Ensure directory exists (skip on Windows: WinFSP requires the mount point to NOT exist)
+	if runtime.GOOS != "windows" {
+		if _, err := os.Stat(req.Path); os.IsNotExist(err) {
+			if err := os.MkdirAll(req.Path, 0755); err != nil {
+				s.fuseManager.mu.Lock()
+				s.fuseManager.status = "error"
+				s.fuseManager.mu.Unlock()
+				return RespondInternalError(c, "Failed to create mount directory", err.Error())
+			}
 		}
 	}
 
@@ -432,13 +435,16 @@ func (s *Server) AutoStartFuse() {
 	s.fuseManager.path = cfg.Fuse.MountPath
 	s.fuseManager.mu.Unlock()
 
-	if _, err := os.Stat(cfg.Fuse.MountPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(cfg.Fuse.MountPath, 0755); err != nil {
-			slog.ErrorContext(context.Background(), "Failed to create auto-mount directory", "path", cfg.Fuse.MountPath, "error", err)
-			s.fuseManager.mu.Lock()
-			s.fuseManager.status = "error"
-			s.fuseManager.mu.Unlock()
-			return
+	// Skip on Windows: WinFSP requires the mount point to NOT exist
+	if runtime.GOOS != "windows" {
+		if _, err := os.Stat(cfg.Fuse.MountPath); os.IsNotExist(err) {
+			if err := os.MkdirAll(cfg.Fuse.MountPath, 0755); err != nil {
+				slog.ErrorContext(context.Background(), "Failed to create auto-mount directory", "path", cfg.Fuse.MountPath, "error", err)
+				s.fuseManager.mu.Lock()
+				s.fuseManager.status = "error"
+				s.fuseManager.mu.Unlock()
+				return
+			}
 		}
 	}
 

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -66,11 +66,13 @@ func (m *Manager) mountWithRetry(ctx context.Context, provider, mountPath, webda
 func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavURL string) error {
 	cfg := m.cfg.GetConfig()
 
-	m.logger.InfoContext(ctx, "Creating mount directory", "provider", provider, "path", mountPath)
-	// Create mount directory
-	if err := os.MkdirAll(mountPath, 0755); err != nil {
-		if !os.IsExist(err) {
-			return fmt.Errorf("failed to create mount directory %s: %w", mountPath, err)
+	// Create mount directory (skip on Windows: WinFSP requires the mount point to NOT exist)
+	if runtime.GOOS != "windows" {
+		m.logger.InfoContext(ctx, "Creating mount directory", "provider", provider, "path", mountPath)
+		if err := os.MkdirAll(mountPath, 0755); err != nil {
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to create mount directory %s: %w", mountPath, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- On Windows, rclone + WinFSP and FUSE via WinFSP require the mount target directory to NOT exist before mounting. AltMount was unconditionally calling `os.MkdirAll(mountPath, 0755)` before mounting, which broke the Windows mount flow.
- Guard the three mount-point `MkdirAll` call sites with `runtime.GOOS != "windows"` so the directory is only auto-created on Linux/macOS, while Windows can mount onto a non-existent path as WinFSP requires.

Affected sites:
- `pkg/rclonecli/client.go` — `performMount` (rclone internal mount)
- `internal/api/fuse_handlers.go` — `handleStartFuseMount` (manual FUSE mount)
- `internal/api/fuse_handlers.go` — `AutoStartFuse` (auto-start FUSE mount)

Config/cache directory `MkdirAll` calls in `pkg/rclonecli/manager.go` are unchanged — they are not mount points.

Fixes #573

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./pkg/rclonecli/... ./internal/api/...` passes
- [ ] Manual (Windows): configure rclone mount + FUSE mount with a non-existent target path, confirm the mount succeeds and the drive/folder appears
- [ ] Manual (Linux/macOS): confirm existing behavior unchanged — mount directory is auto-created when missing