### PR TITLE
fix(metadata): skip unreadable dirs instead of aborting backup

### DIFF
--- a/internal/metadata/backup_worker.go
+++ b/internal/metadata/backup_worker.go
@@ -138,7 +138,16 @@ func (w *BackupWorker) performBackup() {
 			}
 
 			if err != nil {
-				return err
+				// Tolerate per-entry errors (e.g. Windows system folders like
+				// "System Volume Information" / "WindowsApps", or restricted
+				// dirs on Linux) so a single permission failure doesn't abort
+				// the entire backup.
+				slog.WarnContext(w.workerCtx, "Skipping entry during metadata backup",
+					"path", path, "error", err)
+				if info != nil && info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 
 			if info.IsDir() {

--- a/internal/metadata/backup_worker_test.go
+++ b/internal/metadata/backup_worker_test.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -78,4 +79,62 @@ func TestBackupWorker_performBackup(t *testing.T) {
 	dirs, err = os.ReadDir(backupRoot)
 	assert.NoError(t, err)
 	assert.Len(t, dirs, 2) // Should keep only 2 latest folders
+}
+
+// TestBackupWorker_performBackup_SkipsUnreadableDirs verifies that a single
+// inaccessible subdirectory (mimicking Windows "System Volume Information" or
+// a chmod-000 dir on Linux) does not abort the entire backup. Regression test
+// for https://github.com/javi11/altmount/issues/609.
+func TestBackupWorker_performBackup_SkipsUnreadableDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based permission denial is unreliable on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permissions")
+	}
+
+	tempDir, err := os.MkdirTemp("", "metadata-test-skip-*")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	metadataDir := filepath.Join(tempDir, "metadata")
+	backupRoot := filepath.Join(tempDir, "backups")
+	assert.NoError(t, os.MkdirAll(metadataDir, 0755))
+
+	// Readable .meta file at the root.
+	assert.NoError(t, os.WriteFile(filepath.Join(metadataDir, "readable.meta"), []byte("ok"), 0644))
+
+	// Unreadable subdirectory containing a .meta file that should be skipped.
+	denied := filepath.Join(metadataDir, "denied")
+	assert.NoError(t, os.MkdirAll(denied, 0755))
+	assert.NoError(t, os.WriteFile(filepath.Join(denied, "hidden.meta"), []byte("x"), 0644))
+	assert.NoError(t, os.Chmod(denied, 0))
+	// Restore perms so cleanup can succeed.
+	defer os.Chmod(denied, 0755) //nolint:errcheck
+
+	enabled := true
+	cfg := &config.Config{
+		Metadata: config.MetadataConfig{
+			RootPath: metadataDir,
+			Backup: config.MetadataBackupConfig{
+				Enabled:     &enabled,
+				Schedule:    "0 3 * * *",
+				KeepBackups: 2,
+				Path:        backupRoot,
+			},
+		},
+	}
+
+	worker := NewBackupWorker(func() *config.Config { return cfg })
+	worker.performBackup()
+
+	// Backup directory should exist (proving the walk did not abort and
+	// cleanup-on-error did not RemoveAll it).
+	dirs, err := os.ReadDir(backupRoot)
+	assert.NoError(t, err)
+	assert.Len(t, dirs, 1)
+
+	backupDir := filepath.Join(backupRoot, dirs[0].Name())
+	assert.FileExists(t, filepath.Join(backupDir, "readable.meta"))
+	assert.NoFileExists(t, filepath.Join(backupDir, "denied", "hidden.meta"))
 }


### PR DESCRIPTION
## Summary

- Make the metadata backup walker tolerant of per-entry errors: log a warning and continue (`filepath.SkipDir` for directories, `nil` for files) instead of returning the error and aborting the whole backup.
- Add a regression test that places a `chmod 000` subdirectory under the metadata root and verifies the backup still completes and copies sibling files.

## Why

`filepath.Walk` in `internal/metadata/backup_worker.go` returned the first per-entry error it received, which surfaced as `Failed to complete metadata backup` in the logs and `os.RemoveAll`'d the partial backup directory.

On Windows this triggers immediately when `library_dir` is set to a drive root, because `System Volume Information` and `WindowsApps` are not readable by the process. The same pattern would break a Linux deployment if any subdirectory under `library_dir` (or `metadata.root_path`) had restrictive permissions. The fix mirrors the tolerant pattern already used in `internal/health/library_sync.go`.

Fixes #609.

## Scope

- Single behavioral change in `internal/metadata/backup_worker.go`.
- New regression test in `internal/metadata/backup_worker_test.go` (skipped on Windows and when running as root, since `chmod`-based denial does not apply there).
- No config, schema, or API changes. Out of scope: optional user-configurable exclusion list and reducing the existing `library_sync.go` log noise.

## Test plan

- [x] `go test -race -run TestBackupWorker ./internal/metadata/...`
- [x] `go vet ./internal/metadata/...`
- [x] `go build ./...`
- [ ] Manual smoke (Linux): point `health.library_dir` at a directory containing a `chmod 000` subdir, trigger a metadata backup, confirm the warning is logged and `files_copied > 0`.