### PR TITLE
fix(config): unify library_sync_concurrency default to 5

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -170,7 +170,7 @@ health:
   segment_sample_percentage: 5 # Percentage of segments to sample for health validation (1-100, default: 5)
   acceptable_missing_segments_percentage: 0 # Percentage of missing segments allowed before a file is marked as corrupted (0-100, default: 0)
   library_sync_interval_minutes: 360 # Library synchronization interval in minutes (default: 360 = 6 hours)
-  library_sync_concurrency: 1 # Number of concurrent library sync operations (default: 1)
+  library_sync_concurrency: 5 # Number of concurrent library sync operations (default: 5)
   resolve_repair_on_import: false # Automatically resolve pending repairs in the same directory when a new file is imported (default: false)
 
 # WebDAV mount path configuration

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -652,11 +652,7 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 		close(done)
 	}()
 
-	// Get concurrency setting (default to 10 if not set)
-	concurrency := cfg.Health.LibrarySyncConcurrency
-	if concurrency <= 0 {
-		concurrency = 10
-	}
+	concurrency := cfg.GetLibrarySyncConcurrency()
 
 	// Create a worker pool for parallel metadata reading
 	p := pool.New().WithMaxGoroutines(concurrency)
@@ -1744,11 +1740,7 @@ func (lsw *LibrarySyncWorker) syncMetadataOnly(ctx context.Context, startTime ti
 	var filesToAdd []database.AutomaticHealthCheckRecord
 	var filesToAddMu sync.Mutex
 
-	// Get concurrency setting (default to 10 if not set)
-	concurrency := cfg.Health.LibrarySyncConcurrency
-	if concurrency <= 0 {
-		concurrency = 10
-	}
+	concurrency := cfg.GetLibrarySyncConcurrency()
 
 	// Create a worker pool for parallel metadata reading
 	p := pool.New().WithMaxGoroutines(concurrency)


### PR DESCRIPTION
## Summary

Fixes [#616](https://github.com/javi11/altmount/issues/616) — the `library_sync_concurrency` default was inconsistent across three locations (sample comment said `1`, the accessor returned `5`, the inline fallbacks at the call sites used `10`).

- Both call sites in `internal/health/library_sync.go` now route through `cfg.GetLibrarySyncConcurrency()` instead of duplicating an inline `<=0 → 10` fallback.
- `config.sample.yaml` comment updated from `default: 1` to `default: 5` to match the accessor.
- The accessor (`internal/config/accessors.go`) is now the single source of truth, returning `5` when unset. This also aligns with the existing example in `docs/docs/3. Configuration/health-monitoring.md`.

## Test plan

- [x] `go build ./internal/health/... ./internal/config/...` — clean
- [x] `go vet ./internal/health/... ./internal/config/...` — clean
- [ ] Confirm reviewer is happy with `5` (vs `10`) as the canonical default