### PR TITLE
feat(config): allow opt-in symlinks on Windows

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -156,9 +156,10 @@ import:
   import_cache_size_mb: 64 # Cache size in MB for archive analysis
   segment_sample_percentage: 1 # Percentage of segments to sample for validation (1-100)
   import_strategy: 'NONE' # Import strategy: NONE (direct import), SYMLINK (create symlinks), STRM (create .strm files)
-                          # NOTE: SYMLINK is not supported on Windows. Use STRM instead.
+                          # NOTE: SYMLINK on Windows requires `allow_symlinks_on_windows: true` AND Windows Developer Mode enabled. Otherwise use STRM.
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)
                  # Windows example: 'C:\Users\user\Videos'
+  allow_symlinks_on_windows: false # Permit symlink creation on Windows (requires Developer Mode in Windows Settings → For developers). No effect on Linux/macOS. Default: false.
   skip_health_check: true # Bypass Usenet article validation during import (default: true)
   failed_item_retention_hours: 24 # Auto-remove failed queue items and NZB files after this many hours (0 to disable, default: 24)
 

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -364,6 +364,62 @@ export function ImportConfigSection({
 						)}
 					</div>
 
+					{formData.import_strategy === "SYMLINK" && (
+						<>
+							<div className="divider text-base-content/70" />
+
+							<label className="label cursor-pointer items-start justify-start gap-4">
+								<input
+									type="checkbox"
+									className="toggle toggle-primary toggle-sm mt-1 shrink-0"
+									checked={formData.allow_symlinks_on_windows ?? false}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										handleInputChange("allow_symlinks_on_windows", e.target.checked)
+									}
+								/>
+								<div className="min-w-0 flex-1">
+									<span className="block whitespace-normal break-words font-bold text-xs">
+										Allow Symlinks on Windows
+									</span>
+									<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
+										Allow symlink creation on Windows. By default, symlinks are blocked on Windows
+										because they require elevated privileges. Has no effect on Linux/macOS.
+									</span>
+								</div>
+							</label>
+
+							{formData.allow_symlinks_on_windows && (
+								<div className="alert alert-warning mt-2">
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										className="h-5 w-5 shrink-0"
+										fill="none"
+										viewBox="0 0 24 24"
+										stroke="currentColor"
+										aria-hidden="true"
+									>
+										<title>Warning</title>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth={2}
+											d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+										/>
+									</svg>
+									<div className="text-xs">
+										<div className="font-bold">Windows Developer Mode required</div>
+										<div className="mt-1">
+											To create symlinks without admin rights, enable Developer Mode in Windows
+											Settings → Privacy &amp; security → For developers → Developer Mode. Without
+											it, imports will fail with an OS permission error.
+										</div>
+									</div>
+								</div>
+							)}
+						</>
+					)}
+
 					<div className="divider text-base-content/70" />
 
 					<div className="space-y-6">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -230,6 +230,7 @@ export interface ImportConfig {
 	failed_item_retention_hours?: number | null;
 	history_retention_days?: number | null;
 	delete_completed_nzb?: boolean;
+	allow_symlinks_on_windows?: boolean;
 }
 
 // Log configuration
