### PR TITLE
feat(health): restore indexer tracking from webhook Grab and OnImport events

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -85,6 +85,11 @@ type ArrsWebhookRequest struct {
 		Path      string `json:"path"`
 	} `json:"episodeFile"`
 	DeletedFiles ArrsDeletedFiles `json:"deletedFiles,omitempty"`
+	DownloadId   string           `json:"downloadId,omitempty"`
+	Release      *struct {
+		Indexer      string `json:"indexer,omitempty"`
+		ReleaseTitle string `json:"releaseTitle,omitempty"`
+	} `json:"release,omitempty"`
 }
 
 func (req ArrsWebhookRequest) ToMetadata() model.WebhookMetadata {
@@ -244,6 +249,21 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 	case "Test":
 		slog.InfoContext(c.Context(), "Received ARR test webhook")
 		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Test successful"})
+	case "Grab":
+		if req.DownloadId != "" && req.Release != nil && req.Release.Indexer != "" {
+			indexerName := req.Release.Indexer
+			releaseTitle := req.Release.ReleaseTitle
+			s.importerService.StoreGrabbedIndexer(req.DownloadId, releaseTitle, indexerName)
+			slog.InfoContext(c.Context(), "Logged grabbed indexer from webhook", "download_id", req.DownloadId, "release_title", releaseTitle, "indexer", indexerName)
+			// Proactively update any existing queue item with this download ID
+			if err := s.queueRepo.UpdateQueueItemIndexerByDownloadID(c.Context(), req.DownloadId, indexerName); err != nil {
+				slog.WarnContext(c.Context(), "Failed to update indexer for existing queue item", "download_id", req.DownloadId, "indexer", indexerName, "error", err)
+			}
+			// In case the import already completed or failed (e.g. race condition), update history and stats
+			_ = s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName)
+			_ = s.queueRepo.UpdateIndexerStatsByDownloadID(c.Context(), req.DownloadId, indexerName)
+		}
+		return c.Status(200).JSON(fiber.Map{"success": true, "message": "Grab logged successfully"})
 	case "Download", "AlbumImport", "BookImport": // OnImport
 		isScanEvent = true
 		if req.EpisodeFile.Path != "" {
@@ -252,6 +272,21 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			pathsToScan = append(pathsToScan, req.MovieFile.Path)
 		} else if req.FilePath != "" {
 			pathsToScan = append(pathsToScan, req.FilePath)
+		}
+
+		// Update indexer name in database tables if present in webhook
+		if req.DownloadId != "" && req.Release != nil && req.Release.Indexer != "" {
+			indexerName := req.Release.Indexer
+			slog.InfoContext(c.Context(), "Logged indexer from OnImport webhook", "download_id", req.DownloadId, "indexer", indexerName)
+
+			// 1. Update queue if it still exists
+			_ = s.queueRepo.UpdateQueueItemIndexerByDownloadID(c.Context(), req.DownloadId, indexerName)
+
+			// 2. Update import history if it has already completed
+			_ = s.queueRepo.UpdateImportHistoryIndexerByDownloadID(c.Context(), req.DownloadId, indexerName)
+
+			// 3. Update indexer_import_stats from Unknown to actual indexer
+			_ = s.queueRepo.UpdateIndexerStatsByDownloadID(c.Context(), req.DownloadId, indexerName)
 		}
 	case "Rename":
 		isScanEvent = true
@@ -615,9 +650,18 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 				metadataStr = &str
 			}
 
+			var indexer *string = nil
+			if req.Release != nil && req.Release.Indexer != "" {
+				indexer = &req.Release.Indexer
+			} else if req.DownloadId != "" {
+				if idxName, ok := s.importerService.GetGrabbedIndexer(req.DownloadId, ""); ok {
+					indexer = &idxName
+				}
+			}
+
 			// Add to health check (pending status) with high priority (Next) to ensure it's processed right away
 			cfg := s.configManager.GetConfigGetter()()
-			err = s.healthRepo.AddFileToHealthCheckWithMetadata(c.Context(), normalizedPath, &path, cfg.GetMaxRetries(), cfg.GetMaxRepairRetries(), sourceNzb, database.HealthPriorityNext, releaseDate, metadataStr, nil)
+			err = s.healthRepo.AddFileToHealthCheckWithMetadata(c.Context(), normalizedPath, &path, cfg.GetMaxRetries(), cfg.GetMaxRepairRetries(), sourceNzb, database.HealthPriorityNext, releaseDate, metadataStr, indexer)
 			if err != nil {
 				slog.ErrorContext(c.Context(), "Failed to add webhook file to health check", "path", normalizedPath, "error", err)
 			} else {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -208,6 +208,7 @@ type Service struct {
 	// HandleFailure can clean them up without changing the ItemProcessor interface.
 	// Keys are item.ID (int64), values are []string.
 	writtenPathsCache sync.Map
+	grabbedIndexers   sync.Map
 }
 
 // NewService creates a new NZB import service with manual scanning and queue processing capabilities
@@ -684,6 +685,14 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 		itemPriority = *priority
 	}
 
+	// Lookup indexer from grabbedIndexers (Webhook-provided)
+	var indexerName *string = nil
+	if downloadID != nil && *downloadID != "" {
+		if name, ok := s.GetGrabbedIndexer(*downloadID, filepath.Base(filePath)); ok {
+			indexerName = &name
+		}
+	}
+
 	item := &database.ImportQueueItem{
 		DownloadID:   downloadID,
 		NzbPath:      filePath,
@@ -695,6 +704,7 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 		MaxRetries:   3,
 		FileSize:     fileSize,
 		Metadata:     metadata,
+		Indexer:      indexerName,
 		CreatedAt:    time.Now(),
 	}
 
