### PR TITLE
fix(windows): library sync and watch dir on native Windows CLI

### DIFF
--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -306,8 +306,10 @@ func (lsw *LibrarySyncWorker) findFilesToDelete(
 		default:
 		}
 
-		// Check if metadata file exists
-		if _, exists := metaFileSet[dbRecord.FilePath]; !exists {
+		// Check if metadata file exists. Normalize to forward slashes so the
+		// lookup matches the canonical keys built in buildSyncMaps.
+		key := filepath.ToSlash(dbRecord.FilePath)
+		if _, exists := metaFileSet[key]; !exists {
 			filesToDelete = append(filesToDelete, dbRecord.FilePath)
 			continue
 		}
@@ -319,7 +321,7 @@ func (lsw *LibrarySyncWorker) findFilesToDelete(
 				continue
 			}
 
-			if !filesInLibrary[dbRecord.FilePath] {
+			if !filesInLibrary[key] {
 				filesToDelete = append(filesToDelete, dbRecord.FilePath)
 			}
 		}
@@ -432,8 +434,9 @@ func (lsw *LibrarySyncWorker) buildSyncMaps(metadataFiles []string, dbRecords []
 	// Convert database records to map for efficient lookup
 	dbPathSet := make(map[string]database.AutomaticHealthCheckRecord, len(dbRecords))
 	for _, record := range dbRecords {
-		// Use mount relative path as the key
-		dbPathSet[record.FilePath] = record
+		// Normalize to forward slashes so Windows-stored paths match the
+		// canonical mount-relative keys produced above.
+		dbPathSet[filepath.ToSlash(record.FilePath)] = record
 	}
 
 	return syncMaps{
@@ -1082,17 +1085,20 @@ func (lsw *LibrarySyncWorker) getAllMetadataFiles(ctx context.Context) ([]string
 	return metaFiles, nil
 }
 
-// metaPathToMountRelativePath converts a metadata file path to a mount relative file path
+// metaPathToMountRelativePath converts a metadata file path to a mount relative file path.
+// Uses filepath.Rel + filepath.ToSlash so the result is canonical (forward slashes) and
+// tolerant to differences in how the metadata root is spelled in config (./prefix,
+// trailing separator, mixed separators on Windows, etc).
 func (lsw *LibrarySyncWorker) metaPathToMountRelativePath(metaPath string) string {
-	cfg := lsw.configGetter()
-	rootPath := cfg.Metadata.RootPath
+	rootPath := lsw.configGetter().Metadata.RootPath
 
-	// Remove root path and .meta extension
-	relativePath := strings.TrimPrefix(metaPath, rootPath)
-	relativePath = strings.TrimPrefix(relativePath, string(filepath.Separator))
-	mountRelativePath := strings.TrimSuffix(relativePath, ".meta")
-
-	return mountRelativePath
+	rel, err := filepath.Rel(rootPath, metaPath)
+	if err != nil {
+		rel = strings.TrimPrefix(metaPath, rootPath)
+		rel = strings.TrimPrefix(rel, string(filepath.Separator))
+	}
+	rel = strings.TrimSuffix(rel, ".meta")
+	return filepath.ToSlash(rel)
 }
 
 // processMetadataForSync reads metadata and creates an AutomaticHealthCheckRecord.

--- a/internal/health/library_sync_test.go
+++ b/internal/health/library_sync_test.go
@@ -159,3 +159,69 @@ func TestFindFilesToDelete_RepairTriggered(t *testing.T) {
 	require.Len(t, toDelete, 1)
 	assert.Equal(t, "deleted.mkv", toDelete[0])
 }
+
+func TestMetaPathToMountRelativePath(t *testing.T) {
+	sep := string(filepath.Separator)
+
+	cases := []struct {
+		name     string
+		rootPath string
+		metaPath string
+		want     string
+	}{
+		{
+			name:     "simple_root_no_trailing_sep",
+			rootPath: "metadata",
+			metaPath: filepath.Join("metadata", "complete", "foo", "bar.meta"),
+			want:     "complete/foo/bar",
+		},
+		{
+			name:     "root_with_trailing_sep",
+			rootPath: "metadata" + sep,
+			metaPath: filepath.Join("metadata", "complete", "foo", "bar.meta"),
+			want:     "complete/foo/bar",
+		},
+		{
+			name:     "root_with_dot_prefix",
+			rootPath: "." + sep + "metadata",
+			metaPath: filepath.Join("metadata", "complete", "foo", "bar.meta"),
+			want:     "complete/foo/bar",
+		},
+		{
+			name:     "absolute_root",
+			rootPath: filepath.Join(string(filepath.Separator), "var", "lib", "metadata"),
+			metaPath: filepath.Join(string(filepath.Separator), "var", "lib", "metadata", "complete", "foo", "bar.meta"),
+			want:     "complete/foo/bar",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Metadata: config.MetadataConfig{RootPath: tc.rootPath}}
+			worker := &LibrarySyncWorker{
+				configGetter: func() *config.Config { return cfg },
+			}
+			got := worker.metaPathToMountRelativePath(tc.metaPath)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestFindFilesToDelete_NormalizesBackslashes(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("filepath.ToSlash only translates backslashes on Windows")
+	}
+	worker := &LibrarySyncWorker{}
+
+	dbRecords := []database.AutomaticHealthCheckRecord{
+		{FilePath: "complete\\foo\\bar.mkv", Status: database.HealthStatusHealthy},
+		{FilePath: "complete/orphan.mkv", Status: database.HealthStatusHealthy},
+	}
+	metaFileSet := map[string]string{
+		"complete/foo/bar.mkv": "metadata/complete/foo/bar.mkv.meta",
+	}
+
+	toDelete := worker.findFilesToDelete(context.Background(), dbRecords, metaFileSet, nil)
+	require.Len(t, toDelete, 1)
+	assert.Equal(t, "complete/orphan.mkv", toDelete[0])
+}

--- a/internal/importer/scanner/watcher.go
+++ b/internal/importer/scanner/watcher.go
@@ -273,14 +273,13 @@ func (w *Watcher) processNzb(ctx context.Context, watchRoot, filePath string) er
 			"file", filePath,
 			"relPath", relPath)
 	} else {
-		// relPath is "." (root of watch dir)
-		// Use absolute watchRoot as base path
-		absWatchRoot, err := filepath.Abs(watchRoot)
-		if err == nil {
-			relativePath = &absWatchRoot
-		} else {
-			relativePath = &watchRoot
-		}
+		// relPath is "." → file sits directly in the watch root. Leave
+		// relativePath nil so downstream virtual-path computation places the
+		// NZB under the configured CompleteDir (plus category if any) instead
+		// of leaking the host filesystem path — which on Windows would inject
+		// a drive letter like "C:" into the virtual path and break
+		// metadata directory creation.
+		relativePath = nil
 	}
 
 	// Add to queue

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -859,7 +859,32 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 		}
 	}
 
