### PR TITLE
feat(config): add HTTP/HTTPS proxy config for outbound NZB traffic

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -107,7 +107,9 @@ export class APIClient {
 					// empty or non-JSON error body — fall through to status-based message
 				}
 				const errorMessage =
-					(typeof errorData.error === "object" ? (errorData.error as any)?.message : errorData.error) ||
+					(typeof errorData.error === "object"
+						? (errorData.error as any)?.message
+						: errorData.error) ||
 					errorData.message ||
 					`HTTP ${response.status}: ${response.statusText}`;
 				const errorDetails =
@@ -125,7 +127,8 @@ export class APIClient {
 				const errorMessage =
 					(typeof data.error === "object" ? data.error?.message : data.error) ||
 					"API request failed";
-				const errorDetails = (typeof data.error === "object" ? (data.error as any)?.details : "") || "";
+				const errorDetails =
+					(typeof data.error === "object" ? (data.error as any)?.details : "") || "";
 				throw new APIError(response.status, errorMessage, errorDetails);
 			}
 
@@ -174,7 +177,9 @@ export class APIClient {
 				try {
 					const errorData = await response.json();
 					const errorMessage =
-						(typeof errorData.error === "object" ? (errorData.error as any)?.message : errorData.error) ||
+						(typeof errorData.error === "object"
+							? (errorData.error as any)?.message
+							: errorData.error) ||
 						errorData.message ||
 						`HTTP ${response.status}: ${response.statusText}`;
 					const errorDetails =
@@ -203,7 +208,8 @@ export class APIClient {
 				const errorMessage =
 					(typeof data.error === "object" ? data.error?.message : data.error) ||
 					"API request failed";
-				const errorDetails = (typeof data.error === "object" ? (data.error as any)?.details : "") || "";
+				const errorDetails =
+					(typeof data.error === "object" ? (data.error as any)?.details : "") || "";
 				throw new APIError(response.status, errorMessage, errorDetails);
 			}
 
@@ -526,11 +532,15 @@ export class APIClient {
 	}
 
 	async getProviderHistoricalStats(days = 30, interval = "daily") {
-		return this.request<ProviderHistoricalStatsResponse>(`/system/provider-stats?days=${days}&interval=${interval}`);
+		return this.request<ProviderHistoricalStatsResponse>(
+			`/system/provider-stats?days=${days}&interval=${interval}`,
+		);
 	}
 
 	async getProviderSpeedHistory(days = 30) {
-		return this.request<ProviderSpeedTestHistoryResponse>(`/system/provider-speed-history?days=${days}`);
+		return this.request<ProviderSpeedTestHistoryResponse>(
+			`/system/provider-speed-history?days=${days}`,
+		);
 	}
 
 	async directHealthCheck(id: number) {

--- a/frontend/src/components/config/NetworkConfigSection.tsx
+++ b/frontend/src/components/config/NetworkConfigSection.tsx
@@ -1,0 +1,111 @@
+import { Globe } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { ConfigResponse, NetworkConfig } from "../../types/config";
+
+interface NetworkConfigSectionProps {
+	config: ConfigResponse;
+	onUpdate?: (section: string, data: NetworkConfig) => Promise<void>;
+	isReadOnly?: boolean;
+	isUpdating?: boolean;
+}
+
+const emptyNetwork: NetworkConfig = {
+	http_proxy: "",
+	https_proxy: "",
+	no_proxy: "",
+};
+
+export function NetworkConfigSection({
+	config,
+	onUpdate,
+	isReadOnly,
+	isUpdating,
+}: NetworkConfigSectionProps) {
+	const baseline = config.network ?? emptyNetwork;
+	const [data, setData] = useState<NetworkConfig>(baseline);
+	const [hasChanges, setHasChanges] = useState(false);
+
+	useEffect(() => {
+		setData(config.network ?? emptyNetwork);
+		setHasChanges(false);
+	}, [config.network]);
+
+	const handleChange = (field: keyof NetworkConfig, value: string) => {
+		const next: NetworkConfig = { ...data, [field]: value };
+		setData(next);
+		setHasChanges(JSON.stringify(next) !== JSON.stringify(baseline));
+	};
+
+	const handleSave = async () => {
+		if (!onUpdate || !hasChanges) return;
+		await onUpdate("network", data);
+		setHasChanges(false);
+	};
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<Globe className="h-5 w-5" aria-hidden="true" />
+				<h2 className="font-semibold text-xl">Network &amp; Proxy</h2>
+			</div>
+
+			<div className="alert alert-info">
+				<div className="text-sm">
+					Applied to every outbound HTTP request used for indexer search, NZB grabbing, Arrs
+					(Radarr/Sonarr/Lidarr/Readarr/Whisparr), SABnzbd fallback, and the NZBLNK resolver.
+					Internal endpoints (RC server, self-loopback) are not affected. Leave fields blank to
+					connect directly. Changes take effect on the next external request — restart AltMount if
+					you want long-lived clients to pick up the new proxy immediately.
+				</div>
+			</div>
+
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">HTTP Proxy</legend>
+				<input
+					type="text"
+					className="input"
+					placeholder="http://user:pass@host:3128"
+					value={data.http_proxy}
+					disabled={isReadOnly}
+					onChange={(e) => handleChange("http_proxy", e.target.value)}
+				/>
+				<p className="label">Used for plain HTTP outbound requests.</p>
+			</fieldset>
+
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">HTTPS Proxy</legend>
+				<input
+					type="text"
+					className="input"
+					placeholder="http://user:pass@host:3128"
+					value={data.https_proxy}
+					disabled={isReadOnly}
+					onChange={(e) => handleChange("https_proxy", e.target.value)}
+				/>
+				<p className="label">Used for HTTPS outbound requests. May be the same as HTTP Proxy.</p>
+			</fieldset>
+
+			<fieldset className="fieldset">
+				<legend className="fieldset-legend">No Proxy</legend>
+				<input
+					type="text"
+					className="input"
+					placeholder="localhost,127.0.0.1,10.0.0.0/8,*.internal"
+					value={data.no_proxy}
+					disabled={isReadOnly}
+					onChange={(e) => handleChange("no_proxy", e.target.value)}
+				/>
+				<p className="label">Comma-separated hosts, IPs, or CIDRs that bypass the proxy.</p>
+			</fieldset>
+
+			<button
+				type="button"
+				className="btn btn-primary"
+				onClick={handleSave}
+				disabled={!hasChanges || isUpdating || isReadOnly}
+			>
+				{isUpdating ? "Saving..." : "Save Changes"}
+			</button>
+		</div>
+	);
+}

--- a/frontend/src/components/config/RCloneConfigSection.tsx
+++ b/frontend/src/components/config/RCloneConfigSection.tsx
@@ -1,13 +1,4 @@
-import { KeyValueEditor } from "../ui/KeyValueEditor";
-import {
-	Eye,
-	EyeOff,
-	HardDrive,
-	Play,
-	Save,
-	Square,
-	TestTube,
-} from "lucide-react";
+import { Eye, EyeOff, HardDrive, Play, Save, Square, TestTube } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useConfirm } from "../../contexts/ModalContext";
 import { useToast } from "../../contexts/ToastContext";
@@ -17,6 +8,7 @@ import type {
 	RCloneMountFormData,
 	RCloneRCFormData,
 } from "../../types/config";
+import { KeyValueEditor } from "../ui/KeyValueEditor";
 
 interface RCloneConfigSectionProps {
 	config: ConfigResponse;
@@ -92,9 +84,7 @@ export function RCloneConfigSection({
 	});
 
 	// Separate state for mount path since it's a root-level config
-	const [mountPath, setMountPath] = useState(
-		config.mount_path || "/mnt/remotes/altmount",
-	);
+	const [mountPath, setMountPath] = useState(config.mount_path || "/mnt/remotes/altmount");
 
 	const [mountStatus, setMountStatus] = useState<MountStatus | null>(null);
 	const [hasChanges, setHasChanges] = useState(false);
@@ -210,9 +200,7 @@ export function RCloneConfigSection({
 			rc_pass: "",
 			rc_options: config.rclone.rc_options,
 		};
-		setHasChanges(
-			JSON.stringify(newFormData) !== JSON.stringify(initialFormData),
-		);
+		setHasChanges(JSON.stringify(newFormData) !== JSON.stringify(initialFormData));
 	};
 
 	const handleMountInputChange = (
@@ -265,9 +253,7 @@ export function RCloneConfigSection({
 			use_mmap: config.rclone.use_mmap || false,
 			links: config.rclone.links || false,
 		};
-		setHasMountChanges(
-			JSON.stringify(newMountFormData) !== JSON.stringify(initialMountFormData),
-		);
+		setHasMountChanges(JSON.stringify(newMountFormData) !== JSON.stringify(initialMountFormData));
 	};
 
 	const handleMountPathChange = (value: string) => {
@@ -423,9 +409,7 @@ export function RCloneConfigSection({
 	return (
 		<div className="space-y-10">
 			<div className="min-w-0">
-				<h3 className="font-bold text-base-content text-lg tracking-tight">
-					RClone Filesystem
-				</h3>
+				<h3 className="font-bold text-base-content text-lg tracking-tight">RClone Filesystem</h3>
 				<p className="break-words text-base-content/50 text-sm">
 					Manage the virtual mount and Remote Control (RC) interface.
 				</p>
@@ -492,9 +476,7 @@ export function RCloneConfigSection({
 										className="select"
 										value={mountFormData.log_level}
 										disabled={isReadOnly}
-										onChange={(e) =>
-											handleMountInputChange("log_level", e.target.value)
-										}
+										onChange={(e) => handleMountInputChange("log_level", e.target.value)}
 									>
 										<option value="DEBUG">DEBUG (Verbose)</option>
 										<option value="INFO">INFO (Standard)</option>
@@ -514,10 +496,7 @@ export function RCloneConfigSection({
 										value={mountFormData.uid}
 										disabled={isReadOnly}
 										onChange={(e) =>
-											handleMountInputChange(
-												"uid",
-												Number.parseInt(e.target.value, 10) || 1000,
-											)
+											handleMountInputChange("uid", Number.parseInt(e.target.value, 10) || 1000)
 										}
 										placeholder="1000"
 									/>
@@ -532,10 +511,7 @@ export function RCloneConfigSection({
 										value={mountFormData.gid}
 										disabled={isReadOnly}
 										onChange={(e) =>
-											handleMountInputChange(
-												"gid",
-												Number.parseInt(e.target.value, 10) || 1000,
-											)
+											handleMountInputChange("gid", Number.parseInt(e.target.value, 10) || 1000)
 										}
 										placeholder="1000"
 									/>
@@ -549,9 +525,7 @@ export function RCloneConfigSection({
 										className="input"
 										value={mountFormData.umask}
 										disabled={isReadOnly}
-										onChange={(e) =>
-											handleMountInputChange("umask", e.target.value)
-										}
+										onChange={(e) => handleMountInputChange("umask", e.target.value)}
 										placeholder="002"
 									/>
 									<p className="label text-xs">File permission mask.</p>
@@ -559,9 +533,7 @@ export function RCloneConfigSection({
 							</div>
 
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									Security & Flags
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">Security & Flags</h5>
 								<div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
 									<fieldset className="fieldset">
 										<legend className="fieldset-legend">Allow Other</legend>
@@ -572,9 +544,7 @@ export function RCloneConfigSection({
 												className="checkbox"
 												checked={mountFormData.allow_other}
 												disabled={isReadOnly}
-												onChange={(e) =>
-													handleMountInputChange("allow_other", e.target.checked)
-												}
+												onChange={(e) => handleMountInputChange("allow_other", e.target.checked)}
 											/>
 										</label>
 									</fieldset>
@@ -589,10 +559,7 @@ export function RCloneConfigSection({
 												checked={mountFormData.allow_non_empty}
 												disabled={isReadOnly}
 												onChange={(e) =>
-													handleMountInputChange(
-														"allow_non_empty",
-														e.target.checked,
-													)
+													handleMountInputChange("allow_non_empty", e.target.checked)
 												}
 											/>
 										</label>
@@ -607,9 +574,7 @@ export function RCloneConfigSection({
 												className="checkbox"
 												checked={mountFormData.read_only}
 												disabled={isReadOnly}
-												onChange={(e) =>
-													handleMountInputChange("read_only", e.target.checked)
-												}
+												onChange={(e) => handleMountInputChange("read_only", e.target.checked)}
 											/>
 										</label>
 									</fieldset>
@@ -617,9 +582,7 @@ export function RCloneConfigSection({
 							</div>
 
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									VFS Cache Settings
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">VFS Cache Settings</h5>
 								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 									<fieldset className="fieldset">
 										<legend className="fieldset-legend">Cache Mode</legend>
@@ -627,18 +590,14 @@ export function RCloneConfigSection({
 											className="select"
 											value={mountFormData.vfs_cache_mode}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("vfs_cache_mode", e.target.value)
-											}
+											onChange={(e) => handleMountInputChange("vfs_cache_mode", e.target.value)}
 										>
 											<option value="off">off (No cache)</option>
 											<option value="minimal">minimal (Metadata only)</option>
 											<option value="writes">writes (Only modified files)</option>
 											<option value="full">full (Read & Write cache)</option>
 										</select>
-										<p className="label text-xs">
-											Determines how much data RClone caches locally.
-										</p>
+										<p className="label text-xs">Determines how much data RClone caches locally.</p>
 									</fieldset>
 
 									<fieldset className="fieldset">
@@ -648,9 +607,7 @@ export function RCloneConfigSection({
 											className="input"
 											value={mountFormData.cache_dir}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("cache_dir", e.target.value)
-											}
+											onChange={(e) => handleMountInputChange("cache_dir", e.target.value)}
 											placeholder="/config/cache"
 										/>
 										<p className="label text-xs">
@@ -667,17 +624,10 @@ export function RCloneConfigSection({
 											className="input"
 											value={mountFormData.vfs_cache_max_size}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange(
-													"vfs_cache_max_size",
-													e.target.value,
-												)
-											}
+											onChange={(e) => handleMountInputChange("vfs_cache_max_size", e.target.value)}
 											placeholder="50G"
 										/>
-										<p className="label text-xs">
-											Maximum cache size (e.g., 50G, 1T).
-										</p>
+										<p className="label text-xs">Maximum cache size (e.g., 50G, 1T).</p>
 									</fieldset>
 
 									<fieldset className="fieldset">
@@ -687,32 +637,23 @@ export function RCloneConfigSection({
 											className="input"
 											value={mountFormData.vfs_cache_max_age}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("vfs_cache_max_age", e.target.value)
-											}
+											onChange={(e) => handleMountInputChange("vfs_cache_max_age", e.target.value)}
 											placeholder="504h"
 										/>
-										<p className="label text-xs">
-											Maximum cache age (e.g., 504h, 7d).
-										</p>
+										<p className="label text-xs">Maximum cache age (e.g., 504h, 7d).</p>
 									</fieldset>
 								</div>
 
 								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 									<fieldset className="fieldset">
-										<legend className="fieldset-legend">
-											Cache Poll Interval
-										</legend>
+										<legend className="fieldset-legend">Cache Poll Interval</legend>
 										<input
 											type="text"
 											className="input"
 											value={mountFormData.vfs_cache_poll_interval}
 											disabled={isReadOnly}
 											onChange={(e) =>
-												handleMountInputChange(
-													"vfs_cache_poll_interval",
-													e.target.value,
-												)
+												handleMountInputChange("vfs_cache_poll_interval", e.target.value)
 											}
 											placeholder="1m"
 										/>
@@ -728,22 +669,16 @@ export function RCloneConfigSection({
 											className="input"
 											value={mountFormData.vfs_read_ahead}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("vfs_read_ahead", e.target.value)
-											}
+											onChange={(e) => handleMountInputChange("vfs_read_ahead", e.target.value)}
 											placeholder="128M"
 										/>
-										<p className="label text-xs">
-											Read ahead size (e.g., 128M, 256M).
-										</p>
+										<p className="label text-xs">Read ahead size (e.g., 128M, 256M).</p>
 									</fieldset>
 								</div>
 							</div>
 
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									Performance Settings
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">Performance Settings</h5>
 								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 									<fieldset className="fieldset">
 										<legend className="fieldset-legend">Read Chunk Size</legend>
@@ -757,52 +692,37 @@ export function RCloneConfigSection({
 											}
 											placeholder="32M"
 										/>
-										<p className="label text-xs">
-											Initial read chunk size (e.g., 32M, 64M).
-										</p>
+										<p className="label text-xs">Initial read chunk size (e.g., 32M, 64M).</p>
 									</fieldset>
 
 									<fieldset className="fieldset">
-										<legend className="fieldset-legend">
-											Read Chunk Size Limit
-										</legend>
+										<legend className="fieldset-legend">Read Chunk Size Limit</legend>
 										<input
 											type="text"
 											className="input"
 											value={mountFormData.vfs_read_chunk_size_limit}
 											disabled={isReadOnly}
 											onChange={(e) =>
-												handleMountInputChange(
-													"vfs_read_chunk_size_limit",
-													e.target.value,
-												)
+												handleMountInputChange("vfs_read_chunk_size_limit", e.target.value)
 											}
 											placeholder="2G"
 										/>
-										<p className="label text-xs">
-											Maximum read chunk size (e.g., 2G, 4G).
-										</p>
+										<p className="label text-xs">Maximum read chunk size (e.g., 2G, 4G).</p>
 									</fieldset>
 								</div>
 
 								<div className="grid grid-cols-1 gap-6 md:grid-cols-2">
 									<fieldset className="fieldset">
-										<legend className="fieldset-legend">
-											Directory Cache Time
-										</legend>
+										<legend className="fieldset-legend">Directory Cache Time</legend>
 										<input
 											type="text"
 											className="input"
 											value={mountFormData.dir_cache_time}
 											disabled={isReadOnly}
-											onChange={(e) =>
-												handleMountInputChange("dir_cache_time", e.target.value)
-											}
+											onChange={(e) => handleMountInputChange("dir_cache_time", e.target.value)}
 											placeholder="10m"
 										/>
-										<p className="label text-xs">
-											Directory cache time (e.g., 10m, 1h).
-										</p>
+										<p className="label text-xs">Directory cache time (e.g., 10m, 1h).</p>
 									</fieldset>
 
 									<fieldset className="fieldset">
@@ -821,32 +741,24 @@ export function RCloneConfigSection({
 											min="1"
 											max="32"
 										/>
-										<p className="label text-xs">
-											Number of parallel transfers (1-32).
-										</p>
+										<p className="label text-xs">Number of parallel transfers (1-32).</p>
 									</fieldset>
 								</div>
 							</div>
 
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									Advanced Flags
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">Advanced Flags</h5>
 								<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
 									<fieldset className="fieldset">
 										<legend className="fieldset-legend">Async Read</legend>
 										<label className="label cursor-pointer">
-											<span className="label-text">
-												Enable async read operations
-											</span>
+											<span className="label-text">Enable async read operations</span>
 											<input
 												type="checkbox"
 												className="checkbox"
 												checked={mountFormData.async_read}
 												disabled={isReadOnly}
-												onChange={(e) =>
-													handleMountInputChange("async_read", e.target.checked)
-												}
+												onChange={(e) => handleMountInputChange("async_read", e.target.checked)}
 											/>
 										</label>
 									</fieldset>
@@ -860,9 +772,7 @@ export function RCloneConfigSection({
 												className="checkbox"
 												checked={mountFormData.no_mod_time}
 												disabled={isReadOnly}
-												onChange={(e) =>
-													handleMountInputChange("no_mod_time", e.target.checked)
-												}
+												onChange={(e) => handleMountInputChange("no_mod_time", e.target.checked)}
 											/>
 										</label>
 									</fieldset>
@@ -871,9 +781,7 @@ export function RCloneConfigSection({
 
 							{/* Custom Mount Options */}
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									Custom Mount Options
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">Custom Mount Options</h5>
 								<p className="text-[11px] text-base-content/50">
 									Arbitrary flags to pass to the rclone mount command. (e.g.,{" "}
 									<code>no-modtime: true</code>)
@@ -881,9 +789,7 @@ export function RCloneConfigSection({
 								<KeyValueEditor
 									value={mountFormData.mount_options}
 									disabled={isReadOnly}
-									onChange={(val) =>
-										handleMountInputChange("mount_options", val)
-									}
+									onChange={(val) => handleMountInputChange("mount_options", val)}
 									keyPlaceholder="Flag (e.g. no-modtime)"
 									valuePlaceholder="Value (e.g. true)"
 								/>
@@ -893,22 +799,16 @@ export function RCloneConfigSection({
 							<div className="divider opacity-50" />
 
 							{mountStatus && (
-								<div
-									className={`alert ${mountStatus.mounted ? "alert-success" : "alert-warning"}`}
-								>
+								<div className={`alert ${mountStatus.mounted ? "alert-success" : "alert-warning"}`}>
 									<HardDrive className="h-6 w-6" />
 									<div>
 										<div className="font-bold">
 											{mountStatus.mounted ? "Mounted" : "Not Mounted"}
 										</div>
 										{mountStatus.mounted && mountStatus.mount_point && (
-											<div className="text-sm">
-												Mount point: {mountStatus.mount_point}
-											</div>
+											<div className="text-sm">Mount point: {mountStatus.mount_point}</div>
 										)}
-										{mountStatus.error && (
-											<div className="text-sm">{mountStatus.error}</div>
-										)}
+										{mountStatus.error && <div className="text-sm">{mountStatus.error}</div>}
 									</div>
 									<div className="flex gap-2">
 										{mountStatus.mounted ? (
@@ -951,9 +851,7 @@ export function RCloneConfigSection({
 										className={`btn btn-primary px-10 ${hasMountChanges || hasMountPathChanges ? "shadow-lg shadow-primary/20" : "btn-ghost"}`}
 										onClick={handleSaveMount}
 										disabled={
-											(!hasMountChanges && !hasMountPathChanges) ||
-											isUpdating ||
-											isMountLoading
+											(!hasMountChanges && !hasMountPathChanges) || isUpdating || isMountLoading
 										}
 									>
 										{isUpdating ? (
@@ -985,18 +883,14 @@ export function RCloneConfigSection({
 							<span className="label-text">
 								Enable connection for cache refresh notifications
 								{mountFormData.mount_enabled && (
-									<span className="badge badge-info badge-sm ml-2">
-										Managed by mount
-									</span>
+									<span className="badge badge-info badge-sm ml-2">Managed by mount</span>
 								)}
 							</span>
 							<input
 								type="checkbox"
 								className="checkbox checkbox-primary"
 								checked={mountFormData.mount_enabled || formData.rc_enabled}
-								disabled={
-									isReadOnly || mountFormData.mount_enabled || isRCToggleSaving
-								}
+								disabled={isReadOnly || mountFormData.mount_enabled || isRCToggleSaving}
 								onChange={(e) => handleRCEnabledChange(e.target.checked)}
 							/>
 						</label>
@@ -1029,10 +923,7 @@ export function RCloneConfigSection({
 										value={formData.rc_port}
 										disabled={isReadOnly || mountFormData.mount_enabled}
 										onChange={(e) =>
-											handleInputChange(
-												"rc_port",
-												Number.parseInt(e.target.value, 10) || 5572,
-											)
+											handleInputChange("rc_port", Number.parseInt(e.target.value, 10) || 5572)
 										}
 									/>
 								</fieldset>
@@ -1059,9 +950,7 @@ export function RCloneConfigSection({
 											value={formData.rc_pass}
 											disabled={isReadOnly || mountFormData.mount_enabled}
 											onChange={(e) => handleInputChange("rc_pass", e.target.value)}
-											placeholder={
-												config.rclone.rc_pass_set ? "********" : "admin"
-											}
+											placeholder={config.rclone.rc_pass_set ? "********" : "admin"}
 										/>
 										<button
 											type="button"
@@ -1080,9 +969,7 @@ export function RCloneConfigSection({
 
 							{/* Custom RC Options */}
 							<div className="space-y-4">
-								<h5 className="font-medium text-base-content/70 text-sm">
-									Custom RC Options
-								</h5>
+								<h5 className="font-medium text-base-content/70 text-sm">Custom RC Options</h5>
 								<KeyValueEditor
 									value={formData.rc_options || {}}
 									disabled={isReadOnly || mountFormData.mount_enabled}
@@ -1100,9 +987,7 @@ export function RCloneConfigSection({
 										onClick={handleTestConnection}
 										disabled={isTestingConnection}
 									>
-										{isTestingConnection && (
-											<span className="loading loading-spinner loading-xs" />
-										)}
+										{isTestingConnection && <span className="loading loading-spinner loading-xs" />}
 										Test Connection
 									</button>
 									<button
@@ -1111,9 +996,7 @@ export function RCloneConfigSection({
 										onClick={handleSave}
 										disabled={!hasChanges || isUpdating}
 									>
-										{isUpdating && (
-											<span className="loading loading-spinner loading-sm" />
-										)}
+										{isUpdating && <span className="loading loading-spinner loading-sm" />}
 										Save RC Changes
 									</button>
 								</div>

--- a/frontend/src/components/config/SABnzbdConfigSection.tsx
+++ b/frontend/src/components/config/SABnzbdConfigSection.tsx
@@ -246,7 +246,9 @@ export function SABnzbdConfigSection({
 								</fieldset>
 
 								<fieldset className="fieldset">
-									<legend className="fieldset-legend font-semibold">History Retention (minutes)</legend>
+									<legend className="fieldset-legend font-semibold">
+										History Retention (minutes)
+									</legend>
 									<input
 										type="number"
 										className="input input-bordered w-full bg-base-100 font-mono text-sm"

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -374,9 +374,7 @@ export function ImportConfigSection({
 									className="toggle toggle-primary toggle-sm mt-1 shrink-0"
 									checked={formData.allow_symlinks_on_windows ?? false}
 									disabled={isReadOnly}
-									onChange={(e) =>
-										handleInputChange("allow_symlinks_on_windows", e.target.checked)
-									}
+									onChange={(e) => handleInputChange("allow_symlinks_on_windows", e.target.checked)}
 								/>
 								<div className="min-w-0 flex-1">
 									<span className="block whitespace-normal break-words font-bold text-xs">

--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -1,7 +1,7 @@
 import {
+	CheckCircle2,
 	ChevronDown,
 	ChevronUp,
-	CheckCircle2,
 	Download,
 	FileVideo,
 	History,
@@ -190,7 +190,7 @@ export function ActivityHub() {
 											<div className="flex items-center gap-3">
 												<div className="relative">
 													<FileVideo
-														className={`h-8 w-8 shrink-0 ${isStalled ? "text-warning animate-pulse" : "text-primary/70"}`}
+														className={`h-8 w-8 shrink-0 ${isStalled ? "animate-pulse text-warning" : "text-primary/70"}`}
 													/>
 													{!isStalled && (
 														<span className="-bottom-0.5 -right-0.5 absolute flex h-2 w-2">
@@ -371,7 +371,7 @@ export function ActivityHub() {
 									return (
 										<div
 											key={item.id}
-											className={`flex flex-col overflow-hidden rounded-lg border-l-4 border-success bg-base-200/30 transition-all ${isExpanded ? "ring-1 ring-success/20" : ""}`}
+											className={`flex flex-col overflow-hidden rounded-lg border-success border-l-4 bg-base-200/30 transition-all ${isExpanded ? "ring-1 ring-success/20" : ""}`}
 										>
 											<button
 												type="button"
@@ -396,7 +396,7 @@ export function ActivityHub() {
 													</div>
 												</div>
 												<div className="flex shrink-0 items-center gap-2">
-													<span className="whitespace-nowrap text-base-content/40 text-[11px]">
+													<span className="whitespace-nowrap text-[11px] text-base-content/40">
 														{formatRelativeTime(item.completed_at)}
 													</span>
 													{isExpanded ? (
@@ -420,7 +420,9 @@ export function ActivityHub() {
 															<Play className="h-3 w-3" />
 															<span>Dest:</span>
 														</div>
-														<div className="break-all font-mono opacity-80">{item.virtual_path}</div>
+														<div className="break-all font-mono opacity-80">
+															{item.virtual_path}
+														</div>
 
 														{item.library_path && (
 															<>
@@ -428,7 +430,7 @@ export function ActivityHub() {
 																	<CheckCircle2 className="h-3 w-3" />
 																	<span>Library:</span>
 																</div>
-																<div className="break-all font-mono opacity-80 text-success">
+																<div className="break-all font-mono text-success opacity-80">
 																	{item.library_path}
 																</div>
 															</>
@@ -445,7 +447,7 @@ export function ActivityHub() {
 
 														{item.metadata && (
 															<>
-																<div className="col-span-2 mt-1 border-base-content/10 border-t pt-2 font-bold opacity-40 uppercase tracking-widest">
+																<div className="col-span-2 mt-1 border-base-content/10 border-t pt-2 font-bold uppercase tracking-widest opacity-40">
 																	Technical Details
 																</div>
 																{(() => {
@@ -470,14 +472,14 @@ export function ActivityHub() {
 																							<Info className="h-3 w-3" />
 																							<span>Encryption:</span>
 																						</div>
-																						<div className="opacity-80 uppercase">
+																						<div className="uppercase opacity-80">
 																							{meta.encryption}
 																						</div>
 																					</>
 																				)}
 																			</>
 																		);
-																	} catch (e) {
+																	} catch (_e) {
 																		return null;
 																	}
 																})()}
@@ -502,4 +504,3 @@ export function ActivityHub() {
 		</div>
 	);
 }
-

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -24,6 +24,7 @@ import { ComingSoonSection } from "../components/config/ComingSoonSection";
 import { HealthConfigSection } from "../components/config/HealthConfigSection";
 import { MetadataConfigSection } from "../components/config/MetadataConfigSection";
 import { MountConfigSection } from "../components/config/MountConfigSection";
+import { NetworkConfigSection } from "../components/config/NetworkConfigSection";
 import { NzblnkConfigSection } from "../components/config/NzblnkConfigSection";
 import { ProvidersConfigSection } from "../components/config/ProvidersConfigSection";
 import { SABnzbdConfigSection } from "../components/config/SABnzbdConfigSection";
@@ -53,6 +54,7 @@ import type {
 	ImportConfig,
 	LogFormData,
 	MetadataConfig,
+	NetworkConfig,
 	NzblnkConfig,
 	ProviderConfig,
 	SABnzbdConfig,
@@ -99,7 +101,7 @@ const SECTION_GROUPS = [
 	},
 	{
 		title: "System",
-		sections: ["auth", "system"],
+		sections: ["auth", "network", "system"],
 	},
 ];
 
@@ -274,6 +276,11 @@ export function ConfigurationPage() {
 				await updateConfigSection.mutateAsync({
 					section: "nzblnk",
 					config: { nzblnk: data as unknown as NzblnkConfig },
+				});
+			} else if (section === "network") {
+				await updateConfigSection.mutateAsync({
+					section: "network",
+					config: { network: data as unknown as NetworkConfig },
 				});
 			} else if (section === "log") {
 				const logData = data as unknown as LogFormData & { profiler_enabled?: boolean };
@@ -567,6 +574,13 @@ export function ConfigurationPage() {
 										isUpdating={updateConfigSection.isPending}
 									/>
 								)}
+								{activeSection === "network" && (
+									<NetworkConfigSection
+										config={config}
+										onUpdate={handleConfigUpdate}
+										isUpdating={updateConfigSection.isPending}
+									/>
+								)}
 								{![
 									"webdav",
 									"auth",
@@ -581,6 +595,7 @@ export function ConfigurationPage() {
 									"health",
 									"stremio",
 									"nzblnk",
+									"network",
 								].includes(activeSection) && (
 									<ComingSoonSection
 										sectionName={CONFIG_SECTIONS[activeSection]?.title || activeSection}

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderChart.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderChart.tsx
@@ -1,14 +1,32 @@
-import { useState, useMemo } from "react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, Legend, PieChart, Pie, Cell } from "recharts";
-import { useProviderHistoricalStats } from "../../../../hooks/useApi";
+import { useMemo, useState } from "react";
+import {
+	Area,
+	AreaChart,
+	CartesianGrid,
+	Cell,
+	Legend,
+	Pie,
+	PieChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
 import { LoadingSpinner } from "../../../../components/ui/LoadingSpinner";
+import { useProviderHistoricalStats } from "../../../../hooks/useApi";
 import { formatBytes } from "../../../../lib/utils";
 
-const COLORS = [
-	"#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899", "#06b6d4"
-];
+const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899", "#06b6d4"];
 
-const CustomTooltip = ({ active, payload, label }: { active?: boolean, payload?: { value: number, dataKey: string, stroke: string }[], label?: string }) => {
+const CustomTooltip = ({
+	active,
+	payload,
+	label,
+}: {
+	active?: boolean;
+	payload?: { value: number; dataKey: string; stroke: string }[];
+	label?: string;
+}) => {
 	if (!active || !payload) return null;
 
 	const sortedPayload = [...payload].sort((a, b) => b.value - a.value);
@@ -19,7 +37,9 @@ const CustomTooltip = ({ active, payload, label }: { active?: boolean, payload?:
 			<p className="mb-2 border-base-200 border-b pb-1 font-bold">{label}</p>
 			{sortedPayload.map((p) => (
 				<div key={p.dataKey} className="flex justify-between gap-4 py-0.5">
-					<span style={{ color: p.stroke }} className="font-medium">{p.dataKey}:</span>
+					<span style={{ color: p.stroke }} className="font-medium">
+						{p.dataKey}:
+					</span>
 					<span>{formatBytes(p.value)}</span>
 				</div>
 			))}
@@ -33,7 +53,7 @@ const CustomTooltip = ({ active, payload, label }: { active?: boolean, payload?:
 
 export function ProviderChart() {
 	const [days, setDays] = useState(30);
-    const [interval, setInterval] = useState("daily");
+	const [interval, setInterval] = useState("daily");
 	const [activeProviders, setActiveProviders] = useState<Record<string, boolean>>({});
 	const { data: response, isLoading } = useProviderHistoricalStats(days, interval);
 
@@ -50,15 +70,17 @@ export function ProviderChart() {
 			const dateObj = new Date(stat.timestamp);
 			const timeKey = dateObj.toISOString();
 			const timeLabel = dateObj.toLocaleString(undefined, {
-				month: 'short', day: 'numeric'
+				month: "short",
+				day: "numeric",
 			});
 
-			const normalizedID = stat.provider_id.split(':')[0];
+			const normalizedID = stat.provider_id.split(":")[0];
 
 			if (!groupedByTime[timeKey]) groupedByTime[timeKey] = { name: timeLabel };
 
 			const currentVal = groupedByTime[timeKey][normalizedID];
-			groupedByTime[timeKey][normalizedID] = ((typeof currentVal === 'number' ? currentVal : 0) + stat.bytes_downloaded);
+			groupedByTime[timeKey][normalizedID] =
+				(typeof currentVal === "number" ? currentVal : 0) + stat.bytes_downloaded;
 
 			pTotals[normalizedID] = (pTotals[normalizedID] || 0) + stat.bytes_downloaded;
 			total += stat.bytes_downloaded;
@@ -66,7 +88,12 @@ export function ProviderChart() {
 
 		const sortedProviders = Object.keys(pTotals).sort((a, b) => pTotals[b] - pTotals[a]);
 
-		return { chartData: Object.values(groupedByTime), providers: sortedProviders, totalUsage: total, providerTotals: pTotals };
+		return {
+			chartData: Object.values(groupedByTime),
+			providers: sortedProviders,
+			totalUsage: total,
+			providerTotals: pTotals,
+		};
 	}, [response]);
 
 	// Initialize active providers when providers load
@@ -80,19 +107,26 @@ export function ProviderChart() {
 		}
 	}, [providers, activeProviders]);
 
-	if (isLoading) return <div className="flex h-64 items-center justify-center"><LoadingSpinner size="lg" /></div>;
+	if (isLoading)
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<LoadingSpinner size="lg" />
+			</div>
+		);
 
 	const toggleProvider = (provider: string) => {
-		setActiveProviders(prev => ({
+		setActiveProviders((prev) => ({
 			...prev,
-			[provider]: !prev[provider]
+			[provider]: !prev[provider],
 		}));
 	};
 
-	const pieData = providers.map(p => ({
-		name: p,
-		value: providerTotals[p]
-	})).filter(d => activeProviders[d.name]);
+	const pieData = providers
+		.map((p) => ({
+			name: p,
+			value: providerTotals[p],
+		}))
+		.filter((d) => activeProviders[d.name]);
 
 	return (
 		<div className="card border border-base-200 bg-base-100 shadow-xl">
@@ -100,22 +134,24 @@ export function ProviderChart() {
 				<div className="mb-6 flex flex-col items-start justify-between gap-4 lg:flex-row lg:items-center">
 					<div>
 						<h2 className="font-bold text-lg">Data Usage Trends</h2>
-						<p className="text-base-content/60 text-xs">Total: {formatBytes(totalUsage)} in the last {days} days</p>
+						<p className="text-base-content/60 text-xs">
+							Total: {formatBytes(totalUsage)} in the last {days} days
+						</p>
 					</div>
 					<div className="flex flex-wrap items-center gap-2">
-                        <select
+						<select
 							className="select select-bordered select-sm"
-                            value={interval}
-                            onChange={(e) => setInterval(e.target.value)}
-                        >
-                            <option value="daily">Daily</option>
-                            <option value="weekly">Weekly</option>
-                            <option value="monthly">Monthly</option>
-                            <option value="yearly">Yearly</option>
-                        </select>
+							value={interval}
+							onChange={(e) => setInterval(e.target.value)}
+						>
+							<option value="daily">Daily</option>
+							<option value="weekly">Weekly</option>
+							<option value="monthly">Monthly</option>
+							<option value="yearly">Yearly</option>
+						</select>
 						<span className="text-sm">Days:</span>
-						<input 
-							type="number" 
+						<input
+							type="number"
 							className="input input-bordered input-sm w-20"
 							value={days}
 							onChange={(e) => setDays(Number(e.target.value))}
@@ -130,30 +166,40 @@ export function ProviderChart() {
 								<defs>
 									{providers.map((p, i) => (
 										<linearGradient key={`color${p}`} id={`color${p}`} x1="0" y1="0" x2="0" y2="1">
-											<stop offset="5%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.8}/>
-											<stop offset="95%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.1}/>
+											<stop offset="5%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.8} />
+											<stop offset="95%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.1} />
 										</linearGradient>
 									))}
 								</defs>
 								<CartesianGrid strokeDasharray="3 3" opacity={0.1} vertical={false} />
 								<XAxis dataKey="name" tick={{ fontSize: 11 }} axisLine={false} tickLine={false} />
-								<YAxis tick={{ fontSize: 11 }} axisLine={false} tickLine={false} tickFormatter={formatBytes} />
+								<YAxis
+									tick={{ fontSize: 11 }}
+									axisLine={false}
+									tickLine={false}
+									tickFormatter={formatBytes}
+								/>
 								<Tooltip content={<CustomTooltip />} />
-								<Legend 
-									onClick={(e: any) => toggleProvider(e.dataKey as string)} 
-									wrapperStyle={{ cursor: 'pointer', fontSize: '12px' }}
+								<Legend
+									onClick={(e: any) => toggleProvider(e.dataKey as string)}
+									wrapperStyle={{ cursor: "pointer", fontSize: "12px" }}
 									{...({
 										payload: providers.map((p, i) => ({
 											value: p,
-											type: 'rect',
+											type: "rect",
 											id: p,
 											color: COLORS[i % COLORS.length],
 											dataKey: p,
-											inactive: !activeProviders[p]
-										}))
+											inactive: !activeProviders[p],
+										})),
 									} as any)}
 									formatter={(value, entry: any) => (
-										<span style={{ color: !entry.inactive ? 'inherit' : '#999', textDecoration: !entry.inactive ? 'none' : 'line-through' }}>
+										<span
+											style={{
+												color: !entry.inactive ? "inherit" : "#999",
+												textDecoration: !entry.inactive ? "none" : "line-through",
+											}}
+										>
 											{value}
 										</span>
 									)}
@@ -161,17 +207,19 @@ export function ProviderChart() {
 								{[...providers].reverse().map((p) => {
 									const i = providers.indexOf(p);
 									const color = COLORS[i % COLORS.length];
-									return activeProviders[p] && (
-										<Area 
-											key={p} 
-											dataKey={p} 
-											type="monotone"
-											stackId="1" 
-											stroke={color} 
-											fill={`url(#color${p})`} 
-											strokeWidth={2} 
-											activeDot={{ r: 6, strokeWidth: 0 }}
-										/>
+									return (
+										activeProviders[p] && (
+											<Area
+												key={p}
+												dataKey={p}
+												type="monotone"
+												stackId="1"
+												stroke={color}
+												fill={`url(#color${p})`}
+												strokeWidth={2}
+												activeDot={{ r: 6, strokeWidth: 0 }}
+											/>
+										)
 									);
 								})}
 							</AreaChart>
@@ -189,12 +237,20 @@ export function ProviderChart() {
 									dataKey="value"
 								>
 									{pieData.map((entry, index) => (
-										<Cell key={`cell-${index}`} fill={COLORS[providers.indexOf(entry.name) % COLORS.length]} />
+										<Cell
+											key={`cell-${index}`}
+											fill={COLORS[providers.indexOf(entry.name) % COLORS.length]}
+										/>
 									))}
 								</Pie>
-								<Tooltip 
+								<Tooltip
 									formatter={(value: number) => formatBytes(value)}
-									contentStyle={{ borderRadius: '8px', border: '1px solid hsl(var(--bc) / 0.2)', backgroundColor: 'hsl(var(--b1))', fontSize: '12px' }}
+									contentStyle={{
+										borderRadius: "8px",
+										border: "1px solid hsl(var(--bc) / 0.2)",
+										backgroundColor: "hsl(var(--b1))",
+										fontSize: "12px",
+									}}
 								/>
 							</PieChart>
 						</ResponsiveContainer>

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderHealth.tsx
@@ -1,83 +1,137 @@
+import {
+	Activity,
+	ActivitySquare,
+	AlertTriangle,
+	ArrowDown,
+	ArrowUp,
+	ArrowUpDown,
+	CheckCircle2,
+	Gauge,
+	Info,
+	RefreshCw,
+	Wifi,
+	WifiOff,
+	XCircle,
+} from "lucide-react";
 import { useState } from "react";
-import { Activity, AlertTriangle, Wifi, WifiOff, ActivitySquare, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle2, XCircle, Info, Gauge, RefreshCw } from "lucide-react";
-import { usePoolMetrics, useProviderSpeedHistory, useTestProviderSpeed } from "../../../../hooks/useApi";
+import { Line, LineChart, ResponsiveContainer, YAxis } from "recharts";
+import { useToast } from "../../../../contexts/ToastContext";
+import {
+	usePoolMetrics,
+	useProviderSpeedHistory,
+	useTestProviderSpeed,
+} from "../../../../hooks/useApi";
 import { formatBytes, formatRelativeTime } from "../../../../lib/utils";
+import type { ProviderSpeedTestHistoryStat, ProviderStatus } from "../../../../types/api";
 import { ProviderChart } from "./ProviderChart";
 import { ProviderQuota } from "./ProviderQuota";
 import { ProviderSpeedChart } from "./ProviderSpeedChart";
-import { LineChart, Line, ResponsiveContainer, YAxis } from "recharts";
-import type { ProviderSpeedTestHistoryStat, ProviderStatus } from "../../../../types/api";
-import { useToast } from "../../../../contexts/ToastContext";
 
-type SortField = 'host' | 'state' | 'used_connections' | 'missing_count' | 'current_speed_bytes_per_sec' | 'last_speed_test_mbps' | 'ping_ms' | 'error_count' | 'health_score';
-type SortDirection = 'asc' | 'desc';
+type SortField =
+	| "host"
+	| "state"
+	| "used_connections"
+	| "missing_count"
+	| "current_speed_bytes_per_sec"
+	| "last_speed_test_mbps"
+	| "ping_ms"
+	| "error_count"
+	| "health_score";
+type SortDirection = "asc" | "desc";
 
-const SortIcon = ({ field, sortField, sortDirection }: { field: SortField, sortField: SortField, sortDirection: SortDirection }) => {
+const SortIcon = ({
+	field,
+	sortField,
+	sortDirection,
+}: {
+	field: SortField;
+	sortField: SortField;
+	sortDirection: SortDirection;
+}) => {
 	if (sortField !== field) return <ArrowUpDown className="h-3 w-3 opacity-30" />;
-	return sortDirection === 'asc' ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />;
+	return sortDirection === "asc" ? (
+		<ArrowUp className="h-3 w-3" />
+	) : (
+		<ArrowDown className="h-3 w-3" />
+	);
 };
 
 const calculateHealthScore = (provider: ProviderStatus) => {
-    let score = 100;
-    
-    // State penalty
-    if (provider.state !== 'connected' && provider.state !== 'active') {
-        return 0; // If disconnected, health is 0
-    }
-    
-    // Ping penalty
-    if (provider.ping_ms > 1000) score -= 40;
-    else if (provider.ping_ms > 500) score -= 25;
-    else if (provider.ping_ms > 200) score -= 10;
-    else if (provider.ping_ms > 100) score -= 5;
-    
-    // Error penalty
-    score -= Math.min(30, provider.error_count * 5);
-    
-    // Missing count penalty (warning indicator)
-    if (provider.missing_warning) {
-        score -= 20;
-    }
-    if (provider.missing_count > 5000) score -= 15;
-    else if (provider.missing_count > 1000) score -= 10;
-    
-    return Math.max(0, score);
+	let score = 100;
+
+	// State penalty
+	if (provider.state !== "connected" && provider.state !== "active") {
+		return 0; // If disconnected, health is 0
+	}
+
+	// Ping penalty
+	if (provider.ping_ms > 1000) score -= 40;
+	else if (provider.ping_ms > 500) score -= 25;
+	else if (provider.ping_ms > 200) score -= 10;
+	else if (provider.ping_ms > 100) score -= 5;
+
+	// Error penalty
+	score -= Math.min(30, provider.error_count * 5);
+
+	// Missing count penalty (warning indicator)
+	if (provider.missing_warning) {
+		score -= 20;
+	}
+	if (provider.missing_count > 5000) score -= 15;
+	else if (provider.missing_count > 1000) score -= 10;
+
+	return Math.max(0, score);
 };
 
 const HealthIndicator = ({ score }: { score: number }) => {
-    let colorClass = "text-success";
-    let icon = <CheckCircle2 className="h-4 w-4" />;
-    
-    if (score < 50) {
-        colorClass = "text-error";
-        icon = <XCircle className="h-4 w-4" />;
-    } else if (score < 85) {
-        colorClass = "text-warning";
-        icon = <AlertTriangle className="h-4 w-4" />;
-    }
-    
-    return (
-        <div className={`flex items-center gap-1.5 font-bold ${colorClass}`}>
-            {icon}
-            <span>{score}%</span>
-        </div>
-    );
+	let colorClass = "text-success";
+	let icon = <CheckCircle2 className="h-4 w-4" />;
+
+	if (score < 50) {
+		colorClass = "text-error";
+		icon = <XCircle className="h-4 w-4" />;
+	} else if (score < 85) {
+		colorClass = "text-warning";
+		icon = <AlertTriangle className="h-4 w-4" />;
+	}
+
+	return (
+		<div className={`flex items-center gap-1.5 font-bold ${colorClass}`}>
+			{icon}
+			<span>{score}%</span>
+		</div>
+	);
 };
 
 // Sparkline component for speed history
-const SpeedHistorySparkline = ({ providerId, historyData }: { providerId: string, historyData: ProviderSpeedTestHistoryStat[] }) => {
-	const providerHistory = historyData?.filter(h => h.provider_id === providerId) || [];
+const SpeedHistorySparkline = ({
+	providerId,
+	historyData,
+}: {
+	providerId: string;
+	historyData: ProviderSpeedTestHistoryStat[];
+}) => {
+	const providerHistory = historyData?.filter((h) => h.provider_id === providerId) || [];
 	// sort by created_at asc
-	const sortedHistory = [...providerHistory].sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
-	
+	const sortedHistory = [...providerHistory].sort(
+		(a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+	);
+
 	if (sortedHistory.length < 2) return <span className="text-base-content/50" />;
 
 	return (
 		<div className="h-8 w-20 opacity-80 transition-opacity hover:opacity-100">
 			<ResponsiveContainer width="100%" height="100%">
 				<LineChart data={sortedHistory}>
-					<YAxis domain={['dataMin', 'dataMax']} hide />
-					<Line type="stepAfter" dataKey="speed_mbps" stroke="#10b981" strokeWidth={1.5} dot={false} isAnimationActive={false} />
+					<YAxis domain={["dataMin", "dataMax"]} hide />
+					<Line
+						type="stepAfter"
+						dataKey="speed_mbps"
+						stroke="#10b981"
+						strokeWidth={1.5}
+						dot={false}
+						isAnimationActive={false}
+					/>
 				</LineChart>
 			</ResponsiveContainer>
 		</div>
@@ -90,8 +144,8 @@ export function ProviderHealth() {
 	const testSpeed = useTestProviderSpeed();
 	const { showToast } = useToast();
 
-	const [sortField, setSortField] = useState<SortField>('host');
-	const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+	const [sortField, setSortField] = useState<SortField>("host");
+	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 	const [testingId, setTestingId] = useState<string | null>(null);
 
 	if (isLoading) {
@@ -126,17 +180,27 @@ export function ProviderHealth() {
 		return sum;
 	}, 0);
 
-	const connectionPercent = totalMaxConnections > 0 ? Math.round((totalUsedConnections / totalMaxConnections) * 100) : 0;
+	const connectionPercent =
+		totalMaxConnections > 0 ? Math.round((totalUsedConnections / totalMaxConnections) * 100) : 0;
 
-	const maxedProviders = data.providers.filter(p => p.quota_bytes && p.quota_bytes > 0 && p.quota_used && p.quota_used >= p.quota_bytes);
-	const nearMaxProviders = data.providers.filter(p => p.quota_bytes && p.quota_bytes > 0 && p.quota_used && p.quota_used >= p.quota_bytes * 0.85 && p.quota_used < p.quota_bytes);
+	const maxedProviders = data.providers.filter(
+		(p) => p.quota_bytes && p.quota_bytes > 0 && p.quota_used && p.quota_used >= p.quota_bytes,
+	);
+	const nearMaxProviders = data.providers.filter(
+		(p) =>
+			p.quota_bytes &&
+			p.quota_bytes > 0 &&
+			p.quota_used &&
+			p.quota_used >= p.quota_bytes * 0.85 &&
+			p.quota_used < p.quota_bytes,
+	);
 
 	const handleSort = (field: SortField) => {
 		if (sortField === field) {
-			setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+			setSortDirection(sortDirection === "asc" ? "desc" : "asc");
 		} else {
 			setSortField(field);
-			setSortDirection('desc'); // Default to desc for most metrics
+			setSortDirection("desc"); // Default to desc for most metrics
 		}
 	};
 
@@ -160,25 +224,27 @@ export function ProviderHealth() {
 		}
 	};
 
-	const sortedProviders = [...data.providers].map(p => ({ ...p, health_score: calculateHealthScore(p) })).sort((a, b) => {
-		const aRaw = a[sortField as keyof typeof a];
-		const bRaw = b[sortField as keyof typeof b];
+	const sortedProviders = [...data.providers]
+		.map((p) => ({ ...p, health_score: calculateHealthScore(p) }))
+		.sort((a, b) => {
+			const aRaw = a[sortField as keyof typeof a];
+			const bRaw = b[sortField as keyof typeof b];
 
-		let aValue: string | number = 0;
-		let bValue: string | number = 0;
+			let aValue: string | number = 0;
+			let bValue: string | number = 0;
 
-		if (sortField === 'host' || sortField === 'state') {
-			aValue = aRaw?.toString().toLowerCase() || '';
-			bValue = bRaw?.toString().toLowerCase() || '';
-		} else {
-			aValue = Number(aRaw) || 0;
-			bValue = Number(bRaw) || 0;
-		}
+			if (sortField === "host" || sortField === "state") {
+				aValue = aRaw?.toString().toLowerCase() || "";
+				bValue = bRaw?.toString().toLowerCase() || "";
+			} else {
+				aValue = Number(aRaw) || 0;
+				bValue = Number(bRaw) || 0;
+			}
 
-		if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
-		if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
-		return 0;
-	});
+			if (aValue < bValue) return sortDirection === "asc" ? -1 : 1;
+			if (aValue > bValue) return sortDirection === "asc" ? 1 : -1;
+			return 0;
+		});
 
 	return (
 		<div className="space-y-6">
@@ -188,10 +254,10 @@ export function ProviderHealth() {
 					<div>
 						<h3 className="font-bold">Quota Exceeded</h3>
 						<div className="text-sm">
-							{maxedProviders.length === 1 
+							{maxedProviders.length === 1
 								? `${maxedProviders[0].host} has reached its data limit. Downloads from this provider are paused.`
-								: `${maxedProviders.length} providers have reached their data limits. Downloads from these providers are paused.`}
-							{" "}You can reset the quota manually below.
+								: `${maxedProviders.length} providers have reached their data limits. Downloads from these providers are paused.`}{" "}
+							You can reset the quota manually below.
 						</div>
 					</div>
 				</div>
@@ -202,7 +268,7 @@ export function ProviderHealth() {
 					<div>
 						<h3 className="font-bold">Quota Warning</h3>
 						<div className="text-sm">
-							{nearMaxProviders.length === 1 
+							{nearMaxProviders.length === 1
 								? `${nearMaxProviders[0].host} is approaching its data limit.`
 								: `${nearMaxProviders.length} providers are approaching their data limits.`}
 						</div>
@@ -247,9 +313,15 @@ export function ProviderHealth() {
 
 				<div className="stat rounded-box bg-base-100 shadow">
 					<div className="stat-figure text-info">
-						<div 
-							className="radial-progress border-4 border-base-200 text-info" 
-							style={{"--value": connectionPercent, "--size": "3.5rem", "--thickness": "0.4rem"} as React.CSSProperties}
+						<div
+							className="radial-progress border-4 border-base-200 text-info"
+							style={
+								{
+									"--value": connectionPercent,
+									"--size": "3.5rem",
+									"--thickness": "0.4rem",
+								} as React.CSSProperties
+							}
 							role="progressbar"
 						>
 							<span className="font-bold text-xs">{connectionPercent}%</span>
@@ -275,41 +347,123 @@ export function ProviderHealth() {
 				<div className="card-body p-0">
 					<div className="flex items-center justify-between border-base-200 border-b p-4">
 						<h2 className="card-title text-lg">Provider Status</h2>
-                        <div className="badge badge-outline gap-2 py-3">
-                            <Info className="h-3.5 w-3.5" />
-                            <span className="text-xs">Real-time stats updated every 5s</span>
-                        </div>
+						<div className="badge badge-outline gap-2 py-3">
+							<Info className="h-3.5 w-3.5" />
+							<span className="text-xs">Real-time stats updated every 5s</span>
+						</div>
 					</div>
 					<div className="overflow-x-auto">
 						<table className="table-zebra table">
 							<thead>
 								<tr>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('host')}>
-										<div className="flex items-center gap-1">Provider Host <SortIcon sortField={sortField} sortDirection={sortDirection} field="host" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("host")}
+									>
+										<div className="flex items-center gap-1">
+											Provider Host{" "}
+											<SortIcon sortField={sortField} sortDirection={sortDirection} field="host" />
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('health_score')}>
-										<div className="flex items-center gap-1">Health <SortIcon sortField={sortField} sortDirection={sortDirection} field="health_score" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("health_score")}
+									>
+										<div className="flex items-center gap-1">
+											Health{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="health_score"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('state')}>
-										<div className="flex items-center gap-1">State <SortIcon sortField={sortField} sortDirection={sortDirection} field="state" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("state")}
+									>
+										<div className="flex items-center gap-1">
+											State{" "}
+											<SortIcon sortField={sortField} sortDirection={sortDirection} field="state" />
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('used_connections')}>
-										<div className="flex items-center gap-1">Connections <SortIcon sortField={sortField} sortDirection={sortDirection} field="used_connections" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("used_connections")}
+									>
+										<div className="flex items-center gap-1">
+											Connections{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="used_connections"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('ping_ms')}>
-										<div className="flex items-center gap-1">Ping <SortIcon sortField={sortField} sortDirection={sortDirection} field="ping_ms" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("ping_ms")}
+									>
+										<div className="flex items-center gap-1">
+											Ping{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="ping_ms"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('error_count')}>
-										<div className="flex items-center gap-1">Errors <SortIcon sortField={sortField} sortDirection={sortDirection} field="error_count" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("error_count")}
+									>
+										<div className="flex items-center gap-1">
+											Errors{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="error_count"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('missing_count')}>
-										<div className="flex items-center gap-1">Missing <SortIcon sortField={sortField} sortDirection={sortDirection} field="missing_count" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("missing_count")}
+									>
+										<div className="flex items-center gap-1">
+											Missing{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="missing_count"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('current_speed_bytes_per_sec')}>
-										<div className="flex items-center gap-1">Current Speed <SortIcon sortField={sortField} sortDirection={sortDirection} field="current_speed_bytes_per_sec" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("current_speed_bytes_per_sec")}
+									>
+										<div className="flex items-center gap-1">
+											Current Speed{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="current_speed_bytes_per_sec"
+											/>
+										</div>
 									</th>
-									<th className="cursor-pointer transition-colors hover:bg-base-200" onClick={() => handleSort('last_speed_test_mbps')}>
-										<div className="flex items-center gap-1">Top Speed <SortIcon sortField={sortField} sortDirection={sortDirection} field="last_speed_test_mbps" /></div>
+									<th
+										className="cursor-pointer transition-colors hover:bg-base-200"
+										onClick={() => handleSort("last_speed_test_mbps")}
+									>
+										<div className="flex items-center gap-1">
+											Top Speed{" "}
+											<SortIcon
+												sortField={sortField}
+												sortDirection={sortDirection}
+												field="last_speed_test_mbps"
+											/>
+										</div>
 									</th>
 									<th>Actions</th>
 								</tr>
@@ -323,7 +477,7 @@ export function ProviderHealth() {
 											</div>
 										</td>
 										<td>
-                                            <HealthIndicator score={provider.health_score} />
+											<HealthIndicator score={provider.health_score} />
 										</td>
 										<td>
 											<div className="flex items-center gap-2">
@@ -353,12 +507,16 @@ export function ProviderHealth() {
 											</div>
 										</td>
 										<td>
-											<span className={`font-mono text-sm ${provider.ping_ms > 200 ? 'text-warning' : provider.ping_ms > 500 ? 'text-error' : ''}`}>
-												{provider.ping_ms > 0 ? `${provider.ping_ms}ms` : '-'}
+											<span
+												className={`font-mono text-sm ${provider.ping_ms > 200 ? "text-warning" : provider.ping_ms > 500 ? "text-error" : ""}`}
+											>
+												{provider.ping_ms > 0 ? `${provider.ping_ms}ms` : "-"}
 											</span>
 										</td>
 										<td>
-											<span className={`font-mono text-sm ${provider.error_count > 0 ? 'text-error' : ''}`}>
+											<span
+												className={`font-mono text-sm ${provider.error_count > 0 ? "text-error" : ""}`}
+											>
 												{provider.error_count}
 											</span>
 										</td>
@@ -398,9 +556,9 @@ export function ProviderHealth() {
 														)}
 													</div>
 													{speedHistoryResponse?.history && (
-														<SpeedHistorySparkline 
-															providerId={provider.id} 
-															historyData={speedHistoryResponse.history} 
+														<SpeedHistorySparkline
+															providerId={provider.id}
+															historyData={speedHistoryResponse.history}
 														/>
 													)}
 												</div>
@@ -410,7 +568,7 @@ export function ProviderHealth() {
 										</td>
 										<td>
 											<div className="flex items-center gap-2">
-												<button 
+												<button
 													type="button"
 													className="btn btn-ghost btn-xs gap-1"
 													onClick={() => handleRunSpeedTest(provider.id, provider.host)}

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderQuota.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderQuota.tsx
@@ -1,7 +1,7 @@
+import { HardDrive, RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { usePoolMetrics, useResetProviderQuota } from "../../../../hooks/useApi";
 import { formatBytes, formatRelativeTime } from "../../../../lib/utils";
-import { HardDrive, RefreshCw } from "lucide-react";
 import type { ProviderStatus } from "../../../../types/api";
 
 export function ProviderQuota() {
@@ -11,7 +11,9 @@ export function ProviderQuota() {
 
 	if (isLoading || !data) return null;
 
-	const providersWithQuota = data.providers.filter((p: ProviderStatus) => p.quota_bytes && p.quota_bytes > 0);
+	const providersWithQuota = data.providers.filter(
+		(p: ProviderStatus) => p.quota_bytes && p.quota_bytes > 0,
+	);
 
 	if (providersWithQuota.length === 0) {
 		return null; // Don't show the section if no providers have quotas
@@ -40,16 +42,16 @@ export function ProviderQuota() {
 						<p className="text-base-content/60 text-sm">Provider data usage vs limits</p>
 					</div>
 				</div>
-				
+
 				<div className="space-y-6">
 					{providersWithQuota.map((provider: ProviderStatus) => {
 						const used = provider.quota_used || 0;
 						const total = provider.quota_bytes || 0;
 						const percentage = total > 0 ? Math.min(100, Math.round((used / total) * 100)) : 0;
-						
+
 						const isWarning = percentage >= 80 && percentage < 95;
 						const isError = percentage >= 95;
-						
+
 						let progressClass = "progress-primary";
 						if (isError) progressClass = "progress-error";
 						else if (isWarning) progressClass = "progress-warning";
@@ -68,7 +70,9 @@ export function ProviderQuota() {
 													disabled={resettingId === provider.id}
 													title="Reset Quota"
 												>
-													<RefreshCw className={`h-3 w-3 ${resettingId === provider.id ? "animate-spin" : ""}`} />
+													<RefreshCw
+														className={`h-3 w-3 ${resettingId === provider.id ? "animate-spin" : ""}`}
+													/>
 												</button>
 											)}
 										</div>
@@ -85,12 +89,14 @@ export function ProviderQuota() {
 									</div>
 								</div>
 								<div className="flex items-center gap-3">
-									<progress 
-										className={`progress h-3 w-full ${progressClass}`} 
-										value={percentage} 
+									<progress
+										className={`progress h-3 w-full ${progressClass}`}
+										value={percentage}
 										max="100"
 									/>
-									<span className={`w-10 text-right font-mono text-sm ${isError ? 'font-bold text-error' : isWarning ? 'font-bold text-warning' : ''}`}>
+									<span
+										className={`w-10 text-right font-mono text-sm ${isError ? "font-bold text-error" : isWarning ? "font-bold text-warning" : ""}`}
+									>
 										{percentage}%
 									</span>
 								</div>

--- a/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderSpeedChart.tsx
+++ b/frontend/src/pages/HealthPage/components/ProviderHealth/ProviderSpeedChart.tsx
@@ -1,12 +1,22 @@
-import { useMemo, useState } from "react";
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis, Legend, PieChart, Pie, Cell } from "recharts";
-import { useProviderSpeedHistory, usePoolMetrics } from "../../../../hooks/useApi";
-import { LoadingSpinner } from "../../../../components/ui/LoadingSpinner";
 import { Activity } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	Area,
+	AreaChart,
+	CartesianGrid,
+	Cell,
+	Legend,
+	Pie,
+	PieChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { LoadingSpinner } from "../../../../components/ui/LoadingSpinner";
+import { usePoolMetrics, useProviderSpeedHistory } from "../../../../hooks/useApi";
 
-const COLORS = [
-	"#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899", "#06b6d4"
-];
+const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899", "#06b6d4"];
 
 const CustomTooltip = ({ active, payload, label }: any) => {
 	if (!active || !payload) return null;
@@ -19,7 +29,9 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 			<p className="mb-2 border-base-200 border-b pb-1 font-bold">{label}</p>
 			{sortedPayload.map((p) => (
 				<div key={p.dataKey} className="flex justify-between gap-4 py-0.5">
-					<span style={{ color: p.stroke }} className="font-medium">{p.dataKey}:</span>
+					<span style={{ color: p.stroke }} className="font-medium">
+						{p.dataKey}:
+					</span>
 					<span>{p.value.toFixed(2)} Mbps</span>
 				</div>
 			))}
@@ -35,37 +47,40 @@ export function ProviderSpeedChart() {
 	const [days, setDays] = useState(7);
 	const [activeProviders, setActiveProviders] = useState<Record<string, boolean>>({});
 	const { data: historyResponse, isLoading: historyLoading } = useProviderSpeedHistory(days);
-    const { data: poolData } = usePoolMetrics();
+	const { data: poolData } = usePoolMetrics();
 
 	const { chartData, providers, providerMaxes } = useMemo(() => {
 		if (!historyResponse?.history) return { chartData: [], providers: [], providerMaxes: {} };
 
 		const grouped: Record<string, any> = {};
-        const maxes: Record<string, number> = {};
-		
-		historyResponse.history.forEach(stat => {
+		const maxes: Record<string, number> = {};
+
+		historyResponse.history.forEach((stat) => {
 			const date = new Date(stat.created_at);
-            const timestamp = date.toLocaleString(undefined, {
-                month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
-            });
-            
-            if (!grouped[timestamp]) {
-                grouped[timestamp] = { name: timestamp };
-            }
-            
-            const provider = poolData?.providers.find(p => p.id === stat.provider_id);
-            const label = provider ? provider.host : stat.provider_id;
-            
-            grouped[timestamp][label] = stat.speed_mbps;
-            maxes[label] = Math.max(maxes[label] || 0, stat.speed_mbps);
+			const timestamp = date.toLocaleString(undefined, {
+				month: "short",
+				day: "numeric",
+				hour: "2-digit",
+				minute: "2-digit",
+			});
+
+			if (!grouped[timestamp]) {
+				grouped[timestamp] = { name: timestamp };
+			}
+
+			const provider = poolData?.providers.find((p) => p.id === stat.provider_id);
+			const label = provider ? provider.host : stat.provider_id;
+
+			grouped[timestamp][label] = stat.speed_mbps;
+			maxes[label] = Math.max(maxes[label] || 0, stat.speed_mbps);
 		});
 
-        const sortedProviders = Object.keys(maxes).sort((a, b) => maxes[b] - maxes[a]);
+		const sortedProviders = Object.keys(maxes).sort((a, b) => maxes[b] - maxes[a]);
 
 		return { chartData: Object.values(grouped), providers: sortedProviders, providerMaxes: maxes };
 	}, [historyResponse, poolData]);
 
-    // Initialize active providers when providers load
+	// Initialize active providers when providers load
 	useMemo(() => {
 		if (providers.length > 0 && Object.keys(activeProviders).length === 0) {
 			const initialActive: Record<string, boolean> = {};
@@ -76,19 +91,26 @@ export function ProviderSpeedChart() {
 		}
 	}, [providers, activeProviders]);
 
-	if (historyLoading) return <div className="flex h-64 items-center justify-center"><LoadingSpinner size="lg" /></div>;
+	if (historyLoading)
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<LoadingSpinner size="lg" />
+			</div>
+		);
 
-    const toggleProvider = (provider: string) => {
-		setActiveProviders(prev => ({
+	const toggleProvider = (provider: string) => {
+		setActiveProviders((prev) => ({
 			...prev,
-			[provider]: !prev[provider]
+			[provider]: !prev[provider],
 		}));
 	};
 
-	const pieData = providers.map(p => ({
-		name: p,
-		value: providerMaxes[p]
-	})).filter(d => activeProviders[d.name]);
+	const pieData = providers
+		.map((p) => ({
+			name: p,
+			value: providerMaxes[p],
+		}))
+		.filter((d) => activeProviders[d.name]);
 
 	return (
 		<div className="card border border-base-200 bg-base-100 shadow-xl">
@@ -99,12 +121,14 @@ export function ProviderSpeedChart() {
 							<Activity className="h-5 w-5 text-success" />
 							Speed Performance History
 						</h2>
-						<p className="text-base-content/60 text-xs">Top speed (Mbps) per provider over time (stacked)</p>
+						<p className="text-base-content/60 text-xs">
+							Top speed (Mbps) per provider over time (stacked)
+						</p>
 					</div>
-                    <div className="flex items-center gap-2">
+					<div className="flex items-center gap-2">
 						<span className="text-sm">Days:</span>
-						<input 
-							type="number" 
+						<input
+							type="number"
 							className="input input-bordered input-sm w-20"
 							value={days}
 							onChange={(e) => setDays(Number(e.target.value))}
@@ -118,9 +142,16 @@ export function ProviderSpeedChart() {
 							<AreaChart data={chartData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
 								<defs>
 									{providers.map((p, i) => (
-										<linearGradient key={`colorSpeed${p}`} id={`colorSpeed${p}`} x1="0" y1="0" x2="0" y2="1">
-											<stop offset="5%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.8}/>
-											<stop offset="95%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.1}/>
+										<linearGradient
+											key={`colorSpeed${p}`}
+											id={`colorSpeed${p}`}
+											x1="0"
+											y1="0"
+											x2="0"
+											y2="1"
+										>
+											<stop offset="5%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.8} />
+											<stop offset="95%" stopColor={COLORS[i % COLORS.length]} stopOpacity={0.1} />
 										</linearGradient>
 									))}
 								</defs>
@@ -128,47 +159,56 @@ export function ProviderSpeedChart() {
 								<XAxis dataKey="name" tick={{ fontSize: 10 }} axisLine={false} tickLine={false} />
 								<YAxis tick={{ fontSize: 10 }} axisLine={false} tickLine={false} unit=" Mbps" />
 								<Tooltip content={<CustomTooltip />} />
-								<Legend 
-                                    onClick={(e: any) => toggleProvider(e.dataKey as string)} 
-                                    wrapperStyle={{ cursor: 'pointer', fontSize: '12px' }}
-                                    {...({
-                                        payload: providers.map((p, i) => ({
-                                            value: p,
-                                            type: 'rect',
-                                            id: p,
-                                            color: COLORS[i % COLORS.length],
-                                            dataKey: p,
-                                            inactive: !activeProviders[p]
-                                        }))
-                                    } as any)}
-                                    formatter={(value, entry: any) => (
-                                        <span style={{ color: !entry.inactive ? 'inherit' : '#999', textDecoration: !entry.inactive ? 'none' : 'line-through' }}>
-                                            {value}
-                                        </span>
-                                    )}
-                                />
+								<Legend
+									onClick={(e: any) => toggleProvider(e.dataKey as string)}
+									wrapperStyle={{ cursor: "pointer", fontSize: "12px" }}
+									{...({
+										payload: providers.map((p, i) => ({
+											value: p,
+											type: "rect",
+											id: p,
+											color: COLORS[i % COLORS.length],
+											dataKey: p,
+											inactive: !activeProviders[p],
+										})),
+									} as any)}
+									formatter={(value, entry: any) => (
+										<span
+											style={{
+												color: !entry.inactive ? "inherit" : "#999",
+												textDecoration: !entry.inactive ? "none" : "line-through",
+											}}
+										>
+											{value}
+										</span>
+									)}
+								/>
 								{[...providers].reverse().map((p) => {
-                                    const i = providers.indexOf(p);
-                                    const color = COLORS[i % COLORS.length];
-                                    return activeProviders[p] && (
-                                        <Area 
-                                            key={p} 
-                                            dataKey={p} 
-                                            type="monotone"
-                                            stackId="1" 
-                                            stroke={color} 
-                                            fill={`url(#colorSpeed${p})`} 
-                                            strokeWidth={2} 
-                                            activeDot={{ r: 6, strokeWidth: 0 }}
-                                            connectNulls
-                                        />
-                                    );
-                                })}
+									const i = providers.indexOf(p);
+									const color = COLORS[i % COLORS.length];
+									return (
+										activeProviders[p] && (
+											<Area
+												key={p}
+												dataKey={p}
+												type="monotone"
+												stackId="1"
+												stroke={color}
+												fill={`url(#colorSpeed${p})`}
+												strokeWidth={2}
+												activeDot={{ r: 6, strokeWidth: 0 }}
+												connectNulls
+											/>
+										)
+									);
+								})}
 							</AreaChart>
 						</ResponsiveContainer>
 					</div>
-                    <div className="flex hidden h-full w-full flex-col items-center justify-center border-base-200/50 border-l pl-4 lg:flex lg:w-1/4">
-						<span className="mb-2 font-semibold text-base-content/70 text-xs">Peak Performance</span>
+					<div className="flex hidden h-full w-full flex-col items-center justify-center border-base-200/50 border-l pl-4 lg:flex lg:w-1/4">
+						<span className="mb-2 font-semibold text-base-content/70 text-xs">
+							Peak Performance
+						</span>
 						<ResponsiveContainer width="100%" height="100%">
 							<PieChart>
 								<Pie
@@ -179,12 +219,20 @@ export function ProviderSpeedChart() {
 									dataKey="value"
 								>
 									{pieData.map((entry, index) => (
-										<Cell key={`cell-speed-${index}`} fill={COLORS[providers.indexOf(entry.name) % COLORS.length]} />
+										<Cell
+											key={`cell-speed-${index}`}
+											fill={COLORS[providers.indexOf(entry.name) % COLORS.length]}
+										/>
 									))}
 								</Pie>
-								<Tooltip 
+								<Tooltip
 									formatter={(value: number) => `${value.toFixed(2)} Mbps`}
-									contentStyle={{ borderRadius: '8px', border: '1px solid hsl(var(--bc) / 0.2)', backgroundColor: 'hsl(var(--b1))', fontSize: '12px' }}
+									contentStyle={{
+										borderRadius: "8px",
+										border: "1px solid hsl(var(--bc) / 0.2)",
+										backgroundColor: "hsl(var(--b1))",
+										fontSize: "12px",
+									}}
 								/>
 							</PieChart>
 						</ResponsiveContainer>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -22,6 +22,7 @@ export interface ConfigResponse {
 	stremio: StremioConfig;
 	providers: ProviderConfig[];
 	nzblnk: NzblnkConfig;
+	network: NetworkConfig;
 	mount_path: string;
 	mount_type: MountType;
 	api_key?: string;
@@ -46,6 +47,16 @@ export interface APIConfig {
 // Authentication configuration
 export interface AuthConfig {
 	login_required: boolean;
+}
+
+// Network proxy configuration for outbound HTTP (indexers, arrs, SABnzbd, NZBLNK).
+// Empty strings disable proxying for that scheme. Mirrors standard
+// HTTP_PROXY/HTTPS_PROXY/NO_PROXY env-var semantics. Internal endpoints
+// (RC server, self-loopback) are not affected.
+export interface NetworkConfig {
+	http_proxy: string;
+	https_proxy: string;
+	no_proxy: string;
 }
 
 // Database configuration
@@ -321,6 +332,7 @@ export interface ConfigUpdateRequest {
 	stremio?: Partial<StremioConfig>;
 	providers?: ProviderUpdateRequest[];
 	nzblnk?: NzblnkConfig;
+	network?: NetworkConfig;
 	mount_path?: string;
 	mount_type?: MountType;
 	profiler_enabled?: boolean;
@@ -512,6 +524,7 @@ export type ConfigSection =
 	| "arrs"
 	| "stremio"
 	| "nzblnk"
+	| "network"
 	| "system";
 
 // Form data interfaces for UI components
@@ -944,6 +957,13 @@ export const CONFIG_SECTIONS: Record<ConfigSection | "system", ConfigSectionInfo
 		title: "NZBLNK",
 		description: "Settings for resolving nzblnk:// links via public NZB indexers",
 		icon: "Link",
+		canEdit: true,
+	},
+	network: {
+		title: "Network & Proxy",
+		description:
+			"HTTP/HTTPS proxy for outbound indexer, Arrs, NZB grab, and SABnzbd fallback traffic",
+		icon: "Globe",
 		canEdit: true,
 	},
 	system: {

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/winfsp/cgofuse v1.6.0
 	golang.org/x/crypto v0.46.0
+	golang.org/x/net v0.48.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/term v0.38.0
 	golang.org/x/text v0.32.0
@@ -291,7 +292,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20251023183803-a4bb9ffd2546 // indirect
 	golang.org/x/image v0.13.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
-	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc // indirect

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -219,7 +219,7 @@ func (s *Server) handlePatchConfigSection(c *fiber.Ctx) error {
 				newConfig.Providers[i].Password = oldPwdByID[newConfig.Providers[i].ID]
 			}
 		}
-	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "stremio", "nzblnk":
+	case "webdav", "api", "auth", "database", "metadata", "streaming", "health", "rclone", "import", "log", "sabnzbd", "arrs", "fuse", "segment_cache", "system", "mount_path", "mount", "stremio", "nzblnk", "network":
 		err = c.BodyParser(newConfig)
 		// BodyParser will map fields like "profiler_enabled" from JSON to the root of newConfig
 		// because Config struct has it with `json:"profiler_enabled"`.

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/database"
 	internalerrors "github.com/javi11/altmount/internal/errors"
+	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/nzbfile"
 	"github.com/javi11/altmount/internal/nzblnk"
@@ -707,7 +708,8 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 	}
 
 	// Create resolver
-	resolver := nzblnk.NewResolver(s.configManager.GetConfig().Nzblnk.UserAgent)
+	cfg := s.configManager.GetConfig()
+	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
 
 	// Process each link
 	type linkResult struct {
@@ -889,7 +891,8 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 		syntheticLink += "&p=" + url.QueryEscape(req.Password)
 	}
 
-	resolver := nzblnk.NewResolver(s.configManager.GetConfig().Nzblnk.UserAgent)
+	cfg := s.configManager.GetConfig()
+	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
 	resolved, err := resolver.Resolve(c.Context(), syntheticLink)
 	if err != nil {
 		return RespondNotFound(c, "NZB", "Could not find NZB for name '"+req.Name+"': "+err.Error())

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/prowlarr"
 )
 
@@ -177,7 +178,11 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 	prowlarrCfg := cfg.Stremio.Prowlarr
 
 	// Search Prowlarr -- return play-URL options immediately, no download yet
-	client := prowlarr.NewClient(prowlarrCfg.Host, prowlarrCfg.APIKey)
+	client := prowlarr.NewClient(
+		prowlarrCfg.Host,
+		prowlarrCfg.APIKey,
+		httpclient.NewForExternal(cfg.Network, 30*time.Second),
+	)
 	var (
 		results []prowlarr.NZBResult
 		err     error
@@ -374,7 +379,11 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 
 	// Download NZB from Prowlarr
 	prowlarrCfg := cfg.Stremio.Prowlarr
-	client := prowlarr.NewClient(prowlarrCfg.Host, prowlarrCfg.APIKey)
+	client := prowlarr.NewClient(
+		prowlarrCfg.Host,
+		prowlarrCfg.APIKey,
+		httpclient.NewForExternal(cfg.Network, httpclient.LongTimeout),
+	)
 	nzbData, err := client.DownloadNZB(ctx, downloadURL)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to download NZB from Prowlarr",

--- a/internal/arrs/clients/manager.go
+++ b/internal/arrs/clients/manager.go
@@ -3,7 +3,9 @@ package clients
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/javi11/altmount/internal/arrs/model"
 	"golift.io/starr"
@@ -11,25 +13,40 @@ import (
 	"golift.io/starr/radarr"
 	"golift.io/starr/readarr"
 	"golift.io/starr/sonarr"
-	)
+)
 
 type Manager struct {
 	mu              sync.RWMutex
-	radarrClients   map[string]*radarr.Radarr     // key: instance name
-	sonarrClients   map[string]*sonarr.Sonarr     // key: instance name
-	lidarrClients   map[string]*lidarr.Lidarr     // key: instance name
-	readarrClients  map[string]*readarr.Readarr   // key: instance name
-	whisparrClients map[string]*sonarr.Sonarr // key: instance name
+	httpClient      *http.Client
+	radarrClients   map[string]*radarr.Radarr   // key: instance name
+	sonarrClients   map[string]*sonarr.Sonarr   // key: instance name
+	lidarrClients   map[string]*lidarr.Lidarr   // key: instance name
+	readarrClients  map[string]*readarr.Readarr // key: instance name
+	whisparrClients map[string]*sonarr.Sonarr   // key: instance name
 }
 
-func NewManager() *Manager {
+// NewManager creates an arrs client manager. httpClient is shared with every
+// starr.Config, so its Transport (incl. proxy) and Timeout apply to all
+// Radarr/Sonarr/Lidarr/Readarr/Whisparr requests. When nil, a no-proxy 30s
+// default client is used.
+func NewManager(httpClient *http.Client) *Manager {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
 	return &Manager{
+		httpClient:      httpClient,
 		radarrClients:   make(map[string]*radarr.Radarr),
 		sonarrClients:   make(map[string]*sonarr.Sonarr),
 		lidarrClients:   make(map[string]*lidarr.Lidarr),
 		readarrClients:  make(map[string]*readarr.Readarr),
 		whisparrClients: make(map[string]*sonarr.Sonarr),
 	}
+}
+
+// starrConfig builds a starr.Config that reuses the manager's shared
+// *http.Client so proxy + timeout settings apply uniformly.
+func (m *Manager) starrConfig(url, apiKey string) *starr.Config {
+	return &starr.Config{URL: url, APIKey: apiKey, Client: m.httpClient}
 }
 
 // GetOrCreateRadarrClient gets or creates a Radarr client for an instance
@@ -41,7 +58,7 @@ func (m *Manager) GetOrCreateRadarrClient(instanceName, url, apiKey string) (*ra
 		return client, nil
 	}
 
-	client := radarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := radarr.New(m.starrConfig(url, apiKey))
 	m.radarrClients[instanceName] = client
 	return client, nil
 }
@@ -55,7 +72,7 @@ func (m *Manager) GetOrCreateSonarrClient(instanceName, url, apiKey string) (*so
 		return client, nil
 	}
 
-	client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := sonarr.New(m.starrConfig(url, apiKey))
 	m.sonarrClients[instanceName] = client
 	return client, nil
 }
@@ -69,7 +86,7 @@ func (m *Manager) GetOrCreateLidarrClient(instanceName, url, apiKey string) (*li
 		return client, nil
 	}
 
-	client := lidarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := lidarr.New(m.starrConfig(url, apiKey))
 	m.lidarrClients[instanceName] = client
 	return client, nil
 }
@@ -83,7 +100,7 @@ func (m *Manager) GetOrCreateReadarrClient(instanceName, url, apiKey string) (*r
 		return client, nil
 	}
 
-	client := readarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := readarr.New(m.starrConfig(url, apiKey))
 	m.readarrClients[instanceName] = client
 	return client, nil
 }
@@ -97,7 +114,7 @@ func (m *Manager) GetOrCreateWhisparrClient(instanceName, url, apiKey string) (*
 		return client, nil
 	}
 
-	client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
+	client := sonarr.New(m.starrConfig(url, apiKey))
 	m.whisparrClients[instanceName] = client
 	return client, nil
 }
@@ -124,7 +141,7 @@ func (m *Manager) GetOrCreateClient(instance *model.ConfigInstance) (any, error)
 func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey string) error {
 	switch instanceType {
 	case "radarr":
-		client := radarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		client := radarr.New(m.starrConfig(url, apiKey))
 		_, err := client.GetSystemStatusContext(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to connect to Radarr: %w", err)
@@ -132,7 +149,7 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 		return nil
 
 	case "sonarr":
-		client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		client := sonarr.New(m.starrConfig(url, apiKey))
 		_, err := client.GetSystemStatus()
 		if err != nil {
 			return fmt.Errorf("failed to connect to Sonarr: %w", err)
@@ -140,7 +157,7 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 		return nil
 
 	case "lidarr":
-		client := lidarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		client := lidarr.New(m.starrConfig(url, apiKey))
 		_, err := client.GetSystemStatusContext(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to connect to Lidarr: %w", err)
@@ -148,7 +165,7 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 		return nil
 
 	case "readarr":
-		client := readarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		client := readarr.New(m.starrConfig(url, apiKey))
 		_, err := client.GetSystemStatusContext(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to connect to Readarr: %w", err)
@@ -156,7 +173,7 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 		return nil
 
 	case "whisparr":
-		client := sonarr.New(&starr.Config{URL: url, APIKey: apiKey})
+		client := sonarr.New(m.starrConfig(url, apiKey))
 		_, err := client.GetSystemStatus()
 		if err != nil {
 			return fmt.Errorf("failed to connect to Whisparr: %w", err)

--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/javi11/altmount/internal/arrs/worker"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/httpclient"
 	"golift.io/starr"
 )
 
@@ -45,7 +46,7 @@ type Service struct {
 // NewService creates a new arrs service for health monitoring and file repair
 func NewService(configGetter config.ConfigGetter, configManager model.ConfigManager, userRepo *database.UserRepository, queueRepo *database.Repository) *Service {
 	instManager := instances.NewManager(configGetter, configManager)
-	clientManager := clients.NewManager()
+	clientManager := clients.NewManager(httpclient.NewForExternal(configGetter().Network, 30*time.Second))
 	dataManager := data.NewManager()
 	scannerManager := scanner.NewManager(configGetter, instManager, clientManager, dataManager)
 	workerManager := worker.NewWorker(configGetter, instManager, clientManager, queueRepo)

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -54,6 +54,7 @@ type Config struct {
 	SegmentCache    SegmentCacheConfig `yaml:"segment_cache" mapstructure:"segment_cache" json:"segment_cache"`
 	Providers       []ProviderConfig   `yaml:"providers" mapstructure:"providers" json:"providers"`
 	Nzblnk          NzblnkConfig       `yaml:"nzblnk" mapstructure:"nzblnk" json:"nzblnk"`
+	Network         NetworkConfig      `yaml:"network" mapstructure:"network" json:"network"`
 	MountPath       string             `yaml:"mount_path" mapstructure:"mount_path" json:"mount_path"`
 	MountType       MountType          `yaml:"mount_type" mapstructure:"mount_type" json:"mount_type"`
 	ProfilerEnabled bool               `yaml:"profiler_enabled" mapstructure:"profiler_enabled" json:"profiler_enabled" default:"false"`
@@ -65,6 +66,28 @@ type NzblnkConfig struct {
 	// Defaults to a browser-like string. Leave empty to use the default.
 	UserAgent string `yaml:"user_agent" mapstructure:"user_agent" json:"user_agent,omitempty"`
 }
+
+// NetworkConfig holds outbound HTTP routing options applied to every external
+// client (indexers, arrs, SABnzbd fallback, NZBLNK resolver). Internal
+// endpoints (RC server, self-loopback) are unaffected.
+//
+// Semantics mirror Go's standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars.
+// Empty strings disable proxying for that scheme.
+type NetworkConfig struct {
+	HTTPProxy  string `yaml:"http_proxy" mapstructure:"http_proxy" json:"http_proxy,omitempty"`
+	HTTPSProxy string `yaml:"https_proxy" mapstructure:"https_proxy" json:"https_proxy,omitempty"`
+	NoProxy    string `yaml:"no_proxy" mapstructure:"no_proxy" json:"no_proxy,omitempty"`
+}
+
+// GetHTTPProxy returns the configured HTTP proxy URL. Implements the
+// httpclient.NetworkProxyConfig interface to avoid config↔httpclient import cycles.
+func (n NetworkConfig) GetHTTPProxy() string { return n.HTTPProxy }
+
+// GetHTTPSProxy returns the configured HTTPS proxy URL.
+func (n NetworkConfig) GetHTTPSProxy() string { return n.HTTPSProxy }
+
+// GetNoProxy returns the comma-separated bypass list.
+func (n NetworkConfig) GetNoProxy() string { return n.NoProxy }
 
 // SegmentCacheConfig configures the segment-aligned disk cache shared by FUSE and WebDAV.
 // When enabled, this cache replaces the FUSE VFS disk cache and additionally benefits WebDAV.

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func TestConfig_Validate_MountPaths(t *testing.T) {
@@ -222,5 +223,33 @@ func TestConfig_GetDownloadClientBaseURL(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.config.GetDownloadClientBaseURL())
 		})
 	}
+}
+
+func TestConfig_NetworkRoundTrip(t *testing.T) {
+	in := Config{
+		Network: NetworkConfig{
+			HTTPProxy:  "http://proxy:3128",
+			HTTPSProxy: "http://proxy:3128",
+			NoProxy:    "localhost,10.0.0.0/8",
+		},
+	}
+	b, err := yaml.Marshal(in)
+	assert.NoError(t, err)
+
+	var out Config
+	err = yaml.Unmarshal(b, &out)
+	assert.NoError(t, err)
+
+	assert.Equal(t, in.Network, out.Network)
+	assert.Equal(t, "http://proxy:3128", out.Network.GetHTTPProxy())
+	assert.Equal(t, "http://proxy:3128", out.Network.GetHTTPSProxy())
+	assert.Equal(t, "localhost,10.0.0.0/8", out.Network.GetNoProxy())
+}
+
+func TestConfig_NetworkDefaultsEmpty(t *testing.T) {
+	cfg := Config{}
+	assert.Empty(t, cfg.Network.HTTPProxy)
+	assert.Empty(t, cfg.Network.HTTPSProxy)
+	assert.Empty(t, cfg.Network.NoProxy)
 }
 

--- a/internal/httpclient/factory.go
+++ b/internal/httpclient/factory.go
@@ -1,0 +1,31 @@
+package httpclient
+
+import (
+	"net/http"
+	"time"
+)
+
+// NetworkProxyConfig is the minimal interface the factory needs from the
+// application config. Implemented by config.NetworkConfig — declared here
+// to avoid an internal/config ↔ internal/httpclient import cycle.
+type NetworkProxyConfig interface {
+	GetHTTPProxy() string
+	GetHTTPSProxy() string
+	GetNoProxy() string
+}
+
+// NewForExternal builds a proxy-aware *http.Client with the given timeout,
+// reading proxy settings from the supplied config. Used by every external
+// integration (Prowlarr, SABnzbd, NZBLNK resolver, Arrs). Internal endpoints
+// should NOT use this — call New() or use http.DefaultClient instead.
+//
+// A nil net argument disables proxying.
+func NewForExternal(net NetworkProxyConfig, timeout time.Duration) *http.Client {
+	if net == nil {
+		return New(WithTimeout(timeout))
+	}
+	return New(
+		WithTimeout(timeout),
+		WithProxyConfig(net.GetHTTPProxy(), net.GetHTTPSProxy(), net.GetNoProxy()),
+	)
+}

--- a/internal/httpclient/proxy.go
+++ b/internal/httpclient/proxy.go
@@ -1,0 +1,45 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/http/httpproxy"
+)
+
+// buildProxyFunc returns an http.Transport.Proxy function honouring the given
+// http/https/no proxy values. Empty values mean "do not proxy that scheme".
+// It does NOT consult environment variables — config is authoritative.
+func buildProxyFunc(httpProxy, httpsProxy, noProxy string) func(*http.Request) (*url.URL, error) {
+	if httpProxy == "" && httpsProxy == "" {
+		return func(*http.Request) (*url.URL, error) { return nil, nil }
+	}
+	cfg := &httpproxy.Config{
+		HTTPProxy:  httpProxy,
+		HTTPSProxy: httpsProxy,
+		NoProxy:    noProxy,
+	}
+	proxyFn := cfg.ProxyFunc()
+	return func(r *http.Request) (*url.URL, error) {
+		return proxyFn(r.URL)
+	}
+}
+
+// WithProxyConfig returns an Option that installs a proxy-aware
+// *http.Transport derived from the supplied values. Pass empty strings to
+// disable proxying. If a Transport was already set by an earlier option, the
+// proxy function is layered on top of a clone of that transport.
+func WithProxyConfig(httpProxy, httpsProxy, noProxy string) Option {
+	return func(o *Options) {
+		var base *http.Transport
+		if o.Transport != nil {
+			base = o.Transport.Clone()
+		} else if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			base = dt.Clone()
+		} else {
+			base = &http.Transport{}
+		}
+		base.Proxy = buildProxyFunc(httpProxy, httpsProxy, noProxy)
+		o.Transport = base
+	}
+}

--- a/internal/httpclient/proxy_test.go
+++ b/internal/httpclient/proxy_test.go
@@ -1,0 +1,86 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestBuildProxyFunc_AllEmpty(t *testing.T) {
+	fn := buildProxyFunc("", "", "")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	u, err := fn(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if u != nil {
+		t.Fatalf("expected nil proxy URL, got %v", u)
+	}
+}
+
+func TestBuildProxyFunc_HTTPProxy(t *testing.T) {
+	fn := buildProxyFunc("http://proxy:3128", "", "")
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	u, err := fn(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if u == nil || u.Host != "proxy:3128" {
+		t.Fatalf("expected proxy:3128, got %v", u)
+	}
+}
+
+func TestBuildProxyFunc_HTTPSProxy(t *testing.T) {
+	fn := buildProxyFunc("", "http://proxy:3128", "")
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	u, err := fn(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if u == nil || u.Host != "proxy:3128" {
+		t.Fatalf("expected proxy:3128, got %v", u)
+	}
+}
+
+func TestBuildProxyFunc_NoProxyMatch(t *testing.T) {
+	fn := buildProxyFunc("http://proxy:3128", "http://proxy:3128", "internal.local,10.0.0.0/8")
+	req, _ := http.NewRequest("GET", "http://internal.local/x", nil)
+	u, err := fn(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if u != nil {
+		t.Fatalf("expected nil (bypass), got %v", u)
+	}
+}
+
+func TestWithProxyConfig_AppliesTransport(t *testing.T) {
+	c := New(WithProxyConfig("http://proxy:3128", "", ""))
+	if c.Transport == nil {
+		t.Fatalf("expected transport set")
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport")
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	u, _ := tr.Proxy(req)
+	if u == nil || u.Host != "proxy:3128" {
+		t.Fatalf("proxy not applied: %v", u)
+	}
+}
+
+func TestWithProxyConfig_EmptyDisables(t *testing.T) {
+	c := New(WithProxyConfig("", "", ""))
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport")
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	u, err := tr.Proxy(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if u != nil {
+		t.Fatalf("expected nil proxy (disabled), got %v", u)
+	}
+}

--- a/internal/importer/postprocessor/sabnzbd_fallback.go
+++ b/internal/importer/postprocessor/sabnzbd_fallback.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/sabnzbd"
 )
 
@@ -29,8 +30,8 @@ func (c *Coordinator) AttemptFallback(ctx context.Context, item *database.Import
 	// Convert priority to SABnzbd format
 	priority := convertPriorityToSABnzbd(item.Priority)
 
-	// Create client and send
-	client := sabnzbd.NewSABnzbdClient()
+	// Create client and send (proxy-aware per current network config)
+	client := sabnzbd.NewSABnzbdClient(httpclient.NewForExternal(cfg.Network, httpclient.LongTimeout))
 	nzoID, err := client.SendNZBFile(
 		ctx,
 		cfg.SABnzbd.FallbackHost,

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/javi11/altmount/internal/arrs"
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/importer/filesystem"
 	"github.com/javi11/altmount/internal/importer/parser"
 	"github.com/javi11/altmount/internal/importer/postprocessor"
@@ -238,7 +239,7 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 		rcloneClient:    rcloneClient,
 		configGetter:    configGetter,
 		healthRepo:      healthRepo,
-		sabnzbdClient:   sabnzbd.NewSABnzbdClient(),
+		sabnzbdClient:   sabnzbd.NewSABnzbdClient(httpclient.NewForExternal(configGetter().Network, httpclient.LongTimeout)),
 		broadcaster:     broadcaster,
 		userRepo:        userRepo,
 		log:             slog.Default().With("component", "importer-service"),

--- a/internal/nzblnk/resolver.go
+++ b/internal/nzblnk/resolver.go
@@ -39,17 +39,18 @@ type Resolver struct {
 	indexers   []Indexer
 }
 
-// NewResolver creates a new NZBLNK resolver with the given user-agent for indexer requests.
-func NewResolver(userAgent string) *Resolver {
-	client := &http.Client{
-		Timeout: 30 * time.Second,
+// NewResolver creates a new NZBLNK resolver. The supplied httpClient carries
+// the desired Timeout + proxy Transport (typically built via
+// httpclient.NewForExternal). Passing nil yields a no-proxy 30s default.
+func NewResolver(userAgent string, httpClient *http.Client) *Resolver {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
-
 	return &Resolver{
-		httpClient: client,
+		httpClient: httpClient,
 		indexers: []Indexer{
-			NewNZBKingIndexer(client, userAgent),
-			NewNZBIndexIndexer(client, userAgent),
+			NewNZBKingIndexer(httpClient, userAgent),
+			NewNZBIndexIndexer(httpClient, userAgent),
 		},
 	}
 }

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -22,13 +22,24 @@ type Client struct {
 	http     *http.Client
 }
 
-// NewClient creates a new Prowlarr client.
-func NewClient(host, apiKey string) *Client {
-	cfg := starr.New(apiKey, strings.TrimRight(host, "/"), 30*time.Second)
+// NewClient creates a new Prowlarr client. The supplied httpClient is reused
+// for both the starr API and direct NZB downloads, so its Transport (incl. any
+// proxy configuration) and Timeout apply to every outbound call. When nil, a
+// default 30s no-proxy client is used.
+func NewClient(host, apiKey string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	timeout := httpClient.Timeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	cfg := starr.New(apiKey, strings.TrimRight(host, "/"), timeout)
+	cfg.Client = httpClient
 	return &Client{
 		prowlarr: starrprowlarr.New(cfg),
 		apiKey:   apiKey,
-		http:     &http.Client{Timeout: 30 * time.Second},
+		http:     httpClient,
 	}
 }
 

--- a/internal/sabnzbd/client.go
+++ b/internal/sabnzbd/client.go
@@ -21,11 +21,15 @@ type SABnzbdClient struct {
 	httpClient *http.Client
 }
 
-// NewSABnzbdClient creates a new SABnzbd client with reasonable timeouts
-func NewSABnzbdClient() *SABnzbdClient {
-	return &SABnzbdClient{
-		httpClient: httpclient.NewLong(), // 60 second timeout for file uploads
+// NewSABnzbdClient creates a new SABnzbd client. The supplied httpClient
+// carries the desired Timeout + proxy Transport — typically built via
+// httpclient.NewForExternal so outbound requests respect the configured proxy.
+// When nil, a no-proxy 60s client is used.
+func NewSABnzbdClient(httpClient *http.Client) *SABnzbdClient {
+	if httpClient == nil {
+		httpClient = httpclient.NewLong()
 	}
+	return &SABnzbdClient{httpClient: httpClient}
 }
 
 // SABnzbdAPIResponse represents a response from SABnzbd API


### PR DESCRIPTION
## Summary

Adds a top-level `network` config block (`http_proxy`, `https_proxy`, `no_proxy`) exposed via the UI and applied to every outbound HTTP client used for grabbing NZBs and talking to indexers / arrs. Internal endpoints (RC server, self-loopback) are unaffected.

Closes the gap in [#593](https://github.com/javi11/altmount/issues/593) — env-var-only proxy routing is too coarse, leaks into internal calls, and is hard to manage in Docker / Gluetun stacks where indexers enforce IP consistency between search and grab.

## What changed

**Backend**
- New `NetworkConfig` struct (`http_proxy` / `https_proxy` / `no_proxy`) on `config.Config` with yaml/mapstructure/json tags. Defaults to empty (no proxy).
- New `internal/httpclient/proxy.go` + `factory.go`: `WithProxyConfig(...)` option and `NewForExternal(net, timeout)` helper. Backed by `golang.org/x/net/http/httpproxy` so semantics match `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` env vars but the config is authoritative (env is not consulted).
- Constructors updated to accept `*http.Client`:
  - `prowlarr.NewClient` (Stremio addon search + NZB download)
  - `sabnzbd.NewSABnzbdClient` (fallback host)
  - `nzblnk.NewResolver` (NZBKing / NZBIndex)
  - `arrs/clients.NewManager` — `starr.Config.Client` injected for every Radarr / Sonarr / Lidarr / Readarr / Whisparr instance.
- API: `"network"` added to the PATCH switch in `config_handlers.go`. GET serializes through the embedded `*config.Config`, no extra response struct needed (no secrets to mask).

**Frontend**
- `NetworkConfig` TS interface + `ConfigResponse.network` + `ConfigUpdateRequest.network`.
- New `NetworkConfigSection.tsx` under the **System** group with three inputs and a DaisyUI info alert describing scope and the hot-reload caveat.

**Tests**
- 6 new httpclient unit tests covering: all-empty, HTTP-only, HTTPS-only, NO_PROXY match, transport application, and empty disables.
- 2 new config tests covering yaml round-trip and default-empty behaviour.

## Known limitations

- **Per-call clients** (Stremio addon, NZBLNK resolver, SABnzbd fallback) read `cfg.Network` on every request — proxy changes apply on the next outbound call.
- **Long-lived clients** (arrs `clients.Manager`, importer `sabnzbdClient`) are constructed once at startup. The UI alert tells the user to restart AltMount to apply new proxy settings to those. Wiring `config.OnConfigChange` to rebind is a follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/httpclient/... ./internal/config/... -race` — all pass
- [x] `bun run build` (frontend) — production bundle generated
- [ ] Manual: set http_proxy/https_proxy via UI, point at a local Squid / tinyproxy, trigger a Stremio search + arrs queue check + nzblnk grab + SABnzbd fallback, confirm requests appear in the proxy log
- [ ] Manual: add an indexer host to `no_proxy`, confirm bypass
- [ ] Manual: confirm internal calls (`/api/config`, RC server) do **not** route through the proxy