### PR TITLE
fix(importer): normalize Windows path separators in postprocessor and watcher (#585)

### DIFF
--- a/internal/importer/postprocessor/library_path.go
+++ b/internal/importer/postprocessor/library_path.go
@@ -1,0 +1,47 @@
+package postprocessor
+
+import (
+	"path"
+	"strings"
+)
+
+// buildLibraryRelPath strips the configured CompleteDir and category prefixes
+// from relPath (if already present) and reconstructs the canonical
+// [CompleteDir]/[Category]/<remainder> layout.
+//
+// relPath may use either '/' or OS-native separators; the result always uses
+// '/'. Backslashes are always converted to forward slashes regardless of host
+// OS — filepath.ToSlash is a no-op on non-Windows and would miss the Windows
+// shape returned by filepath.Rel/filepath.WalkDir when callers feed those in.
+// Stripping is done once, so a path that already includes either prefix is
+// not double-prefixed.
+func buildLibraryRelPath(relPath, completeDir, category string) string {
+	relPath = strings.TrimPrefix(strings.ReplaceAll(relPath, `\`, "/"), "/")
+	completeDir = strings.Trim(strings.ReplaceAll(completeDir, `\`, "/"), "/")
+	category = strings.Trim(strings.ReplaceAll(category, `\`, "/"), "/")
+
+	if completeDir != "" {
+		if after, ok := strings.CutPrefix(relPath, completeDir+"/"); ok {
+			relPath = after
+		} else if relPath == completeDir {
+			relPath = ""
+		}
+	}
+	if category != "" {
+		if after, ok := strings.CutPrefix(relPath, category+"/"); ok {
+			relPath = after
+		} else if relPath == category {
+			relPath = ""
+		}
+	}
+
+	parts := make([]string, 0, 3)
+	if completeDir != "" {
+		parts = append(parts, completeDir)
+	}
+	if category != "" {
+		parts = append(parts, category)
+	}
+	parts = append(parts, relPath)
+	return path.Clean(path.Join(parts...))
+}

--- a/internal/importer/postprocessor/library_path_test.go
+++ b/internal/importer/postprocessor/library_path_test.go
@@ -1,0 +1,100 @@
+package postprocessor
+
+import "testing"
+
+func TestBuildLibraryRelPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		relPath     string
+		completeDir string
+		category    string
+		want        string
+	}{
+		{
+			name:        "forward slash with both prefixes already present",
+			relPath:     "complete/Movies/Moviefolder/file.mkv",
+			completeDir: "/complete",
+			category:    "Movies",
+			want:        "complete/Movies/Moviefolder/file.mkv",
+		},
+		{
+			// Regression test for issue #585 Bug A: Windows-style backslash
+			// input from filepath.Rel must be normalised before stripping
+			// or the category/complete prefix gets doubled.
+			name:        "backslash input (Windows shape) with both prefixes",
+			relPath:     `complete\Movies\Moviefolder\file.mkv`,
+			completeDir: "/complete",
+			category:    "Movies",
+			want:        "complete/Movies/Moviefolder/file.mkv",
+		},
+		{
+			name:        "backslash input, empty completeDir, category present",
+			relPath:     `Movies\Moviefolder\file.mkv`,
+			completeDir: "",
+			category:    "Movies",
+			want:        "Movies/Moviefolder/file.mkv",
+		},
+		{
+			name:        "category missing from relPath gets injected once",
+			relPath:     "Moviefolder/file.mkv",
+			completeDir: "",
+			category:    "Movies",
+			want:        "Movies/Moviefolder/file.mkv",
+		},
+		{
+			name:        "complete and category both missing get injected once",
+			relPath:     "Moviefolder/file.mkv",
+			completeDir: "/complete",
+			category:    "Movies",
+			want:        "complete/Movies/Moviefolder/file.mkv",
+		},
+		{
+			name:        "both prefixes empty, slash-normalises only",
+			relPath:     `subdir\file.mkv`,
+			completeDir: "",
+			category:    "",
+			want:        "subdir/file.mkv",
+		},
+		{
+			name:        "relPath equals completeDir, no remainder",
+			relPath:     "complete",
+			completeDir: "complete",
+			category:    "",
+			want:        "complete",
+		},
+		{
+			name:        "relPath equals category, no remainder",
+			relPath:     "Movies",
+			completeDir: "",
+			category:    "Movies",
+			want:        "Movies",
+		},
+		{
+			name:        "leading slash in relPath stripped",
+			relPath:     "/complete/Movies/file.mkv",
+			completeDir: "complete",
+			category:    "Movies",
+			want:        "complete/Movies/file.mkv",
+		},
+		{
+			name:        "completeDir with surrounding slashes is trimmed",
+			relPath:     "complete/Movies/file.mkv",
+			completeDir: "/complete/",
+			category:    "Movies",
+			want:        "complete/Movies/file.mkv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildLibraryRelPath(tt.relPath, tt.completeDir, tt.category)
+			if got != tt.want {
+				t.Errorf("buildLibraryRelPath(%q, %q, %q) = %q; want %q",
+					tt.relPath, tt.completeDir, tt.category, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -29,44 +29,14 @@ func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.Import
 	// Keep the original resulting path for metadata and streaming URL
 	originalResultingPath := resultingPath
 
-	// 1. Get the internal relative path (relative to FUSE mount)
-	relPath := strings.TrimPrefix(resultingPath, "/")
-
-	// 2. Strip any existing /complete or /category prefix from the internal path to start clean
 	category := ""
-	if item.Category != nil && *item.Category != "" {
-		category = strings.Trim(*item.Category, "/")
+	if item.Category != nil {
+		category = *item.Category
 	}
 
-	if cfg.SABnzbd.CompleteDir != "" {
-		completeDir := strings.Trim(filepath.ToSlash(cfg.SABnzbd.CompleteDir), "/")
-		if after, ok := strings.CutPrefix(relPath, completeDir+"/"); ok {
-			relPath = after
-		} else if relPath == completeDir {
-			relPath = ""
-		}
-	}
-	if category != "" {
-		if after, ok := strings.CutPrefix(relPath, category+"/"); ok {
-			relPath = after
-		} else if relPath == category {
-			relPath = ""
-		}
-	}
-
-	// 3. Build the clean, isolated library path
-	// Construct: [CompleteDir] + [Category] + RelPath
-	pathParts := []string{}
-	if cfg.SABnzbd.CompleteDir != "" {
-		pathParts = append(pathParts, strings.Trim(cfg.SABnzbd.CompleteDir, "/"))
-	}
-	if category != "" {
-		pathParts = append(pathParts, category)
-	}
-	pathParts = append(pathParts, relPath)
-
-	resultingPath = filepath.Join(pathParts...)
-	resultingPath = filepath.ToSlash(filepath.Clean(resultingPath))
+	// Build the clean, isolated library path: [CompleteDir]/[Category]/<remainder>,
+	// stripping any of those prefixes that are already present in the source path.
+	resultingPath = buildLibraryRelPath(resultingPath, cfg.SABnzbd.CompleteDir, category)
 
 	// Check the metadata directory to determine if this is a file or directory
 	metadataPath := filepath.Join(cfg.Metadata.RootPath, strings.TrimPrefix(originalResultingPath, "/"))
@@ -114,44 +84,15 @@ func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.Import
 		// Remove .meta extension
 		relPath := strings.TrimSuffix(relPathWithMeta, ".meta")
 
-		// 1. Get the internal relative path (relative to FUSE mount)
-		relPath = strings.TrimPrefix(relPath, "/")
-
-		// 2. Strip any existing /complete or /category prefix from the internal path to start clean
 		category := ""
-		if item.Category != nil && *item.Category != "" {
-			category = strings.Trim(*item.Category, "/")
+		if item.Category != nil {
+			category = *item.Category
 		}
 
-		if cfg.SABnzbd.CompleteDir != "" {
-			completeDir := strings.Trim(filepath.ToSlash(cfg.SABnzbd.CompleteDir), "/")
-			if after, ok := strings.CutPrefix(relPath, completeDir+"/"); ok {
-				relPath = after
-			} else if relPath == completeDir {
-				relPath = ""
-			}
-		}
-		if category != "" {
-			if after, ok := strings.CutPrefix(relPath, category+"/"); ok {
-				relPath = after
-			} else if relPath == category {
-				relPath = ""
-			}
-		}
-
-		// 3. Build the clean, isolated library path
-		// Construct: [CompleteDir] + [Category] + RelPath
-		pathParts := []string{}
-		if cfg.SABnzbd.CompleteDir != "" {
-			pathParts = append(pathParts, strings.Trim(cfg.SABnzbd.CompleteDir, "/"))
-		}
-		if category != "" {
-			pathParts = append(pathParts, category)
-		}
-		pathParts = append(pathParts, relPath)
-
-		strmResultingPath := filepath.Join(pathParts...)
-		strmResultingPath = filepath.ToSlash(filepath.Clean(strmResultingPath))
+		// filepath.Rel returns OS-native separators (backslashes on Windows);
+		// buildLibraryRelPath normalises them before stripping so we don't
+		// double-prefix the category/CompleteDir on Windows (issue #585).
+		strmResultingPath := buildLibraryRelPath(relPath, cfg.SABnzbd.CompleteDir, category)
 
 		if err := c.CreateSingleStrmFile(ctx, strmResultingPath, relPathWithMeta, cfg.WebDAV.Port); err != nil {
 			c.log.ErrorContext(ctx, "Failed to create STRM file",

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -36,44 +36,14 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 	// Keep the original resulting path for metadata and actual mount path lookups
 	originalResultingPath := resultingPath
 
-	// 1. Get the internal relative path (relative to FUSE mount)
-	relPath := strings.TrimPrefix(resultingPath, "/")
-
-	// 2. Strip any existing /complete or /category prefix from the internal path to start clean
 	category := ""
-	if item.Category != nil && *item.Category != "" {
-		category = strings.Trim(*item.Category, "/")
+	if item.Category != nil {
+		category = *item.Category
 	}
 
-	if cfg.SABnzbd.CompleteDir != "" {
-		completeDir := strings.Trim(filepath.ToSlash(cfg.SABnzbd.CompleteDir), "/")
-		if after, ok := strings.CutPrefix(relPath, completeDir+"/"); ok {
-			relPath = after
-		} else if relPath == completeDir {
-			relPath = ""
-		}
-	}
-	if category != "" {
-		if after, ok := strings.CutPrefix(relPath, category+"/"); ok {
-			relPath = after
-		} else if relPath == category {
-			relPath = ""
-		}
-	}
-
-	// 3. Build the clean, isolated library path
-	// Construct: [CompleteDir] + [Category] + RelPath
-	pathParts := []string{}
-	if cfg.SABnzbd.CompleteDir != "" {
-		pathParts = append(pathParts, strings.Trim(cfg.SABnzbd.CompleteDir, "/"))
-	}
-	if category != "" {
-		pathParts = append(pathParts, category)
-	}
-	pathParts = append(pathParts, relPath)
-
-	resultingPath = filepath.Join(pathParts...)
-	resultingPath = filepath.ToSlash(filepath.Clean(resultingPath))
+	// Build the clean, isolated library path: [CompleteDir]/[Category]/<remainder>,
+	// stripping any of those prefixes that are already present in the source path.
+	resultingPath = buildLibraryRelPath(resultingPath, cfg.SABnzbd.CompleteDir, category)
 
 	// Get the actual metadata/mount path (where the content actually lives)
 	actualPath := filepath.Join(cfg.MountPath, strings.TrimPrefix(originalResultingPath, "/"))
@@ -127,44 +97,15 @@ func (c *Coordinator) CreateSymlinks(ctx context.Context, item *database.ImportQ
 		// Build the actual file path in the mount
 		actualFilePath := filepath.Join(cfg.MountPath, strings.TrimPrefix(relPath, "/"))
 
-		// 1. Get the internal relative path (relative to FUSE mount)
-		relPath = strings.TrimPrefix(relPath, "/")
-
-		// 2. Strip any existing /complete or /category prefix from the internal path to start clean
 		category := ""
-		if item.Category != nil && *item.Category != "" {
-			category = strings.Trim(*item.Category, "/")
+		if item.Category != nil {
+			category = *item.Category
 		}
 
-		if cfg.SABnzbd.CompleteDir != "" {
-			completeDir := strings.Trim(filepath.ToSlash(cfg.SABnzbd.CompleteDir), "/")
-			if after, ok := strings.CutPrefix(relPath, completeDir+"/"); ok {
-				relPath = after
-			} else if relPath == completeDir {
-				relPath = ""
-			}
-		}
-		if category != "" {
-			if after, ok := strings.CutPrefix(relPath, category+"/"); ok {
-				relPath = after
-			} else if relPath == category {
-				relPath = ""
-			}
-		}
-
-		// 3. Build the clean, isolated library path
-		// Construct: [CompleteDir] + [Category] + RelPath
-		pathParts := []string{}
-		if cfg.SABnzbd.CompleteDir != "" {
-			pathParts = append(pathParts, strings.Trim(cfg.SABnzbd.CompleteDir, "/"))
-		}
-		if category != "" {
-			pathParts = append(pathParts, category)
-		}
-		pathParts = append(pathParts, relPath)
-
-		symlinkResultingPath := filepath.Join(pathParts...)
-		symlinkResultingPath = filepath.ToSlash(filepath.Clean(symlinkResultingPath))
+		// filepath.Rel returns OS-native separators (backslashes on Windows);
+		// buildLibraryRelPath normalises them before stripping so we don't
+		// double-prefix the category/CompleteDir on Windows (issue #585).
+		symlinkResultingPath := buildLibraryRelPath(relPath, cfg.SABnzbd.CompleteDir, category)
 
 		if err := c.createSingleSymlink(actualFilePath, symlinkResultingPath); err != nil {
 			c.log.ErrorContext(ctx, "Failed to create symlink",

--- a/internal/importer/scanner/watcher.go
+++ b/internal/importer/scanner/watcher.go
@@ -245,11 +245,17 @@ func (w *Watcher) processNzb(ctx context.Context, watchRoot, filePath string) er
 		return nil
 	}
 
-	// Calculate relative path from watch root to file's directory
+	// Calculate relative path from watch root to file's directory.
+	// Normalise to forward slashes so the value stored in
+	// ImportQueueItem.RelativePath is virtual-path-shaped on every OS — on
+	// Windows filepath.Rel returns backslashes which downstream consumers
+	// (calculateProcessVirtualDir, sanitizeVirtualPath, postprocessor stripping)
+	// would otherwise see in inconsistent form. See issue #585.
 	relPath, err := filepath.Rel(watchRoot, filepath.Dir(filePath))
 	if err != nil {
 		return fmt.Errorf("failed to calculate relative path: %w", err)
 	}
+	relPath = filepath.ToSlash(relPath)
 
 	var category *string
 	var relativePath *string

--- a/internal/importer/scanner/watcher_test.go
+++ b/internal/importer/scanner/watcher_test.go
@@ -1,0 +1,92 @@
+package scanner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// stubQueueAdder captures what processNzb passes to AddToQueue so the test
+// can assert relativePath has no OS-native backslashes (regression for
+// issue #585 Bug B on Windows).
+type stubQueueAdder struct {
+	mu                 sync.Mutex
+	lastRelativePath   *string
+	lastCategory       *string
+	addToQueueCalls    int
+	isFileInQueueCalls int
+}
+
+func (s *stubQueueAdder) AddToQueue(
+	_ context.Context,
+	_ string,
+	relativePath *string,
+	category *string,
+	_ *database.QueuePriority,
+	_ *string,
+	_ *string,
+) (*database.ImportQueueItem, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.addToQueueCalls++
+	s.lastRelativePath = relativePath
+	s.lastCategory = category
+	return &database.ImportQueueItem{ID: 1}, nil
+}
+
+func (s *stubQueueAdder) IsFileInQueue(_ context.Context, _ string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.isFileInQueueCalls++
+	return false, nil
+}
+
+// TestProcessNzb_RelativePathHasNoBackslashes is a regression test for #585
+// Bug B. The watcher must store relativePath using forward slashes so
+// downstream virtual-path computation cannot accidentally join an absolute
+// Windows-shaped value into a filesystem path like
+// filepath.Join("D:\Metadata", "D:\Downloads\…").
+//
+// On Linux this passes trivially because filepath.Rel already returns
+// forward slashes. On Windows it would fail without the
+// `relPath = filepath.ToSlash(relPath)` normalisation in watcher.processNzb.
+func TestProcessNzb_RelativePathHasNoBackslashes(t *testing.T) {
+	tmp := t.TempDir()
+	watchRoot := filepath.Join(tmp, "watch")
+	subDir := filepath.Join(watchRoot, "sub", "nested")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	nzbPath := filepath.Join(subDir, "release.nzb")
+	if err := os.WriteFile(nzbPath, []byte("<nzb/>"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg := &config.Config{}
+	stub := &stubQueueAdder{}
+	w := NewWatcher(stub, func() *config.Config { return cfg })
+
+	if err := w.processNzb(context.Background(), watchRoot, nzbPath); err != nil {
+		t.Fatalf("processNzb: %v", err)
+	}
+
+	if stub.addToQueueCalls != 1 {
+		t.Fatalf("AddToQueue calls = %d, want 1", stub.addToQueueCalls)
+	}
+	if stub.lastRelativePath == nil {
+		t.Fatalf("relativePath was nil, want %q", "sub/nested")
+	}
+	got := *stub.lastRelativePath
+	if strings.ContainsRune(got, '\\') {
+		t.Errorf("relativePath = %q contains backslash; watcher must normalise to forward slashes", got)
+	}
+	if got != "sub/nested" {
+		t.Errorf("relativePath = %q, want %q", got, "sub/nested")
+	}
+}


### PR DESCRIPTION
Fixes [#585](https://github.com/javi11/altmount/issues/585).

## Summary

Two Windows-only path bugs traced to the same root cause: `filepath.Rel`
returns OS-native separators (backslashes on Windows), but the
downstream stripping logic compared against forward-slash literals.
`strings.CutPrefix` silently missed, then the prefix was re-prepended
on top of the unstripped path.

- **Bug A — symlink/STRM category doubled.** With `ImportDir =
  D:\Downloads` and category `Movies`, files ended up at
  `D:\Downloads\Movies\Movies\Moviefolder\…`. With `SABnzbd.CompleteDir`
  set, the entire prefix was doubled
  (`…\Complete\Movies\Complete\Movies\Movies\…`). This broke
  Radarr/Sonarr post-processing because files weren't at the path the
  download client root said.
- **Bug B — folder watcher absolute-path leak.** The watcher stored
  the backslash-shaped `relPath` into `ImportQueueItem.RelativePath`.
  Downstream virtual-path computation in `calculateProcessVirtualDir`
  assigns `*basePath` directly to `virtualDir` in several branches,
  opening a window where `filepath.Join(metadataRoot, virtualPath)`
  could produce
  `D:\Altmount\Metadata\D:\Altmount\Downloads\…` — exactly the shape the
  reporter saw.

## What changed

- New helper `buildLibraryRelPath` in
  `internal/importer/postprocessor/library_path.go`. Normalises `\` →
  `/` before stripping `CompleteDir` / `category`, rebuilds the
  canonical `[CompleteDir]/[Category]/<remainder>` path, and always
  returns forward slashes. Both call sites in `symlink_creator.go` and
  both in `strm_generator.go` now use it — ~110 lines of duplicated
  stripping removed.
- One-line `relPath = filepath.ToSlash(relPath)` in
  `internal/importer/scanner/watcher.go` after `filepath.Rel`, so the
  DB value is virtual-path-shaped on every OS and matches the
  convention already used by the SAB-API entry point.

## Tests

- New `TestBuildLibraryRelPath` (table-driven): backslash regression
  for #585, prefix-already-present, prefix-must-be-injected, both
  empty, equality-with-prefix edge cases.
- New `TestProcessNzb_RelativePathHasNoBackslashes`: stubs
  `WatchQueueAdder` and asserts the captured `relativePath` contains no
  `\`. Passes trivially on Linux/macOS, catches a regression if
  reintroduced on Windows.
- Existing `TestCreateSymlinks_WithIsolation`,
  `TestCreateStrmFiles_WithIsolation`, and
  `TestCreateSymlinks_WithCategoryInjection` pass unchanged.

## Notes for reviewers

- The `buildLibraryRelPath` helper uses `strings.ReplaceAll(\, /)`
  rather than `filepath.ToSlash` so the Linux test suite actually
  exercises the Windows-shape code path. `filepath.ToSlash` is a no-op
  on non-Windows.
- The watcher fix uses `filepath.ToSlash` directly because the value
  comes from `filepath.Rel` whose output is OS-native by definition;
  on non-Windows this is a no-op.
- Windows users who locally patched `symlink_creator.go` (per the
  reporter's workaround) should revert that change before pulling.

## Test plan

- [x] `go test -race ./internal/importer/...`
- [x] `go build ./...`
- [x] `golangci-lint run` on touched packages
- [ ] Windows reporter confirmation (welcomed but not blocking — the new
      regression tests simulate the backslash input)