### PR TITLE
fix(health): preserve SABnzbd category dirs in library sync

### DIFF
--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -1526,6 +1526,61 @@ func (lsw *LibrarySyncWorker) getLibraryPath(metaPath string, filesInUse map[str
 	return nil
 }
 
+// buildProtectedImportDirs returns the set of clean absolute paths under
+// ImportDir that must never be deleted by removeEmptyDirectories. This
+// covers ImportDir itself, the optional CompleteDir level, and every
+// configured SABnzbd category dir (plus the default category when no
+// categories are configured). Without this protection, transiently-empty
+// category folders get pruned between imports and arrs (Radarr v6+) raise
+// a permanent RemotePathMappingCheck health error.
+func buildProtectedImportDirs(cfg *config.Config) map[string]struct{} {
+	protected := map[string]struct{}{}
+	if cfg == nil || cfg.Import.ImportDir == nil || *cfg.Import.ImportDir == "" {
+		return protected
+	}
+
+	importDir := filepath.Clean(*cfg.Import.ImportDir)
+	protected[importDir] = struct{}{}
+
+	base := importDir
+	if cfg.SABnzbd.CompleteDir != "" {
+		base = filepath.Join(importDir, cfg.SABnzbd.CompleteDir)
+		protected[filepath.Clean(base)] = struct{}{}
+	}
+
+	addCategory := func(dir string) {
+		if dir == "" {
+			return
+		}
+		full := filepath.Clean(filepath.Join(base, dir))
+		protected[full] = struct{}{}
+		// Also protect every parent up to (but not including) the base level,
+		// so nested category Dirs like "media/movies" keep their "media"
+		// ancestor as well.
+		for parent := filepath.Dir(full); parent != filepath.Clean(base) && parent != "." && parent != string(filepath.Separator); parent = filepath.Dir(parent) {
+			protected[parent] = struct{}{}
+		}
+	}
+
+	if len(cfg.SABnzbd.Categories) == 0 {
+		addCategory(config.DefaultCategoryDir)
+		return protected
+	}
+
+	for _, cat := range cfg.SABnzbd.Categories {
+		dir := cat.Dir
+		if dir == "" {
+			if cat.Name == config.DefaultCategoryName {
+				dir = config.DefaultCategoryDir
+			} else {
+				dir = cat.Name
+			}
+		}
+		addCategory(dir)
+	}
+	return protected
+}
+
 // removeEmptyDirectories removes empty directories from the library, import, and metadata directories
 func (lsw *LibrarySyncWorker) removeEmptyDirectories(ctx context.Context) (int, error) {
 	cfg := lsw.configGetter()
@@ -1597,6 +1652,7 @@ func (lsw *LibrarySyncWorker) removeEmptyDirectories(ctx context.Context) (int, 
 	// Iteratively remove empty directories
 	deletedCount := 0
 	maxIterations := 5 // Reduced iterations, sorting by depth usually handles it in 1-2
+	protectedImportDirs := buildProtectedImportDirs(cfg)
 	for range maxIterations {
 		removedThisIteration := 0
 
@@ -1619,6 +1675,9 @@ func (lsw *LibrarySyncWorker) removeEmptyDirectories(ctx context.Context) (int, 
 			}
 
 			if cleanDir == cleanMount || cleanDir == cleanLibDir || cleanDir == "/" || cleanDir == "." {
+				continue
+			}
+			if _, ok := protectedImportDirs[cleanDir]; ok {
 				continue
 			}
 

--- a/internal/health/library_sync_cleanup_test.go
+++ b/internal/health/library_sync_cleanup_test.go
@@ -1,0 +1,206 @@
+package health
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveEmptyDirectories_PreservesCategoryDirs reproduces Bug 2:
+// transiently-empty category folders under ImportDir get deleted by the
+// library sync, which makes Radarr's RemotePathMappingCheck go red until
+// the next import lands. The fix must preserve configured category dirs.
+func TestRemoveEmptyDirectories_PreservesCategoryDirs(t *testing.T) {
+	tests := []struct {
+		name        string
+		completeDir string
+		categories  []config.SABnzbdCategory
+		// dirs to pre-create relative to ImportDir
+		setupDirs []string
+		// dirs that MUST still exist after cleanup, relative to ImportDir
+		mustKeep []string
+		// dirs that MUST be removed (genuine release leftovers), relative to ImportDir
+		mustRemove []string
+	}{
+		{
+			name:        "no complete_dir, explicit categories — names",
+			completeDir: "",
+			categories: []config.SABnzbdCategory{
+				{Name: "movies"},
+				{Name: "tv"},
+			},
+			setupDirs:  []string{"movies", "tv", "movies/Some.Release.2024"},
+			mustKeep:   []string{"movies", "tv"},
+			mustRemove: []string{"movies/Some.Release.2024"},
+		},
+		{
+			name:        "no complete_dir, category Dir overrides Name",
+			completeDir: "",
+			categories: []config.SABnzbdCategory{
+				{Name: "movies", Dir: "films"},
+			},
+			setupDirs:  []string{"films", "films/Old.Release"},
+			mustKeep:   []string{"films"},
+			mustRemove: []string{"films/Old.Release"},
+		},
+		{
+			name:        "complete_dir set + categories",
+			completeDir: "complete",
+			categories: []config.SABnzbdCategory{
+				{Name: "movies"},
+				{Name: "tv"},
+			},
+			setupDirs:  []string{"complete", "complete/movies", "complete/tv", "complete/movies/Stale.Release"},
+			mustKeep:   []string{"complete", "complete/movies", "complete/tv"},
+			mustRemove: []string{"complete/movies/Stale.Release"},
+		},
+		{
+			name:        "no categories configured — default category dir is protected",
+			completeDir: "",
+			categories:  nil,
+			setupDirs:   []string{config.DefaultCategoryDir, filepath.Join(config.DefaultCategoryDir, "Old.Release")},
+			mustKeep:    []string{config.DefaultCategoryDir},
+			mustRemove:  []string{filepath.Join(config.DefaultCategoryDir, "Old.Release")},
+		},
+		{
+			name:        "nested category Dir (e.g. media/movies)",
+			completeDir: "",
+			categories: []config.SABnzbdCategory{
+				{Name: "movies", Dir: "media/movies"},
+			},
+			setupDirs:  []string{"media", "media/movies", "media/movies/Release.X"},
+			mustKeep:   []string{"media", "media/movies"},
+			mustRemove: []string{"media/movies/Release.X"},
+		},
+		{
+			// Matches the common real-world config where complete_dir is set
+			// to the literal "/" — Go's filepath.Join normalizes this to the
+			// same path layout as an empty complete_dir.
+			name:        "complete_dir set to root slash collapses to ImportDir",
+			completeDir: "/",
+			categories: []config.SABnzbdCategory{
+				{Name: "movies"},
+				{Name: "tv"},
+			},
+			setupDirs:  []string{"movies", "tv", "movies/Stale.Release"},
+			mustKeep:   []string{"movies", "tv"},
+			mustRemove: []string{"movies/Stale.Release"},
+		},
+		{
+			// Real-world TV layout: Show/Season N/Episode N folders. Every
+			// level *below* the category must still get pruned when empty,
+			// even multiple levels deep.
+			name:        "deep nesting under category gets fully pruned",
+			completeDir: "",
+			categories: []config.SABnzbdCategory{
+				{Name: "tv"},
+			},
+			setupDirs: []string{
+				"tv",
+				"tv/Walking.Dead",
+				"tv/Walking.Dead/Season.02",
+				"tv/Walking.Dead/Season.02/episode.x",
+			},
+			mustKeep: []string{"tv"},
+			mustRemove: []string{
+				"tv/Walking.Dead",
+				"tv/Walking.Dead/Season.02",
+				"tv/Walking.Dead/Season.02/episode.x",
+			},
+		},
+		{
+			// Category that contains only files (no release subdir) goes
+			// empty after Sonarr imports the single .mkv. Category must
+			// survive even though it is the only thing left at that level.
+			name:        "category becomes directly empty after import",
+			completeDir: "",
+			categories: []config.SABnzbdCategory{
+				{Name: "tv"},
+			},
+			setupDirs:  []string{"tv"},
+			mustKeep:   []string{"tv"},
+			mustRemove: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			importDir := t.TempDir()
+
+			for _, rel := range tc.setupDirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(importDir, rel), 0o755))
+			}
+
+			cfg := &config.Config{
+				MountPath: t.TempDir(), // separate, unused here
+				Import: config.ImportConfig{
+					ImportDir:      &importDir,
+					ImportStrategy: config.ImportStrategySYMLINK,
+				},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: tc.completeDir,
+					Categories:  tc.categories,
+				},
+			}
+
+			worker := &LibrarySyncWorker{
+				configGetter: func() *config.Config { return cfg },
+			}
+
+			_, err := worker.removeEmptyDirectories(context.Background())
+			require.NoError(t, err)
+
+			for _, rel := range tc.mustKeep {
+				full := filepath.Join(importDir, rel)
+				_, statErr := os.Stat(full)
+				assert.NoError(t, statErr, "category dir must be preserved: %s", rel)
+			}
+			for _, rel := range tc.mustRemove {
+				full := filepath.Join(importDir, rel)
+				_, statErr := os.Stat(full)
+				assert.True(t, os.IsNotExist(statErr),
+					"non-category empty dir must still be cleaned up: %s (stat err=%v)", rel, statErr)
+			}
+
+			// ImportDir root itself must always survive.
+			_, statErr := os.Stat(importDir)
+			assert.NoError(t, statErr, "ImportDir root must always survive")
+		})
+	}
+}
+
+// TestBuildProtectedImportDirs_NoImportDir confirms the helper degrades to
+// an empty set when ImportDir is unset — there is nothing under ImportDir
+// to protect because removeEmptyDirectories will not scan it either.
+func TestBuildProtectedImportDirs_NoImportDir(t *testing.T) {
+	t.Run("ImportDir nil", func(t *testing.T) {
+		cfg := &config.Config{
+			SABnzbd: config.SABnzbdConfig{
+				CompleteDir: "complete",
+				Categories:  []config.SABnzbdCategory{{Name: "movies"}},
+			},
+		}
+		got := buildProtectedImportDirs(cfg)
+		assert.Empty(t, got, "no ImportDir → no protected paths")
+	})
+
+	t.Run("ImportDir empty string", func(t *testing.T) {
+		empty := ""
+		cfg := &config.Config{
+			Import:  config.ImportConfig{ImportDir: &empty},
+			SABnzbd: config.SABnzbdConfig{Categories: []config.SABnzbdCategory{{Name: "tv"}}},
+		}
+		got := buildProtectedImportDirs(cfg)
+		assert.Empty(t, got, "empty ImportDir → no protected paths")
+	})
+
+	t.Run("nil cfg", func(t *testing.T) {
+		got := buildProtectedImportDirs(nil)
+		assert.Empty(t, got, "nil cfg → no protected paths")
+	})
+}


