### PR TITLE
fix(ui): apply current category when uploading NZB files

### DIFF
--- a/frontend/src/components/queue/ImportMethods.tsx
+++ b/frontend/src/components/queue/ImportMethods.tsx
@@ -246,7 +246,7 @@ function EnhancedUploadSection() {
 			try {
 				const response = await uploadMutation.mutateAsync({
 					file: uploadFile.file,
-					category: uploadFile.category,
+					category: category || undefined,
 				});
 
 				setUploadedFiles((prev) =>
@@ -274,7 +274,7 @@ function EnhancedUploadSection() {
 				);
 			}
 		}
-	}, [uploadedFiles, uploadMutation]);
+	}, [uploadedFiles, uploadMutation, category]);
 
 	const handleLinkSubmit = useCallback(async () => {
 		const links = parseLinks(linkInput);


### PR DESCRIPTION
## Summary
- The file upload path in `EnhancedUploadSection` captured the `category` value at file-add time into each `UploadedFile`, then used that stale value on submit.
- Changing the category dropdown after files were queued had no effect — uploads went out with the old (or empty) category.
- Fix reads the current `category` state inside `handleUploadAll`, matching how the NZBLNK and By Name paths already work.

## Test plan
- [ ] Open Import → Upload, add an NZB file, switch category, click "Add to Queue", confirm the chosen category is applied on the new queue entry.
- [ ] Verify NZBLNK and By Name flows still apply category correctly (no regression).