### PR TITLE
feat(arrs): native SABnzbd form-field auth + Sportarr arr type

### DIFF
--- a/frontend/src/components/config/ArrsConfigSection.tsx
+++ b/frontend/src/components/config/ArrsConfigSection.tsx
@@ -36,6 +36,7 @@ const ARR_TYPES: { type: ArrsType; label: string; color: string; defaultCategory
 	{ type: "lidarr", label: "Lidarr", color: "bg-accent", defaultCategory: "music" },
 	{ type: "readarr", label: "Readarr", color: "bg-info", defaultCategory: "books" },
 	{ type: "whisparr", label: "Whisparr", color: "bg-warning", defaultCategory: "movies" },
+	{ type: "sportarr", label: "Sportarr", color: "bg-success", defaultCategory: "sports" },
 ];
 
 export function ArrsConfigSection({
@@ -164,7 +165,7 @@ export function ArrsConfigSection({
 			category = arrTypeMeta?.defaultCategory || "movies";
 		}
 		const instances = [
-			...(formData[instancesKey] as ArrsInstanceConfig[]),
+			...((formData[instancesKey] as ArrsInstanceConfig[]) || []),
 			{
 				name: newInstance.name,
 				url: newInstance.url,

--- a/frontend/src/components/config/ArrsInstanceCard.tsx
+++ b/frontend/src/components/config/ArrsInstanceCard.tsx
@@ -85,6 +85,8 @@ export function ArrsInstanceCard({
 				return "bg-info";
 			case "whisparr":
 				return "bg-warning";
+			case "sportarr":
+				return "bg-success";
 			default:
 				return "bg-base-300";
 		}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -705,7 +705,7 @@ export interface SABnzbdFormData {
 }
 
 // Arrs configuration types
-export type ArrsType = "radarr" | "sonarr" | "lidarr" | "readarr" | "whisparr";
+export type ArrsType = "radarr" | "sonarr" | "lidarr" | "readarr" | "whisparr" | "sportarr";
 
 // Sync status types
 export type SyncStatus = "idle" | "running" | "cancelling" | "completed" | "failed";
@@ -748,6 +748,7 @@ export interface ArrsConfig {
 	lidarr_instances: ArrsInstanceConfig[];
 	readarr_instances: ArrsInstanceConfig[];
 	whisparr_instances: ArrsInstanceConfig[];
+	sportarr_instances: ArrsInstanceConfig[];
 	queue_cleanup_enabled?: boolean;
 	queue_cleanup_interval_seconds?: number;
 	queue_cleanup_grace_period_minutes?: number;
@@ -785,6 +786,7 @@ export interface ArrsFormData {
 	lidarr_instances: ArrsInstanceConfig[];
 	readarr_instances: ArrsInstanceConfig[];
 	whisparr_instances: ArrsInstanceConfig[];
+	sportarr_instances: ArrsInstanceConfig[];
 	queue_cleanup_enabled?: boolean;
 	queue_cleanup_interval_seconds?: number;
 	queue_cleanup_grace_period_minutes?: number;

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -655,6 +655,8 @@ type ArrsStatsResponse struct {
 	EnabledReadarr   int     `json:"enabled_readarr"`
 	TotalWhisparr    int     `json:"total_whisparr"`
 	EnabledWhisparr  int     `json:"enabled_whisparr"`
+	TotalSportarr    int     `json:"total_sportarr"`
+	EnabledSportarr  int     `json:"enabled_sportarr"`
 	DueForSync       int     `json:"due_for_sync"`
 	LastSync         *string `json:"last_sync"`
 }
@@ -742,7 +744,7 @@ func (s *Server) handleListArrsInstances(c *fiber.Ctx) error {
 //	@Description	Returns a specific ARR instance by type and name.
 //	@Tags			ARRs
 //	@Produce		json
-//	@Param			type	path		string	true	"Instance type (sonarr, radarr, lidarr, readarr, or whisparr)"
+//	@Param			type	path		string	true	"Instance type (sonarr, radarr, lidarr, readarr, whisparr, or sportarr)"
 //	@Param			name	path		string	true	"Instance name"
 //	@Success		200		{object}	APIResponse
 //	@Failure		404		{object}	APIResponse
@@ -854,6 +856,7 @@ func (s *Server) handleGetArrsStats(c *fiber.Ctx) error {
 	// Calculate stats from instances
 	var totalRadarr, enabledRadarr, totalSonarr, enabledSonarr int
 	var totalLidarr, enabledLidarr, totalReadarr, enabledReadarr, totalWhisparr, enabledWhisparr int
+	var totalSportarr, enabledSportarr int
 	for _, instance := range instances {
 		switch instance.Type {
 		case "radarr":
@@ -881,12 +884,17 @@ func (s *Server) handleGetArrsStats(c *fiber.Ctx) error {
 			if instance.Enabled {
 				enabledWhisparr++
 			}
+		case "sportarr":
+			totalSportarr++
+			if instance.Enabled {
+				enabledSportarr++
+			}
 		}
 	}
 
 	response := &ArrsStatsResponse{
-		TotalInstances:   totalRadarr + totalSonarr + totalLidarr + totalReadarr + totalWhisparr,
-		EnabledInstances: enabledRadarr + enabledSonarr + enabledLidarr + enabledReadarr + enabledWhisparr,
+		TotalInstances:   totalRadarr + totalSonarr + totalLidarr + totalReadarr + totalWhisparr + totalSportarr,
+		EnabledInstances: enabledRadarr + enabledSonarr + enabledLidarr + enabledReadarr + enabledWhisparr + enabledSportarr,
 		TotalRadarr:      totalRadarr,
 		EnabledRadarr:    enabledRadarr,
 		TotalSonarr:      totalSonarr,
@@ -897,6 +905,8 @@ func (s *Server) handleGetArrsStats(c *fiber.Ctx) error {
 		EnabledReadarr:   enabledReadarr,
 		TotalWhisparr:    totalWhisparr,
 		EnabledWhisparr:  enabledWhisparr,
+		TotalSportarr:    totalSportarr,
+		EnabledSportarr:  enabledSportarr,
 		DueForSync:       0, // Not applicable with config-first approach
 	}
 

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -48,6 +48,18 @@ func (s *Server) getDefaultCategory() config.SABnzbdCategory {
 	}
 }
 
+// qf returns a request parameter from the query string, falling back to the
+// form body when absent. AltMount historically read auth/mode from the query
+// string only; some SABnzbd clients (e.g. Sportarr) send these as multipart
+// form fields, which is also valid per the SABnzbd API. Query takes precedence
+// so existing query-string clients (Sonarr/Radarr) are unaffected.
+func qf(c *fiber.Ctx, key string) string {
+	if v := c.Query(key); v != "" {
+		return v
+	}
+	return c.FormValue(key)
+}
+
 // handleSABnzbd is the main handler for SABnzbd API endpoints
 func (s *Server) handleSABnzbd(c *fiber.Ctx) error {
 	// Check if SABnzbd API is enabled
@@ -59,9 +71,9 @@ func (s *Server) handleSABnzbd(c *fiber.Ctx) error {
 	}
 
 	// Extract authentication parameters
-	apiKey := c.Query("apikey")
-	maUsername := c.Query("ma_username") // ARR URL
-	maPassword := c.Query("ma_password") // ARR API key
+	apiKey := qf(c, "apikey")
+	maUsername := qf(c, "ma_username") // ARR URL
+	maPassword := qf(c, "ma_password") // ARR API key
 
 	// Determine authentication method
 	authenticated := false
@@ -101,7 +113,7 @@ func (s *Server) handleSABnzbd(c *fiber.Ctx) error {
 	}
 
 	// Get mode parameter to determine which API method to call
-	mode := c.Query("mode")
+	mode := qf(c, "mode")
 	switch mode {
 	case "addfile":
 		return s.handleSABnzbdAddFile(c)

--- a/internal/arrs/clients/manager.go
+++ b/internal/arrs/clients/manager.go
@@ -23,6 +23,7 @@ type Manager struct {
 	lidarrClients   map[string]*lidarr.Lidarr   // key: instance name
 	readarrClients  map[string]*readarr.Readarr // key: instance name
 	whisparrClients map[string]*sonarr.Sonarr   // key: instance name
+	sportarrClients map[string]*Sportarr        // key: instance name (native client)
 }
 
 // NewManager creates an arrs client manager. httpClient is shared with every
@@ -40,6 +41,7 @@ func NewManager(httpClient *http.Client) *Manager {
 		lidarrClients:   make(map[string]*lidarr.Lidarr),
 		readarrClients:  make(map[string]*readarr.Readarr),
 		whisparrClients: make(map[string]*sonarr.Sonarr),
+		sportarrClients: make(map[string]*Sportarr),
 	}
 }
 
@@ -119,6 +121,20 @@ func (m *Manager) GetOrCreateWhisparrClient(instanceName, url, apiKey string) (*
 	return client, nil
 }
 
+// GetOrCreateSportarrClient gets or creates a native Sportarr client for an instance
+func (m *Manager) GetOrCreateSportarrClient(instanceName, url, apiKey string) (*Sportarr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if client, exists := m.sportarrClients[instanceName]; exists {
+		return client, nil
+	}
+
+	client := NewSportarr(url, apiKey, m.httpClient)
+	m.sportarrClients[instanceName] = client
+	return client, nil
+}
+
 // GetOrCreateClient is a helper to get or create the appropriate client
 func (m *Manager) GetOrCreateClient(instance *model.ConfigInstance) (any, error) {
 	switch instance.Type {
@@ -132,6 +148,8 @@ func (m *Manager) GetOrCreateClient(instance *model.ConfigInstance) (any, error)
 		return m.GetOrCreateReadarrClient(instance.Name, instance.URL, instance.APIKey)
 	case "whisparr":
 		return m.GetOrCreateWhisparrClient(instance.Name, instance.URL, instance.APIKey)
+	case "sportarr":
+		return m.GetOrCreateSportarrClient(instance.Name, instance.URL, instance.APIKey)
 	default:
 		return nil, fmt.Errorf("unsupported instance type: %s", instance.Type)
 	}
@@ -179,6 +197,10 @@ func (m *Manager) TestConnection(ctx context.Context, instanceType, url, apiKey 
 			return fmt.Errorf("failed to connect to Whisparr: %w", err)
 		}
 		return nil
+
+	case "sportarr":
+		// Sportarr is not starr-compatible; use the native client's health check.
+		return NewSportarr(url, apiKey, m.httpClient).Health(ctx)
 
 	default:
 		return fmt.Errorf("unsupported instance type: %s", instanceType)

--- a/internal/arrs/clients/sportarr.go
+++ b/internal/arrs/clients/sportarr.go
@@ -1,0 +1,147 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Sportarr is a thin native HTTP client for Sportarr.
+//
+// Unlike Sonarr/Radarr/Lidarr/Readarr/Whisparr, Sportarr is NOT driveable through
+// the golift.io/starr library: its /api/v3 surface is a narrow Sonarr-compat shim
+// where only system/status and indexer are real, while /api/v3/queue and
+// /api/v3/command fall through to the SPA. Sportarr's real, JSON-returning API
+// lives at the unversioned /api/* paths (queue, history, pending-imports), so we
+// talk to those directly here.
+//
+// The main management value AltMount adds for Sportarr is queue cleanup; Sportarr
+// already self-imports finished downloads on its own poll interval.
+type Sportarr struct {
+	baseURL string
+	apiKey  string
+	hc      *http.Client
+}
+
+// SportarrStatusMessage mirrors the Servarr status-message shape used by the
+// queue-cleanup allowlist matching.
+type SportarrStatusMessage struct {
+	Title    string   `json:"title"`
+	Messages []string `json:"messages"`
+}
+
+// SportarrQueueItem maps the fields of a Sportarr native queue record that the
+// queue-cleanup worker needs. Field names follow the Servarr convention; unknown
+// fields are ignored by the JSON decoder.
+type SportarrQueueItem struct {
+	ID                    int64                   `json:"id"`
+	Title                 string                  `json:"title"`
+	Status                string                  `json:"status"`
+	Protocol              string                  `json:"protocol"`
+	DownloadClient        string                  `json:"downloadClient"`
+	OutputPath            string                  `json:"outputPath"`
+	TrackedDownloadStatus string                  `json:"trackedDownloadStatus"`
+	TrackedDownloadState  string                  `json:"trackedDownloadState"`
+	StatusMessages        []SportarrStatusMessage `json:"statusMessages"`
+}
+
+// NewSportarr builds a native Sportarr client. The shared *http.Client carries
+// the manager's proxy/timeout configuration.
+func NewSportarr(baseURL, apiKey string, hc *http.Client) *Sportarr {
+	return &Sportarr{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		hc:      hc,
+	}
+}
+
+func (s *Sportarr) newRequest(ctx context.Context, method, path string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, s.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", s.apiKey)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+
+// Health verifies connectivity using the one /api/v3 endpoint Sportarr implements
+// for real (system/status).
+func (s *Sportarr) Health(ctx context.Context) error {
+	req, err := s.newRequest(ctx, http.MethodGet, "/api/v3/system/status")
+	if err != nil {
+		return err
+	}
+	resp, err := s.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to connect to Sportarr: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Sportarr health check returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// GetQueue returns the current Sportarr queue. Sportarr's native /api/queue may
+// return either a bare JSON array or a paged object with a "records" array, so we
+// tolerate both shapes.
+func (s *Sportarr) GetQueue(ctx context.Context) ([]SportarrQueueItem, error) {
+	req, err := s.newRequest(ctx, http.MethodGet, "/api/queue")
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Sportarr queue: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Sportarr queue request returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Sportarr queue response: %w", err)
+	}
+
+	// Try the bare-array shape first.
+	var items []SportarrQueueItem
+	if err := json.Unmarshal(body, &items); err == nil {
+		return items, nil
+	}
+
+	// Fall back to the paged-object shape.
+	var paged struct {
+		Records []SportarrQueueItem `json:"records"`
+	}
+	if err := json.Unmarshal(body, &paged); err != nil {
+		return nil, fmt.Errorf("failed to decode Sportarr queue response: %w", err)
+	}
+	return paged.Records, nil
+}
+
+// DeleteQueueItem removes a queue item, also instructing Sportarr to remove the
+// download from the (AltMount) download client. It does not blocklist.
+func (s *Sportarr) DeleteQueueItem(ctx context.Context, id int64) error {
+	path := fmt.Sprintf("/api/queue/%d?removeFromClient=true&blocklist=false", id)
+	req, err := s.newRequest(ctx, http.MethodDelete, path)
+	if err != nil {
+		return err
+	}
+	resp, err := s.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to delete Sportarr queue item %d: %w", id, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("404: queue item %d not found", id)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("Sportarr delete queue item %d returned status %d", id, resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -107,6 +107,21 @@ func (m *Manager) GetAllInstances() []*model.ConfigInstance {
 		}
 	}
 
+	// Convert Sportarr instances (native API, not starr-compatible)
+	if len(cfg.Arrs.SportarrInstances) > 0 {
+		for _, sportarrConfig := range cfg.Arrs.SportarrInstances {
+			instance := &model.ConfigInstance{
+				Name:     sportarrConfig.Name,
+				Type:     "sportarr",
+				URL:      sportarrConfig.URL,
+				APIKey:   sportarrConfig.APIKey,
+				Category: sportarrConfig.Category,
+				Enabled:  sportarrConfig.Enabled != nil && *sportarrConfig.Enabled,
+			}
+			instances = append(instances, instance)
+		}
+	}
+
 	return instances
 }
 
@@ -226,6 +241,8 @@ func (m *Manager) RegisterInstance(ctx context.Context, arrURL, apiKey string) (
 		newConfig.Arrs.ReadarrInstances = append(newConfig.Arrs.ReadarrInstances, newInstance)
 	case "whisparr":
 		newConfig.Arrs.WhisparrInstances = append(newConfig.Arrs.WhisparrInstances, newInstance)
+	case "sportarr":
+		newConfig.Arrs.SportarrInstances = append(newConfig.Arrs.SportarrInstances, newInstance)
 	}
 
 	// Create category for this ARR type
@@ -394,6 +411,8 @@ func (m *Manager) categoryUsedByOtherInstance(arrType, category string) bool {
 		instances = cfg.Arrs.ReadarrInstances
 	case "whisparr":
 		instances = cfg.Arrs.WhisparrInstances
+	case "sportarr":
+		instances = cfg.Arrs.SportarrInstances
 	}
 
 	for _, instance := range instances {
@@ -410,6 +429,8 @@ func (m *Manager) categoryUsedByOtherInstance(arrType, category string) bool {
 				instanceCat = "books"
 			case "whisparr":
 				instanceCat = "movies"
+			case "sportarr":
+				instanceCat = "sports"
 			}
 		}
 

--- a/internal/arrs/model/types.go
+++ b/internal/arrs/model/types.go
@@ -15,7 +15,7 @@ var (
 // ConfigInstance represents an arrs instance from configuration
 type ConfigInstance struct {
 	Name     string `json:"name"`
-	Type     string `json:"type"` // "radarr", "sonarr", "lidarr", "readarr", or "whisparr"
+	Type     string `json:"type"` // "radarr", "sonarr", "lidarr", "readarr", "whisparr", or "sportarr"
 	URL      string `json:"url"`
 	APIKey   string `json:"api_key"`
 	Category string `json:"category"`

--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -272,6 +272,15 @@ func (s *Service) GetHealth(ctx context.Context) (map[string]any, error) {
 			if err == nil {
 				_ = client.GetInto(ctx, starr.Request{URI: "/health"}, &health)
 			}
+		case "sportarr":
+			// Sportarr is not starr-compatible; report reachability via its native
+			// status endpoint rather than a starr /health call.
+			client, err := s.clients.GetOrCreateSportarrClient(instance.Name, instance.URL, instance.APIKey)
+			if err == nil {
+				if hErr := client.Health(ctx); hErr == nil {
+					health = []any{} // healthy: no issues reported
+				}
+			}
 		}
 		if health != nil {
 			results[instance.Name] = health

--- a/internal/arrs/worker/worker.go
+++ b/internal/arrs/worker/worker.go
@@ -176,6 +176,11 @@ func (w *Worker) CleanupQueue(ctx context.Context) error {
 				slog.WarnContext(ctx, "Failed to cleanup Sonarr queue",
 					"instance", instance.Name, "error", err)
 			}
+		case "sportarr":
+			if err := w.cleanupSportarrQueue(ctx, instance, cfg); err != nil {
+				slog.WarnContext(ctx, "Failed to cleanup Sportarr queue",
+					"instance", instance.Name, "error", err)
+			}
 		}
 	}
 
@@ -435,6 +440,125 @@ func (w *Worker) cleanupSonarrQueue(ctx context.Context, instance *model.ConfigI
 			}
 		}
 		slog.InfoContext(ctx, "Cleaned up Sonarr queue items",
+			"instance", instance.Name, "count", len(idsToRemove))
+	}
+	return nil
+}
+
+// cleanupSportarrQueue mirrors cleanupSonarrQueue but talks to Sportarr's native
+// API via the thin client (Sportarr is not starr-compatible). It reuses the same
+// ghost-detection, allowlist and grace-period logic.
+func (w *Worker) cleanupSportarrQueue(ctx context.Context, instance *model.ConfigInstance, cfg *config.Config) error {
+	client, err := w.clients.GetOrCreateSportarrClient(instance.Name, instance.URL, instance.APIKey)
+	if err != nil {
+		return fmt.Errorf("failed to get Sportarr client: %w", err)
+	}
+
+	queue, err := client.GetQueue(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get Sportarr queue: %w", err)
+	}
+
+	var idsToRemove []int64
+	for _, q := range queue {
+		// Only operate on queue items owned by AltMount's registered download client.
+		// Items from other clients may reference paths AltMount cannot see and must
+		// never be touched — see issue #523.
+		if q.DownloadClient != registrar.AltmountDownloadClientName {
+			continue
+		}
+
+		// Strategy 1: Immediate cleanup for already imported files
+		if w.checkGhostByImportHistory(ctx, q.OutputPath, cfg, instance.Name, q.Title) {
+			idsToRemove = append(idsToRemove, q.ID)
+			continue
+		}
+
+		// Fallback: path-gone check with safety guards
+		if w.isGhostByPathGone(ctx, q.OutputPath, q.ID, cfg, instance.Name, q.Title) {
+			idsToRemove = append(idsToRemove, q.ID)
+			continue
+		}
+
+		// Strategy 2: Graceful cleanup for blocked/failed imports
+		if q.Status != "completed" || q.TrackedDownloadStatus != "warning" || (q.TrackedDownloadState != "importPending" && q.TrackedDownloadState != "importBlocked") {
+			continue
+		}
+
+		// Check if path is within managed directories (import_dir, mount_path, or complete_dir)
+		if !w.isPathManaged(q.OutputPath, cfg) {
+			continue
+		}
+
+		// Check status messages for known issues
+		shouldCleanup := false
+		for _, msg := range q.StatusMessages {
+			allMessages := strings.Join(msg.Messages, " ")
+
+			// Automatic import failure cleanup (configurable)
+			if cfg.Arrs.CleanupAutomaticImportFailure != nil && *cfg.Arrs.CleanupAutomaticImportFailure &&
+				strings.Contains(allMessages, "Automatic import is not possible") {
+				shouldCleanup = true
+				break
+			}
+
+			// Check configured allowlist
+			for _, allowedMsg := range cfg.Arrs.QueueCleanupAllowlist {
+				if allowedMsg.Enabled && (strings.Contains(allMessages, allowedMsg.Message) || strings.Contains(msg.Title, allowedMsg.Message)) {
+					shouldCleanup = true
+					break
+				}
+			}
+
+			if shouldCleanup {
+				break
+			}
+		}
+
+		key := fmt.Sprintf("%s|%d", instance.Name, q.ID)
+		if shouldCleanup {
+			w.firstSeenMu.Lock()
+			seenTime, exists := w.firstSeen[key]
+			if !exists {
+				w.firstSeen[key] = time.Now()
+				w.firstSeenMu.Unlock()
+				slog.DebugContext(ctx, "First saw failed import pending item, starting grace period",
+					"path", q.OutputPath, "title", q.Title, "instance", instance.Name)
+				continue
+			}
+			w.firstSeenMu.Unlock()
+
+			gracePeriod := time.Duration(cfg.Arrs.QueueCleanupGracePeriodMinutes) * time.Minute
+			if time.Since(seenTime) < gracePeriod {
+				continue
+			}
+
+			slog.InfoContext(ctx, "Found failed import pending item after grace period",
+				"path", q.OutputPath, "title", q.Title, "instance", instance.Name)
+			idsToRemove = append(idsToRemove, q.ID)
+
+			w.firstSeenMu.Lock()
+			delete(w.firstSeen, key)
+			w.firstSeenMu.Unlock()
+		} else {
+			w.firstSeenMu.Lock()
+			delete(w.firstSeen, key)
+			w.firstSeenMu.Unlock()
+		}
+	}
+
+	if len(idsToRemove) > 0 {
+		for _, id := range idsToRemove {
+			if err := client.DeleteQueueItem(ctx, id); err != nil {
+				if strings.Contains(err.Error(), "404") {
+					slog.DebugContext(ctx, "Queue item already removed from Sportarr", "id", id)
+				} else {
+					slog.ErrorContext(ctx, "Failed to delete queue item",
+						"id", id, "error", err)
+				}
+			}
+		}
+		slog.InfoContext(ctx, "Cleaned up Sportarr queue items",
 			"instance", instance.Name, "count", len(idsToRemove))
 	}
 	return nil

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -436,6 +436,7 @@ type ArrsConfig struct {
 	LidarrInstances                []ArrsInstanceConfig `yaml:"lidarr_instances" mapstructure:"lidarr_instances" json:"lidarr_instances"`
 	ReadarrInstances               []ArrsInstanceConfig `yaml:"readarr_instances" mapstructure:"readarr_instances" json:"readarr_instances"`
 	WhisparrInstances              []ArrsInstanceConfig `yaml:"whisparr_instances" mapstructure:"whisparr_instances" json:"whisparr_instances"`
+	SportarrInstances              []ArrsInstanceConfig `yaml:"sportarr_instances" mapstructure:"sportarr_instances" json:"sportarr_instances"`
 	QueueCleanupEnabled            *bool                `yaml:"queue_cleanup_enabled" mapstructure:"queue_cleanup_enabled" json:"queue_cleanup_enabled,omitempty"`
 	QueueCleanupIntervalSeconds    int                  `yaml:"queue_cleanup_interval_seconds" mapstructure:"queue_cleanup_interval_seconds" json:"queue_cleanup_interval_seconds,omitempty"`
 	CleanupAutomaticImportFailure  *bool                `yaml:"cleanup_automatic_import_failure" mapstructure:"cleanup_automatic_import_failure" json:"cleanup_automatic_import_failure,omitempty"`
@@ -1483,6 +1484,7 @@ func DefaultConfig(configDir ...string) *Config {
 			LidarrInstances:                []ArrsInstanceConfig{},
 			ReadarrInstances:               []ArrsInstanceConfig{},
 			WhisparrInstances:              []ArrsInstanceConfig{},
+			SportarrInstances:              []ArrsInstanceConfig{},
 			CleanupAutomaticImportFailure:  &cleanupAutomaticImportFailure,
 			QueueCleanupGracePeriodMinutes: 10, // Default to 10 minutes
 			QueueCleanupAllowlist: []IgnoredMessage{


### PR DESCRIPTION
Part A — fix SABnzbd auth for clients that send params as form fields. handleSABnzbd read apikey/ma_username/ma_password/mode from the query string only, so SAB clients like Sportarr (which post these as multipart form fields) failed auth with "Authentication required". Add a qf() helper that falls back to the form body; query still takes precedence so existing query-string clients (Sonarr/Radarr) are unaffected.

Part B — add Sportarr as a first-class arr type. Sportarr is not driveable through golift/starr (its /api/v3 queue/command fall through to the SPA), so introduce a thin native HTTP client (Health, GetQueue, DeleteQueueItem) against Sportarr's real /api/* endpoints. Wire it through config, the instances/clients managers, the queue-cleanup worker (mirrors the Sonarr path incl. download-client filter, ghost detection, allowlist and grace period), service health, API stats, and the arrs management UI. Scanner and registrar treat sportarr as a graceful no-op: Sportarr self-imports finished downloads and its download client is configured manually.