### PR TITLE
fix(api): broadcast SSE queue-changed events from SABnzbd handlers

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"mime"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -167,6 +167,10 @@ func (s *Server) handleSABnzbdSwitch(c *fiber.Ctx) error {
 	id, err := strconv.ParseInt(value, 10, 64)
 	if err == nil {
 		if err := s.queueRepo.UpdateQueueItemPriority(c.Context(), id, priority); err == nil {
+			// When priority is updated by ID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdResponse{Status: true})
 		}
 	}
@@ -176,6 +180,10 @@ func (s *Server) handleSABnzbdSwitch(c *fiber.Ctx) error {
 		item, err := s.queueRepo.GetQueueItemByDownloadID(c.Context(), value)
 		if err == nil && item != nil {
 			if err := s.queueRepo.UpdateQueueItemPriority(c.Context(), item.ID, priority); err == nil {
+				// When priority is updated by DownloadID, notify web UI of queue change
+				if s.progressBroadcaster != nil {
+					s.progressBroadcaster.BroadcastQueueChanged()
+				}
 				return s.writeSABnzbdResponseFiber(c, SABnzbdResponse{Status: true})
 			}
 		}
@@ -226,6 +234,10 @@ func (s *Server) handleSABnzbdQueuePause(c *fiber.Ctx, pause bool) error {
 		}
 	}
 
+	// When an item is paused or resumed, notify web UI of queue change
+	if s.progressBroadcaster != nil {
+		s.progressBroadcaster.BroadcastQueueChanged()
+	}
 	return s.writeSABnzbdResponseFiber(c, SABnzbdResponse{Status: true})
 }
 
@@ -694,6 +706,10 @@ func (s *Server) handleSABnzbdQueueDelete(c *fiber.Ctx) error {
 			_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), id)
 			_, _ = s.queueRepo.RemoveFromHistory(c.Context(), id)
 
+			// When a queue item is deleted by ID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 	}
@@ -712,6 +728,10 @@ func (s *Server) handleSABnzbdQueueDelete(c *fiber.Ctx) error {
 				_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), item.ID)
 			}
 
+			// When a queue item is deleted by DownloadID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 	}
@@ -1087,6 +1107,10 @@ func (s *Server) handleSABnzbdHistoryDelete(c *fiber.Ctx) error {
 		if err == nil {
 			_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), id)
 			_, _ = s.queueRepo.RemoveFromHistory(c.Context(), id)
+			// When a history item is deleted by queue ID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 
@@ -1094,11 +1118,19 @@ func (s *Server) handleSABnzbdHistoryDelete(c *fiber.Ctx) error {
 		// Try by original NzbID first
 		affected, histErr := s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), id)
 		if histErr == nil && affected > 0 {
+			// When a history item is deleted by NZB ID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 
 		affected, histErr = s.queueRepo.RemoveFromHistory(c.Context(), id)
 		if histErr == nil && affected > 0 {
+			// When a history item is deleted by history ID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 	}
@@ -1116,11 +1148,19 @@ func (s *Server) handleSABnzbdHistoryDelete(c *fiber.Ctx) error {
 			if item != nil {
 				_, _ = s.queueRepo.RemoveFromHistoryByNzbID(c.Context(), item.ID)
 			}
+			// When a history item is deleted by DownloadID, notify web UI of queue change
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 
 		// If item was found in queue but not in history, consider it handled
 		if item != nil {
+			// When a queue item is removed by DownloadID during history delete, notify web UI
+			if s.progressBroadcaster != nil {
+				s.progressBroadcaster.BroadcastQueueChanged()
+			}
 			return s.writeSABnzbdResponseFiber(c, SABnzbdDeleteResponse{Status: true})
 		}
 	}


### PR DESCRIPTION
### Problem

When an item finishes processing and *arr imports it, *arr removes the item from the queue via AltMount's SABnzbd-compatible API (mode=queue&name=delete or mode=history&name=delete). However, the web UI doesn't get notified of this deletion, so the item stays visible in the queue view until the user manually refreshes.
The same issue occurs for pause/resume and queue reordering operations initiated by ARR apps via the SABnzbd API.
### Root Cause
The SABnzbd API handlers in internal/api/sabnzbd_handlers.go delete/update queue items in the database but never call BroadcastQueueChanged() to notify SSE subscribers. The frontend's useQueueStream hook relies on these SSE events to trigger refetch() and update the queue view.

Affected handlers:
- `handleSABnzbdQueueDelete` - removes items from queue but doesn't broadcast
- `handleSABnzbdHistoryDelete` - removes items from history but doesn't broadcast
- `handleSABnzbdSwitch` - changes queue priority but doesn't broadcast
- `handleSABnzbdQueuePause` - pauses/resumes items but doesn't broadcast
### Fix
Added `s.progressBroadcaster.BroadcastQueueChanged()` calls after every successful mutation in the SABnzbd API handlers.
Files changed:
- `internal/api/sabnzbd_handlers.go` — Added SSE broadcasts to queue delete, history delete, switch, and pause/resume handlers
### Flow after fix
1. AltMount finishes processing, item shows as "completed" in queue
2. *arr imports the file, then calls mode=queue&name=delete to remove it
3. Handler deletes the item and broadcasts QueueChanged SSE event
4. Frontend receives SSE, calls refetch(), item disappears from view
Note on failed items
Failed items are intentionally retained in the queue for a configurable retention period (failed_item_retention_hours, default 24h), after which a periodic cleanup job removes them. This behavior is unchanged.