### PR DESCRIPTION
## Summary
- `library_sync.removeEmptyDirectories` walked `ImportDir` and deleted every empty subdirectory it found, guarded only against `MountPath`, `LibraryDir`, `/` and `.`. SABnzbd category folders (movies, tv, …) were not protected, so the moment a category went transiently empty between imports the sync wiped it.
- Radarr v6 has dropped the `Disabled Health Check Notifications` setting entirely (verified by source search — no occurrence of `disabledHealthChecks` in modern Radarr), so the resulting `RemotePathMappingCheck` error ("places downloads in `/mnt/.../movies` but this directory does not appear to exist") cannot be silenced client-side anymore. The only fix is for altmount to stop deleting the dirs.
- Added `buildProtectedImportDirs(cfg)` which derives the protected set from config: `ImportDir` itself, the optional `CompleteDir` level, every category dir (using `Dir||Name` fallback), the default category when no categories are configured, plus parents-of-nested-category-dirs (e.g. the `media` ancestor when a category `Dir` is `media/movies`). Wired into the existing `removeEmptyDirectories` guard with one extra membership check.

<img width="1541" height="409" alt="2026-05-20 at 21 37 06" src="https://github.com/user-attachments/assets/c40e2baa-382b-4b1c-929f-2d04e055fd83" />

