### PR TITLE
fix(arrs): skip webhook directory deletion when storage path is in use

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -17,6 +17,13 @@ import (
 	"github.com/javi11/altmount/internal/database"
 )
 
+// arrWebhookDeleteGrace is how long after a queue item completes its
+// storage_path is still considered "in use" by the arr webhook directory
+// deletion handler. Within this window the handler skips deleting the
+// metadata/symlink tree so a freshly written release folder is not wiped
+// out by a stale Download webhook from a previous grab.
+const arrWebhookDeleteGrace = 10 * time.Minute
+
 // ArrsInstanceRequest represents a request to create/update an arrs instance
 type ArrsInstanceRequest struct {
 	Name              string `json:"name"`
@@ -409,6 +416,28 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 		slog.InfoContext(c.Context(), "Processing webhook directory deletion",
 			"original_path", path,
 			"normalized_path", normalizedPath)
+
+		// Race guard: skip deletion if another import_queue row references this
+		// storage path and is still active (pending/processing/paused) or was
+		// completed within the recent grace window. This prevents arr "Download"
+		// webhooks for a previous grab from wiping the metadata/symlink tree
+		// that a sibling re-grab/upgrade just wrote into the same release dir.
+		if s.queueRepo != nil {
+			busy, err := s.queueRepo.HasActiveOrRecentQueueItemForStoragePath(
+				c.Context(), normalizedPath, arrWebhookDeleteGrace,
+			)
+			if err != nil {
+				slog.WarnContext(c.Context(), "Failed to check active queue items before webhook directory deletion; proceeding cautiously and skipping deletion",
+					"path", normalizedPath, "error", err)
+				continue
+			}
+			if busy {
+				slog.InfoContext(c.Context(), "Skipping webhook directory deletion: active or recently-completed queue item references this storage path",
+					"path", normalizedPath,
+					"grace", arrWebhookDeleteGrace.String())
+				continue
+			}
+		}
 
 		// Delete health records — try by library_path first, fall back to file_path prefix
 		var metadataPaths []string

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -370,6 +370,60 @@ func (r *Repository) RemoveFromQueueByDownloadID(ctx context.Context, downloadID
 	return nil
 }
 
+// HasActiveOrRecentQueueItemForStoragePath reports whether any import_queue
+// row references a storage_path equal to (or nested under) the given relative
+// path and is either still active (pending/processing/paused/retrying) or was
+// completed within the supplied grace window. It is used to guard against arr
+// webhook directory deletions racing a sibling import that just wrote into
+// the same release folder.
+//
+// relPath is matched as a path prefix; both "<relPath>" and "/<relPath>" are
+// considered (storage_path is typically absolute, e.g. "/moviesHQ/release/...",
+// while webhook-normalized paths are relative).
+func (r *Repository) HasActiveOrRecentQueueItemForStoragePath(
+	ctx context.Context,
+	relPath string,
+	completedGrace time.Duration,
+) (bool, error) {
+	relPath = strings.Trim(relPath, "/")
+	if relPath == "" {
+		return false, nil
+	}
+
+	cutoff := time.Now().Add(-completedGrace)
+	withSlash := "/" + relPath
+	prefixWithSlash := withSlash + "/"
+	prefixNoSlash := relPath + "/"
+
+	query := `
+		SELECT 1 FROM import_queue
+		WHERE storage_path IS NOT NULL
+		  AND (
+		        storage_path = ? OR storage_path LIKE ?
+		     OR storage_path = ? OR storage_path LIKE ?
+		      )
+		  AND (
+		        status IN ('pending', 'processing', 'paused')
+		     OR (status = 'completed' AND completed_at IS NOT NULL AND completed_at > ?)
+		      )
+		LIMIT 1
+	`
+
+	var exists int
+	err := r.db.QueryRowContext(ctx, query,
+		withSlash, prefixWithSlash+"%",
+		relPath, prefixNoSlash+"%",
+		cutoff,
+	).Scan(&exists)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check active queue items for storage path: %w", err)
+	}
+	return true, nil
+}
+
 // RemoveFromQueue removes an item from the queue
 func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
 	query := `DELETE FROM import_queue WHERE id = ?`


### PR DESCRIPTION
## Summary

Guards the arr webhook directory-deletion path against a race that wipes the metadata/symlink tree of a freshly written release.

## What was happening

Sonarr/Radarr "Download" webhooks called `metadataService.DeleteDirectory(normalizedPath)` unconditionally on the release folder. When a sibling grab (upgrade, retry, manual re-search) wrote into the **same storage path**, the webhook for the previous grab could wipe the metadata/symlink tree the new grab had just produced. The arr's next SAB-history poll then saw a missing path and import failed with:

```
[Error] DownloadedMovieImportService: Import failed, path does not exist or is not accessible by Radarr:
/mnt/disk1/cloud/alt_downloads/moviesHQ/<release>
```

Users also saw the corresponding `sabnzbd history: reported path does not exist on disk` WARN in altmount logs. The issue was reported on multiple versions, ruling out the recent stremio cleanup change.

## What changed

- **`internal/database/repository.go`** — new `HasActiveOrRecentQueueItemForStoragePath(ctx, relPath, grace)`. Returns true if any `import_queue` row's `storage_path` equals or is nested under `relPath` AND is either active (`pending`/`processing`/`paused`) or completed within `grace`. Handles both absolute (`/<relPath>`) and relative forms because DB `storage_path` is absolute while webhook-normalized paths are relative.
- **`internal/api/arrs_handlers.go`** — added a 10-minute `arrWebhookDeleteGrace` constant and a guard before `DeleteDirectory(normalizedPath)`. When another queue item references the same storage path, the handler logs and `continue`s — health records, metadata, and the symlink tree are left intact. DB errors **fail-safe**: skip the deletion rather than risk wiping the wrong folder.

Stale paths beyond the grace window are still cleaned up by `library_sync`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/database/... ./internal/api/...`
- [x] `go test -race ./internal/database/...`
- [ ] Manual: trigger an upgrade grab while a previous Download webhook is in flight; confirm the release folder survives and the new arr import succeeds.
- [ ] Manual: trigger a webhook directory deletion with no active queue item for that path; confirm the path is still cleaned up.

## Reviewer notes

- Grace window (10 min) is tunable via the `arrWebhookDeleteGrace` constant.
- The guard does **not** alter the file-deletion loop above it — only the directory loop (line 407+). The file-deletion loop already has an `isBeingScanned` guard for in-place upgrades.
- Method placed on `*database.Repository` (the one wired into the API server), not on the parallel `*database.QueueRepository` type used elsewhere.