### PR TITLE
fix(frontend): show save button when mount type is disabled

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -483,36 +483,34 @@ export function MountConfigSection({ config, onUpdate, isUpdating }: MountConfig
 			)}
 
 			{/* Save Button */}
-			{mountType !== "none" && (
-				<div className="flex flex-col gap-2 pt-4">
-					{mountPathChanged && (
-						<label className="flex cursor-pointer items-center gap-2 self-end">
-							<input
-								type="checkbox"
-								className="checkbox checkbox-sm"
-								checked={regenerateOnSave}
-								onChange={(e) => setRegenerateOnSave(e.target.checked)}
-							/>
-							<span className="text-sm">Regenerate all library symlinks to the new mount path</span>
-						</label>
-					)}
-					<div className="flex justify-end">
-						<button
-							type="button"
-							className={`btn btn-primary btn-md px-10 shadow-lg shadow-primary/20 ${!hasChanges && "btn-ghost border-base-300"}`}
-							onClick={handleSave}
-							disabled={!hasChanges || isUpdating || !mountPath}
-						>
-							{isUpdating ? (
-								<span className="loading loading-spinner loading-sm" />
-							) : (
-								<Save className="h-4 w-4" />
-							)}
-							{isUpdating ? "Saving..." : "Save Configuration"}
-						</button>
-					</div>
+			<div className="flex flex-col gap-2 pt-4">
+				{mountType !== "none" && mountPathChanged && (
+					<label className="flex cursor-pointer items-center gap-2 self-end">
+						<input
+							type="checkbox"
+							className="checkbox checkbox-sm"
+							checked={regenerateOnSave}
+							onChange={(e) => setRegenerateOnSave(e.target.checked)}
+						/>
+						<span className="text-sm">Regenerate all library symlinks to the new mount path</span>
+					</label>
+				)}
+				<div className="flex justify-end">
+					<button
+						type="button"
+						className={`btn btn-primary btn-md px-10 shadow-lg shadow-primary/20 ${!hasChanges && "btn-ghost border-base-300"}`}
+						onClick={handleSave}
+						disabled={!hasChanges || isUpdating || (mountType !== "none" && !mountPath)}
+					>
+						{isUpdating ? (
+							<span className="loading loading-spinner loading-sm" />
+						) : (
+							<Save className="h-4 w-4" />
+						)}
+						{isUpdating ? "Saving..." : "Save Configuration"}
+					</button>
 				</div>
-			)}
+			</div>
 
 			{/* Status & Control Bar */}
 			{showMountControls && (


### PR DESCRIPTION
## Summary

Fixes #611 — selecting the **Disabled** mount type left the user with no
Save button, so the change could not be persisted through the UI (users
had to hand-edit `config.yaml` or call the REST API).

## Root cause

In [`MountConfigSection.tsx`](frontend/src/components/config/MountConfigSection.tsx)
the entire Save block was wrapped in `{mountType !== "none" && (...)}`.
Once "Disabled" was selected the block (and the button) disappeared.
The button was also disabled while `!mountPath`, which has no meaning
when the mount is disabled.

## Change

- Render the Save block unconditionally.
- Keep the "Regenerate symlinks" checkbox gated on `mountType !== "none" && mountPathChanged` (it only applies to an active mount).
- Relax the disabled check to `(mountType !== "none" && !mountPath)` so an empty path no longer blocks saving the disabled state.

No backend change needed — `mount_type: "none"` is already accepted, and the
success toast already produces "Mount type set to disabled".

## Test plan

- [ ] `cd frontend && bun run build` succeeds.
- [ ] Start the app, open Configuration → Mount.
- [ ] With an active mount (e.g. `fuse` or `rclone`) selected, click **Disabled**, confirm the dialog, and verify the Save button now appears and is enabled.
- [ ] Click Save and verify the success toast ("Mount type set to disabled") and that the disabled state persists across reload.
- [ ] With mount already disabled and no pending changes, verify the Save button is visible but disabled.
- [ ] Switch from Disabled back to an active type and verify the existing behavior (sub-sections appear, mount path required) is unchanged.