### PR TITLE
fix(logging): apply log level changes dynamically without restart

### DIFF
--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -57,7 +57,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	}
 
 	// Setup logging
-	logger := slogutil.SetupLogRotationWithFallback(cfg.Log, cfg.Log.Level)
+	logger, dynamicLeveler := slogutil.SetupLogRotationWithFallback(cfg.Log, cfg.Log.Level)
 	slog.SetDefault(logger)
 
 	// 2. Create context and managers
@@ -169,7 +169,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 	// 7. Register config change handlers
 	pool.RegisterConfigHandlers(ctx, configManager, poolManager)
 	webdav.RegisterConfigHandlers(ctx, configManager, webdavHandler)
-	api.RegisterLogLevelHandler(ctx, configManager, debugMode)
+	api.RegisterLogLevelHandler(ctx, configManager, debugMode, dynamicLeveler)
 	apiServer.RegisterFuseConfigChangeHandler(configManager)
 
 	// Register segment cache config change handler for dynamic path/size/expiry changes.

--- a/internal/api/config_handlers.go
+++ b/internal/api/config_handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/slogutil"
 	"github.com/javi11/nntppool/v4"
 )
 
@@ -45,13 +46,6 @@ func parseLogLevel(level string) slog.Level {
 	}
 }
 
-// ApplyLogLevel applies the log level to the global logger
-func ApplyLogLevel(level string) {
-	if level != "" {
-		slog.SetLogLoggerLevel(parseLogLevel(level))
-	}
-}
-
 // getEffectiveLogLevel returns the effective log level, preferring new config over legacy
 func getEffectiveLogLevel(newLevel, legacyLevel string) string {
 	if newLevel != "" {
@@ -64,7 +58,7 @@ func getEffectiveLogLevel(newLevel, legacyLevel string) string {
 }
 
 // RegisterLogLevelHandler registers handler for log level configuration changes
-func RegisterLogLevelHandler(ctx context.Context, configManager *config.Manager, debugMode *bool) {
+func RegisterLogLevelHandler(ctx context.Context, configManager *config.Manager, debugMode *bool, dynamicLeveler *slogutil.DynamicLeveler) {
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
 		// Determine old and new log levels
 		oldLevel := getEffectiveLogLevel(oldConfig.Log.Level, oldConfig.Log.Level)
@@ -72,7 +66,7 @@ func RegisterLogLevelHandler(ctx context.Context, configManager *config.Manager,
 
 		// Apply log level change if it changed
 		if oldLevel != newLevel {
-			ApplyLogLevel(newLevel)
+			dynamicLeveler.SetLevel(parseLogLevel(newLevel))
 			// Update Fiber logger debug mode
 			*debugMode = newLevel == "debug"
 			slog.InfoContext(ctx, "Log level updated dynamically",

--- a/internal/slogutil/config.go
+++ b/internal/slogutil/config.go
@@ -119,7 +119,8 @@ func GetLogFilePath(logConfig config.LogConfig) string {
 // SetupLogRotation configures slog with log rotation using lumberjack.
 // Always logs to both stdout (text format) and a file (JSON format).
 // The file path defaults to "activity.log" if logConfig.File is empty.
-func SetupLogRotation(logConfig config.LogConfig) *slog.Logger {
+// Returns the logger and a DynamicLeveler for runtime level changes.
+func SetupLogRotation(logConfig config.LogConfig) (*slog.Logger, *DynamicLeveler) {
 	logFile := GetLogFilePath(logConfig)
 
 	fileWriter := &lumberjack.Logger{
@@ -136,8 +137,11 @@ func SetupLogRotation(logConfig config.LogConfig) *slog.Logger {
 		level = "info"
 	}
 
+	dynamicLeveler := &DynamicLeveler{}
+	dynamicLeveler.SetLevel(parseLevel(level).Level())
+
 	opts := &slog.HandlerOptions{
-		Level: parseLevel(level),
+		Level: dynamicLeveler,
 	}
 
 	// Text handler for human-readable stdout, JSON handler for machine-readable file.
@@ -146,12 +150,12 @@ func SetupLogRotation(logConfig config.LogConfig) *slog.Logger {
 
 	combined := multiHandler{handlers: []slog.Handler{textHandler, jsonHandler}}
 
-	return slog.New(WrapHandler(combined))
+	return slog.New(WrapHandler(combined)), dynamicLeveler
 }
 
 // SetupLogRotationWithFallback sets up log rotation with backward compatibility
 // It checks both new log config and legacy log_level setting
-func SetupLogRotationWithFallback(logConfig config.LogConfig, legacyLogLevel string) *slog.Logger {
+func SetupLogRotationWithFallback(logConfig config.LogConfig, legacyLogLevel string) (*slog.Logger, *DynamicLeveler) {
 	// Use legacy log level if new config level is empty
 	if logConfig.Level == "" && legacyLogLevel != "" {
 		logConfig.Level = legacyLogLevel


### PR DESCRIPTION
**Description:**
The DynamicLeveler in slogutil has existed since day one but was never wired into the logger setup. Log level changes from the config UI required a full application restart to take effect. Under the hood, SetupLogRotation was baking a static slog.Level value into HandlerOptions, and the registered change handler was calling slog.SetLogLoggerLevel — which only affects the package-level default logger, not the custom handlers.

**Changes:**
- `internal/slogutil/config.go`: SetupLogRotation and SetupLogRotationWithFallback now return a *DynamicLeveler alongside the logger. Both the text and JSON handlers reference the DynamicLeveler as their Leveler, so level changes propagate atomically to all active handlers via atomic.Value.
- `internal/api/config_handlers.go`: RegisterLogLevelHandler now accepts a *slogutil.DynamicLeveler parameter and calls SetLevel() on it when the config changes. Removed the now-unused ApplyLogLevel function.
- `cmd/altmount/cmd/serve.go`: Captures the DynamicLeveler from SetupLogRotationWithFallback and threads it to RegisterLogLevelHandler.

**Testing:** 
Built locally, deployed to the altmount pod. Services initialized cleanly. NNTP pool, queue workers, health checks all started without error. Was able to dynamically change logging levels without restarting the application.