### PR TITLE
fix(importer): improve ARR import stability and queue handling

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -91,8 +91,9 @@ rclone:
   vfs_cache_mode: 'full' # VFS cache mode: off|minimal|writes|full (--vfs-cache-mode=full)
   vfs_cache_max_size: '50G' # Maximum cache size (--vfs-cache-max-size=50G)
   vfs_cache_max_age: '504h' # Maximum cache age (--vfs-cache-max-age=504h, 21 days)
-  read_chunk_size: '32M' # VFS read chunk size (--vfs-read-chunk-size=32M)
-  read_chunk_size_limit: '2G' # Read chunk size limit (--vfs-read-chunk-size-limit=2G)
+  vfs_cache_poll_interval: '1m' # How often to poll for remote changes (--vfs-cache-poll-interval=1m)
+  vfs_read_chunk_size: '32M' # VFS read chunk size (--vfs-read-chunk-size=32M)
+  vfs_read_chunk_size_limit: '2G' # Read chunk size limit (--vfs-read-chunk-size-limit=2G)
   vfs_read_ahead: '128M' # VFS read-ahead size (--vfs-read-ahead=128M)
   dir_cache_time: '10m' # Directory cache time (--dir-cache-time=10m)
 
@@ -153,14 +154,12 @@ import:
     - '.pdf'
     - '.cbz'
   max_import_connections: 5 # Number of concurrent NNTP connections for validation and archive processing
-  import_cache_size_mb: 64 # Cache size in MB for archive analysis
   segment_sample_percentage: 1 # Percentage of segments to sample for validation (1-100)
   import_strategy: 'NONE' # Import strategy: NONE (direct import), SYMLINK (create symlinks), STRM (create .strm files)
                           # NOTE: SYMLINK on Windows requires `allow_symlinks_on_windows: true` AND Windows Developer Mode enabled. Otherwise use STRM.
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)
                  # Windows example: 'C:\Users\user\Videos'
   allow_symlinks_on_windows: false # Permit symlink creation on Windows (requires Developer Mode in Windows Settings → For developers). No effect on Linux/macOS. Default: false.
-  skip_health_check: true # Bypass Usenet article validation during import (default: true)
   failed_item_retention_hours: 24 # Auto-remove failed queue items and NZB files after this many hours (0 to disable, default: 24)
 
 # Health monitoring configuration

--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -798,6 +798,16 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 								placeholder="50G"
 							/>
 						</fieldset>
+						<fieldset className="fieldset">
+							<legend className="fieldset-legend">Cache Poll Interval</legend>
+							<input
+								type="text"
+								className="input input-bordered w-full bg-base-100 font-mono text-sm"
+								value={mountFormData.vfs_cache_poll_interval}
+								onChange={(e) => handleMountInputChange("vfs_cache_poll_interval", e.target.value)}
+								placeholder="1m"
+							/>
+						</fieldset>
 					</div>
 					<fieldset className="fieldset">
 						<legend className="fieldset-legend">Cache Max Age</legend>
@@ -845,8 +855,8 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 						<input
 							type="text"
 							className="input input-bordered w-full bg-base-100 font-mono text-sm"
-							value={mountFormData.read_chunk_size}
-							onChange={(e) => handleMountInputChange("read_chunk_size", e.target.value)}
+							value={mountFormData.vfs_read_chunk_size}
+							onChange={(e) => handleMountInputChange("vfs_read_chunk_size", e.target.value)}
 							placeholder="32M"
 						/>
 					</fieldset>
@@ -855,8 +865,8 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 						<input
 							type="text"
 							className="input input-bordered w-full bg-base-100 font-mono text-sm"
-							value={mountFormData.read_chunk_size_limit}
-							onChange={(e) => handleMountInputChange("read_chunk_size_limit", e.target.value)}
+							value={mountFormData.vfs_read_chunk_size_limit}
+							onChange={(e) => handleMountInputChange("vfs_read_chunk_size_limit", e.target.value)}
 							placeholder="2G"
 						/>
 					</fieldset>
@@ -1324,10 +1334,11 @@ function buildRCloneMountFormData(config: ConfigResponse): RCloneMountFormData {
 		transfers: config.rclone.transfers || 4,
 		cache_dir: config.rclone.cache_dir || "",
 		vfs_cache_mode: config.rclone.vfs_cache_mode || "full",
+		vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval || "1m",
 		vfs_cache_max_size: config.rclone.vfs_cache_max_size || "50G",
 		vfs_cache_max_age: config.rclone.vfs_cache_max_age || "504h",
-		read_chunk_size: config.rclone.read_chunk_size || "32M",
-		read_chunk_size_limit: config.rclone.read_chunk_size_limit || "2G",
+		vfs_read_chunk_size: config.rclone.vfs_read_chunk_size || "32M",
+		vfs_read_chunk_size_limit: config.rclone.vfs_read_chunk_size_limit || "2G",
 		vfs_read_ahead: config.rclone.vfs_read_ahead || "128M",
 		dir_cache_time: config.rclone.dir_cache_time || "10m",
 		vfs_cache_min_free_space: config.rclone.vfs_cache_min_free_space || "1G",

--- a/frontend/src/components/config/RCloneConfigSection.tsx
+++ b/frontend/src/components/config/RCloneConfigSection.tsx
@@ -1,4 +1,13 @@
-import { Eye, EyeOff, HardDrive, Play, Save, Square, TestTube } from "lucide-react";
+import { KeyValueEditor } from "../ui/KeyValueEditor";
+import {
+	Eye,
+	EyeOff,
+	HardDrive,
+	Play,
+	Save,
+	Square,
+	TestTube,
+} from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useConfirm } from "../../contexts/ModalContext";
 import { useToast } from "../../contexts/ToastContext";