@@ -436,6 +437,7 @@ export interface ImportUpdateRequest {
 	allow_nested_rar_extraction?: boolean;
 	rename_to_nzb_name?: boolean;
 	filter_sample_files?: boolean;
+	allow_symlinks_on_windows?: boolean;
 }
 
 // Log update request

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -277,6 +277,7 @@ type ImportConfig struct {
 	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 	HistoryRetentionDays           *int           `yaml:"history_retention_days" mapstructure:"history_retention_days" json:"history_retention_days,omitempty"`
 	DeleteCompletedNzb             *bool          `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
+	AllowSymlinksOnWindows         *bool          `yaml:"allow_symlinks_on_windows" mapstructure:"allow_symlinks_on_windows" json:"allow_symlinks_on_windows,omitempty"`
 }
 
 // ShouldDeleteCompletedNzb returns whether the NZB file should be removed from

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -206,8 +206,8 @@ func (c *Coordinator) createAbsoluteSymlink(actualPath, destPath string) error {
 		}
 	}
 
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("symlinks are not supported on Windows; use STRM import strategy instead")
+	if err := windowsSymlinkAllowed(c.configGetter()); err != nil {
+		return err
 	}
 
 	if err := os.Symlink(actualPath, destPath); err != nil {
@@ -237,12 +237,27 @@ func (c *Coordinator) createSingleSymlink(actualPath, resultingPath string) erro
 	}
 
 	// Create the symlink using the absolute actual path
-	if runtime.GOOS == "windows" {
-		return fmt.Errorf("symlinks are not supported on Windows; use STRM import strategy instead")
+	if err := windowsSymlinkAllowed(c.configGetter()); err != nil {
+		return err
 	}
 	if err := os.Symlink(actualPath, symlinkPath); err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
 
 	return nil
+}
+
+// windowsSymlinkAllowed returns an error when running on Windows and the
+// AllowSymlinksOnWindows opt-in flag is not enabled. On non-Windows platforms
+// it always returns nil. When the flag is enabled on Windows, callers proceed
+// to os.Symlink which will only succeed if the process has the required
+// privilege (typically granted by enabling Developer Mode).
+func windowsSymlinkAllowed(cfg *config.Config) error {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	if cfg != nil && cfg.Import.AllowSymlinksOnWindows != nil && *cfg.Import.AllowSymlinksOnWindows {
+		return nil
+	}
+	return fmt.Errorf("symlinks are not supported on Windows by default; enable 'Allow symlinks on Windows' in config (requires Windows Developer Mode) or use STRM import strategy instead")
 }


### PR DESCRIPTION
## Summary

Adds a new `import.allow_symlinks_on_windows` config toggle so Windows users with **Developer Mode** enabled can use the SYMLINK import strategy instead of being forced onto STRM.

Previously, `symlink_creator.go` unconditionally rejected symlink creation on Windows. However, Windows 10+ permits `os.Symlink` from non-admin processes when Developer Mode is enabled, so the hard block was overly restrictive for that subset of users.

## Changes

- **Backend**
  - `internal/config/manager.go` — new `AllowSymlinksOnWindows *bool` field on `ImportConfig` (default `false`, preserves existing behavior).
  - `internal/importer/postprocessor/symlink_creator.go` — replaced the two inlined Windows guards with a shared `windowsSymlinkAllowed(cfg)` helper. When the flag is enabled the call proceeds to `os.Symlink`; if Developer Mode isn't actually on, the OS error surfaces normally. The error message now references the new toggle.
- **Frontend**
  - `frontend/src/types/config.ts` — added `allow_symlinks_on_windows?: boolean` to both `ImportConfig` and `ImportUpdateRequest`.
  - `frontend/src/components/config/WorkersConfigSection.tsx` — new toggle, shown only when the SYMLINK strategy is selected. When on, a `alert-warning` callout explains that Windows Developer Mode is required (Settings → Privacy & security → For developers).
- **Docs**
  - `config.sample.yaml` — documented the new option and updated the existing "not supported on Windows" comment to mention the opt-in path.

## Reviewer notes

- Default value remains `false`, so existing Windows installs continue to get a blocking error — just with an improved message pointing them at the toggle and Developer Mode.
- Linux/macOS behavior is unchanged: `windowsSymlinkAllowed` short-circuits to `nil` on non-Windows GOOS.
- No new dependencies.

## Test plan

- [ ] `make` (Go build + frontend) passes
- [ ] Load config UI on a fresh install — toggle is hidden unless SYMLINK strategy is picked
- [ ] Toggle the option on, save, confirm round-trip via `GET /api/config` returns `allow_symlinks_on_windows: true`
- [ ] Linux: symlink imports continue to work with the toggle either on or off (no runtime effect)
- [ ] Windows + Developer Mode ON + toggle ON: symlink import succeeds
- [ ] Windows + toggle OFF: import fails with the new error message mentioning the toggle and Developer Mode