### PR TITLE
perf(parser): cap per-segment NNTP fetch timeouts at 2s

### DIFF
--- a/internal/importer/parser/par2/descriptor.go
+++ b/internal/importer/parser/par2/descriptor.go
@@ -104,10 +104,10 @@ func readFileDescriptors(
 		return descriptors, fmt.Errorf("PAR2 file has no segments")
 	}
 
-	// Create context with timeout (30s per segment, capped at 90s ceiling).
+	// Create context with timeout (2s per segment, capped at 90s ceiling).
 	// Capping prevents runaway waits on large index files where the real cost
 	// is dominated by latency, not sequential segment fetches.
-	timeout := min(time.Second*30*time.Duration(len(par2File.Segments)), 90*time.Second)
+	timeout := min(time.Second*2*time.Duration(len(par2File.Segments)), 90*time.Second)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -32,6 +32,11 @@ import (
 	concpool "github.com/sourcegraph/conc/pool"
 )
 
+// segmentFetchTimeout bounds a single NNTP article fetch during parsing so a
+// slow or flaky provider fallback cannot stall the import. Per-segment budget,
+// not per-NZB (that is the 10-minute ParseFile context).
+const segmentFetchTimeout = 2 * time.Second
+
 // FirstSegmentData holds cached data from the first segment of an NZB file
 // This avoids redundant fetching when both PAR2 extraction and file parsing need the same data
 type FirstSegmentData struct {
@@ -530,7 +535,7 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 			firstSegment := fileToFetch.Segments[0]
 
 			// Create context with timeout
-			ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+			ctx, cancel := context.WithTimeout(ctx, segmentFetchTimeout)
 			defer cancel()
 
 			// Get body for the first segment (v4 returns decoded bytes + YEnc metadata)
@@ -732,7 +737,7 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 			g, gctx := errgroup.WithContext(ctx)
 			for i, seg := range segsNeeded {
 				g.Go(func() error {
-					segCtx, segCancel := context.WithTimeout(gctx, time.Second*30)
+					segCtx, segCancel := context.WithTimeout(gctx, segmentFetchTimeout)
 					defer segCancel()
 					sr, err := cp.Body(segCtx, seg.ID)
 					if err != nil {
@@ -776,6 +781,10 @@ func (p *Parser) fetchYencHeaders(ctx context.Context, segment nzbparser.NzbSegm
 	if err != nil {
 		return nntppool.YEncMeta{}, errors.NewNonRetryableError("no connection pool available", err)
 	}
+
+	// Bound the fetch so a slow/flaky provider fallback can't stall the import.
+	ctx, cancel := context.WithTimeout(ctx, segmentFetchTimeout)
+	defer cancel()
 
 	// onMeta fires after =ybegin/=ypart parsing (~first 2 lines),
 	// while the body continues draining to io.Discard in the background.


### PR DESCRIPTION
## What

Caps every per-segment NNTP article fetch in the importer parser at **2 seconds**.

| Site | Before | After |
|------|--------|-------|
| First-segment `cp.Body` (`parser.go`) | 30s | 2s |
| 16KB-completion `cp.Body` (`parser.go`) | 30s | 2s |
| `fetchYencHeaders` (`parser.go`) | *unbounded* (inherited 10m `ParseFile` ctx) | 2s |
| PAR2 index read (`par2/descriptor.go`) | 30s × segments (cap 90s) | 2s × segments (cap 90s) |

Introduces a `segmentFetchTimeout = 2 * time.Second` constant for the `parser` package; the `par2` package uses a literal (separate package).

## Why

When an article is missing on the primary NNTP provider, nntppool falls back to the next provider. The rotation itself is cheap (no sleep on `430`), but the fallback forces a connection acquisition on the other provider — a fresh TCP dial + TLS + AUTHINFO handshake (capped at nntppool's `defaultHandshakeTimeout = 10s`). When that fallback provider is slow or flaky, each missing-on-primary lookup hangs for seconds, and the parser issues one such lookup per file's first segment, per 16KB-completion segment, and per yEnc-header segment — so the stalls multiply and import slows down dramatically.

The previous timeouts (30s per segment, and effectively unbounded for the yEnc path) let those slow fallbacks run far longer than necessary. Failing fast at 2s lets the parser move on instead of stalling the whole import.

## Reviewer notes

- The 10-minute whole-NZB `ParseFile` safety budget (`parser.go`) is intentionally **unchanged** — this only tightens per-segment fetches.
- **Tradeoff:** 2s must cover a possible cold-connection handshake *plus* downloading a full article body (~700–800KB for a full segment). On healthy/fast providers this is ample; on a genuinely slow link a legitimate fetch could occasionally time out and be treated as missing. The named constant keeps it trivially tunable.
- `notFoundIDs` caching from a prior change still skips redundant re-lookups of known-missing articles; this PR addresses the cost of the *first* lookup of each missing article.

## Verification

- `go build ./...` ✅
- `go test -race ./internal/importer/parser/...` ✅ (all pass, including `parser_storm_test.go`)