### PR TITLE
fix(windows): remove remaining SYMLINK guards missed by #607

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -542,10 +541,6 @@ func (c *Config) Validate() error {
 	if !validStrategies[c.Import.ImportStrategy] {
 		return fmt.Errorf("import_strategy must be one of: NONE, SYMLINK, STRM")
 	}
-	if runtime.GOOS == "windows" && c.Import.ImportStrategy == ImportStrategySYMLINK {
-		return fmt.Errorf("import_strategy SYMLINK is not supported on Windows; use STRM instead")
-	}
-
 	// Validate import directory when strategy requires it
 	if c.Import.ImportStrategy == ImportStrategySYMLINK || c.Import.ImportStrategy == ImportStrategySTRM {
 		if c.Import.ImportDir == nil || *c.Import.ImportDir == "" {

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1185,9 +1184,6 @@ func updateSymlinkForMountChange(
 	}
 
 	// Create new symlink
-	if runtime.GOOS == "windows" {
-		return currentTarget, false, fmt.Errorf("symlinks are not supported on Windows")
-	}
 	if err := os.Symlink(newTarget, symlinkPath); err != nil {
 		slog.ErrorContext(ctx, "Failed to create updated symlink",
 			"path", symlinkPath,


### PR DESCRIPTION
## Summary

#607 removed the Windows SYMLINK guards from `symlink_creator.go` and `health_handlers.go` but two more remained that prevent altmount from starting or functioning on Windows:

- **`internal/config/manager.go`**: startup config validator rejects `import_strategy: SYMLINK` on Windows with `"SYMLINK is not supported on Windows; use STRM instead"` — the binary exits immediately without serving
- **`internal/health/library_sync.go`**: guard blocks symlink updates during library sync on Windows

Both blocks follow the same `runtime.GOOS == "windows"` pattern as the ones removed in #607. Also removed the now-unused `"runtime"` imports from both files.

## Test plan

- [x] `go build ./...` clean on Windows
- [x] altmount starts successfully with `import_strategy: SYMLINK` on Windows
- [x] Symlinks created correctly on import