### PR TITLE
refactor(config): remove allow_symlinks_on_windows flag

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -156,10 +156,8 @@ import:
   max_import_connections: 5 # Number of concurrent NNTP connections for validation and archive processing
   segment_sample_percentage: 1 # Percentage of segments to sample for validation (1-100)
   import_strategy: 'NONE' # Import strategy: NONE (direct import), SYMLINK (create symlinks), STRM (create .strm files)
-                          # NOTE: SYMLINK on Windows requires `allow_symlinks_on_windows: true` AND Windows Developer Mode enabled. Otherwise use STRM.
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)
                  # Windows example: 'C:\Users\user\Videos'
-  allow_symlinks_on_windows: false # Permit symlink creation on Windows (requires Developer Mode in Windows Settings → For developers). No effect on Linux/macOS. Default: false.
   failed_item_retention_hours: 24 # Auto-remove failed queue items and NZB files after this many hours (0 to disable, default: 24)
 
 # Health monitoring configuration

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -364,60 +364,6 @@ export function ImportConfigSection({
 						)}
 					</div>
 
-					{formData.import_strategy === "SYMLINK" && (
-						<>
-							<div className="divider text-base-content/70" />
-
-							<label className="label cursor-pointer items-start justify-start gap-4">
-								<input
-									type="checkbox"
-									className="toggle toggle-primary toggle-sm mt-1 shrink-0"
-									checked={formData.allow_symlinks_on_windows ?? false}
-									disabled={isReadOnly}
-									onChange={(e) => handleInputChange("allow_symlinks_on_windows", e.target.checked)}
-								/>
-								<div className="min-w-0 flex-1">
-									<span className="block whitespace-normal break-words font-bold text-xs">
-										Allow Symlinks on Windows
-									</span>
-									<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-										Allow symlink creation on Windows. By default, symlinks are blocked on Windows
-										because they require elevated privileges. Has no effect on Linux/macOS.
-									</span>
-								</div>
-							</label>
-
-							{formData.allow_symlinks_on_windows && (
-								<div className="alert alert-warning mt-2">
-									<svg
-										xmlns="http://www.w3.org/2000/svg"
-										className="h-5 w-5 shrink-0"
-										fill="none"
-										viewBox="0 0 24 24"
-										stroke="currentColor"
-										aria-hidden="true"
-									>
-										<title>Warning</title>
-										<path
-											strokeLinecap="round"
-											strokeLinejoin="round"
-											strokeWidth={2}
-											d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
-										/>
-									</svg>
-									<div className="text-xs">
-										<div className="font-bold">Windows Developer Mode required</div>
-										<div className="mt-1">
-											To create symlinks without admin rights, enable Developer Mode in Windows
-											Settings → Privacy &amp; security → For developers → Developer Mode. Without
-											it, imports will fail with an OS permission error.
-										</div>
-									</div>
-								</div>
-							)}
-						</>
-					)}
-
 					<div className="divider text-base-content/70" />
 
 					<div className="space-y-6">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -250,7 +250,6 @@ export interface ImportConfig {
 	failed_item_retention_hours?: number | null;
 	history_retention_days?: number | null;
 	delete_completed_nzb?: boolean;
-	allow_symlinks_on_windows?: boolean;
 }
 
 // Log configuration
