### PR TITLE
fix(iso): clamp UDF short_ad directory extents

### DIFF
--- a/internal/importer/archive/iso/fs.go
+++ b/internal/importer/archive/iso/fs.go
@@ -373,7 +373,8 @@ func udfReadDirEntries(rs io.ReadSeeker, physSect uint32, metaMap []udfMetaSpan,
 			if rerr != nil {
 				return nil, rerr
 			}
-			dirData = append(dirData, sector[:ad.length]...)
+			take := min(int(ad.length), len(sector))
+			dirData = append(dirData, sector[:take]...)
 		}
 	case 1: // long_ad
 		for off := 0; off+16 <= allocDescLen; off += 16 {

--- a/internal/importer/archive/iso/fs_test.go
+++ b/internal/importer/archive/iso/fs_test.go
@@ -1,0 +1,26 @@
+package iso
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestUDFReadDirEntriesShortADClampsExtentLength(t *testing.T) {
+	image := make([]byte, iso9660SectorSize*21)
+	dirICBSector := image[10*iso9660SectorSize : 11*iso9660SectorSize]
+	binary.LittleEndian.PutUint16(dirICBSector[0:2], 261)
+	dirICBSector[34] = 0
+	binary.LittleEndian.PutUint32(dirICBSector[168:172], 0)
+	binary.LittleEndian.PutUint32(dirICBSector[172:176], 8)
+	binary.LittleEndian.PutUint32(dirICBSector[176:180], 2796)
+	binary.LittleEndian.PutUint32(dirICBSector[180:184], 20)
+
+	entries, err := udfReadDirEntries(bytes.NewReader(image), 10, nil, 0)
+	if err != nil {
+		t.Fatalf("udfReadDirEntries() error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("udfReadDirEntries() returned %d entries, want 0", len(entries))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a panic in the UDF ISO parser when reading directory entries backed by short allocation descriptors.

The `short_ad` branch in `udfReadDirEntries` sliced the 2048-byte sector buffer directly with `ad.length`. Some UDF images report a directory extent length larger than one sector, for example 2796 bytes, which caused:

```text
panic: runtime error: slice bounds out of range [:2796] with capacity 2048
```

The `long_ad` branch already clamps the copied length to `len(sector)`. This applies the same bound to `short_ad`.

## Context

I ran into this while hosting AltMount with a queue of RAR-backed Blu-ray/ISO imports. Several NZBs repeatedly crashed the container during archive analysis, causing a restart loop because the queue workers picked up the same items again after each restart.

The crash consistently pointed to:

```text
github.com/javi11/altmount/internal/importer/archive/iso.udfReadDirEntries
/app/internal/importer/archive/iso/fs.go:376
```

The failing releases included Blu-ray/BD25/BD50-style uploads where AltMount expanded RAR contents and attempted to inspect embedded ISO/UDF content.

## Changes

- Clamp `short_ad` directory extent reads to the sector buffer length.
- Add a regression test covering a 2796-byte `short_ad` extent against a 2048-byte sector.