### PR TITLE
fix(nzbdav): discover SubType=201 children + backfill missing NzbNames

### DIFF
--- a/internal/nzbdav/parser.go
+++ b/internal/nzbdav/parser.go
@@ -63,41 +63,120 @@ func (p *Parser) Parse() (<-chan *ParsedNzb, <-chan error) {
 	errChan := make(chan error, 1)
 
 	go func() {
-		db, err := sql.Open("sqlite3", p.dbPath+"?mode=ro&_journal_mode=WAL")
+		defer close(out)
+		defer close(errChan)
+
+		// Open read-only first to detect storage flavor. The blob-based path
+		// needs writes (NzbNames backfill — see backfillNzbNames), so it
+		// re-opens against a temp copy. Legacy storage stays on the read-only
+		// handle to avoid ever touching the source DB.
+		//
+		// immutable=1 promises SQLite the file won't change underneath it, and
+		// in return SQLite never writes anything (no WAL/SHM sidecars, no
+		// header rewrites). mode=ro alone still mutates the header on open
+		// because go-sqlite3 issues PRAGMAs that touch the file.
+		roDB, err := sql.Open("sqlite3", p.dbPath+"?mode=ro&immutable=1")
 		if err != nil {
 			errChan <- fmt.Errorf("failed to open database: %w", err)
-			close(out)
-			close(errChan)
+			return
+		}
+		defer roDB.Close()
+		roDB.SetMaxOpenConns(25)
+		roDB.SetMaxIdleConns(10)
+
+		// Blob-based (alpha) storage is detected by presence of the NzbNames
+		// table and a configured blobs directory.
+		isBlobStorage := p.blobsPath != "" && hasTable(roDB, "NzbNames")
+
+		if isBlobStorage {
+			slog.InfoContext(context.Background(), "Detected blob-based NZBDav storage")
+
+			// All DB-bound work (backfill, tree load, discovery scan) is done
+			// inside this helper. The temp DB copy and its handle are released
+			// as soon as the helper returns — before any blob streaming or
+			// channel sends happen — so the temp file doesn't sit on disk for
+			// the (potentially long) duration of the consumer draining.
+			tree, blobOrder, rowsByBlob, err := p.prepareBlobImport()
+			if err != nil {
+				errChan <- err
+				return
+			}
+			p.parseBlobs(tree, blobOrder, rowsByBlob, out)
 			return
 		}
 
-		defer func() {
-			db.Close()
-			close(out)
-			close(errChan)
-		}()
-
-		db.SetMaxOpenConns(25)
-		db.SetMaxIdleConns(10)
-
-		tree, err := loadDavTree(db)
+		tree, err := loadDavTree(roDB)
 		if err != nil {
 			errChan <- fmt.Errorf("failed to load DavItems tree: %w", err)
 			return
 		}
-
-		// Blob-based (alpha) storage is detected by presence of the NzbNames table
-		// and a configured blobs directory.
-		if p.blobsPath != "" && hasTable(db, "NzbNames") {
-			slog.InfoContext(context.Background(), "Detected blob-based NZBDav storage")
-			p.parseBlobs(db, tree, out, errChan)
-			return
-		}
-
-		p.parseLegacy(db, tree, out, errChan)
+		p.parseLegacy(roDB, tree, out, errChan)
 	}()
 
 	return out, errChan
+}
+
+// copyDBToTemp duplicates the SQLite file at src to a sibling temp file the
+// caller owns. Returns the temp path and a cleanup func that removes both the
+// copy and any -wal/-shm sidecars that SQLite may create during use.
+func copyDBToTemp(src string) (string, func(), error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return "", nil, err
+	}
+	defer in.Close()
+
+	tmp, err := os.CreateTemp("", "altmount-nzbdav-*.db")
+	if err != nil {
+		return "", nil, err
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return "", nil, err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", nil, err
+	}
+
+	cleanup := func() {
+		os.Remove(tmpPath)
+		os.Remove(tmpPath + "-wal")
+		os.Remove(tmpPath + "-shm")
+	}
+	return tmpPath, cleanup, nil
+}
+
+// backfillNzbNames materializes a NzbNames row for every DavItem that points
+// at a non-empty NzbBlobId but has no matching name entry. nzbdav can land
+// rows in this half-populated state for release-folder children (SubType=201)
+// and the discovery query's INNER JOIN drops them on the floor.
+//
+// The synthetic FileName is the DavItem's Name with a .nzb suffix (stripping
+// a common media extension first to avoid double-suffix files like
+// "Foo.mkv.nzb" reading awkwardly).
+func backfillNzbNames(db *sql.DB) error {
+	_, err := db.Exec(`
+		INSERT OR IGNORE INTO NzbNames (Id, FileName)
+		SELECT DISTINCT
+			d.NzbBlobId,
+			CASE
+				WHEN d.Name LIKE '%.mkv' OR d.Name LIKE '%.mp4' OR d.Name LIKE '%.avi'
+					THEN substr(d.Name, 1, length(d.Name) - 4) || '.nzb'
+				ELSE d.Name || '.nzb'
+			END
+		FROM DavItems d
+		LEFT JOIN NzbNames n ON n.Id = d.NzbBlobId
+		WHERE d.SubType IN (201, 203)
+			AND d.NzbBlobId IS NOT NULL
+			AND d.NzbBlobId != ''
+			AND d.NzbBlobId != '00000000-0000-0000-0000-000000000000'
+			AND n.Id IS NULL
+	`)
+	return err
 }
 
 func hasTable(db *sql.DB, name string) bool {
@@ -189,8 +268,37 @@ type blobRow struct {
 	id, fileName, davName, releasePath, blobId string
 }
 
-func (p *Parser) parseBlobs(db *sql.DB, tree *davTree, out chan<- *ParsedNzb, errChan chan<- error) {
-	rows, err := db.Query(`
+// prepareBlobImport does every DB-touching step for the blob-storage path —
+// stages a temp DB copy, runs the NzbNames backfill, loads the DavItems tree,
+// and buffers the full discovery result set into memory. All resources tied to
+// the temp DB (handle + on-disk file + WAL/SHM sidecars) are released before
+// this function returns, so the subsequent (potentially long) blob streaming
+// phase doesn't pin them.
+func (p *Parser) prepareBlobImport() (*davTree, []string, map[string][]blobRow, error) {
+	copyPath, cleanup, err := copyDBToTemp(p.dbPath)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to stage temp DB copy: %w", err)
+	}
+	defer cleanup()
+
+	rwDB, err := sql.Open("sqlite3", copyPath+"?_journal_mode=WAL")
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to open temp DB copy: %w", err)
+	}
+	defer rwDB.Close()
+	rwDB.SetMaxOpenConns(25)
+	rwDB.SetMaxIdleConns(10)
+
+	if err := backfillNzbNames(rwDB); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to backfill NzbNames: %w", err)
+	}
+
+	tree, err := loadDavTree(rwDB)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to load DavItems tree: %w", err)
+	}
+
+	rows, err := rwDB.Query(`
 		SELECT
 			d.Id,
 			n.FileName,
@@ -202,15 +310,16 @@ func (p *Parser) parseBlobs(db *sql.DB, tree *davTree, out chan<- *ParsedNzb, er
 		WHERE d.NzbBlobId IS NOT NULL
 		AND d.NzbBlobId != ''
 		AND d.NzbBlobId != '00000000-0000-0000-0000-000000000000'
-		AND d.SubType = 203
+		AND d.SubType IN (201, 203)
 	`)
 	if err != nil {
-		errChan <- fmt.Errorf("failed to query blob files: %w", err)
-		return
+		return nil, nil, nil, fmt.Errorf("failed to query blob files: %w", err)
 	}
 	defer rows.Close()
 
-	// Pass 1: collect all rows grouped by blobId, preserving first-seen order.
+	// Buffer all rows grouped by blobId, preserving first-seen order. Once
+	// this loop ends and the deferred Close/cleanup chain unwinds, the temp
+	// DB is gone from disk.
 	var blobOrder []string
 	rowsByBlob := make(map[string][]blobRow)
 	for rows.Next() {
@@ -224,8 +333,15 @@ func (p *Parser) parseBlobs(db *sql.DB, tree *davTree, out chan<- *ParsedNzb, er
 		}
 		rowsByBlob[r.blobId] = append(rowsByBlob[r.blobId], r)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to iterate blob files: %w", err)
+	}
 
-	// Pass 2: emit one ParsedNzb per blob group.
+	return tree, blobOrder, rowsByBlob, nil
+}
+
+func (p *Parser) parseBlobs(tree *davTree, blobOrder []string, rowsByBlob map[string][]blobRow, out chan<- *ParsedNzb) {
+	// Emit one ParsedNzb per blob group.
 	// The first row in each group becomes the canonical item; additional rows
 	// become ParsedNzbAlias entries so the scanner can register migration rows
 	// for every DavItem ID that shares the blob.

--- a/internal/nzbdav/parser_test.go
+++ b/internal/nzbdav/parser_test.go
@@ -1,10 +1,13 @@
 package nzbdav
 
 import (
+	"bytes"
 	"database/sql"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -425,6 +428,157 @@ func TestParser_Parse_Blobs_DeduplicateNestedSubType203(t *testing.T) {
 
 	require.Len(t, got, 1, "expected exactly one ParsedNzb despite two SubType=203 rows for the same release")
 	assert.Equal(t, "Big.Release", got[0].Name)
+}
+
+// TestParser_Parse_Blobs_SubType201_BackfillsAndDiscovers covers two real-world
+// nzbdav DB shapes the importer previously dropped:
+//
+//   - A release folder (SubType=101) containing per-file children with
+//     SubType=201 instead of 203. The discovery query restricted to SubType=203
+//     missed them entirely.
+//   - A SubType=201/203 row with a non-empty NzbBlobId but no matching NzbNames
+//     row. The discovery INNER JOIN on NzbNames silently dropped them.
+//
+// The fix expands discovery to SubType IN (201, 203) and backfills missing
+// NzbNames rows before discovery runs.
+func TestParser_Parse_Blobs_SubType201_BackfillsAndDiscovers(t *testing.T) {
+	tmpDir := t.TempDir()
+	blobsDir := filepath.Join(tmpDir, "blobs")
+	dbPath := filepath.Join(tmpDir, "subtype201.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE DavItems (
+			Id TEXT PRIMARY KEY, ParentId TEXT, Name TEXT, FileSize INTEGER,
+			Path TEXT, NzbBlobId TEXT, SubType INTEGER
+		);
+		CREATE TABLE NzbNames (Id TEXT PRIMARY KEY, FileName TEXT);
+	`)
+	require.NoError(t, err)
+
+	blob201 := "1111aaaa2222bbbb"
+	blob203 := "3333cccc4444dddd"
+	writeZstdBlob(t, filepath.Join(blobsDir, "11", "11", blob201), []byte("<nzb id=\"201\"/>"))
+	writeZstdBlob(t, filepath.Join(blobsDir, "33", "33", blob203), []byte("<nzb id=\"203\"/>"))
+
+	// item201 is a SubType=201 row with NO NzbNames entry — represents the
+	// release-folder-child shape the importer used to drop. item203 has a
+	// NzbNames row pre-seeded so the test also covers the existing happy path.
+	_, err = db.Exec(`
+		INSERT INTO NzbNames (Id, FileName) VALUES ('3333cccc4444dddd', 'Already.Named.nzb');
+		INSERT INTO DavItems (Id, ParentId, Name, Path, NzbBlobId, SubType) VALUES
+		('root',     NULL,       '/',                          '/',                                          NULL,               1),
+		('uncat',    'root',     'uncategorized',              '/uncategorized',                             NULL,               1),
+		('rel201',   'uncat',    'Release.With.201.Children',  '/uncategorized/Release.With.201.Children',   NULL,               101),
+		('item201',  'rel201',   'episode1.mkv',               '/uncategorized/Release.With.201.Children/episode1.mkv', '1111aaaa2222bbbb', 201),
+		('rel203',   'uncat',    'Release.With.203.Standalone','/uncategorized/Release.With.203.Standalone', NULL,               101),
+		('item203',  'rel203',   'movie.mkv',                  '/uncategorized/Release.With.203.Standalone/movie.mkv',  '3333cccc4444dddd', 203);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	// Snapshot the source DB so we can prove the import doesn't mutate it.
+	srcBefore, err := os.ReadFile(dbPath)
+	require.NoError(t, err)
+
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+	got := collect(t, out, errChan)
+
+	require.Len(t, got, 2, "expected both SubType=201 and SubType=203 items to be discovered")
+
+	byID := map[string]*ParsedNzb{}
+	for _, n := range got {
+		byID[n.ID] = n
+	}
+
+	// The 201 row had no NzbNames entry on disk; without backfill the
+	// discovery JOIN would have dropped it. With backfill it's discovered and
+	// resolves to its parent release folder's name.
+	rel201, ok := byID["item201"]
+	require.True(t, ok, "SubType=201 item was not discovered (got IDs: %v)", slices.Sorted(maps.Keys(byID)))
+	assert.Equal(t, "Release.With.201.Children", rel201.Name)
+
+	rel203, ok := byID["item203"]
+	require.True(t, ok, "SubType=203 item was not discovered (got IDs: %v)", slices.Sorted(maps.Keys(byID)))
+	assert.Equal(t, "Release.With.203.Standalone", rel203.Name)
+
+	// Source DB must be byte-identical — backfill should land in a temp copy,
+	// never the user's file.
+	srcAfter, err := os.ReadFile(dbPath)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(srcBefore, srcAfter), "source DB was mutated by import")
+}
+
+// TestParser_Parse_Blobs_TempDBCleanedBeforeStreaming verifies that the temp
+// DB copy used for backfill is deleted from disk before parseBlobs starts
+// emitting onto the channel. Without this, a slow consumer would pin the
+// temp file on disk for the entire import duration.
+func TestParser_Parse_Blobs_TempDBCleanedBeforeStreaming(t *testing.T) {
+	// Redirect os.CreateTemp to a dir we own so we can inspect it without
+	// false positives from other processes.
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+
+	srcDir := t.TempDir()
+	blobsDir := filepath.Join(srcDir, "blobs")
+	dbPath := filepath.Join(srcDir, "src.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE DavItems (
+			Id TEXT PRIMARY KEY, ParentId TEXT, Name TEXT, FileSize INTEGER,
+			Path TEXT, NzbBlobId TEXT, SubType INTEGER
+		);
+		CREATE TABLE NzbNames (Id TEXT PRIMARY KEY, FileName TEXT);
+	`)
+	require.NoError(t, err)
+
+	blobId := "aaaa1111bbbb2222"
+	writeZstdBlob(t, filepath.Join(blobsDir, "aa", "aa", blobId), []byte("<nzb/>"))
+	_, err = db.Exec(`
+		INSERT INTO NzbNames (Id, FileName) VALUES ('aaaa1111bbbb2222', 'M.nzb');
+		INSERT INTO DavItems (Id, ParentId, Name, Path, NzbBlobId, SubType) VALUES
+		('root',   NULL,   '/',         '/',               NULL,               1),
+		('movies', 'root', 'movies',    '/movies',         NULL,               1),
+		('rel',    'movies','M',        '/movies/M',       NULL,               101),
+		('item',   'rel',  'M.mkv',     '/movies/M/M.mkv', 'aaaa1111bbbb2222', 203);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	countTempDBs := func() int {
+		entries, err := os.ReadDir(tmpRoot)
+		require.NoError(t, err)
+		n := 0
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), "altmount-nzbdav-") {
+				n++
+			}
+		}
+		return n
+	}
+
+	out, errChan := NewParser(dbPath, blobsDir).Parse()
+
+	// Don't drain immediately. Receive the first ParsedNzb so we know the
+	// goroutine has reached the streaming phase, then check that the temp
+	// DB is already gone from disk while the channel still has work to
+	// flush (Content pipe + close of channel).
+	first, ok := <-out
+	require.True(t, ok, "expected at least one ParsedNzb")
+	require.NotNil(t, first)
+
+	assert.Equal(t, 0, countTempDBs(),
+		"temp DB copy should be removed before streaming begins; found %d altmount-nzbdav-* files in %s", countTempDBs(), tmpRoot)
+
+	// Drain the rest so the goroutine exits cleanly.
+	_, _ = io.ReadAll(first.Content)
+	for range out {
+	}
+	for range errChan {
+	}
 }
 
 func TestParser_Parse_Blobs_WithExtracted(t *testing.T) {


### PR DESCRIPTION
The nzbdav blob importer silently dropped most of the library in two real-world DB shapes:

- Release folders (SubType=101) whose children carry SubType=201 instead of 203. The discovery query restricted to `SubType = 203` skipped them entirely.
- Rows with a non-empty NzbBlobId but no matching NzbNames entry. The discovery INNER JOIN on NzbNames dropped them.

Both cases now resolve:
- Expand the discovery predicate to `SubType IN (201, 203)`.
- Run `INSERT OR IGNORE INTO NzbNames (Id, FileName) SELECT DISTINCT ...` before discovery so half-populated rows get a synthesized FileName derived from the DavItem's Name (stripping .mkv/.mp4/.avi, suffixing .nzb).

Because the backfill is a write, we cannot run it against the user's db.sqlite — that file may live on a read-only mount, and even when it doesn't, mutating someone else's source DB is poor neighbour behaviour.

The new prepareBlobImport helper stages a temp copy of the DB (`os.CreateTemp`), opens it RW, runs the backfill + tree load + discovery scan, then releases the handle and deletes the file (plus any WAL/SHM sidecars) BEFORE parseBlobs begins streaming on the channel. So the temp file lives on disk only for the few hundred ms of DB work, not for the full duration of the import.

Also switch the read-only handle DSN from `?mode=ro&_journal_mode=WAL` to `?mode=ro&immutable=1`. The previous form mutated the source file's SQLite header on open (go-sqlite3 issues PRAGMAs that touch the file even in ro mode); `immutable=1` promises SQLite the file won't change and in return guarantees no writes (no sidecars, no header rewrite).

Tests:
- TestParser_Parse_Blobs_SubType201_BackfillsAndDiscovers: verifies a SubType=201 row with no NzbNames entry is discovered; pre-existing SubType=203 rows still work; source DB is byte-identical after import (SHA-equal).
- TestParser_Parse_Blobs_TempDBCleanedBeforeStreaming: redirects TMPDIR, receives the first ParsedNzb from the channel, then asserts no altmount-nzbdav-* files remain in the temp dir — proves cleanup happens before the consumer starts draining.