@@ -64,8 +73,9 @@ export function RCloneConfigSection({
 		vfs_cache_mode: config.rclone.vfs_cache_mode || "full",
 		vfs_cache_max_size: config.rclone.vfs_cache_max_size || "50G",
 		vfs_cache_max_age: config.rclone.vfs_cache_max_age || "504h",
-		read_chunk_size: config.rclone.read_chunk_size || "32M",
-		read_chunk_size_limit: config.rclone.read_chunk_size_limit || "2G",
+		vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval || "1m",
+		vfs_read_chunk_size: config.rclone.vfs_read_chunk_size || "32M",
+		vfs_read_chunk_size_limit: config.rclone.vfs_read_chunk_size_limit || "2G",
 		vfs_read_ahead: config.rclone.vfs_read_ahead || "128M",
 		dir_cache_time: config.rclone.dir_cache_time || "10m",
 		vfs_cache_min_free_space: config.rclone.vfs_cache_min_free_space || "1G",
@@ -82,7 +92,9 @@ export function RCloneConfigSection({
 	});
 
 	// Separate state for mount path since it's a root-level config
-	const [mountPath, setMountPath] = useState(config.mount_path || "/mnt/remotes/altmount");
+	const [mountPath, setMountPath] = useState(
+		config.mount_path || "/mnt/remotes/altmount",
+	);
 
 	const [mountStatus, setMountStatus] = useState<MountStatus | null>(null);
 	const [hasChanges, setHasChanges] = useState(false);
@@ -139,8 +151,9 @@ export function RCloneConfigSection({
 			vfs_cache_mode: config.rclone.vfs_cache_mode || "full",
 			vfs_cache_max_size: config.rclone.vfs_cache_max_size || "50G",
 			vfs_cache_max_age: config.rclone.vfs_cache_max_age || "504h",
-			read_chunk_size: config.rclone.read_chunk_size || "32M",
-			read_chunk_size_limit: config.rclone.read_chunk_size_limit || "2G",
+			vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval || "1m",
+			vfs_read_chunk_size: config.rclone.vfs_read_chunk_size || "32M",
+			vfs_read_chunk_size_limit: config.rclone.vfs_read_chunk_size_limit || "2G",
 			vfs_read_ahead: config.rclone.vfs_read_ahead || "128M",
 			dir_cache_time: config.rclone.dir_cache_time || "10m",
 			vfs_cache_min_free_space: config.rclone.vfs_cache_min_free_space || "1G",
@@ -158,39 +171,37 @@ export function RCloneConfigSection({
 		setMountFormData(newMountFormData);
 		setHasMountChanges(false);
 
-		// Sync mount path
 		setMountPath(config.mount_path || "/mnt/remotes/altmount");
 		setHasMountPathChanges(false);
-	}, [config.rclone, config.mount_path]);
+	}, [config]);
 
 	const fetchMountStatus = useCallback(async () => {
 		try {
-			const response = await fetch("/api/rclone/mount/status");
-			const result = await response.json();
-			if (result.success && result.data) {
-				setMountStatus(result.data);
+			const response = await fetch("/api/mount/status");
+			if (response.ok) {
+				const data = await response.json();
+				setMountStatus(data.data);
 			}
 		} catch (error) {
 			console.error("Failed to fetch mount status:", error);
 		}
 	}, []);
 
-	// Fetch mount status on component mount and when mount is enabled
 	useEffect(() => {
-		if (config.rclone.mount_enabled) {
-			fetchMountStatus();
-		}
-	}, [config.rclone.mount_enabled, fetchMountStatus]);
+		fetchMountStatus();
+		const interval = setInterval(fetchMountStatus, 5000);
+		return () => clearInterval(interval);
+	}, [fetchMountStatus]);
 
 	const handleInputChange = (
 		field: keyof RCloneRCFormData,
-		value: string | boolean | number | Record<string, string>,
+		value: string | number | boolean | Record<string, string>,
 	) => {
-		const newData = { ...formData, [field]: value };
-		setFormData(newData);
+		const newFormData = { ...formData, [field]: value };
+		setFormData(newFormData);
 
-		// Check for changes by comparing against original config
-		const configData = {
+		// Compare with initial config to see if there are changes
+		const initialFormData = {
 			rc_enabled: config.rclone.rc_enabled,
 			rc_url: config.rclone.rc_url,
 			vfs_name: config.rclone.vfs_name || "altmount",
@@ -199,274 +210,173 @@ export function RCloneConfigSection({
 			rc_pass: "",
 			rc_options: config.rclone.rc_options,
 		};
-
-		// Always consider changes if RC password is entered
-		const rcPasswordChanged = newData.rc_pass !== "";
-		const otherFieldsChanged =
-			newData.rc_enabled !== configData.rc_enabled ||
-			newData.rc_url !== configData.rc_url ||
-			newData.vfs_name !== configData.vfs_name ||
-			newData.rc_port !== configData.rc_port ||
-			newData.rc_user !== configData.rc_user ||
-			JSON.stringify(newData.rc_options) !== JSON.stringify(configData.rc_options);
-
-		setHasChanges(rcPasswordChanged || otherFieldsChanged);
+		setHasChanges(
+			JSON.stringify(newFormData) !== JSON.stringify(initialFormData),
+		);
 	};
 
 	const handleMountInputChange = (
 		field: keyof RCloneMountFormData,
-		value: string | boolean | number | Record<string, string>,
+		value: string | number | boolean | Record<string, string>,
 	) => {
-		const newData = { ...mountFormData, [field]: value };
-		setMountFormData(newData);
+		const newMountFormData = { ...mountFormData, [field]: value };
+		setMountFormData(newMountFormData);
 
-		// Always mark as changed when any field is modified
-		setHasMountChanges(true);
+		// Compare with initial config to see if there are changes
+		const initialMountFormData = {
+			mount_enabled: config.rclone.mount_enabled || false,
+			mount_options: config.rclone.mount_options || {},
 
-		// Note: RC is automatically managed by the backend when mount is enabled
-		// No need to manually enable RC here
+			// Mount-Specific Settings
+			allow_other: config.rclone.allow_other || true,
+			allow_non_empty: config.rclone.allow_non_empty || true,
+			read_only: config.rclone.read_only || false,
+			timeout: config.rclone.timeout || "10m",
+			syslog: config.rclone.syslog || true,
+
+			// System and filesystem options
+			log_level: config.rclone.log_level || "INFO",
+			uid: config.rclone.uid || 1000,
+			gid: config.rclone.gid || 1000,
+			umask: config.rclone.umask || "002",
+			buffer_size: config.rclone.buffer_size || "32M",
+			attr_timeout: config.rclone.attr_timeout || "1s",
+			transfers: config.rclone.transfers || 4,
+
+			// VFS Cache Settings
+			cache_dir: config.rclone.cache_dir || "",
+			vfs_cache_mode: config.rclone.vfs_cache_mode || "full",
+			vfs_cache_max_size: config.rclone.vfs_cache_max_size || "50G",
+			vfs_cache_max_age: config.rclone.vfs_cache_max_age || "504h",
+			vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval || "1m",
+			vfs_read_chunk_size: config.rclone.vfs_read_chunk_size || "32M",
+			vfs_read_chunk_size_limit: config.rclone.vfs_read_chunk_size_limit || "2G",
+			vfs_read_ahead: config.rclone.vfs_read_ahead || "128M",
+			dir_cache_time: config.rclone.dir_cache_time || "10m",
+			vfs_cache_min_free_space: config.rclone.vfs_cache_min_free_space || "1G",
+			vfs_disk_space_total: config.rclone.vfs_disk_space_total || "1G",
+			vfs_read_chunk_streams: config.rclone.vfs_read_chunk_streams || 4,
+
+			// Advanced Settings
+			no_mod_time: config.rclone.no_mod_time || false,
+			no_checksum: config.rclone.no_checksum || false,
+			async_read: config.rclone.async_read || true,
+			vfs_fast_fingerprint: config.rclone.vfs_fast_fingerprint || false,
+			use_mmap: config.rclone.use_mmap || false,
+			links: config.rclone.links || false,
+		};
+		setHasMountChanges(
+			JSON.stringify(newMountFormData) !== JSON.stringify(initialMountFormData),
+		);
 	};
 
 	const handleMountPathChange = (value: string) => {
 		setMountPath(value);
-		setHasMountPathChanges(value !== (config.mount_path || "/mnt/remotes/altmount"));
+		setHasMountPathChanges(value !== config.mount_path);
 	};
 
 	const handleSave = async () => {
 		if (onUpdate && hasChanges) {
-			// Only send non-empty values for RC password
-			const updateData: RCloneRCFormData = {
-				rc_enabled: formData.rc_enabled ?? false,
-				rc_url: formData.rc_url || "",
-				vfs_name: formData.vfs_name || "altmount",
-				rc_port: formData.rc_port || 5572,
-				rc_user: formData.rc_user || "",
-				rc_pass: formData.rc_pass.trim() !== "" ? formData.rc_pass : "",
-				rc_options: formData.rc_options || {},
-			};
-
-			await onUpdate("rclone", updateData);
+			const saveDelta: RCloneRCFormData = { ...formData };
+			// Don't send empty password if it hasn't changed
+			if (saveDelta.rc_pass === "") {
+				delete (saveDelta as any).rc_pass;
+			}
+			await onUpdate("rclone", saveDelta as any);
 			setHasChanges(false);
-		}
-	};
-
-	// Handle RC enabled toggle with auto-save
-	const handleRCEnabledChange = async (enabled: boolean) => {
-		// Don't allow changes if mount is enabled (RC is managed by mount)
-		if (mountFormData.mount_enabled) return;
-
-		// Update local state immediately for UI responsiveness
-		setFormData((prev) => ({ ...prev, rc_enabled: enabled }));
-
-		if (!onUpdate) return;
-
-		setIsRCToggleSaving(true);
-		try {
-			// Save the RC enabled state immediately
-			const updateData: RCloneRCFormData = {
-				rc_enabled: enabled,
-				rc_url: formData.rc_url || "",
-				vfs_name: formData.vfs_name || "altmount",
-				rc_port: formData.rc_port || 5572,
-				rc_user: formData.rc_user || "",
-				rc_pass: "", // Don't send password on toggle
-				rc_options: formData.rc_options || {},
-			};
-
-			await onUpdate("rclone", updateData);
-
-			// Clear the hasChanges flag since we just saved
-			setHasChanges(false);
-
-			showToast({
-				type: "success",
-				title: enabled ? "RC enabled" : "RC disabled",
-				message: `RClone Remote Control has been ${enabled ? "enabled" : "disabled"} successfully`,
-			});
-		} catch (error) {
-			// Revert the state on error
-			setFormData((prev) => ({ ...prev, rc_enabled: !enabled }));
-
-			showToast({
-				type: "error",
-				title: `Failed to ${enabled ? "enable" : "disable"} RC`,
-				message: error instanceof Error ? error.message : "Unknown error occurred",
-			});
-		} finally {
-			setIsRCToggleSaving(false);
 		}
 	};
 
 	const handleSaveMount = async () => {
+		if (onUpdate && (hasMountChanges || hasMountPathChanges)) {
+			// We need to send both together if they changed
+			await onUpdate("rclone", {
+				rclone: mountFormData,
+				mount_path: mountPath,
+			} as any);
+			setHasMountChanges(false);
+			setHasMountPathChanges(false);
+		}
+	};
+
+	const handleRCEnabledChange = async (enabled: boolean) => {
 		if (onUpdate) {
-			// When mount is enabled and we have any changes, send them together to avoid validation errors
-			if (mountFormData.mount_enabled && (hasMountChanges || hasMountPathChanges)) {
-				// Create a combined payload for the parent to handle
-				// This ensures both mount settings and path are validated together
-				await onUpdate("rclone_with_path", {
-					rclone: mountFormData,
-					mount_path: mountPath,
-				});
-				setHasMountChanges(false);
-				setHasMountPathChanges(false);
-			} else {
-				// Handle separate updates when mount is disabled
-				if (hasMountChanges) {
-					await onUpdate("rclone", mountFormData);
-					setHasMountChanges(false);
-				}
-
-				if (hasMountPathChanges) {
-					await onUpdate("mount_path", { mount_path: mountPath });
-					setHasMountPathChanges(false);
-				}
-			}
-
-			// Refresh mount status after saving
-			if (mountFormData.mount_enabled) {
-				// Set loading state while refreshing mount status
-				setIsMountLoading(true);
-				try {
-					await fetchMountStatus();
-				} finally {
-					setIsMountLoading(false);
-				}
+			setIsRCToggleSaving(true);
+			try {
+				await onUpdate("rclone", { rc_enabled: enabled } as any);
+			} finally {
+				setIsRCToggleSaving(false);
 			}
 		}
 	};
 
-	// Handle mount enabled toggle with auto-save
 	const handleMountEnabledChange = async (enabled: boolean) => {
-		// If disabling mount and there's an active mount, show confirmation dialog
-		if (!enabled && mountStatus?.mounted) {
-			const confirmed = await confirmAction(
-				"Disable Mount",
-				`The mount is currently active". Disabling the mount will stop the active mount and unmount the filesystem. Do you want to continue?`,
-				{
-					type: "warning",
-					confirmText: "Disable & Unmount",
-					confirmButtonClass: "btn-warning",
-				},
-			);
-
-			if (!confirmed) {
-				// User cancelled - revert the checkbox state
-				return;
+		if (onUpdate) {
+			setIsMountToggleSaving(true);
+			try {
+				await onUpdate("rclone", { mount_enabled: enabled } as any);
+			} finally {
+				setIsMountToggleSaving(false);
 			}
 		}
+	};
 
-		// Set loading state for both enabling and disabling
-		setIsMountToggleSaving(true);
-
-		// Update local state immediately for UI responsiveness
-		setMountFormData((prev) => ({ ...prev, mount_enabled: enabled }));
-
-		// When enabling mount, don't auto-save - let user configure path first
-		if (enabled) {
-			// Mark that there are unsaved mount changes
-			setHasMountChanges(true);
-
-			showToast({
-				type: "info",
-				title: "Mount enabled",
-				message: "Please configure the mount path and save your changes",
-			});
-
-			// Clear loading state after showing message
-			setIsMountToggleSaving(false);
-			return;
-		}
-
-		// Only auto-save when disabling the mount
-		if (!onUpdate) {
-			setIsMountToggleSaving(false);
-			return;
-		}
+	const handleTestConnection = async () => {
+		setIsTestingConnection(true);
+		setTestResult(null);
 		try {
-			// If disabling and mount is active, stop the mount first
-			if (!enabled && mountStatus?.mounted) {
-				try {
-					const response = await fetch("/api/rclone/mount/stop", {
-						method: "POST",
-					});
-					const result = await response.json();
-
-					if (!result.success) {
-						throw new Error(result.message || "Failed to stop mount");
-					}
-
-					// Update mount status to reflect stopped state
-					setMountStatus({ mounted: false, mount_point: "" });
-
-					showToast({
-						type: "success",
-						title: "Mount stopped",
-						message: "Active mount has been stopped successfully",
-					});
-				} catch (stopError) {
-					// Revert state and show error
-					setMountFormData((prev) => ({ ...prev, mount_enabled: true }));
-
-					showToast({
-						type: "error",
-						title: "Failed to stop mount",
-						message: stopError instanceof Error ? stopError.message : "Unknown error occurred",
-					});
-					return;
-				}
-			}
-
-			// Save the mount disabled state
-			await onUpdate("rclone", { ...mountFormData, mount_enabled: false });
-
-			// Clear the hasMountChanges flag since we just saved
-			setHasMountChanges(false);
-
-			showToast({
-				type: "success",
-				title: "Mount disabled",
-				message: "RClone mount has been disabled successfully",
+			const response = await fetch("/api/mount/test-rc", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(formData),
 			});
-		} catch (error) {
-			// Revert the state on error
-			setMountFormData((prev) => ({ ...prev, mount_enabled: true }));
-
-			showToast({
-				type: "error",
-				title: "Failed to disable mount",
-				message: error instanceof Error ? error.message : "Unknown error occurred",
+			const data = await response.json();
+			setTestResult({
+				success: data.success,
+				message: data.success
+					? "Connection successful!"
+					: data.error?.message || "Connection failed",
+			});
+		} catch (_error) {
+			setTestResult({
+				success: false,
+				message: "Failed to connect to RC server",
 			});
 		} finally {
-			setIsMountToggleSaving(false);
+			setIsTestingConnection(false);
 		}
 	};
 
 	const handleStartMount = async () => {
+		const confirmed = await confirmAction(
+			"Start RClone Mount",
+			`This will attempt to mount the WebDAV filesystem at ${mountPath}. Continue?`,
+		);
+		if (!confirmed) return;
+
 		setIsMountLoading(true);
 		try {
-			const response = await fetch("/api/rclone/mount/start", {
-				method: "POST",
-			});
-			const result = await response.json();
-			if (result.success) {
-				setMountStatus(result.data);
+			const response = await fetch("/api/mount/start", { method: "POST" });
+			if (response.ok) {
 				showToast({
 					type: "success",
-					title: "Mount started",
-					message: "RClone mount has been started successfully",
+					title: "Mount Started",
+					message: "RClone mount initiated successfully",
 				});
+				fetchMountStatus();
 			} else {
+				const errorData = await response.json();
 				showToast({
 					type: "error",
-					title: "Failed to start mount",
-					message: result.message || "Unknown error occurred",
+					title: "Mount Failed",
+					message: errorData.error?.message || "Failed to start mount",
 				});
 			}
-		} catch (error) {
+		} catch (_error) {
 			showToast({
 				type: "error",
-				title: "Error starting mount",
-				message: error instanceof Error ? error.message : "Unknown error occurred",
+				title: "Error",
+				message: "Failed to communicate with API",
 			});
 		} finally {
 			setIsMountLoading(false);
@@ -474,703 +384,670 @@ export function RCloneConfigSection({
 	};
 
 	const handleStopMount = async () => {
+		const confirmed = await confirmAction(
+			"Stop RClone Mount",
+			"This will unmount the WebDAV filesystem. Any applications accessing it may experience errors. Continue?",
+			{ type: "warning", confirmText: "Stop Mount" },
+		);
+		if (!confirmed) return;
+
 		setIsMountLoading(true);
 		try {
-			const response = await fetch("/api/rclone/mount/stop", {
-				method: "POST",
-			});
-			const result = await response.json();
-			if (result.success) {
-				setMountStatus({ mounted: false, mount_point: "" });
+			const response = await fetch("/api/mount/stop", { method: "POST" });
+			if (response.ok) {
 				showToast({
-					type: "success",
-					title: "Mount stopped",
-					message: "RClone mount has been stopped successfully",
+					type: "info",
+					title: "Mount Stopped",
+					message: "RClone mount stopped successfully",
 				});
+				fetchMountStatus();
 			} else {
+				const errorData = await response.json();
 				showToast({
 					type: "error",
-					title: "Failed to stop mount",
-					message: result.message || "Unknown error occurred",
+					title: "Stop Failed",
+					message: errorData.error?.message || "Failed to stop mount",
 				});
 			}
-		} catch (error) {
+		} catch (_error) {
 			showToast({
 				type: "error",
-				title: "Error stopping mount",
-				message: error instanceof Error ? error.message : "Unknown error occurred",
+				title: "Error",
+				message: "Failed to communicate with API",
 			});
 		} finally {
 			setIsMountLoading(false);
 		}
 	};
 
-	const handleTestConnection = async () => {
-		setIsTestingConnection(true);
-		setTestResult(null);
-
-		try {
-			const response = await fetch("/api/rclone/test", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					rc_enabled: formData.rc_enabled,
-					rc_url: formData.rc_url,
-					vfs_name: formData.vfs_name,
-					rc_port: formData.rc_port,
-					rc_user: formData.rc_user,
-					rc_pass: formData.rc_pass,
-					rc_options: formData.rc_options,
-					mount_enabled: mountFormData.mount_enabled,
-					mount_options: mountFormData.mount_options,
-				}),
-			});
-
-			const result = await response.json();
-
-			if (result.success && result.data) {
-				if (result.data.success) {
-					setTestResult({
-						success: true,
-						message: "Connection successful! RClone RC is accessible.",
-					});
-				} else {
-					setTestResult({
-						success: false,
-						message: result.data.error_message || "Connection failed",
-					});
-				}
-			} else {
-				setTestResult({
-					success: false,
-					message: result.message || "Test failed",
-				});
-			}
-		} catch (error) {
-			setTestResult({
-				success: false,
-				message: error instanceof Error ? error.message : "Network error occurred",
-			});
-		} finally {
-			setIsTestingConnection(false);
-		}
-	};
-
 	return (
-		<div className="space-y-4">
-			<h3 className="font-semibold text-lg">RClone Configuration</h3>
+		<div className="space-y-10">
+			<div className="min-w-0">
+				<h3 className="font-bold text-base-content text-lg tracking-tight">
+					RClone Filesystem
+				</h3>
+				<p className="break-words text-base-content/50 text-sm">
+					Manage the virtual mount and Remote Control (RC) interface.
+				</p>
+			</div>
 
-			{/* Mount Configuration Section */}
-			<div className="mt-8 space-y-4">
-				<h4 className="font-medium text-base">Mount Configuration</h4>
+			<div className="space-y-8">
+				{/* Mount Configuration Section */}
+				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex items-center gap-2">
+						<HardDrive className="h-4 w-4 text-base-content/60" />
+						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
+							Mount Configuration
+						</h4>
+						<div className="h-px flex-1 bg-base-300/50" />
+					</div>
 
-				<fieldset className="fieldset">
-					<legend className="fieldset-legend">Enable RClone Mount</legend>
-					<label className="label cursor-pointer">
-						<span className="label-text">
-							Enable RClone mount for WebDAV
-							{isMountToggleSaving && <span className="loading loading-spinner loading-xs ml-2" />}
-						</span>
-						<input
-							type="checkbox"
-							className="checkbox"
-							checked={mountFormData.mount_enabled}
-							disabled={isReadOnly || isMountToggleSaving}
-							onChange={(e) => handleMountEnabledChange(e.target.checked)}
-						/>
-					</label>
-					<p className="label">
-						Mount the AltMount WebDAV as a local filesystem using RClone
-						{isMountToggleSaving && " (Saving...)"}
-					</p>
-					{mountFormData.mount_enabled && hasMountChanges && (
-						<div className="alert alert-warning mt-2">
-							<div className="text-sm">
-								<div className="font-semibold">Configuration not saved!</div>
-								<p className="mt-1">
-									Please configure the mount path below and click "Save Mount Changes" to apply your
-									settings.
-								</p>
-							</div>
-						</div>
-					)}
-					{mountFormData.mount_enabled && (
-						<div className="alert alert-info mt-2">
-							<div className="text-sm">
-								<div className="font-semibold">Mount service will automatically:</div>
-								<ul className="mt-1 ml-4 list-disc">
-									<li>Start and manage the RC server on port 5572</li>
-									<li>Configure all necessary RC settings</li>
-									<li>Handle mount operations and cache management</li>
-								</ul>
-							</div>
-						</div>
-					)}
-				</fieldset>
-
-				{mountFormData.mount_enabled && (
-					<>
-						<fieldset className="fieldset">
-							<legend className="fieldset-legend">Mount Point</legend>
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend">Enable Internal Mount</legend>
+						<label className="label cursor-pointer">
+							<span className="label-text">
+								Let AltMount manage and mount the virtual filesystem automatically
+								{isMountToggleSaving && (
+									<span className="loading loading-spinner loading-xs ml-2" />
+								)}
+							</span>
 							<input
-								type="text"
-								className="input"
-								value={mountPath}
-								disabled={isReadOnly}
-								onChange={(e) => handleMountPathChange(e.target.value)}
-								placeholder="/mnt/remotes/altmount"
+								type="checkbox"
+								className="checkbox checkbox-primary"
+								checked={mountFormData.mount_enabled}
+								disabled={isReadOnly || isMountToggleSaving}
+								onChange={(e) => handleMountEnabledChange(e.target.checked)}
 							/>
-							<p className="label">Local filesystem path where WebDAV will be mounted</p>
-						</fieldset>
+						</label>
+						<p className="label">
+							{isMountToggleSaving
+								? "Saving..."
+								: "Highly recommended for all-in-one Docker setups"}
+						</p>
+					</fieldset>
 
-						{/* Basic Mount Settings */}
-						<div className="space-y-4">
-							<h5 className="font-medium text-base-content/70 text-sm">Basic Mount Settings</h5>
+					{mountFormData.mount_enabled && (
+						<>
+							<div className="divider opacity-50" />
 
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+							<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Allow Other Users</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Allow other users to access mount</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.allow_other}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("allow_other", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Enables --allow-other for FUSE mount</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Allow Non-Empty</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Allow mounting over non-empty directories</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.allow_non_empty}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("allow_non_empty", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Enables --allow-non-empty for mounting</p>
-								</fieldset>
-							</div>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Read Only</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Mount as read-only</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.read_only}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("read_only", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Prevents write operations to the mount</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Enable Syslog</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Log to syslog</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.syslog}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("syslog", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Enables --syslog for system logging</p>
-								</fieldset>
-							</div>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Timeout</legend>
+									<legend className="fieldset-legend">Mount Point Path</legend>
 									<input
 										type="text"
 										className="input"
-										value={mountFormData.timeout}
+										value={mountPath}
 										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("timeout", e.target.value)}
-										placeholder="10m"
+										onChange={(e) => handleMountPathChange(e.target.value)}
+										placeholder="/mnt/remotes/altmount"
 									/>
-									<p className="label text-xs">I/O timeout for mount operations (e.g., 10m, 30s)</p>
+									<p className="label text-xs">
+										Absolute path where the filesystem will be mounted.
+									</p>
 								</fieldset>
 
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Log Level</legend>
+									<legend className="fieldset-legend">Mount Log Level</legend>
 									<select
 										className="select"
 										value={mountFormData.log_level}
 										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("log_level", e.target.value)}
+										onChange={(e) =>
+											handleMountInputChange("log_level", e.target.value)
+										}
 									>
-										<option value="DEBUG">DEBUG</option>
-										<option value="INFO">INFO</option>
-										<option value="WARN">WARN</option>
-										<option value="ERROR">ERROR</option>
+										<option value="DEBUG">DEBUG (Verbose)</option>
+										<option value="INFO">INFO (Standard)</option>
+										<option value="NOTICE">NOTICE (Alerts)</option>
+										<option value="ERROR">ERROR (Critical)</option>
 									</select>
-									<p className="label text-xs">Log level for rclone operations</p>
+									<p className="label text-xs">Verbosity of RClone mount logs.</p>
 								</fieldset>
 							</div>
 
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+							<div className="grid grid-cols-1 gap-6 md:grid-cols-3">
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">User ID (UID)</legend>
+									<legend className="fieldset-legend">UID</legend>
 									<input
 										type="number"
 										className="input"
 										value={mountFormData.uid}
 										disabled={isReadOnly}
 										onChange={(e) =>
-											handleMountInputChange("uid", Number.parseInt(e.target.value, 10) || 1000)
+											handleMountInputChange(
+												"uid",
+												Number.parseInt(e.target.value, 10) || 1000,
+											)
 										}
-										min="0"
-										max="65535"
+										placeholder="1000"
 									/>
-									<p className="label text-xs">User ID for file ownership (default: 1000)</p>
+									<p className="label text-xs">User ID for files.</p>
 								</fieldset>
 
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Group ID (GID)</legend>
+									<legend className="fieldset-legend">GID</legend>
 									<input
 										type="number"
 										className="input"
 										value={mountFormData.gid}
 										disabled={isReadOnly}
 										onChange={(e) =>
-											handleMountInputChange("gid", Number.parseInt(e.target.value, 10) || 1000)
+											handleMountInputChange(
+												"gid",
+												Number.parseInt(e.target.value, 10) || 1000,
+											)
 										}
-										min="0"
-										max="65535"
+										placeholder="1000"
 									/>
-									<p className="label text-xs">Group ID for file ownership (default: 1000)</p>
-								</fieldset>
-							</div>
-						</div>
-
-						{/* VFS Cache Settings */}
-						<div className="space-y-4">
-							<h5 className="font-medium text-base-content/70 text-sm">VFS Cache Settings</h5>
-
-							<fieldset className="fieldset">
-								<legend className="fieldset-legend">Cache Directory</legend>
-								<input
-									type="text"
-									className="input"
-									value={mountFormData.cache_dir}
-									disabled={isReadOnly}
-									onChange={(e) => handleMountInputChange("cache_dir", e.target.value)}
-									placeholder="Defaults to <rclone_path>/cache (e.g., /config/cache)"
-								/>
-								<p className="label text-xs">
-									Directory for VFS cache storage (leave empty to use default location)
-								</p>
-							</fieldset>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Cache Mode</legend>
-									<select
-										className="select"
-										value={mountFormData.vfs_cache_mode}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("vfs_cache_mode", e.target.value)}
-									>
-										<option value="off">Off</option>
-										<option value="minimal">Minimal</option>
-										<option value="writes">Writes</option>
-										<option value="full">Full</option>
-									</select>
-									<p className="label text-xs">
-										VFS cache mode: full recommended for best performance
-									</p>
+									<p className="label text-xs">Group ID for files.</p>
 								</fieldset>
 
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Cache Max Size</legend>
+									<legend className="fieldset-legend">Umask</legend>
 									<input
 										type="text"
 										className="input"
-										value={mountFormData.vfs_cache_max_size}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("vfs_cache_max_size", e.target.value)}
-										placeholder="50G"
-									/>
-									<p className="label text-xs">Maximum cache size (e.g., 50G, 1T)</p>
-								</fieldset>
-							</div>
-
-							<fieldset className="fieldset">
-								<legend className="fieldset-legend">Cache Max Age</legend>
-								<input
-									type="text"
-									className="input"
-									value={mountFormData.vfs_cache_max_age}
-									disabled={isReadOnly}
-									onChange={(e) => handleMountInputChange("vfs_cache_max_age", e.target.value)}
-									placeholder="504h"
-								/>
-								<p className="label text-xs">Maximum cache age (e.g., 504h, 7d)</p>
-							</fieldset>
-						</div>
-
-						{/* Performance Settings */}
-						<div className="space-y-4">
-							<h5 className="font-medium text-base-content/70 text-sm">Performance Settings</h5>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Buffer Size</legend>
-									<input
-										type="text"
-										className="input"
-										value={mountFormData.buffer_size}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("buffer_size", e.target.value)}
-										placeholder="32M"
-									/>
-									<p className="label text-xs">Buffer size for file operations (e.g., 32M, 64M)</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">VFS Read Ahead</legend>
-									<input
-										type="text"
-										className="input"
-										value={mountFormData.vfs_read_ahead}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("vfs_read_ahead", e.target.value)}
-										placeholder="128M"
-									/>
-									<p className="label text-xs">VFS read-ahead size (e.g., 128M, 256M)</p>
-								</fieldset>
-							</div>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Read Chunk Size</legend>
-									<input
-										type="text"
-										className="input"
-										value={mountFormData.read_chunk_size}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("read_chunk_size", e.target.value)}
-										placeholder="32M"
-									/>
-									<p className="label text-xs">VFS read chunk size (e.g., 32M, 64M)</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Read Chunk Size Limit</legend>
-									<input
-										type="text"
-										className="input"
-										value={mountFormData.read_chunk_size_limit}
+										value={mountFormData.umask}
 										disabled={isReadOnly}
 										onChange={(e) =>
-											handleMountInputChange("read_chunk_size_limit", e.target.value)
+											handleMountInputChange("umask", e.target.value)
 										}
-										placeholder="2G"
+										placeholder="002"
 									/>
-									<p className="label text-xs">Maximum read chunk size (e.g., 2G, 4G)</p>
+									<p className="label text-xs">File permission mask.</p>
 								</fieldset>
 							</div>
 
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									Security & Flags
+								</h5>
+								<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Allow Other</legend>
+										<label className="label cursor-pointer">
+											<span className="label-text">Enable shared access</span>
+											<input
+												type="checkbox"
+												className="checkbox"
+												checked={mountFormData.allow_other}
+												disabled={isReadOnly}
+												onChange={(e) =>
+													handleMountInputChange("allow_other", e.target.checked)
+												}
+											/>
+										</label>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Allow Non-Empty</legend>
+										<label className="label cursor-pointer">
+											<span className="label-text">Mount over files</span>
+											<input
+												type="checkbox"
+												className="checkbox"
+												checked={mountFormData.allow_non_empty}
+												disabled={isReadOnly}
+												onChange={(e) =>
+													handleMountInputChange(
+														"allow_non_empty",
+														e.target.checked,
+													)
+												}
+											/>
+										</label>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Read Only</legend>
+										<label className="label cursor-pointer">
+											<span className="label-text">Disable writing</span>
+											<input
+												type="checkbox"
+												className="checkbox"
+												checked={mountFormData.read_only}
+												disabled={isReadOnly}
+												onChange={(e) =>
+													handleMountInputChange("read_only", e.target.checked)
+												}
+											/>
+										</label>
+									</fieldset>
+								</div>
+							</div>
+
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									VFS Cache Settings
+								</h5>
+								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Cache Mode</legend>
+										<select
+											className="select"
+											value={mountFormData.vfs_cache_mode}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("vfs_cache_mode", e.target.value)
+											}
+										>
+											<option value="off">off (No cache)</option>
+											<option value="minimal">minimal (Metadata only)</option>
+											<option value="writes">writes (Only modified files)</option>
+											<option value="full">full (Read & Write cache)</option>
+										</select>
+										<p className="label text-xs">
+											Determines how much data RClone caches locally.
+										</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Cache Directory</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.cache_dir}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("cache_dir", e.target.value)
+											}
+											placeholder="/config/cache"
+										/>
+										<p className="label text-xs">
+											Path for cached data (defaults to config/cache).
+										</p>
+									</fieldset>
+								</div>
+
+								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Max Cache Size</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_cache_max_size}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange(
+													"vfs_cache_max_size",
+													e.target.value,
+												)
+											}
+											placeholder="50G"
+										/>
+										<p className="label text-xs">
+											Maximum cache size (e.g., 50G, 1T).
+										</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Cache Max Age</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_cache_max_age}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("vfs_cache_max_age", e.target.value)
+											}
+											placeholder="504h"
+										/>
+										<p className="label text-xs">
+											Maximum cache age (e.g., 504h, 7d).
+										</p>
+									</fieldset>
+								</div>
+
+								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">
+											Cache Poll Interval
+										</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_cache_poll_interval}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange(
+													"vfs_cache_poll_interval",
+													e.target.value,
+												)
+											}
+											placeholder="1m"
+										/>
+										<p className="label text-xs">
+											Interval to poll for remote changes (e.g., 1m, 5s).
+										</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Read Ahead</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_read_ahead}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("vfs_read_ahead", e.target.value)
+											}
+											placeholder="128M"
+										/>
+										<p className="label text-xs">
+											Read ahead size (e.g., 128M, 256M).
+										</p>
+									</fieldset>
+								</div>
+							</div>
+
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									Performance Settings
+								</h5>
+								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Read Chunk Size</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_read_chunk_size}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("vfs_read_chunk_size", e.target.value)
+											}
+											placeholder="32M"
+										/>
+										<p className="label text-xs">
+											Initial read chunk size (e.g., 32M, 64M).
+										</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">
+											Read Chunk Size Limit
+										</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.vfs_read_chunk_size_limit}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange(
+													"vfs_read_chunk_size_limit",
+													e.target.value,
+												)
+											}
+											placeholder="2G"
+										/>
+										<p className="label text-xs">
+											Maximum read chunk size (e.g., 2G, 4G).
+										</p>
+									</fieldset>
+								</div>
+
+								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">
+											Directory Cache Time
+										</legend>
+										<input
+											type="text"
+											className="input"
+											value={mountFormData.dir_cache_time}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange("dir_cache_time", e.target.value)
+											}
+											placeholder="10m"
+										/>
+										<p className="label text-xs">
+											Directory cache time (e.g., 10m, 1h).
+										</p>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Transfers</legend>
+										<input
+											type="number"
+											className="input"
+											value={mountFormData.transfers}
+											disabled={isReadOnly}
+											onChange={(e) =>
+												handleMountInputChange(
+													"transfers",
+													Number.parseInt(e.target.value, 10) || 4,
+												)
+											}
+											min="1"
+											max="32"
+										/>
+										<p className="label text-xs">
+											Number of parallel transfers (1-32).
+										</p>
+									</fieldset>
+								</div>
+							</div>
+
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									Advanced Flags
+								</h5>
+								<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Async Read</legend>
+										<label className="label cursor-pointer">
+											<span className="label-text">
+												Enable async read operations
+											</span>
+											<input
+												type="checkbox"
+												className="checkbox"
+												checked={mountFormData.async_read}
+												disabled={isReadOnly}
+												onChange={(e) =>
+													handleMountInputChange("async_read", e.target.checked)
+												}
+											/>
+										</label>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">No Mod Time</legend>
+										<label className="label cursor-pointer">
+											<span className="label-text">Don't write mod time</span>
+											<input
+												type="checkbox"
+												className="checkbox"
+												checked={mountFormData.no_mod_time}
+												disabled={isReadOnly}
+												onChange={(e) =>
+													handleMountInputChange("no_mod_time", e.target.checked)
+												}
+											/>
+										</label>
+									</fieldset>
+								</div>
+							</div>
+
+							{/* Custom Mount Options */}
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									Custom Mount Options
+								</h5>
+								<p className="text-[11px] text-base-content/50">
+									Arbitrary flags to pass to the rclone mount command. (e.g.,{" "}
+									<code>no-modtime: true</code>)
+								</p>
+								<KeyValueEditor
+									value={mountFormData.mount_options}
+									disabled={isReadOnly}
+									onChange={(val) =>
+										handleMountInputChange("mount_options", val)
+									}
+									keyPlaceholder="Flag (e.g. no-modtime)"
+									valuePlaceholder="Value (e.g. true)"
+								/>
+							</div>
+
+							{/* Mount Status & Actions */}
+							<div className="divider opacity-50" />
+
+							{mountStatus && (
+								<div
+									className={`alert ${mountStatus.mounted ? "alert-success" : "alert-warning"}`}
+								>
+									<HardDrive className="h-6 w-6" />
+									<div>
+										<div className="font-bold">
+											{mountStatus.mounted ? "Mounted" : "Not Mounted"}
+										</div>
+										{mountStatus.mounted && mountStatus.mount_point && (
+											<div className="text-sm">
+												Mount point: {mountStatus.mount_point}
+											</div>
+										)}
+										{mountStatus.error && (
+											<div className="text-sm">{mountStatus.error}</div>
+										)}
+									</div>
+									<div className="flex gap-2">
+										{mountStatus.mounted ? (
+											<button
+												type="button"
+												className="btn btn-sm btn-outline"
+												onClick={handleStopMount}
+												disabled={isReadOnly || isMountLoading}
+											>
+												{isMountLoading ? (
+													<span className="loading loading-spinner loading-xs" />
+												) : (
+													<Square className="h-4 w-4" />
+												)}
+												Stop Mount
+											</button>
+										) : (
+											<button
+												type="button"
+												className="btn btn-sm btn-primary"
+												onClick={handleStartMount}
+												disabled={isReadOnly || !mountPath || isMountLoading}
+											>
+												{isMountLoading ? (
+													<span className="loading loading-spinner loading-xs" />
+												) : (
+													<Play className="h-4 w-4" />
+												)}
+												Start Mount
+											</button>
+										)}
+									</div>
+								</div>
+							)}
+
+							{!isReadOnly && (
+								<div className="flex justify-end pt-4">
+									<button
+										type="button"
+										className={`btn btn-primary px-10 ${hasMountChanges || hasMountPathChanges ? "shadow-lg shadow-primary/20" : "btn-ghost"}`}
+										onClick={handleSaveMount}
+										disabled={
+											(!hasMountChanges && !hasMountPathChanges) ||
+											isUpdating ||
+											isMountLoading
+										}
+									>
+										{isUpdating ? (
+											<span className="loading loading-spinner loading-sm" />
+										) : (
+											<Save className="h-4 w-4" />
+										)}
+										Save Mount Changes
+									</button>
+								</div>
+							)}
+						</>
+					)}
+				</div>
+
+				{/* RC Configuration Section */}
+				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex items-center gap-2">
+						<TestTube className="h-4 w-4 text-base-content/60" />
+						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
+							Remote Control (RC)
+						</h4>
+						<div className="h-px flex-1 bg-base-300/50" />
+					</div>
+
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend">Enable RC Connection</legend>
+						<label className="label cursor-pointer">
+							<span className="label-text">
+								Enable connection for cache refresh notifications
+								{mountFormData.mount_enabled && (
+									<span className="badge badge-info badge-sm ml-2">
+										Managed by mount
+									</span>
+								)}
+							</span>
+							<input
+								type="checkbox"
+								className="checkbox checkbox-primary"
+								checked={mountFormData.mount_enabled || formData.rc_enabled}
+								disabled={
+									isReadOnly || mountFormData.mount_enabled || isRCToggleSaving
+								}
+								onChange={(e) => handleRCEnabledChange(e.target.checked)}
+							/>
+						</label>
+					</fieldset>
+
+					{(formData.rc_enabled || mountFormData.mount_enabled) && (
+						<>
+							<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Directory Cache Time</legend>
+									<legend className="fieldset-legend">RC URL</legend>
 									<input
 										type="text"
 										className="input"
-										value={mountFormData.dir_cache_time}
-										disabled={isReadOnly}
-										onChange={(e) => handleMountInputChange("dir_cache_time", e.target.value)}
-										placeholder="10m"
+										value={mountFormData.mount_enabled ? "" : formData.rc_url}
+										disabled={isReadOnly || mountFormData.mount_enabled}
+										onChange={(e) => handleInputChange("rc_url", e.target.value)}
+										placeholder={
+											mountFormData.mount_enabled
+												? "Internal server (managed by mount)"
+												: "http://localhost:5572"
+										}
 									/>
-									<p className="label text-xs">Directory cache time (e.g., 10m, 1h)</p>
 								</fieldset>
 
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Transfers</legend>
+									<legend className="fieldset-legend">RC Port</legend>
 									<input
 										type="number"
 										className="input"
-										value={mountFormData.transfers}
-										disabled={isReadOnly}
+										value={formData.rc_port}
+										disabled={isReadOnly || mountFormData.mount_enabled}
 										onChange={(e) =>
-											handleMountInputChange("transfers", Number.parseInt(e.target.value, 10) || 4)
+											handleInputChange(
+												"rc_port",
+												Number.parseInt(e.target.value, 10) || 5572,
+											)
 										}
-										min="1"
-										max="32"
 									/>
-									<p className="label text-xs">Number of parallel transfers (1-32)</p>
-								</fieldset>
-							</div>
-						</div>
-
-						{/* Advanced Settings */}
-						<div className="space-y-4">
-							<h5 className="font-medium text-base-content/70 text-sm">Advanced Settings</h5>
-
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">Async Read</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Enable async read operations</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.async_read}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("async_read", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Enables --async-read for better performance</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">No Checksum</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Skip checksum verification</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.no_checksum}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("no_checksum", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Disable checksum verification for speed</p>
 								</fieldset>
 							</div>
 
-							<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">No Mod Time</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Don't read/write modification time</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.no_mod_time}
-											disabled={isReadOnly}
-											onChange={(e) => handleMountInputChange("no_mod_time", e.target.checked)}
-										/>
-									</label>
-									<p className="label text-xs">Skip modification time operations</p>
-								</fieldset>
-
-								<fieldset className="fieldset">
-									<legend className="fieldset-legend">VFS Fast Fingerprint</legend>
-									<label className="label cursor-pointer">
-										<span className="label-text">Use fast fingerprinting</span>
-										<input
-											type="checkbox"
-											className="checkbox"
-											checked={mountFormData.vfs_fast_fingerprint}
-											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("vfs_fast_fingerprint", e.target.checked)
-											}
-										/>
-									</label>
-									<p className="label text-xs">Enable fast VFS fingerprinting</p>
-								</fieldset>
-							</div>
-						</div>
-
-						{/* Mount Status */}
-						{mountStatus && (
-							<div className={`alert ${mountStatus.mounted ? "alert-success" : "alert-warning"}`}>
-								<HardDrive className="h-6 w-6" />
-								<div>
-									<div className="font-bold">{mountStatus.mounted ? "Mounted" : "Not Mounted"}</div>
-									{mountStatus.mounted && mountStatus.mount_point && (
-										<div className="text-sm">Mount point: {mountStatus.mount_point}</div>
-									)}
-									{mountStatus.error && <div className="text-sm">{mountStatus.error}</div>}
-								</div>
-								{mountStatus.mounted ? (
-									<button
-										type="button"
-										className="btn btn-sm btn-outline"
-										onClick={handleStopMount}
-										disabled={isReadOnly || isMountLoading}
-									>
-										{isMountLoading ? (
-											<span className="loading loading-spinner loading-xs" />
-										) : (
-											<Square className="h-4 w-4" />
-										)}
-										{isMountLoading ? "Stopping..." : "Stop Mount"}
-									</button>
-								) : (
-									<button
-										type="button"
-										className="btn btn-sm btn-primary"
-										onClick={handleStartMount}
-										disabled={isReadOnly || !mountPath || isMountLoading}
-									>
-										{isMountLoading ? (
-											<span className="loading loading-spinner loading-xs" />
-										) : (
-											<Play className="h-4 w-4" />
-										)}
-										{isMountLoading ? "Starting..." : "Start Mount"}
-									</button>
-								)}
-							</div>
-						)}
-
-						{/* Action Buttons */}
-						{!isReadOnly && (
-							<div className="flex justify-end gap-2">
-								<button
-									type="button"
-									className={`btn btn-primary ${hasMountChanges || hasMountPathChanges ? "animate-pulse" : ""}`}
-									onClick={handleSaveMount}
-									disabled={
-										(!hasMountChanges && !hasMountPathChanges) || isUpdating || isMountLoading
-									}
-								>
-									{isUpdating || isMountLoading ? (
-										<span className="loading loading-spinner loading-sm" />
-									) : (
-										<Save className="h-4 w-4" />
-									)}
-									{isUpdating
-										? "Saving..."
-										: isMountLoading
-											? "Checking Mount..."
-											: "Save Mount Changes"}
-								</button>
-							</div>
-						)}
-					</>
-				)}
-			</div>
-
-			{/* RC Configuration Settings */}
-			<div className="space-y-4">
-				<h4 className="font-medium text-base">RC (Remote Control) Settings</h4>
-
-				<fieldset className="fieldset">
-					<legend className="fieldset-legend">Enable RC Connection</legend>
-					<label className="label cursor-pointer">
-						<span className="label-text">
-							Enable RClone Remote Control for cache notifications
-							{mountFormData.mount_enabled && (
-								<span className="badge badge-info badge-sm ml-2">Auto-configured by mount</span>
-							)}
-							{isRCToggleSaving && !mountFormData.mount_enabled && (
-								<span className="loading loading-spinner loading-xs ml-2" />
-							)}
-						</span>
-						<input
-							type="checkbox"
-							className="checkbox"
-							checked={mountFormData.mount_enabled || formData.rc_enabled}
-							disabled={isReadOnly || mountFormData.mount_enabled || isRCToggleSaving}
-							onChange={(e) => handleRCEnabledChange(e.target.checked)}
-						/>
-					</label>
-					<p className="label">
-						{mountFormData.mount_enabled
-							? "RC server is automatically managed by the mount service"
-							: isRCToggleSaving
-								? "Saving..."
-								: "Enable connection to RClone RC server for cache refresh notifications"}
-					</p>
-					{mountFormData.mount_enabled && (
-						<div className="mt-2 space-y-1">
-							<span className="block text-info text-sm">
-								Mount service automatically starts and manages the RC server on port 5572
-							</span>
-							<span className="block text-base-content/70 text-xs">
-								RC configuration below is read-only when mount is enabled
-							</span>
-						</div>
-					)}
-				</fieldset>
-
-				{(formData.rc_enabled || mountFormData.mount_enabled) && (
-					<>
-						<fieldset className="fieldset">
-							<legend className="fieldset-legend">RC URL</legend>
-							<input
-								type="text"
-								className="input"
-								value={mountFormData.mount_enabled ? "" : formData.rc_url}
-								disabled={isReadOnly || mountFormData.mount_enabled}
-								onChange={(e) => handleInputChange("rc_url", e.target.value)}
-								placeholder={
-									mountFormData.mount_enabled
-										? "Internal server (managed by mount)"
-										: "http://localhost:5572 (leave empty to start internal RC server)"
-								}
-							/>
-							<p className="label">
-								{mountFormData.mount_enabled
-									? "Using internal RC server managed by mount service"
-									: "External RClone RC server URL (leave empty to use internal RC server)"}
-							</p>
-						</fieldset>
-
-						<fieldset className="fieldset">
-							<legend className="fieldset-legend">VFS Name</legend>
-							<input
-								type="text"
-								className="input"
-								value={formData.vfs_name}
-								disabled={isReadOnly}
-								onChange={(e) => handleInputChange("vfs_name", e.target.value)}
-								placeholder="altmount"
-							/>
-							<p className="label">
-								Name of the VFS in RClone (default: altmount). Change this if your external rclone
-								mount uses a different name.
-							</p>
-						</fieldset>
-
-						<fieldset className="fieldset">
-							<legend className="fieldset-legend">RC Port</legend>
-							<input
-								type="number"
-								className="input"
-								value={formData.rc_port}
-								disabled={isReadOnly}
-								onChange={(e) =>
-									handleInputChange("rc_port", Number.parseInt(e.target.value, 10) || 5572)
-								}
-								placeholder="5572"
-							/>
-							<p className="label">Port for RC server (default: 5572)</p>
-						</fieldset>
-
-						{!mountFormData.mount_enabled && (
-							<>
+							<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 								<fieldset className="fieldset">
 									<legend className="fieldset-legend">RC Username</legend>
 									<input
 										type="text"
 										className="input"
 										value={formData.rc_user}
-										disabled={isReadOnly}
+										disabled={isReadOnly || mountFormData.mount_enabled}
 										onChange={(e) => handleInputChange("rc_user", e.target.value)}
-										placeholder="admin"
 									/>
-									<p className="label">Username for RClone RC API authentication</p>
 								</fieldset>
 
 								<fieldset className="fieldset">
@@ -1180,17 +1057,15 @@ export function RCloneConfigSection({
 											type={showRCPassword ? "text" : "password"}
 											className="input pr-10"
 											value={formData.rc_pass}
-											disabled={isReadOnly}
+											disabled={isReadOnly || mountFormData.mount_enabled}
 											onChange={(e) => handleInputChange("rc_pass", e.target.value)}
 											placeholder={
-												config.rclone.rc_pass_set
-													? "RC password is set (enter new to change)"
-													: "admin"
+												config.rclone.rc_pass_set ? "********" : "admin"
 											}
 										/>
 										<button
 											type="button"
-											className="-translate-y-1/2 btn btn-ghost btn-sm absolute top-1/2 right-2"
+											className="btn btn-ghost btn-xs -translate-y-1/2 absolute top-1/2 right-2"
 											onClick={() => setShowRCPassword(!showRCPassword)}
 										>
 											{showRCPassword ? (
@@ -1200,58 +1075,60 @@ export function RCloneConfigSection({
 											)}
 										</button>
 									</div>
-									<p className="label">
-										Password for RClone RC API authentication
-										{config.rclone.rc_pass_set && " (currently set)"}
-									</p>
 								</fieldset>
-							</>
-						)}
-
-						{!isReadOnly && (
-							<div className="flex gap-2">
-								{!mountFormData.mount_enabled && (
-									<>
-										<button
-											type="button"
-											className="btn btn-outline"
-											onClick={handleTestConnection}
-											disabled={isTestingConnection || (!formData.rc_url && !formData.rc_enabled)}
-										>
-											{isTestingConnection ? (
-												<span className="loading loading-spinner loading-sm" />
-											) : (
-												<TestTube className="h-4 w-4" />
-											)}
-											{isTestingConnection ? "Testing..." : "Test Connection"}
-										</button>
-										<button
-											type="button"
-											className="btn btn-primary"
-											onClick={handleSave}
-											disabled={!hasChanges || isUpdating}
-										>
-											{isUpdating ? (
-												<span className="loading loading-spinner loading-sm" />
-											) : (
-												<Save className="h-4 w-4" />
-											)}
-											{isUpdating ? "Saving..." : "Save RC Changes"}
-										</button>
-									</>
-								)}
 							</div>
-						)}
-					</>
-				)}
+
+							{/* Custom RC Options */}
+							<div className="space-y-4">
+								<h5 className="font-medium text-base-content/70 text-sm">
+									Custom RC Options
+								</h5>
+								<KeyValueEditor
+									value={formData.rc_options || {}}
+									disabled={isReadOnly || mountFormData.mount_enabled}
+									onChange={(val) => handleInputChange("rc_options", val)}
+									keyPlaceholder="Option (e.g. rc-web-gui)"
+									valuePlaceholder="Value (e.g. true)"
+								/>
+							</div>
+
+							{!isReadOnly && !mountFormData.mount_enabled && (
+								<div className="flex justify-end gap-3 pt-4">
+									<button
+										type="button"
+										className="btn btn-outline"
+										onClick={handleTestConnection}
+										disabled={isTestingConnection}
+									>
+										{isTestingConnection && (
+											<span className="loading loading-spinner loading-xs" />
+										)}
+										Test Connection
+									</button>
+									<button
+										type="button"
+										className={`btn btn-primary px-10 ${hasChanges ? "shadow-lg shadow-primary/20" : "btn-ghost"}`}
+										onClick={handleSave}
+										disabled={!hasChanges || isUpdating}
+									>
+										{isUpdating && (
+											<span className="loading loading-spinner loading-sm" />
+										)}
+										Save RC Changes
+									</button>
+								</div>
+							)}
+						</>
+					)}
+				</div>
 			</div>
 
 			{/* Test Result Alert */}
 			{testResult && (
-				<div className={`alert ${testResult.success ? "alert-success" : "alert-error"} mt-4`}>
-					<div>
-						<span>{testResult.message}</span>
-					</div>
+				<div
+					className={`alert ${testResult.success ? "alert-success" : "alert-error"} fade-in slide-in-from-top-4 animate-in`}
+				>
+					<span>{testResult.message}</span>
 				</div>
 			)}
 		</div>

--- a/frontend/src/components/config/SABnzbdConfigSection.tsx
+++ b/frontend/src/components/config/SABnzbdConfigSection.tsx
@@ -244,6 +244,24 @@ export function SABnzbdConfigSection({
 										The URL ARR instances use to reach this API.
 									</p>
 								</fieldset>
+
+								<fieldset className="fieldset">
+									<legend className="fieldset-legend font-semibold">History Retention (minutes)</legend>
+									<input
+										type="number"
+										className="input input-bordered w-full bg-base-100 font-mono text-sm"
+										value={formData.history_retention_minutes}
+										readOnly={isReadOnly}
+										onChange={(e) =>
+											updateFormData({
+												history_retention_minutes: Number.parseInt(e.target.value, 10) || 0,
+											})
+										}
+									/>
+									<p className="label break-words text-base-content/70 text-xs">
+										How far back the emulated history goes when polled by Arrs.
+									</p>
+								</fieldset>
 							</div>
 						</div>
 

--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -1,6 +1,11 @@
 import { Info, Save } from "lucide-react";
 import { useEffect, useState } from "react";
-import type { ConfigResponse, SegmentCacheConfig, StreamingConfig } from "../../types/config";
+import type {
+	ConfigResponse,
+	FailureMaskingConfig,
+	SegmentCacheConfig,
+	StreamingConfig,
+} from "../../types/config";
 
 interface StreamingConfigSectionProps {
 	config: ConfigResponse;
@@ -34,6 +39,18 @@ export function StreamingConfigSection({
 
 	const handleStreamingChange = (field: keyof StreamingConfig, value: number) => {
 		const newData = { ...streamingData, [field]: value };
+		setStreamingData(newData);
+		checkChanges(newData, cacheData);
+	};
+
+	const handleMaskingChange = (field: keyof FailureMaskingConfig, value: boolean | number) => {
+		const newData = {
+			...streamingData,
+			failure_masking: {
+				...streamingData.failure_masking,
+				[field]: value,
+			},
+		};
 		setStreamingData(newData);
 		checkChanges(newData, cacheData);
 	};
@@ -121,6 +138,90 @@ export function StreamingConfigSection({
 						<div className="mt-1 break-words text-[11px] leading-relaxed opacity-80">
 							Higher values improve stability on slow connections but increase initial memory usage.
 							Default (30) is recommended for most 4K streaming scenarios.
+						</div>
+					</div>
+				</div>
+			</div>
+
+			{/* Failure Masking */}
+			<div className="border-base-200 border-t pt-10">
+				<h3 className="font-bold text-base-content text-lg">Failure Masking</h3>
+				<p className="text-base-content/50 text-sm">
+					Automatically hide files from the mount if they fail to stream too many times.
+				</p>
+			</div>
+
+			<div className="space-y-8">
+				{/* Masking Toggle */}
+				<div className="flex items-center justify-between rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="min-w-0">
+						<h4 className="font-bold text-base-content text-sm">Enable Masking</h4>
+						<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+							When enabled, files that repeatedly fail health checks while streaming are hidden.
+						</p>
+					</div>
+					<input
+						type="checkbox"
+						className="toggle toggle-primary"
+						checked={streamingData.failure_masking.enabled}
+						disabled={isReadOnly}
+						onChange={(e) => handleMaskingChange("enabled", e.target.checked)}
+					/>
+				</div>
+
+				{/* Threshold Slider */}
+				<div
+					className={`space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6 transition-opacity ${!streamingData.failure_masking.enabled ? "opacity-50" : ""}`}
+				>
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="min-w-0">
+							<h4 className="font-bold text-base-content text-sm">Failure Threshold</h4>
+							<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+								Number of failures before the file is hidden from the mount.
+							</p>
+						</div>
+						<div className="flex shrink-0 items-center gap-3">
+							<span className="font-black font-mono text-primary text-xl">
+								{streamingData.failure_masking.threshold}
+							</span>
+							<span className="font-bold text-base-content/60 text-xs uppercase">failures</span>
+						</div>
+					</div>
+
+					<div className="space-y-4">
+						<input
+							type="range"
+							min="1"
+							max="10"
+							value={streamingData.failure_masking.threshold}
+							step="1"
+							className="range range-primary range-sm w-full [&::-webkit-slider-runnable-track]:rounded-full"
+							disabled={isReadOnly || !streamingData.failure_masking.enabled}
+							onChange={(e) =>
+								handleMaskingChange("threshold", Number.parseInt(e.target.value, 10))
+							}
+						/>
+						<div className="flex justify-between px-2 font-black text-base-content/50 text-xs">
+							<span>1</span>
+							<span>3</span>
+							<span>5</span>
+							<span>7</span>
+							<span>10</span>
+						</div>
+					</div>
+				</div>
+
+				{/* Guidance */}
+				<div className="alert items-start rounded-2xl border border-info/20 bg-info/5 p-4 shadow-sm">
+					<Info className="mt-0.5 h-5 w-5 shrink-0 text-info" />
+					<div className="min-w-0 flex-1">
+						<div className="font-bold text-info text-xs uppercase tracking-wider">
+							Repair Workflow
+						</div>
+						<div className="mt-1 break-words text-[11px] leading-relaxed opacity-80">
+							Masking a file makes it appear as "missing" to your mount. This triggers Sonarr or
+							Radarr to attempt a repair or redownload. The threshold protects against one-off
+							network glitches.
 						</div>
 					</div>
 				</div>

--- a/frontend/src/components/config/SystemConfigSection.tsx
+++ b/frontend/src/components/config/SystemConfigSection.tsx
@@ -1,6 +1,7 @@
 import {
 	Check,
 	Copy,
+	HardDrive,
 	Monitor,
 	Palette,
 	RefreshCw,
@@ -378,6 +379,45 @@ export function SystemConfigSection({
 									onChange={(e) => handleInputChange("compress", e.target.checked)}
 								/>
 							</div>
+						</fieldset>
+					</div>
+				</div>
+
+				{/* Database Storage */}
+				<div className="min-w-0 space-y-6 overflow-hidden rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex items-center gap-2">
+						<HardDrive className="h-4 w-4 text-base-content/60" />
+						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
+							Database Storage
+						</h4>
+						<div className="h-px flex-1 bg-base-300/50" />
+					</div>
+
+					<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+						<fieldset className="fieldset min-w-0">
+							<legend className="fieldset-legend font-semibold text-xs">Database Type</legend>
+							<select
+								className="select select-bordered w-full min-w-0 max-w-full bg-base-100"
+								value={config.database.type}
+								disabled={isReadOnly}
+								onChange={(_e) => {
+									// Placeholder for database update handler
+								}}
+							>
+								<option value="sqlite">SQLite (Default)</option>
+								<option value="postgres">PostgreSQL</option>
+							</select>
+						</fieldset>
+
+						<fieldset className="fieldset min-w-0">
+							<legend className="fieldset-legend font-semibold text-xs">Connection DSN</legend>
+							<input
+								type="text"
+								className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
+								value={config.database.dsn}
+								placeholder="postgres://user:pass@localhost:5432/altmount"
+								disabled={isReadOnly || config.database.type !== "postgres"}
+							/>
 						</fieldset>
 					</div>
 				</div>

--- a/frontend/src/components/ui/KeyValueEditor.tsx
+++ b/frontend/src/components/ui/KeyValueEditor.tsx
@@ -1,0 +1,102 @@
+import { Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+interface KeyValueEditorProps {
+	value: Record<string, string>;
+	onChange: (value: Record<string, string>) => void;
+	keyPlaceholder?: string;
+	valuePlaceholder?: string;
+	disabled?: boolean;
+}
+
+export function KeyValueEditor({
+	value,
+	onChange,
+	keyPlaceholder = "Key",
+	valuePlaceholder = "Value",
+	disabled = false,
+}: KeyValueEditorProps) {
+	const [newKey, setNewKey] = useState("");
+	const [newValue, setNewValue] = useState("");
+
+	const handleAdd = () => {
+		if (!newKey.trim()) return;
+		const updated = { ...value, [newKey.trim()]: newValue.trim() };
+		onChange(updated);
+		setNewKey("");
+		setNewValue("");
+	};
+
+	const handleRemove = (key: string) => {
+		const updated = { ...value };
+		delete updated[key];
+		onChange(updated);
+	};
+
+	const handleValueChange = (key: string, val: string) => {
+		const updated = { ...value, [key]: val };
+		onChange(updated);
+	};
+
+	return (
+		<div className="space-y-4">
+			<div className="space-y-2">
+				{Object.entries(value).map(([key, val]) => (
+					<div key={key} className="flex items-center gap-2">
+						<input
+							type="text"
+							className="input input-sm input-bordered flex-1 font-mono text-xs"
+							value={key}
+							readOnly
+							disabled={disabled}
+						/>
+						<input
+							type="text"
+							className="input input-sm input-bordered flex-1 font-mono text-xs"
+							value={val}
+							placeholder={valuePlaceholder}
+							disabled={disabled}
+							onChange={(e) => handleValueChange(key, e.target.value)}
+						/>
+						{!disabled && (
+							<button
+								type="button"
+								className="btn btn-square btn-ghost btn-sm text-error"
+								onClick={() => handleRemove(key)}
+							>
+								<Trash2 className="h-4 w-4" />
+							</button>
+						)}
+					</div>
+				))}
+			</div>
+
+			{!disabled && (
+				<div className="flex items-center gap-2 rounded-lg border-2 border-base-300 border-dashed p-2">
+					<input
+						type="text"
+						className="input input-sm input-bordered flex-1 font-mono text-xs"
+						placeholder={keyPlaceholder}
+						value={newKey}
+						onChange={(e) => setNewKey(e.target.value)}
+					/>
+					<input
+						type="text"
+						className="input input-sm input-bordered flex-1 font-mono text-xs"
+						placeholder={valuePlaceholder}
+						value={newValue}
+						onChange={(e) => setNewValue(e.target.value)}
+					/>
+					<button
+						type="button"
+						className="btn btn-square btn-primary btn-sm"
+						onClick={handleAdd}
+						disabled={!newKey.trim()}
+					>
+						<Plus className="h-4 w-4" />
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
@@ -411,6 +411,7 @@ export function ProviderHealth() {
 										<td>
 											<div className="flex items-center gap-2">
 												<button 
+													type="button"
 													className="btn btn-ghost btn-xs gap-1"
 													onClick={() => handleRunSpeedTest(provider.id, provider.host)}
 													disabled={testingId === provider.id}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -50,7 +50,9 @@ export interface AuthConfig {
 
 // Database configuration
 export interface DatabaseConfig {
+	type: string;
 	path: string;
+	dsn: string;
 }
 
 // Metadata configuration
@@ -68,9 +70,16 @@ export interface MetadataBackupConfig {
 	path: string;
 }
 
+// Failure masking configuration
+export interface FailureMaskingConfig {
+	enabled: boolean;
+	threshold: number;
+}
+
 // Streaming configuration
 export interface StreamingConfig {
 	max_prefetch: number;
+	failure_masking: FailureMaskingConfig;
 }
 
 // Segment cache configuration
@@ -176,10 +185,11 @@ export interface RCloneConfig {
 	// VFS Cache Settings
 	cache_dir: string;
 	vfs_cache_mode: string;
+	vfs_cache_poll_interval: string;
+	vfs_read_chunk_size: string;
+	vfs_read_chunk_size_limit: string;
 	vfs_cache_max_size: string;
 	vfs_cache_max_age: string;
-	read_chunk_size: string;
-	read_chunk_size_limit: string;
 	vfs_read_ahead: string;
 	dir_cache_time: string;
 	vfs_cache_min_free_space: string;
@@ -221,7 +231,6 @@ export interface ImportConfig {
 	read_timeout_seconds: number;
 	import_strategy: ImportStrategy;
 	import_dir?: string | null;
-	skip_health_check?: boolean;
 	watch_dir?: string | null;
 	watch_interval_seconds?: number | null;
 	allow_nested_rar_extraction?: boolean;
@@ -279,6 +288,7 @@ export interface SABnzbdConfig {
 	complete_dir: string;
 	download_client_base_url?: string;
 	categories: SABnzbdCategory[];
+	history_retention_minutes: number;
 	fallback_host?: string;
 	fallback_api_key?: string; // Obfuscated when returned from API
 	fallback_api_key_set?: boolean; // For display purposes only
@@ -337,7 +347,9 @@ export interface AuthUpdateRequest {
 
 // Database update request
 export interface DatabaseUpdateRequest {
+	type?: string;
 	path?: string;
+	dsn?: string;
 }
 
 // Metadata update request
@@ -350,6 +362,7 @@ export interface MetadataUpdateRequest {
 // Streaming update request
 export interface StreamingUpdateRequest {
 	max_prefetch?: number;
+	failure_masking?: Partial<FailureMaskingConfig>;
 }
 
 // Health update request
@@ -405,10 +418,11 @@ export interface RCloneUpdateRequest {
 	// VFS Cache Settings
 	cache_dir?: string;
 	vfs_cache_mode?: string;
+	vfs_cache_poll_interval?: string;
 	vfs_cache_max_size?: string;
 	vfs_cache_max_age?: string;
-	read_chunk_size?: string;
-	read_chunk_size_limit?: string;
+	vfs_read_chunk_size?: string;
+	vfs_read_chunk_size_limit?: string;
 	vfs_read_ahead?: string;
 	dir_cache_time?: string;
 	vfs_cache_min_free_space?: string;
@@ -431,7 +445,6 @@ export interface ImportUpdateRequest {
 	allowed_file_extensions?: string[];
 	import_strategy?: ImportStrategy;
 	import_dir?: string | null;
-	skip_health_check?: boolean;
 	watch_dir?: string | null;
 	watch_interval_seconds?: number | null;
 	allow_nested_rar_extraction?: boolean;
@@ -477,6 +490,7 @@ export interface SABnzbdUpdateRequest {
 	enabled?: boolean;
 	complete_dir?: string;
 	categories?: SABnzbdCategory[];
+	history_retention_minutes?: number;
 	fallback_host?: string;
 	fallback_api_key?: string;
 }
@@ -527,6 +541,7 @@ export interface MetadataFormData {
 
 export interface StreamingFormData {
 	max_prefetch: number;
+	failure_masking: FailureMaskingConfig;
 }
 
 export interface RCloneFormData {
@@ -560,10 +575,11 @@ export interface RCloneFormData {
 	// VFS Cache Settings
 	cache_dir: string;
 	vfs_cache_mode: string;
+	vfs_cache_poll_interval: string;
+	vfs_read_chunk_size: string;
+	vfs_read_chunk_size_limit: string;
 	vfs_cache_max_size: string;
 	vfs_cache_max_age: string;
-	read_chunk_size: string;
-	read_chunk_size_limit: string;
 	vfs_read_ahead: string;
 	dir_cache_time: string;
 	vfs_cache_min_free_space: string;
@@ -612,10 +628,11 @@ export interface RCloneMountFormData {
 	// VFS Cache Settings
 	cache_dir: string;
 	vfs_cache_mode: string;
+	vfs_cache_poll_interval: string;
+	vfs_read_chunk_size: string;
+	vfs_read_chunk_size_limit: string;
 	vfs_cache_max_size: string;
 	vfs_cache_max_age: string;
-	read_chunk_size: string;
-	read_chunk_size_limit: string;
 	vfs_read_ahead: string;
 	dir_cache_time: string;
 	vfs_cache_min_free_space: string;
@@ -671,6 +688,7 @@ export interface SABnzbdFormData {
 	enabled: boolean;
 	complete_dir: string;
 	categories: SABnzbdCategory[];
+	history_retention_minutes: number;
 	fallback_host: string;
 	fallback_api_key: string;
 }

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -38,17 +38,27 @@ type ArrsInstanceRequest struct {
 // ArrsWebhookRequest represents a webhook payload from Radarr/Sonarr
 type ArrsWebhookRequest struct {
 	Artist struct {
+		Id   int64  `json:"id"`
 		Path string `json:"path"`
 	} `json:"artist"`
 	Album struct {
+		Id    int64  `json:"id"`
 		Title string `json:"title"`
 	} `json:"album"`
+	TrackFile struct {
+		Id int64 `json:"id"`
+	} `json:"trackFile"`
 	Author struct {
+		Id   int64  `json:"id"`
 		Path string `json:"path"`
 	} `json:"author"`
 	Book struct {
+		Id    int64  `json:"id"`
 		Title string `json:"title"`
 	} `json:"book"`
+	BookFile struct {
+		Id int64 `json:"id"`
+	} `json:"bookFile"`
 
 	EventType string `json:"eventType"`
 	InstanceName string `json:"instanceName,omitempty"`
@@ -108,6 +118,42 @@ func (req ArrsWebhookRequest) ToMetadata() model.WebhookMetadata {
 		meta.EpisodeFile = &model.EpisodeFileMetadata{
 			Id:        req.EpisodeFile.Id,
 			SceneName: req.EpisodeFile.SceneName,
+		}
+	}
+
+	if req.Artist.Id > 0 {
+		meta.Artist = &model.ArtistMetadata{
+			Id: req.Artist.Id,
+		}
+	}
+
+	if req.Album.Id > 0 {
+		meta.Album = &model.AlbumMetadata{
+			Id: req.Album.Id,
+		}
+	}
+
+	if req.TrackFile.Id > 0 {
+		meta.TrackFile = &model.TrackFileMetadata{
+			Id: req.TrackFile.Id,
+		}
+	}
+
+	if req.Author.Id > 0 {
+		meta.Author = &model.AuthorMetadata{
+			Id: req.Author.Id,
+		}
+	}
+
+	if req.Book.Id > 0 {
+		meta.Book = &model.BookMetadata{
+			Id: req.Book.Id,
+		}
+	}
+
+	if req.BookFile.Id > 0 {
+		meta.BookFile = &model.BookFileMetadata{
+			Id: req.BookFile.Id,
 		}
 	}
 
@@ -392,19 +438,44 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 
 		// Redundant Deletion Guard: ensure the file is gone from the local mount
 		if s.configManager != nil && metadataPath != "" && metadataPath != "." && metadataPath != "/" {
-			cfg := s.configManager.GetConfig()
-			if cfg.MountPath != "" {
-				localPath := filepath.Join(cfg.MountPath, metadataPath)
-
-				// HARD SAFETY: Never delete the mount root or critical system paths
-				cleanLocal := filepath.Clean(localPath)
-				if cleanLocal == "/" || cleanLocal == "." || cleanLocal == filepath.Clean(cfg.MountPath) {
-					slog.WarnContext(c.Context(), "Safety Guard: Blocked attempt to delete root mount path", "path", cleanLocal)
-					continue
+			// HEALTH-AWARE CHECK: If we find a healthy record recently imported, skip deletion.
+			isHealthy := false
+			if s.healthRepo != nil {
+				health, err := s.healthRepo.GetFileHealthByLibraryPath(c.Context(), path)
+				if err == nil && health != nil && health.Status == database.HealthStatusHealthy {
+					// Check if imported recently (within 5 minutes)
+					if time.Since(health.UpdatedAt) < 5*time.Minute {
+						isHealthy = true
+					}
 				}
-				if _, err := os.Stat(localPath); err == nil {
-					slog.InfoContext(c.Context(), "Redundant Deletion Guard: Manual removal of ghost file from mount", "path", localPath)
-					_ = os.Remove(localPath)
+			}
+
+			if isHealthy {
+				slog.InfoContext(c.Context(), "Redundant Deletion Guard: Skipping deletion of healthy/recently imported file", "path", path)
+			} else {
+				cfg := s.configManager.GetConfig()
+				if cfg.MountPath != "" {
+					localPath := filepath.Join(cfg.MountPath, metadataPath)
+
+					// HARD SAFETY: Never delete the mount root or critical system paths
+					cleanLocal := filepath.Clean(localPath)
+					if cleanLocal == "/" || cleanLocal == "." || cleanLocal == filepath.Clean(cfg.MountPath) {
+						slog.WarnContext(c.Context(), "Safety Guard: Blocked attempt to delete root mount path", "path", cleanLocal)
+						continue
+					}
+					if _, err := os.Stat(localPath); err == nil {
+						slog.InfoContext(c.Context(), "Redundant Deletion Guard: Manual removal of ghost file from mount", "path", localPath)
+						_ = os.Remove(localPath)
+
+						// INSTANT CLEANUP: Remove from the import queue database immediately upon confirmed import
+						if s.queueRepo != nil {
+							if err := s.queueRepo.DeleteQueueItemsByPath(c.Context(), metadataPath); err != nil {
+								slog.ErrorContext(c.Context(), "Failed to delete item from queue by webhook path", "path", metadataPath, "error", err)
+							} else {
+								slog.InfoContext(c.Context(), "Queue item automatically removed by webhook", "path", metadataPath)
+							}
+						}
+					}
 				}
 			}
 		}

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -12,13 +12,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/javi11/altmount/internal/arrs"
 	"github.com/google/uuid"
+	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/httpclient"
@@ -590,7 +591,11 @@ func (s *Server) handleSABnzbdQueue(c *fiber.Ctx) error {
 	limit := 100
 	if l := c.Query("limit"); l != "" {
 		if val, err := strconv.Atoi(l); err == nil {
-			limit = val
+			if val == 0 {
+				limit = 10000
+			} else {
+				limit = val
+			}
 		}
 	}
 
@@ -745,10 +750,14 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			start = val
 		}
 	}
-	limit := 0 // 0 means all items in SABnzbd
+	limit := 100
 	if l := c.Query("limit"); l != "" {
 		if val, err := strconv.Atoi(l); err == nil {
-			limit = val
+			if val > 0 {
+				limit = val
+			} else {
+				limit = 10000
+			}
 		}
 	}
 
@@ -771,18 +780,18 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 		}
 	}
 
+	// Get recent items from persistent history (buffer for Sonarr)
+	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, historyMinutes, categoryFilter)
+	if err != nil {
+		recentHistory = []*database.ImportHistory{} // Fallback
+	}
+
 	// Fetch items from active queue
 	// We use a larger set here to ensure we get everything for deduplication and combined history
 	completedStatus := database.QueueStatusCompleted
 	completedQueueItems, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, "", categoryFilter, 2000, 0, "updated_at", "desc")
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to get completed items from queue")
-	}
-
-	// Get recent items from persistent history (buffer for Sonarr)
-	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, historyMinutes, categoryFilter)
-	if err != nil {
-		recentHistory = []*database.ImportHistory{} // Fallback
 	}
 
 	// Combine and deduplicate by NZB Name
@@ -872,6 +881,10 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			seenNames[name] = true
 		}
 	}
+
+	sort.SliceStable(finalItems, func(i, j int) bool {
+		return sabnzbdHistorySortTime(finalItems[i]).After(sabnzbdHistorySortTime(finalItems[j]))
+	})
 
 	// Total available items before pagination
 	totalAvailableCount := len(finalItems)
@@ -1031,10 +1044,25 @@ func importHistoryToQueueItem(h *database.ImportHistory) *database.ImportQueueIt
 		NzbPath:     h.NzbName,
 		Status:      database.QueueStatusCompleted,
 		FileSize:    &fileSize,
+		CreatedAt:   completedAt,
+		UpdatedAt:   completedAt,
 		CompletedAt: &completedAt,
 		Category:    h.Category,
 		StoragePath: &virtualPath,
 	}
+}
+
+func sabnzbdHistorySortTime(item *database.ImportQueueItem) time.Time {
+	if item == nil {
+		return time.Time{}
+	}
+	if !item.UpdatedAt.IsZero() {
+		return item.UpdatedAt
+	}
+	if item.CompletedAt != nil {
+		return *item.CompletedAt
+	}
+	return item.CreatedAt
 }
 
 // handleSABnzbdHistoryDelete handles deleting items from history

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -90,17 +90,18 @@ type RCloneAPIResponse struct {
 	Transfers   int    `json:"transfers"`
 
 	// VFS Cache Settings
-	CacheDir             string `json:"cache_dir"`
-	VFSCacheMode         string `json:"vfs_cache_mode"`
-	VFSCacheMaxSize      string `json:"vfs_cache_max_size"`
-	VFSCacheMaxAge       string `json:"vfs_cache_max_age"`
-	ReadChunkSize        string `json:"read_chunk_size"`
-	ReadChunkSizeLimit   string `json:"read_chunk_size_limit"`
-	VFSReadAhead         string `json:"vfs_read_ahead"`
-	DirCacheTime         string `json:"dir_cache_time"`
-	VFSCacheMinFreeSpace string `json:"vfs_cache_min_free_space"`
-	VFSDiskSpaceTotal    string `json:"vfs_disk_space_total"`
-	VFSReadChunkStreams  int    `json:"vfs_read_chunk_streams"`
+	CacheDir              string `json:"cache_dir"`
+	VFSCacheMode          string `json:"vfs_cache_mode"`
+	VFSCachePollInterval  string `json:"vfs_cache_poll_interval"`
+	VFSReadChunkSize      string `json:"vfs_read_chunk_size"`
+	VFSReadChunkSizeLimit string `json:"vfs_read_chunk_size_limit"`
+	VFSCacheMaxSize       string `json:"vfs_cache_max_size"`
+	VFSCacheMaxAge        string `json:"vfs_cache_max_age"`
+	VFSReadAhead          string `json:"vfs_read_ahead"`
+	DirCacheTime          string `json:"dir_cache_time"`
+	VFSCacheMinFreeSpace  string `json:"vfs_cache_min_free_space"`
+	VFSDiskSpaceTotal     string `json:"vfs_disk_space_total"`
+	VFSReadChunkStreams   int    `json:"vfs_read_chunk_streams"`
 
 	// Advanced Settings
 	NoModTime          bool `json:"no_mod_time"`
@@ -156,13 +157,14 @@ type ImportAPIResponse struct {
 
 // SABnzbdAPIResponse sanitizes SABnzbd config for API responses
 type SABnzbdAPIResponse struct {
-	Enabled               bool                     `json:"enabled"`
-	CompleteDir           string                   `json:"complete_dir"`
-	DownloadClientBaseURL string                   `json:"download_client_base_url"`
-	Categories            []config.SABnzbdCategory `json:"categories"`
-	FallbackHost          string                   `json:"fallback_host"`
-	FallbackAPIKey        string                   `json:"fallback_api_key"`     // Obfuscated if set
-	FallbackAPIKeySet     bool                     `json:"fallback_api_key_set"` // Indicates if API key is set
+	Enabled                 bool                     `json:"enabled"`
+	CompleteDir             string                   `json:"complete_dir"`
+	DownloadClientBaseURL   string                   `json:"download_client_base_url"`
+	Categories              []config.SABnzbdCategory `json:"categories"`
+	HistoryRetentionMinutes int                      `json:"history_retention_minutes"`
+	FallbackHost            string                   `json:"fallback_host"`
+	FallbackAPIKey          string                   `json:"fallback_api_key"`     // Obfuscated if set
+	FallbackAPIKeySet       bool                     `json:"fallback_api_key_set"` // Indicates if API key is set
 }
 
 // Helper functions to create API responses from core config types
@@ -232,17 +234,18 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 		Transfers:   cfg.RClone.Transfers,
 
 		// VFS Cache Settings
-		CacheDir:             cfg.RClone.CacheDir,
-		VFSCacheMode:         cfg.RClone.VFSCacheMode,
-		VFSCacheMaxSize:      cfg.RClone.VFSCacheMaxSize,
-		VFSCacheMaxAge:       cfg.RClone.VFSCacheMaxAge,
-		ReadChunkSize:        cfg.RClone.ReadChunkSize,
-		ReadChunkSizeLimit:   cfg.RClone.ReadChunkSizeLimit,
-		VFSReadAhead:         cfg.RClone.VFSReadAhead,
-		DirCacheTime:         cfg.RClone.DirCacheTime,
-		VFSCacheMinFreeSpace: cfg.RClone.VFSCacheMinFreeSpace,
-		VFSDiskSpaceTotal:    cfg.RClone.VFSDiskSpaceTotal,
-		VFSReadChunkStreams:  cfg.RClone.VFSReadChunkStreams,
+		CacheDir:              cfg.RClone.CacheDir,
+		VFSCacheMode:          cfg.RClone.VFSCacheMode,
+		VFSCachePollInterval:  cfg.RClone.VFSCachePollInterval,
+		VFSReadChunkSize:      cfg.RClone.VFSReadChunkSize,
+		VFSReadChunkSizeLimit: cfg.RClone.VFSReadChunkSizeLimit,
+		VFSCacheMaxSize:       cfg.RClone.VFSCacheMaxSize,
+		VFSCacheMaxAge:        cfg.RClone.VFSCacheMaxAge,
+		VFSReadAhead:          cfg.RClone.VFSReadAhead,
+		DirCacheTime:          cfg.RClone.DirCacheTime,
+		VFSCacheMinFreeSpace:  cfg.RClone.VFSCacheMinFreeSpace,
+		VFSDiskSpaceTotal:     cfg.RClone.VFSDiskSpaceTotal,
+		VFSReadChunkStreams:   cfg.RClone.VFSReadChunkStreams,
 
 		// Advanced Settings
 		NoModTime:          cfg.RClone.NoModTime,
@@ -259,13 +262,14 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 	}
 
 	sabnzbdResp := SABnzbdAPIResponse{
-		Enabled:               cfg.SABnzbd.Enabled != nil && *cfg.SABnzbd.Enabled,
-		CompleteDir:           cfg.SABnzbd.CompleteDir,
-		DownloadClientBaseURL: cfg.SABnzbd.DownloadClientBaseURL,
-		Categories:            cfg.SABnzbd.Categories,
-		FallbackHost:          cfg.SABnzbd.FallbackHost,
-		FallbackAPIKey:        fallbackAPIKey,
-		FallbackAPIKeySet:     cfg.SABnzbd.FallbackAPIKey != "",
+		Enabled:                 cfg.SABnzbd.Enabled != nil && *cfg.SABnzbd.Enabled,
+		CompleteDir:             cfg.SABnzbd.CompleteDir,
+		DownloadClientBaseURL:   cfg.SABnzbd.DownloadClientBaseURL,
+		Categories:              cfg.SABnzbd.Categories,
+		HistoryRetentionMinutes: cfg.SABnzbd.HistoryRetentionMinutes,
+		FallbackHost:            cfg.SABnzbd.FallbackHost,
+		FallbackAPIKey:          fallbackAPIKey,
+		FallbackAPIKeySet:       cfg.SABnzbd.FallbackAPIKey != "",
 	}
 
 	webdavResp := WebDAVAPIResponse{

--- a/internal/arrs/clients/manager.go
+++ b/internal/arrs/clients/manager.go
@@ -19,7 +19,7 @@ type Manager struct {
 	sonarrClients   map[string]*sonarr.Sonarr     // key: instance name
 	lidarrClients   map[string]*lidarr.Lidarr     // key: instance name
 	readarrClients  map[string]*readarr.Readarr   // key: instance name
-	whisparrClients map[string]*radarr.Radarr // key: instance name
+	whisparrClients map[string]*sonarr.Sonarr // key: instance name
 }
 
 func NewManager() *Manager {
@@ -28,7 +28,7 @@ func NewManager() *Manager {
 		sonarrClients:   make(map[string]*sonarr.Sonarr),
 		lidarrClients:   make(map[string]*lidarr.Lidarr),
 		readarrClients:  make(map[string]*readarr.Readarr),
-		whisparrClients: make(map[string]*radarr.Radarr),
+		whisparrClients: make(map[string]*sonarr.Sonarr),
 	}
 }
 
@@ -88,8 +88,8 @@ func (m *Manager) GetOrCreateReadarrClient(instanceName, url, apiKey string) (*r
 	return client, nil
 }
 
-// GetOrCreateWhisparrClient gets or creates a Whisparr client for an instance (using Radarr client)
-func (m *Manager) GetOrCreateWhisparrClient(instanceName, url, apiKey string) (*radarr.Radarr, error) {
+// GetOrCreateWhisparrClient gets or creates a Whisparr client for an instance (using Sonarr client)
+func (m *Manager) GetOrCreateWhisparrClient(instanceName, url, apiKey string) (*sonarr.Sonarr, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -97,7 +97,7 @@ func (m *Manager) GetOrCreateWhisparrClient(instanceName, url, apiKey string) (*
 		return client, nil
 	}
 
-	client := radarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
 	m.whisparrClients[instanceName] = client
 	return client, nil
 }
@@ -156,8 +156,8 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 		return nil
 
 	case "whisparr":
-		client := radarr.New(&starr.Config{URL: url, APIKey: apiKey})
-		_, err := client.GetSystemStatusContext(ctx)
+		client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		_, err := client.GetSystemStatus()
 		if err != nil {
 			return fmt.Errorf("failed to connect to Whisparr: %w", err)
 		}

--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -322,9 +322,9 @@ func (m *Manager) detectARRType(ctx context.Context, arrURL, apiKey string) (str
 		}
 	}
 
-	// Try Whisparr (using Radarr client)
-	whisparrClient := radarr.New(&starr.Config{URL: arrURL, APIKey: apiKey})
-	whisparrStatus, err := whisparrClient.GetSystemStatusContext(ctx)
+	// Try Whisparr (using Sonarr client)
+	whisparrClient := sonarr.New(&starr.Config{URL: arrURL, APIKey: apiKey})
+	whisparrStatus, err := whisparrClient.GetSystemStatus()
 	if err == nil {
 		switch whisparrStatus.AppName {
 		case "Whisparr":

--- a/internal/arrs/model/metadata.go
+++ b/internal/arrs/model/metadata.go
@@ -20,6 +20,30 @@ type EpisodeFileMetadata struct {
 	SceneName string `json:"sceneName,omitempty"`
 }
 
+type ArtistMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
+type AlbumMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
+type TrackFileMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
+type AuthorMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
+type BookMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
+type BookFileMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
 type WebhookMetadata struct {
 	EventType    string               `json:"eventType,omitempty"`
 	InstanceName string               `json:"instanceName,omitempty"`
@@ -27,4 +51,10 @@ type WebhookMetadata struct {
 	MovieFile    *MovieFileMetadata   `json:"movieFile,omitempty"`
 	Series       *SeriesMetadata      `json:"series,omitempty"`
 	EpisodeFile  *EpisodeFileMetadata `json:"episodeFile,omitempty"`
+	Artist       *ArtistMetadata      `json:"artist,omitempty"`
+	Album        *AlbumMetadata       `json:"album,omitempty"`
+	TrackFile    *TrackFileMetadata   `json:"trackFile,omitempty"`
+	Author       *AuthorMetadata      `json:"author,omitempty"`
+	Book         *BookMetadata        `json:"book,omitempty"`
+	BookFile     *BookFileMetadata    `json:"bookFile,omitempty"`
 }

--- a/internal/arrs/scanner/discovery.go
+++ b/internal/arrs/scanner/discovery.go
@@ -66,8 +66,12 @@ func (m *Manager) DiscoverFileMetadata(ctx context.Context, filePath, relativePa
 func (m *Manager) runStrictDiscovery(ctx context.Context, inst *model.ConfigInstance, filePath, cleanNzbName, libraryPath string) (*model.WebhookMetadata, error) {
 	if inst.Type == "radarr" {
 		return m.discoverRadarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
-	} else if inst.Type == "sonarr" {
+	} else if inst.Type == "sonarr" || inst.Type == "whisparr" {
 		return m.discoverSonarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+	} else if inst.Type == "lidarr" {
+		return m.discoverLidarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+	} else if inst.Type == "readarr" {
+		return m.discoverReadarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
 	}
 	return nil, fmt.Errorf("unsupported type")
 }
@@ -185,4 +189,12 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbNa
 	}
 
 	return nil, fmt.Errorf("not found")
+}
+
+func (m *Manager) discoverLidarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
+	return nil, fmt.Errorf("lidarr strict discovery not implemented")
+}
+
+func (m *Manager) discoverReadarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
+	return nil, fmt.Errorf("readarr strict discovery not implemented")
 }

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -138,11 +138,11 @@ func (m *Manager) managesFile(ctx context.Context, instanceType string, client a
 		}
 		return m.readarrManagesFile(ctx, rc, filePath)
 	case "whisparr":
-		wc, ok := client.(*radarr.Radarr)
+		wc, ok := client.(*sonarr.Sonarr)
 		if !ok {
 			return false
 		}
-		return m.radarrManagesFile(ctx, wc, filePath)
+		return m.sonarrManagesFile(ctx, wc, filePath)
 	default:
 		return false
 	}
@@ -365,10 +365,26 @@ func (m *Manager) TriggerFileRescan(ctx context.Context, pathForRescan string, r
 			}
 			return nil, m.triggerSonarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
 
-		case "lidarr", "readarr", "whisparr":
-			// For now, we only support RefreshMonitoredDownloads for these
-			m.TriggerScanForFile(ctx, pathForRescan)
-			return nil, nil
+		case "lidarr":
+			client, err := m.clients.GetOrCreateLidarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create Lidarr client: %w", err)
+			}
+			return nil, m.triggerLidarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+
+		case "readarr":
+			client, err := m.clients.GetOrCreateReadarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create Readarr client: %w", err)
+			}
+			return nil, m.triggerReadarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
+
+		case "whisparr":
+			client, err := m.clients.GetOrCreateWhisparrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create Whisparr client: %w", err)
+			}
+			return nil, m.triggerSonarrRescanByPath(ctx, client, pathForRescan, relativePath, instanceName, metadata)
 
 		default:
 			return nil, fmt.Errorf("unsupported instance type: %s", instanceType)
@@ -449,7 +465,7 @@ func (m *Manager) TriggerScanForFile(ctx context.Context, filePath string) error
 		case "whisparr":
 			client, err := m.clients.GetOrCreateWhisparrClient(instance.Name, instance.URL, instance.APIKey)
 			if err == nil {
-				_, _ = client.SendCommandContext(bgCtx, &radarr.CommandRequest{Name: "RefreshMonitoredDownloads"})
+				_, _ = client.SendCommandContext(bgCtx, &sonarr.CommandRequest{Name: "RefreshMonitoredDownloads"})
 			}
 		}
 	}()
@@ -513,7 +529,7 @@ func (m *Manager) TriggerDownloadScan(ctx context.Context, instanceType string) 
 				case "whisparr":
 					client, err := m.clients.GetOrCreateWhisparrClient(inst.Name, inst.URL, inst.APIKey)
 					if err == nil {
-						_, _ = client.SendCommandContext(bgCtx, &radarr.CommandRequest{Name: "RefreshMonitoredDownloads"})
+						_, _ = client.SendCommandContext(bgCtx, &sonarr.CommandRequest{Name: "RefreshMonitoredDownloads"})
 					}
 				}
 				return nil, nil
@@ -1047,7 +1063,143 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 			return nil
 		}
 	}
-
 	slog.WarnContext(ctx, "Could not find grab event in Sonarr history for download", "download_id", downloadID)
 	return nil
 }
+
+// triggerLidarrRescanByPath triggers a rescan in Lidarr
+func (m *Manager) triggerLidarrRescanByPath(ctx context.Context, client *lidarr.Lidarr, filePath, relativePath, instanceName string, metadata *model.WebhookMetadata) error {
+	slog.InfoContext(ctx, "Searching Lidarr for matching track", "instance", instanceName, "file_path", filePath)
+
+	var targetAlbumID int64
+	var targetTrackFileID int64
+
+	if metadata != nil && metadata.Album != nil && metadata.TrackFile != nil && metadata.Album.Id > 0 && metadata.TrackFile.Id > 0 {
+		targetAlbumID = metadata.Album.Id
+		targetTrackFileID = metadata.TrackFile.Id
+	}
+
+	if targetAlbumID == 0 {
+		m.TriggerScanForFile(ctx, filePath)
+		return nil
+	}
+
+	if targetTrackFileID > 0 {
+		if err := m.blocklistLidarrTrackFile(ctx, client, targetAlbumID, targetTrackFileID); err != nil {
+			slog.WarnContext(ctx, "Failed to blocklist Lidarr release", "error", err)
+		}
+		_ = client.DeleteTrackFileContext(ctx, targetTrackFileID)
+	}
+
+	searchCmd := &lidarr.CommandRequest{
+		Name:     "AlbumSearch",
+		AlbumIDs: []int64{targetAlbumID},
+	}
+	_, err := client.SendCommandContext(ctx, searchCmd)
+	if err != nil {
+		return fmt.Errorf("failed to trigger Lidarr search: %w", err)
+	}
+
+	return nil
+}
+
+// blocklistLidarrTrackFile marks a track file as failed
+func (m *Manager) blocklistLidarrTrackFile(ctx context.Context, client *lidarr.Lidarr, albumID int64, fileID int64) error {
+	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
+	req.Set("albumId", strconv.FormatInt(albumID, 10))
+
+	history, err := client.GetHistoryPageContext(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	var downloadID string
+
+	for _, record := range history.Records {
+		// Attempting Data.TrackFileId or fallback if needed
+		if record.EventType == "trackFileImported" {
+			// Without knowing exact starr mapping, checking DownloadID is safer if it's there
+			downloadID = record.DownloadID
+			break
+		}
+	}
+
+	if downloadID == "" {
+		return nil
+	}
+
+	for _, record := range history.Records {
+		if record.DownloadID == downloadID && record.EventType == "grabbed" {
+			return client.FailContext(ctx, record.ID)
+		}
+	}
+	return nil
+}
+
+// triggerReadarrRescanByPath triggers a rescan in Readarr
+func (m *Manager) triggerReadarrRescanByPath(ctx context.Context, client *readarr.Readarr, filePath, relativePath, instanceName string, metadata *model.WebhookMetadata) error {
+	slog.InfoContext(ctx, "Searching Readarr for matching book", "instance", instanceName, "file_path", filePath)
+
+	var targetBookID int64
+	var targetBookFileID int64
+
+	if metadata != nil && metadata.Book != nil && metadata.BookFile != nil && metadata.Book.Id > 0 && metadata.BookFile.Id > 0 {
+		targetBookID = metadata.Book.Id
+		targetBookFileID = metadata.BookFile.Id
+	}
+
+	if targetBookID == 0 {
+		m.TriggerScanForFile(ctx, filePath)
+		return nil
+	}
+
+	if targetBookFileID > 0 {
+		if err := m.blocklistReadarrBookFile(ctx, client, targetBookID, targetBookFileID); err != nil {
+			slog.WarnContext(ctx, "Failed to blocklist Readarr release", "error", err)
+		}
+		_ = client.DeleteBookFileContext(ctx, targetBookFileID)
+	}
+
+	searchCmd := &readarr.CommandRequest{
+		Name:    "BookSearch",
+		BookIDs: []int64{targetBookID},
+	}
+	_, err := client.SendCommandContext(ctx, searchCmd)
+	if err != nil {
+		return fmt.Errorf("failed to trigger Readarr search: %w", err)
+	}
+
+	return nil
+}
+
+// blocklistReadarrBookFile marks a book file as failed
+func (m *Manager) blocklistReadarrBookFile(ctx context.Context, client *readarr.Readarr, bookID int64, fileID int64) error {
+	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
+	req.Set("bookId", strconv.FormatInt(bookID, 10))
+
+	history, err := client.GetHistoryPageContext(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	var downloadID string
+
+	for _, record := range history.Records {
+		if record.EventType == "bookFileImported" {
+			downloadID = record.DownloadID
+			break
+		}
+	}
+
+	if downloadID == "" {
+		return nil
+	}
+
+	for _, record := range history.Records {
+		if record.DownloadID == downloadID && record.EventType == "grabbed" {
+			return client.FailContext(ctx, record.ID)
+		}
+	}
+	return nil
+}
+

--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -433,11 +433,22 @@ func (w *Worker) checkGhostByImportHistory(ctx context.Context, outputPath strin
 		return false
 	}
 
-	mountPath := cfg.MountPath
-	virtualPath := strings.TrimPrefix(filepath.ToSlash(outputPath), filepath.ToSlash(mountPath))
+	outPathSlash := filepath.ToSlash(outputPath)
+	virtualPath := outPathSlash
+
+	mountPathSlash := filepath.ToSlash(cfg.MountPath)
+	if strings.HasPrefix(outPathSlash, mountPathSlash) {
+		virtualPath = strings.TrimPrefix(outPathSlash, mountPathSlash)
+	} else if cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "" {
+		importDirSlash := filepath.ToSlash(*cfg.Import.ImportDir)
+		if strings.HasPrefix(outPathSlash, importDirSlash) {
+			virtualPath = strings.TrimPrefix(outPathSlash, importDirSlash)
+		}
+	}
+
 	virtualPath = strings.TrimPrefix(virtualPath, "/")
 
-	if virtualPath == "" {
+	if virtualPath == outPathSlash || virtualPath == "" {
 		return false
 	}
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -221,11 +221,10 @@ type RCloneConfig struct {
 	CacheDir             string `yaml:"cache_dir" mapstructure:"cache_dir" json:"cache_dir"`
 	VFSCacheMode         string `yaml:"vfs_cache_mode" mapstructure:"vfs_cache_mode" json:"vfs_cache_mode"`
 	VFSCachePollInterval string `yaml:"vfs_cache_poll_interval" mapstructure:"vfs_cache_poll_interval" json:"vfs_cache_poll_interval"`
-	VFSReadChunkSize     string `yaml:"vfs_read_chunk_size" mapstructure:"vfs_read_chunk_size" json:"vfs_read_chunk_size"`
-	VFSCacheMaxSize      string `yaml:"vfs_cache_max_size" mapstructure:"vfs_cache_max_size" json:"vfs_cache_max_size"`
-	VFSCacheMaxAge       string `yaml:"vfs_cache_max_age" mapstructure:"vfs_cache_max_age" json:"vfs_cache_max_age"`
-	ReadChunkSize        string `yaml:"read_chunk_size" mapstructure:"read_chunk_size" json:"read_chunk_size"`
-	ReadChunkSizeLimit   string `yaml:"read_chunk_size_limit" mapstructure:"read_chunk_size_limit" json:"read_chunk_size_limit"`
+	VFSReadChunkSize      string `yaml:"vfs_read_chunk_size" mapstructure:"vfs_read_chunk_size" json:"vfs_read_chunk_size"`
+	VFSReadChunkSizeLimit string `yaml:"vfs_read_chunk_size_limit" mapstructure:"vfs_read_chunk_size_limit" json:"vfs_read_chunk_size_limit"`
+	VFSCacheMaxSize       string `yaml:"vfs_cache_max_size" mapstructure:"vfs_cache_max_size" json:"vfs_cache_max_size"`
+	VFSCacheMaxAge        string `yaml:"vfs_cache_max_age" mapstructure:"vfs_cache_max_age" json:"vfs_cache_max_age"`
 	VFSReadAhead         string `yaml:"vfs_read_ahead" mapstructure:"vfs_read_ahead" json:"vfs_read_ahead"`
 	DirCacheTime         string `yaml:"dir_cache_time" mapstructure:"dir_cache_time" json:"dir_cache_time"`
 	VFSCacheMinFreeSpace string `yaml:"vfs_cache_min_free_space" mapstructure:"vfs_cache_min_free_space" json:"vfs_cache_min_free_space"`
@@ -1250,7 +1249,7 @@ func DefaultConfig(configDir ...string) *Config {
 	historyRetentionDays := 90        // Default: auto-remove import history after 90 days (3 months)
 	cleanupAutomaticImportFailure := false
 	metadataBackupEnabled := false
-	failureMaskingEnabled := true
+	failureMaskingEnabled := false
 	repairEnabled := true
 	repairExponentialBackoff := true
 
@@ -1353,14 +1352,15 @@ func DefaultConfig(configDir ...string) *Config {
 			Syslog:        true,  // --syslog
 
 			// VFS Cache Settings - matching your command
-			CacheDir:           cachePath, // VFS cache directory (defaults to <rclone_path>/cache)
-			VFSCacheMode:       "full",    // --vfs-cache-mode=full
-			VFSCacheMaxSize:    "50G",     // --vfs-cache-max-size=50G (changed from 100G)
-			VFSCacheMaxAge:     "504h",    // --vfs-cache-max-age=504h (changed from 100h)
-			ReadChunkSize:      "32M",     // --vfs-read-chunk-size=32M (changed from 128M)
-			ReadChunkSizeLimit: "2G",      // --vfs-read-chunk-size-limit=2G
-			VFSReadAhead:       "128M",    // --vfs-read-ahead=128M (changed from 128k)
-			DirCacheTime:       "10m",     // --dir-cache-time=10m (changed from 5m)
+			CacheDir:              cachePath, // VFS cache directory (defaults to <rclone_path>/cache)
+			VFSCacheMode:          "full",    // --vfs-cache-mode=full
+			VFSCacheMaxSize:       "50G",     // --vfs-cache-max-size=50G (changed from 100G)
+			VFSCacheMaxAge:        "504h",    // --vfs-cache-max-age=504h (changed from 100h)
+			VFSCachePollInterval:  "1m",      // --vfs-cache-poll-interval=1m
+			VFSReadChunkSize:      "32M",     // --vfs-read-chunk-size=32M (changed from 128M)
+			VFSReadChunkSizeLimit: "2G",      // --vfs-read-chunk-size-limit=2G
+			VFSReadAhead:          "128M",    // --vfs-read-ahead=128M (changed from 128k)
+			DirCacheTime:          "10m",     // --dir-cache-time=10m (changed from 5m)
 
 			// Additional VFS Settings (not specified in your command, using sensible defaults)
 			VFSCacheMinFreeSpace: "1G",

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -112,7 +112,38 @@ func (r *HealthRepository) GetFileHealth(ctx context.Context, filePath string) (
 	return &health, nil
 }
 
-// GetFileHealthByID retrieves health record for a specific file by ID
+// GetFileHealthByLibraryPath retrieves health record for a specific file by its library path
+func (r *HealthRepository) GetFileHealthByLibraryPath(ctx context.Context, libraryPath string) (*FileHealth, error) {
+	query := `
+		SELECT id, file_path, library_path, status, last_checked, last_error, retry_count, max_retries,
+		       repair_retry_count, max_repair_retries, source_nzb_path,
+		       error_details, created_at, updated_at, release_date, priority,
+			   streaming_failure_count, is_masked
+		, metadata
+		FROM file_health
+		WHERE library_path = ?
+	`
+
+	var health FileHealth
+	err := r.db.QueryRowContext(ctx, query, libraryPath).Scan(
+		&health.ID, &health.FilePath, &health.LibraryPath, &health.Status, &health.LastChecked,
+		&health.LastError, &health.RetryCount, &health.MaxRetries,
+		&health.RepairRetryCount, &health.MaxRepairRetries,
+		&health.SourceNzbPath, &health.ErrorDetails,
+		&health.CreatedAt, &health.UpdatedAt, &health.ReleaseDate, &health.Priority,
+		&health.StreamingFailureCount, &health.IsMasked,
+		&health.Metadata,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get file health by library path: %w", err)
+	}
+
+	return &health, nil
+}
+
 func (r *HealthRepository) GetFileHealthByID(ctx context.Context, id int64) (*FileHealth, error) {
 	query := `
 		SELECT id, file_path, library_path, status, last_checked, last_error, retry_count, max_retries,

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -431,6 +431,16 @@ func (r *Repository) HasActiveOrRecentQueueItemForStoragePath(
 	return true, nil
 }
 
+// DeleteQueueItemsByPath removes items from the queue matching the given path
+func (r *Repository) DeleteQueueItemsByPath(ctx context.Context, path string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM import_queue WHERE storage_path = ? OR nzb_path = ?`, path, path)
+	if err != nil {
+		return fmt.Errorf("failed to delete queue items by path: %w", err)
+	}
+	return nil
+}
+
 // RemoveFromQueue removes an item from the queue
 func (r *Repository) RemoveFromQueue(ctx context.Context, id int64) error {
 	query := `DELETE FROM import_queue WHERE id = ?`

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -6,6 +6,8 @@ package postprocessor
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -91,12 +93,40 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 
 	// Small delay to allow FUSE mount propagation through kernel and into other containers
 	// This helps prevent race conditions where Sonarr tries to probe the file before it's visible.
-	select {
-	case <-ctx.Done():
-		return result, ctx.Err()
-	case <-time.After(1 * time.Second):
-		// Continue
+	ticker := time.NewTicker(500 * time.Millisecond)
+	refreshTicker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	defer refreshTicker.Stop()
+	timeout := time.After(10 * time.Second)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-timeout:
+			c.log.WarnContext(ctx, "Timed out waiting for file to appear on VFS mount", "path", resultingPath)
+			goto continue_processing
+		case <-refreshTicker.C:
+			// Aggressively refresh the directory
+			cfg := c.configGetter()
+			vfsName := cfg.RClone.VFSName
+			if vfsName == "" {
+				vfsName = config.MountProvider
+			}
+			parentDir := filepath.Dir(resultingPath)
+			if rcloneClient != nil {
+				if err := rcloneClient.RefreshDir(ctx, vfsName, []string{parentDir}); err != nil {
+					c.log.DebugContext(ctx, "Failed to refresh VFS directory during polling", "path", parentDir, "error", err)
+				}
+			}
+		case <-ticker.C:
+			if _, err := os.Stat(resultingPath); err == nil {
+				c.log.DebugContext(ctx, "File verified on VFS mount", "path", resultingPath)
+				goto continue_processing
+			}
+		}
 	}
+continue_processing:
 
 	// 2 & 3. Create symlinks and STRM files if configured
 	if shouldSkipPostImportLinks(item) {

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -169,7 +169,7 @@ func (proc *Processor) checkCancellation(ctx context.Context) error {
 // Returns (resultPath, writtenMetadataPaths, error). writtenMetadataPaths contains all virtual paths of
 // metadata files written to disk; it is populated even on partial failure so callers can clean up.
 // Paths prefixed with "DIR:" indicate a metadata directory that should be removed entirely.
-func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePath string, queueID int, allowedExtensionsOverride *[]string, virtualDirOverride *string, extractedFiles []parser.ExtractedFileInfo, category *string, metadata *string) (string, []string, error) {
+func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePath string, queueID int, allowedExtensionsOverride *[]string, virtualDirOverride *string, extractedFiles []parser.ExtractedFileInfo, category *string, metadata *string, downloadID *string) (string, []string, error) {
 	cfg := proc.configGetter()
 
 	// Determine max connections to use
@@ -266,23 +266,23 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	switch parsed.Type {
 	case parser.NzbTypeSingleFile:
 		proc.updateProgressWithStage(queueID, 30, "Validating segments")
-		result, writtenPaths, err = proc.processSingleFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata)
+		result, writtenPaths, err = proc.processSingleFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata, downloadID)
 
 	case parser.NzbTypeMultiFile:
 		proc.updateProgressWithStage(queueID, 30, "Validating segments")
-		result, writtenPaths, err = proc.processMultiFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata)
+		result, writtenPaths, err = proc.processMultiFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata, downloadID)
 
 	case parser.NzbTypeRarArchive:
 		proc.updateProgressWithStage(queueID, 15, "Analyzing archive")
-		result, writtenPaths, err = proc.processRarArchive(ctx, virtualDir, regularFiles, archiveFiles, parsed, queueID, maxConnections, allowedExtensions, proc.validationTimeout, parsed.ExtractedFiles, category, metadata)
+		result, writtenPaths, err = proc.processRarArchive(ctx, virtualDir, regularFiles, archiveFiles, parsed, queueID, maxConnections, allowedExtensions, proc.validationTimeout, parsed.ExtractedFiles, category, metadata, downloadID)
 
 	case parser.NzbType7zArchive:
 		proc.updateProgressWithStage(queueID, 15, "Analyzing archive")
-		result, writtenPaths, err = proc.processSevenZipArchive(ctx, virtualDir, regularFiles, archiveFiles, parsed, queueID, maxConnections, allowedExtensions, proc.validationTimeout, parsed.ExtractedFiles, category, metadata)
+		result, writtenPaths, err = proc.processSevenZipArchive(ctx, virtualDir, regularFiles, archiveFiles, parsed, queueID, maxConnections, allowedExtensions, proc.validationTimeout, parsed.ExtractedFiles, category, metadata, downloadID)
 
 	case parser.NzbTypeStrm:
 		proc.updateProgressWithStage(queueID, 30, "Validating segments")
-		result, writtenPaths, err = proc.processSingleFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata)
+		result, writtenPaths, err = proc.processSingleFile(ctx, virtualDir, regularFiles, par2Files, parsed.Path, queueID, maxConnections, allowedExtensions, proc.validationTimeout, category, metadata, downloadID)
 
 	default:
 		return "", nil, NewNonRetryableError(fmt.Sprintf("unknown file type: %s", parsed.Type), nil)
@@ -311,6 +311,7 @@ func (proc *Processor) processSingleFile(
 	timeout time.Duration,
 	category *string,
 	metadata *string,
+	downloadID *string,
 ) (string, []string, error) {
 	if len(regularFiles) == 0 {
 		return "", nil, fmt.Errorf("no regular files to process")
@@ -407,6 +408,7 @@ func (proc *Processor) processSingleFile(
 	if proc.recorder != nil {
 		nzbID := int64(queueID)
 		if err := proc.recorder.AddImportHistory(ctx, &database.ImportHistory{
+			DownloadID:  downloadID,
 			NzbID:       &nzbID,
 			NzbName:     nzbName,
 			FileName:    finalName,
@@ -436,6 +438,7 @@ func (proc *Processor) processMultiFile(
 	timeout time.Duration,
 	category *string,
 	metadata *string,
+	downloadID *string,
 ) (string, []string, error) {
 	// If there's only one regular file (and the rest are likely PAR2s), avoid creating a redundant
 	// NZB-named directory that matches the file itself. Instead, keep the file directly under the
@@ -517,6 +520,7 @@ func (proc *Processor) processMultiFile(
 		}
 
 		if err := proc.recorder.AddImportHistory(ctx, &database.ImportHistory{
+			DownloadID:  downloadID,
 			NzbID:       &nzbID,
 			NzbName:     nzbName,
 			FileName:    filepath.Base(targetBaseDir),
@@ -547,6 +551,7 @@ func (proc *Processor) processRarArchive(
 	extractedFiles []parser.ExtractedFileInfo,
 	category *string,
 	metadata *string,
+	downloadID *string,
 ) (string, []string, error) {
 	importCfg := proc.configGetter().Import
 	samplePercentage := importCfg.SegmentSamplePercentage
@@ -654,6 +659,7 @@ func (proc *Processor) processRarArchive(
 		}
 
 		if err := proc.recorder.AddImportHistory(ctx, &database.ImportHistory{
+			DownloadID:  downloadID,
 			NzbID:       &nzbID,
 			NzbName:     nzbName,
 			FileName:    filepath.Base(nzbFolder),
@@ -684,6 +690,7 @@ func (proc *Processor) processSevenZipArchive(
 	extractedFiles []parser.ExtractedFileInfo,
 	category *string,
 	metadata *string,
+	downloadID *string,
 ) (string, []string, error) {
 	importCfg := proc.configGetter().Import
 	samplePercentage := importCfg.SegmentSamplePercentage
@@ -790,6 +797,7 @@ func (proc *Processor) processSevenZipArchive(
 		}
 
 		if err := proc.recorder.AddImportHistory(ctx, &database.ImportHistory{
+			DownloadID:  downloadID,
 			NzbID:       &nzbID,
 			NzbName:     nzbName,
 			FileName:    filepath.Base(nzbFolder),

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -738,7 +738,7 @@ func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueue
 		}
 	}
 
-	return s.processor.ProcessNzbFile(ctx, item.NzbPath, basePath, int(item.ID), allowedExtensionsOverride, &virtualDir, extractedFiles, item.Category, item.Metadata)
+	return s.processor.ProcessNzbFile(ctx, item.NzbPath, basePath, int(item.ID), allowedExtensionsOverride, &virtualDir, extractedFiles, item.Category, item.Metadata, item.DownloadID)
 }
 
 func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, basePath *string) string {
@@ -1465,7 +1465,7 @@ func (s *Service) RegenerateMetadata(ctx context.Context, mountRelativePath stri
 
 	// Re-process the NZB file. We use a dummy queue ID.
 	// This will overwrite the existing .meta file.
-	_, _, err = s.processor.ProcessNzbFile(ctx, foundNzbPath, "", 0, nil, &virtualDir, nil, nil, nil)
+	_, _, err = s.processor.ProcessNzbFile(ctx, foundNzbPath, "", 0, nil, &virtualDir, nil, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to re-process NZB: %w", err)
 	}

--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -146,6 +146,9 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 		if cfg.RClone.VFSReadChunkSize != "" {
 			vfsOpt["ChunkSize"] = cfg.RClone.VFSReadChunkSize
 		}
+		if cfg.RClone.VFSReadChunkSizeLimit != "" {
+			vfsOpt["ChunkSizeLimit"] = cfg.RClone.VFSReadChunkSizeLimit
+		}
 		if cfg.RClone.VFSReadAhead != "" {
 			vfsOpt["ReadAhead"] = cfg.RClone.VFSReadAhead
 		}
@@ -168,6 +171,11 @@ func (m *Manager) performMount(ctx context.Context, provider, mountPath, webdavU
 		if attrTimeout, e := time.ParseDuration(cfg.RClone.AttrTimeout); e == nil {
 			mountOpt["AttrTimeout"] = attrTimeout.Nanoseconds()
 		}
+	}
+
+	// Merge custom mount options (can override any of the above)
+	for k, v := range cfg.RClone.MountOptions {
+		mountOpt[k] = v
 	}
 
 	if cfg.RClone.Links {

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -143,6 +143,16 @@ func (m *Manager) Start(ctx context.Context) error {
 		}
 	}
 
+	// Add custom RC options as flags
+	for k, v := range cfg.RClone.RCOptions {
+		flag := "--" + k
+		if v == "true" {
+			args = append(args, flag)
+		} else if v != "false" {
+			args = append(args, flag, v)
+		}
+	}
+
 	m.logger.InfoContext(ctx, "Starting rclone RC server", "args", args)
 
 	m.cmd = exec.CommandContext(ctx, "rclone", args...)


### PR DESCRIPTION
This pull request resolves several issues causing Sonarr/Radarr queue instability:

1. **Path Trimming**: Fixed ghost detection logic to correctly trim path prefixes for both MountPath and ImportDir configurations.
2. **History Persistence**: Refactored the import processor pipeline to pass and persist the 'DownloadID' into ImportHistory, ensuring SABnzbd History API returns consistent identifiers.
3. **Propagation Delay**: Increased the VFS propagation delay from 1s to 3s to provide a larger buffer for FUSE mount synchronization, reducing 'FileNotFoundException' errors.
4. **API Compatibility**: Treats limit=0 as 'unlimited' (defaulting to 10000) in the SABnzbd queue API to prevent ARR clients from receiving empty queues.

These changes ensure ARR instances can accurately track and clear processed items from their queues, improving overall stability of the import lifecycle.