<img width="1443" height="403" alt="2026-05-20 at 21 37 39" src="https://github.com/user-attachments/assets/6184f6f9-5aab-4a84-96ef-d0c719dc3be9" />


## Scope
Single source of truth for the deletion (`removeEmptyDirectories`) is `internal/health/library_sync.go` — verified by auditing every other `os.Remove` / `RemoveAll` site in the codebase:

- All other `os.Remove` calls operate on individual files (NZBs, symlinks) at the leaf, not directories.
- The arrs-webhook deletion path (`internal/api/arrs_handlers.go`) goes through `metadataService.DeleteDirectory`, which targets the metadata root tree (`ms.rootPath`), not `ImportDir`.

## Behavior preserved
Genuine empty release subfolders *inside* a category (e.g. `<ImportDir>/movies/Some.Release.2024/`) still get cleaned up. Only the configured category-level paths (and their structural ancestors) are protected.

## Test plan
- [x] Six failing-then-passing subtests covering every config shape that appears in the wild:
  - `complete_dir: ""` + explicit categories (by Name)
  - `complete_dir: ""` + category `Dir` overrides `Name`
  - `complete_dir: "complete"` + categories
  - `complete_dir: ""` + no categories (Default category dir)
  - `complete_dir: ""` + nested category `Dir` (`media/movies`)
  - `complete_dir: "/"` collapses to `ImportDir` (real-world config from this issue)
- [x] Three subtests for the `buildProtectedImportDirs` helper degrade cases: nil `ImportDir`, empty `ImportDir`, nil `cfg` — all return an empty set.
- [x] Each preservation test also asserts that empty release subfolders *under* the category still get cleaned up — no over-protection.
- [x] Full `go test -race ./internal/health/...` passes.
- [x] `golangci-lint ./internal/health/...` clean.
- [x] `go build ./...` succeeds.
- [x] Manual: verify Radarr v6 health check clears after deploying the patched build.