@@ -1022,6 +1032,22 @@ func (s *Service) resolveCategoryPath(category string) string {
 
 // handleProcessingSuccess handles all steps after successful NZB processing
 func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.ImportQueueItem, resultingPath string) error {
+	// Log persistent indexer statistic
+	indexerName := "Unknown"
+	if item.Indexer != nil && *item.Indexer != "" {
+		indexerName = *item.Indexer
+	}
+	if (indexerName == "Unknown" || indexerName == "") && item.DownloadID != nil && *item.DownloadID != "" {
+		if latestItem, err := s.database.Repository.GetQueueItemByDownloadID(ctx, *item.DownloadID); err == nil && latestItem != nil && latestItem.Indexer != nil && *latestItem.Indexer != "" {
+			indexerName = *latestItem.Indexer
+		} else if name, ok := s.GetGrabbedIndexer(*item.DownloadID, filepath.Base(item.NzbPath)); ok {
+			indexerName = name
+		}
+	}
+	if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "success", "", item.DownloadID); err != nil {
+		s.log.WarnContext(ctx, "Failed to log indexer success statistic", "indexer", indexerName, "error", err)
+	}
+
 	// Add storage path to database
 	if err := s.database.Repository.AddStoragePath(ctx, item.ID, resultingPath); err != nil {
 		s.log.ErrorContext(ctx, "Failed to add storage path", "queue_id", item.ID, "error", err)
@@ -1128,6 +1154,25 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 // handleProcessingFailure handles when processing fails
 func (s *Service) handleProcessingFailure(ctx context.Context, item *database.ImportQueueItem, processingErr error) {
 	errorMessage := processingErr.Error()
+
+	// Log persistent indexer statistic
+	indexerName := "Unknown"
+	if item.Indexer != nil && *item.Indexer != "" {
+		indexerName = *item.Indexer
+	}
+	if (indexerName == "Unknown" || indexerName == "") && item.DownloadID != nil && *item.DownloadID != "" {
+		if latestItem, err := s.database.Repository.GetQueueItemByDownloadID(ctx, *item.DownloadID); err == nil && latestItem != nil && latestItem.Indexer != nil && *latestItem.Indexer != "" {
+			indexerName = *latestItem.Indexer
+		} else if name, ok := s.GetGrabbedIndexer(*item.DownloadID, filepath.Base(item.NzbPath)); ok {
+			indexerName = name
+		}
+	}
+	// Don't log if it was just cancelled by the user
+	if !strings.Contains(errorMessage, "context canceled") && !strings.Contains(errorMessage, "processing cancelled") {
+		if err := s.database.Repository.LogIndexerImport(ctx, indexerName, "failed", errorMessage, item.DownloadID); err != nil {
+			s.log.WarnContext(ctx, "Failed to log indexer failure statistic", "indexer", indexerName, "error", err)
+		}
+	}
 
 	// Check if the error was due to cancellation
 	if strings.Contains(errorMessage, "context canceled") || strings.Contains(errorMessage, "processing cancelled") {
@@ -1503,4 +1548,64 @@ func (s *Service) RegenerateMetadata(ctx context.Context, mountRelativePath stri
 
 	s.log.InfoContext(ctx, "Successfully regenerated metadata", "path", mountRelativePath)
 	return nil
+}
+
+type grabbedIndexerInfo struct {
+	indexer   string
+	timestamp time.Time
+}
+
+// StoreGrabbedIndexer stores a downloadID to indexer mapping in-memory
+func (s *Service) StoreGrabbedIndexer(downloadID string, releaseTitle string, indexer string) {
+	info := grabbedIndexerInfo{
+		indexer:   indexer,
+		timestamp: time.Now(),
+	}
+
+	if downloadID != "" {
+		s.grabbedIndexers.Store(downloadID, info)
+	}
+	// Sanitize and use release title as an alternative fallback key
+	if releaseTitle != "" {
+		cleanTitle := strings.TrimSpace(strings.ToLower(releaseTitle))
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".gz")
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".nzb")
+		s.grabbedIndexers.Store(cleanTitle, info)
+	}
+}
+
+// GetGrabbedIndexer retrieves a grabbed indexer by download ID or release title
+// It only returns a match if it was stored within the last 15 seconds.
+func (s *Service) GetGrabbedIndexer(downloadID string, releaseTitle string) (string, bool) {
+	now := time.Now()
+
+	check := func(key string) (string, bool) {
+		if val, ok := s.grabbedIndexers.Load(key); ok {
+			if info, isInfo := val.(grabbedIndexerInfo); isInfo {
+				if now.Sub(info.timestamp) < 15*time.Second {
+					return info.indexer, true
+				}
+				// Cleanup expired entry
+				s.grabbedIndexers.Delete(key)
+			}
+		}
+		return "", false
+	}
+
+	if downloadID != "" {
+		if name, ok := check(downloadID); ok {
+			return name, true
+		}
+	}
+
+	if releaseTitle != "" {
+		cleanTitle := strings.TrimSpace(strings.ToLower(releaseTitle))
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".gz")
+		cleanTitle = strings.TrimSuffix(cleanTitle, ".nzb")
+		if name, ok := check(cleanTitle); ok {
+			return name, true
+		}
+	}
+
+	return "", false
 }


### PR DESCRIPTION
This PR restores the indexer tracking functionality from webhook Grab and OnImport events.

### Summary
1. **Webhook Grab & OnImport**: Restored payload fields and webhook event receivers so *arr instances capture and report indexer names upon grab/import events.
2. **In-Memory Tracking**: Restored `grabbedIndexers` map inside the importer service to map incoming download IDs with grabbed indexers and display indexer badges under Queue and Health dashboards.
3. **Optimized and Cleaned**: Completely aligns with database models without introducing complex XML comments fallback parsing.