### PR TITLE
fix(rclone): stop mount service before restart to release log file

### DIFF
--- a/internal/api/system_handlers.go
+++ b/internal/api/system_handlers.go
@@ -361,6 +361,23 @@ func (s *Server) performRestart(ctx context.Context) {
 	// Give a moment for the HTTP response to be sent
 	time.Sleep(100 * time.Millisecond)
 
+	// Stop the rclone mount service before re-execing so the child rclone
+	// subprocess is terminated cleanly and releases its log file. This is
+	// critical on Windows where syscall.Exec is unavailable: the fallback
+	// path calls os.Exit, which skips the SIGINT shutdown sequence and would
+	// otherwise orphan the rclone process (keeping rclone.log locked and
+	// breaking the next startup). Use a fresh context with its own timeout
+	// because the request context is already canceled by this point.
+	if s.mountService != nil {
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
+		if err := s.mountService.Stop(stopCtx); err != nil {
+			slog.WarnContext(stopCtx, "Failed to stop mount service before restart", "error", err)
+		} else {
+			slog.InfoContext(stopCtx, "Mount service stopped for restart")
+		}
+		stopCancel()
+	}
+
 	// Get the current executable path
 	executable, err := os.Executable()
 	if err != nil {

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -108,10 +108,15 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 	logFile := filepath.Join(logDir, "rclone.log")
 
-	// Delete old log file if it exists
+	// Delete old log file if it exists. If removal fails (e.g. another process
+	// still holds the file open on Windows after an unclean shutdown), fall
+	// back to a timestamped log file so startup is not blocked.
 	if _, err := os.Stat(logFile); err == nil {
 		if err := os.Remove(logFile); err != nil {
-			return fmt.Errorf("failed to remove old rclone log file: %w", err)
+			fallback := filepath.Join(logDir, fmt.Sprintf("rclone-%d.log", time.Now().UnixNano()))
+			m.logger.WarnContext(ctx, "Failed to remove old rclone log file, falling back to a new log file",
+				"err", err, "original_log_file", logFile, "fallback_log_file", fallback)
+			logFile = fallback
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #581 — restarting the AltMount server via the web UI on Windows fails because the new process can't delete `rclone.log` (held by the previous, still-running rclone child).

- `performRestart` now calls `mountService.Stop` with a 15s timeout before re-exec, using a fresh context (the request context is already canceled at that point). This terminates the rclone subprocess cleanly and releases `rclone.log` before the new altmount process tries to remove it. Critical on Windows where `syscall.Exec` is unavailable and the fallback path uses `os.Exit`, which skips the SIGINT shutdown sequence.
- `rclonecli.Manager.Start` no longer aborts when the old `rclone.log` cannot be removed; it logs a warning and falls back to `rclone-<unixnano>.log`. Defense-in-depth in case an unrelated process still holds the file open (e.g. orphan from an earlier crash).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/api/... ./pkg/rclonecli/...` clean
- [ ] Manual Windows 11: trigger restart from web UI with `mount_type=rclone`; confirm new process starts and `Starting RClone mount` succeeds (no sharing-violation error).
- [ ] Manual Windows 11 negative path: hold `rclone.log` open from another process and cold-start altmount; confirm warning is logged and a timestamped log file is used.
- [ ] Linux regression: restart flow still works via `syscall.Exec`.