### PR TITLE
fix(queue): clear started_at when retrying queue item

### DIFF
--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -257,6 +257,13 @@ func (r *Repository) UpdateQueueItemStatus(ctx context.Context, id int64, status
 	case QueueStatusProcessing:
 		query = `UPDATE import_queue SET status = ?, started_at = ?, updated_at = ? WHERE id = ?`
 		args = []any{status, now, now, id}
+	case QueueStatusPending:
+		// Reset lifecycle columns so the worker can claim the item immediately.
+		// ClaimNextQueueItem skips pending rows whose started_at is within the
+		// last 10 minutes (orphan-recovery gate), so we must clear started_at
+		// when transitioning back to pending via retry.
+		query = `UPDATE import_queue SET status = ?, started_at = NULL, completed_at = NULL, error_message = NULL, retry_count = 0, updated_at = ? WHERE id = ?`
+		args = []any{status, now, id}
 	case QueueStatusCompleted:
 		query = `UPDATE import_queue SET status = ?, completed_at = ?, updated_at = ?, error_message = NULL WHERE id = ?`
 		args = []any{status, now, now, id}


### PR DESCRIPTION
## Summary

- Fixes "Start Now" / "Retry Task" leaving queue items stuck in `pending` for up to 10 minutes.
- `Repository.UpdateQueueItemStatus` now resets `started_at`, `completed_at`, `error_message`, and `retry_count` when transitioning a row to `pending`, matching `RestartQueueItemsBulk` semantics.

## Root cause

`ClaimNextQueueItem` gates pending rows with `started_at IS NULL OR started_at + 10 min < now()` (orphan-recovery for crashed workers). The retry handler called `UpdateQueueItemStatus(..., QueueStatusPending, nil)`, which fell through to the `default` branch and only updated `status` / `error_message` / `updated_at` — leaving `started_at` populated from the prior attempt. The worker then skipped the item for up to 10 minutes.

Since #570 (`fix: enqueue retried items instead of processing immediately`) the retry handler no longer triggers immediate processing, so this regression became user-visible.

## Test plan

- [ ] Retry a `failed` queue item — verify it transitions to `processing` within one worker tick.
- [ ] Click **Start Now** on a `pending` item that was previously processing — verify same behavior.
- [ ] Inspect DB after retry: `started_at`, `completed_at`, `error_message` should be NULL and `retry_count` should be 0.
- [ ] `go build ./...` passes.