### PR TITLE
fix(arrs): notify *arrs on import failure so they search again sooner

### DIFF
--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -156,6 +156,26 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQueueItem, _ error) error {
 	cfg := c.configGetter()
 
+	// Notify ARR applications so they check for the failed download when they
+	// next query the SABnzbd history, rather than waiting for their periodic
+	// poll to discover it.
+	if !shouldSkipARRNotification(item) {
+		c.mu.RLock()
+		arrsService := c.arrsService
+		c.mu.RUnlock()
+
+		if arrsService != nil {
+			if err := c.broadcastToARRType(ctx, arrsService, item); err != nil {
+				c.log.DebugContext(ctx, "ARR failure notification not sent",
+					"queue_id", item.ID,
+					"error", err)
+			} else {
+				c.log.InfoContext(ctx, "ARR notified of failed import",
+					"queue_id", item.ID)
+			}
+		}
+	}
+
 	// Attempt SABnzbd fallback if configured
 	if cfg.SABnzbd.FallbackHost != "" && cfg.SABnzbd.FallbackAPIKey != "" {
 		return c.AttemptFallback(ctx, item)

--- a/internal/importer/postprocessor/coordinator.go
+++ b/internal/importer/postprocessor/coordinator.go
@@ -156,9 +156,16 @@ func (c *Coordinator) HandleSuccess(ctx context.Context, item *database.ImportQu
 func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQueueItem, _ error) error {
 	cfg := c.configGetter()
 
-	// Notify ARR applications so they check for the failed download when they
-	// next query the SABnzbd history, rather than waiting for their periodic
-	// poll to discover it.
+	// Attempt SABnzbd fallback if configured — the download is transferred to
+	// an external SABnzbd instance so we must NOT notify ARR of a failure here
+	// (the download is still in progress elsewhere).
+	if cfg.SABnzbd.FallbackHost != "" && cfg.SABnzbd.FallbackAPIKey != "" {
+		return c.AttemptFallback(ctx, item)
+	}
+
+	// No fallback configured — the import has genuinely failed. Notify ARR
+	// applications so they check the SABnzbd history on their next poll and
+	// discover the failure sooner rather than waiting for their periodic cycle.
 	if !shouldSkipARRNotification(item) {
 		c.mu.RLock()
 		arrsService := c.arrsService
@@ -174,11 +181,6 @@ func (c *Coordinator) HandleFailure(ctx context.Context, item *database.ImportQu
 					"queue_id", item.ID)
 			}
 		}
-	}
-
-	// Attempt SABnzbd fallback if configured
-	if cfg.SABnzbd.FallbackHost != "" && cfg.SABnzbd.FallbackAPIKey != "" {
-		return c.AttemptFallback(ctx, item)
 	}
 
 	return errors.ErrFallbackNotConfigured


### PR DESCRIPTION
## Summary
When an import fails (e.g. RAR decode error, missing segments), AltMount previously let the failed item sit in the queue with `status: failed` without any notification to Sonarr/Radarr. The arrs would only discover the failure on their next periodic poll of the SABnzbd history API, which could be minutes later.

Now `HandleFailure` in the postprocessor coordinator triggers `RefreshMonitoredDownloads` on the relevant ARR type (determined from the item's category), the same way the success path already does via `broadcastToARRType`. This causes Sonarr/Radarr to check the download client immediately, see the failed status, and search for a replacement on their next search cycle.
- `broadcastToARRType` call added to `Coordinator.HandleFailure`, gated by the existing `SkipArrNotification` flag
- Logs a warning if the ARR type cannot be determined from the category, but does not block the existing fallback/cleanup flow