@@ -462,7 +461,6 @@ export interface ImportUpdateRequest {
 	allow_nested_rar_extraction?: boolean;
 	rename_to_nzb_name?: boolean;
 	filter_sample_files?: boolean;
-	allow_symlinks_on_windows?: boolean;
 }
 
 // Log update request

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -1463,11 +1462,7 @@ func (s *Server) handleRegenerateLibraryFiles(c *fiber.Ctx) error {
 				creationErr = fmt.Errorf("importer service or post-processor not available")
 			}
 		} else {
-			if runtime.GOOS == "windows" {
-				creationErr = fmt.Errorf("symlinks not supported on Windows")
-			} else {
-				creationErr = os.Symlink(actualPath, libraryPath)
-			}
+			creationErr = os.Symlink(actualPath, libraryPath)
 		}
 
 		if creationErr != nil {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -306,7 +306,6 @@ type ImportConfig struct {
 	FailedItemRetentionHours       *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 	HistoryRetentionDays           *int           `yaml:"history_retention_days" mapstructure:"history_retention_days" json:"history_retention_days,omitempty"`
 	DeleteCompletedNzb             *bool          `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
-	AllowSymlinksOnWindows         *bool          `yaml:"allow_symlinks_on_windows" mapstructure:"allow_symlinks_on_windows" json:"allow_symlinks_on_windows,omitempty"`
 }
 
 // ShouldDeleteCompletedNzb returns whether the NZB file should be removed from

--- a/internal/importer/postprocessor/symlink_creator.go
+++ b/internal/importer/postprocessor/symlink_creator.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/javi11/altmount/internal/config"
@@ -147,10 +146,6 @@ func (c *Coordinator) createAbsoluteSymlink(actualPath, destPath string) error {
 		}
 	}
 
-	if err := windowsSymlinkAllowed(c.configGetter()); err != nil {
-		return err
-	}
-
 	if err := os.Symlink(actualPath, destPath); err != nil {
 		return fmt.Errorf("failed to create symlink at target path: %w", err)
 	}
@@ -178,27 +173,9 @@ func (c *Coordinator) createSingleSymlink(actualPath, resultingPath string) erro
 	}
 
 	// Create the symlink using the absolute actual path
-	if err := windowsSymlinkAllowed(c.configGetter()); err != nil {
-		return err
-	}
 	if err := os.Symlink(actualPath, symlinkPath); err != nil {
 		return fmt.Errorf("failed to create symlink: %w", err)
 	}
 
 	return nil
-}
-
-// windowsSymlinkAllowed returns an error when running on Windows and the
-// AllowSymlinksOnWindows opt-in flag is not enabled. On non-Windows platforms
-// it always returns nil. When the flag is enabled on Windows, callers proceed
-// to os.Symlink which will only succeed if the process has the required
-// privilege (typically granted by enabling Developer Mode).
-func windowsSymlinkAllowed(cfg *config.Config) error {
-	if runtime.GOOS != "windows" {
-		return nil
-	}
-	if cfg != nil && cfg.Import.AllowSymlinksOnWindows != nil && *cfg.Import.AllowSymlinksOnWindows {
-		return nil
-	}
-	return fmt.Errorf("symlinks are not supported on Windows by default; enable 'Allow symlinks on Windows' in config (requires Windows Developer Mode) or use STRM import strategy instead")
 }


### PR DESCRIPTION
## Summary

- Remove the `allow_symlinks_on_windows` opt-in flag from the config schema, YAML sample, frontend types, and Workers UI.
- Drop the Windows-specific `os.Symlink` guard (`windowsSymlinkAllowed`) from the importer post-processor; both call sites now call `os.Symlink` directly.
- Drop the matching `runtime.GOOS == "windows"` block from `internal/api/health_handlers.go` (library file regeneration) so it matches the importer behavior.
- Remove the now-unused `runtime` import from both Go files and the toggle + warning alert from `WorkersConfigSection.tsx`.

## Why

The importer respected the user's opt-in, but the health regeneration handler ignored the flag entirely and always errored on Windows — two different behaviors for the same OS-level operation. Collapsing both paths to call `os.Symlink` directly makes a Windows symlink failure (when Developer Mode isn't on, or the user lacks the privilege) surface as a normal OS error, matching every other filesystem call in the codebase.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Grep confirms no remaining `AllowSymlinksOnWindows` / `allow_symlinks_on_windows` / `windowsSymlinkAllowed` references
- [ ] Frontend `bun run check` (not run — `node_modules` not installed in the worktree; changes are pure field deletions with all references removed)
- [ ] Manual: with `import_strategy: SYMLINK`, trigger `POST /api/health/regenerate-symlinks` on Linux — symlinks created as before
- [ ] Manual: open the Workers config UI with SYMLINK selected and confirm the "Allow Symlinks on Windows" toggle is gone