### PR TITLE
fix(arrs): stop queue cleanup worker when arrs is disabled at runtime

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -221,6 +221,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	if err := arrsService.StartWorker(ctx); err != nil {
 		logger.ErrorContext(ctx, "Failed to start ARR queue cleanup worker", "error", err)
 	}
+	arrsService.RegisterConfigChangeHandler(ctx, configManager)
 
 	// Start metadata backup worker
 	metadataBackupWorker := metadata.NewBackupWorker(configManager.GetConfigGetter())

--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -168,6 +168,27 @@ func (s *Service) StopWorker(ctx context.Context) {
 	s.worker.Stop(ctx)
 }
 
+// RegisterConfigChangeHandler subscribes to config changes and starts/stops
+// the queue cleanup worker when arrs.enabled or arrs.queue_cleanup_enabled flips.
+func (s *Service) RegisterConfigChangeHandler(ctx context.Context, configManager *config.Manager) {
+	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
+		oldOn := worker.IsQueueCleanupEnabled(oldConfig)
+		newOn := worker.IsQueueCleanupEnabled(newConfig)
+		if oldOn == newOn {
+			return
+		}
+		if newOn {
+			slog.InfoContext(ctx, "ARR worker enabled via config change, starting")
+			if err := s.worker.Start(ctx); err != nil {
+				slog.ErrorContext(ctx, "Failed to start ARR worker", "error", err)
+			}
+			return
+		}
+		slog.InfoContext(ctx, "ARR worker disabled via config change, stopping")
+		s.worker.Stop(ctx)
+	})
+}
+
 // CleanupQueue checks all ARR instances for importPending items with empty folders
 func (s *Service) CleanupQueue(ctx context.Context) error {
 	return s.worker.CleanupQueue(ctx)

--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -139,10 +139,25 @@ func (w *Worker) safeCleanup() {
 	}
 }
 
+// IsQueueCleanupEnabled reports whether the queue cleanup feature should be
+// active based on the global arrs.enabled and arrs.queue_cleanup_enabled flags.
+func IsQueueCleanupEnabled(cfg *config.Config) bool {
+	if cfg.Arrs.Enabled == nil || !*cfg.Arrs.Enabled {
+		return false
+	}
+	if cfg.Arrs.QueueCleanupEnabled != nil && !*cfg.Arrs.QueueCleanupEnabled {
+		return false
+	}
+	return true
+}
+
 // CleanupQueue checks all ARR instances for importPending items with empty folders
 // and removes them from the queue after deleting the empty folder
 func (w *Worker) CleanupQueue(ctx context.Context) error {
 	cfg := w.configGetter()
+	if !IsQueueCleanupEnabled(cfg) {
+		return nil
+	}
 	instances := w.instances.GetAllInstances()
 
 	for _, instance := range instances {


### PR DESCRIPTION
## Summary

- Toggling `arrs.enabled` (or `arrs.queue_cleanup_enabled`) off via config previously did not stop the already-running queue cleanup worker. It kept ticking on its configured interval and logging `Failed to cleanup Sonarr queue` against the now-disabled Sonarr/Radarr instances.
- Root cause: the gate check lived only in `Worker.Start` (internal/arrs/worker/worker.go); there was no `OnConfigChange` handler for the ARR subsystem, unlike the health subsystem which already does this.
- Fix mirrors the existing pattern in `internal/health/controller.go`:
  - New `Service.RegisterConfigChangeHandler` subscribes to config changes and starts/stops the worker when `arrs.enabled` or `arrs.queue_cleanup_enabled` flips.
  - New exported helper `worker.IsQueueCleanupEnabled(cfg)` centralizes the predicate.
  - Defensive early-return at the top of `Worker.CleanupQueue` so any in-flight tick after a disable no-ops cleanly.
  - Wired the handler in `cmd/altmount/cmd/serve.go` right after `StartWorker`, alongside the other `OnConfigChange` registrations.

## Test plan

- [ ] Start with `arrs.enabled: true` and a reachable Sonarr instance — confirm `ARR queue cleanup worker started` appears.
- [ ] Set `arrs.enabled: false` (config.yaml or UI). Expect `ARR worker disabled via config change, stopping` followed by `ARR queue cleanup worker stopped`, and **no further** `Failed to cleanup Sonarr queue` warnings on subsequent ticks.
- [ ] Toggle back to `true`. Expect `ARR worker enabled via config change, starting` and the worker resumes.
- [ ] Verify the `queue_cleanup_enabled: false` sub-toggle (while `arrs.enabled` stays true) produces the same stop/start behavior.
- [ ] `go build ./...` and `go vet ./...` pass (verified locally).