-	return filepath.ToSlash(virtualDir)
+	return sanitizeVirtualPath(virtualDir)
+}
+
+// sanitizeVirtualPath canonicalizes a virtual path to forward slashes and strips
+// any filesystem-specific syntax that is invalid as a virtual path component —
+// most importantly Windows drive letters (e.g. "C:") which would otherwise leak
+// into metadata directory creation and fail with mkdir errors.
+// driveLetterRe matches a single Windows drive letter path component (e.g. "C:")
+// anywhere it appears as its own segment.
+var driveLetterRe = regexp.MustCompile(`(?i)(^|/)[a-z]:(?:/|$)`)
+
+func sanitizeVirtualPath(p string) string {
+	// Virtual paths always use forward slashes regardless of host OS.
+	p = strings.ReplaceAll(p, `\`, "/")
+	// Drop any "<letter>:" segment (typically a Windows drive letter that
+	// leaked through from a filesystem path).
+	for driveLetterRe.MatchString(p) {
+		p = driveLetterRe.ReplaceAllString(p, "$1")
+	}
+	// Strip any remaining colons (defensive — not valid in path components
+	// on Windows and meaningless in our virtual namespace).
+	p = strings.ReplaceAll(p, ":", "")
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
 }
 
 // ensurePersistentNzb moves the NZB file to a persistent location in the metadata directory

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -862,24 +862,15 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 	return sanitizeVirtualPath(virtualDir)
 }
 
-// sanitizeVirtualPath canonicalizes a virtual path to forward slashes and strips
-// any filesystem-specific syntax that is invalid as a virtual path component —
-// most importantly Windows drive letters (e.g. "C:") which would otherwise leak
-// into metadata directory creation and fail with mkdir errors.
-// driveLetterRe matches a single Windows drive letter path component (e.g. "C:")
-// anywhere it appears as its own segment.
+// driveLetterRe matches a "<letter>:" segment anywhere in a forward-slash path.
 var driveLetterRe = regexp.MustCompile(`(?i)(^|/)[a-z]:(?:/|$)`)
 
+// sanitizeVirtualPath canonicalizes a virtual path to forward slashes and strips
+// Windows drive-letter segments and stray colons — these would otherwise leak
+// into metadata directory creation and fail with mkdir on Windows.
 func sanitizeVirtualPath(p string) string {
-	// Virtual paths always use forward slashes regardless of host OS.
 	p = strings.ReplaceAll(p, `\`, "/")
-	// Drop any "<letter>:" segment (typically a Windows drive letter that
-	// leaked through from a filesystem path).
-	for driveLetterRe.MatchString(p) {
-		p = driveLetterRe.ReplaceAllString(p, "$1")
-	}
-	// Strip any remaining colons (defensive — not valid in path components
-	// on Windows and meaningless in our virtual namespace).
+	p = driveLetterRe.ReplaceAllString(p, "$1")
 	p = strings.ReplaceAll(p, ":", "")
 	if !strings.HasPrefix(p, "/") {
 		p = "/" + p

--- a/internal/importer/service_path_test.go
+++ b/internal/importer/service_path_test.go
@@ -118,3 +118,42 @@ func TestCalculateProcessVirtualDir_FailedPath(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateProcessVirtualDir_WindowsDriveLetterStripped(t *testing.T) {
+	s := &Service{
+		configGetter: func() *config.Config {
+			return &config.Config{
+				Database: config.DatabaseConfig{Path: "/config/altmount.db"},
+				SABnzbd:  config.SABnzbdConfig{CompleteDir: "/complete"},
+			}
+		},
+	}
+
+	// Simulates the Windows CLI case where the watcher previously passed the
+	// absolute watch directory (drive-lettered) as basePath. The virtual path
+	// must NOT carry the drive letter or colon into the metadata layer.
+	item := &database.ImportQueueItem{NzbPath: filepath.FromSlash("/config/.nzbs/test1.nzb")}
+	basePath := `C:\rclone\altmount\nzb`
+
+	got := s.calculateProcessVirtualDir(item, &basePath)
+
+	assert.NotContains(t, got, ":", "virtual path must not leak Windows drive letters")
+	assert.Equal(t, "/complete/rclone/altmount/nzb", filepath.ToSlash(got))
+}
+
+func TestSanitizeVirtualPath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/complete/foo/bar", "/complete/foo/bar"},
+		{`C:\rclone\altmount\nzb`, "/rclone/altmount/nzb"},
+		{"/C:/rclone/altmount/nzb", "/rclone/altmount/nzb"},
+		{"/complete/C:/x", "/complete/x"},
+		{"plain/no/slash", "/plain/no/slash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, sanitizeVirtualPath(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the two Windows-CLI-only regressions reported in #582:

1. **Library sync with `NONE` import strategy adds 0 health records.** `metaPathToMountRelativePath` stripped `cfg.Metadata.RootPath` with a literal `TrimPrefix` + `filepath.Separator`. On Windows this fails whenever the config spelling differs from what `filepath.WalkDir` returns (trailing slash, `./` prefix, mixed separators), so the supposed mount-relative path still contains the root. `ReadFileMetadata` then can't resolve it and silently returns `(nil, nil)`, leaving `filesToAdd` empty — matching the user's `total: 3, added: 0` log with no error line. Switched to `filepath.Rel` + `filepath.ToSlash`, and normalized DB-record keys in `buildSyncMaps` / `findFilesToDelete` with `filepath.ToSlash` so backslash-stored paths still match.

2. **Absolute Windows watch dir (`C:\rclone\altmount\nzb`) broke imports.** When the NZB sat directly in the watch root, the watcher set `relativePath = filepath.Abs(watchRoot)`, leaking the drive letter into the virtual path (`/complete/C:/rclone/altmount/nzb`). Downstream `GetMetadataDirectoryPath` joined that with the metadata root, producing `metadata\complete\C:\...` which `mkdir` rejects (`C:` is not a valid path component mid-path). The watcher now passes `nil` for that case so the NZB lands under `CompleteDir` alone. `calculateProcessVirtualDir` also runs the final path through a new `sanitizeVirtualPath` helper that strips drive-letter segments and stray colons defensively.

`filepath.ToSlash` is a no-op on Linux, and `sanitizeVirtualPath` leaves clean POSIX paths unchanged, so Docker/Linux behavior is unaffected.

## Changes

- `internal/health/library_sync.go` — canonicalize meta paths and DB-record keys to forward slashes.
- `internal/importer/scanner/watcher.go` — stop using the absolute watch dir as a virtual base path.
- `internal/importer/service.go` — add `sanitizeVirtualPath` and apply it as the final step of `calculateProcessVirtualDir`.
- Tests: `TestMetaPathToMountRelativePath` (root-path spelling variants), `TestFindFilesToDelete_NormalizesBackslashes` (Windows-only), `TestCalculateProcessVirtualDir_WindowsDriveLetterStripped`, `TestSanitizeVirtualPath`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/health/... ./internal/importer/...`
- [x] `go test -race ./internal/health/... ./internal/importer/...`
- [ ] Manual on native Windows CLI: NONE strategy library sync populates Health tab; `watch_dir: C:\rclone\altmount\nzb` processes NZBs without `mkdir metadata\complete\C:` errors.
- [ ] Linux regression: existing Docker import + library sync flows still produce `added: N` and route to the same virtual paths as before.

Closes #582