### PR TITLE
fix(rclonecli): improve vfs cache refresh/forget logic and parameter types

### DIFF
--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -341,38 +341,46 @@ func (m *Manager) RefreshDir(ctx context.Context, provider string, dirs []string
 	if len(dirs) == 0 {
 		dirs = []string{"/"}
 	}
-	args := map[string]any{
-		"fs": fmt.Sprintf("%s:", provider),
-	}
-	for i, dir := range dirs {
-		if dir != "" {
-			if i == 0 {
-				args["dir"] = dir
-			} else {
-				args[fmt.Sprintf("dir%d", i+1)] = dir
-			}
+	// Issue a vfs/forget call for each directory to ensure all parents/children are forgotten
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		forgetArgs := map[string]any{
+			"fs":  fmt.Sprintf("%s:", provider),
+			"dir": dir,
+		}
+		req := RCRequest{
+			Command: "vfs/forget",
+			Args:    forgetArgs,
+		}
+		_, err := m.makeRequest(req, true)
+		if err != nil {
+			m.logger.ErrorContext(ctx, "Failed to forget directory", "err", err, "provider", provider, "dir", dir)
+			return fmt.Errorf("failed to forget directory %s for provider %s: %w", dir, provider, err)
 		}
 	}
-	req := RCRequest{
-		Command: "vfs/forget",
-		Args:    args,
-	}
 
-	_, err := m.makeRequest(req, true)
-	if err != nil {
-		m.logger.ErrorContext(ctx, "Failed to refresh directory", "err", err, "provider", provider)
-		return fmt.Errorf("failed to refresh directory %s for provider %s: %w", dirs, provider, err)
-	}
-
-	req = RCRequest{
-		Command: "vfs/refresh",
-		Args:    args,
-	}
-
-	_, err = m.makeRequest(req, true)
-	if err != nil {
-		m.logger.ErrorContext(ctx, "Failed to refresh directory", "err", err, "provider", provider)
-		return fmt.Errorf("failed to refresh directory %s for provider %s: %w", dirs, provider, err)
+	// Issue a vfs/refresh call for each directory individually
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		refreshArgs := map[string]any{
+			"fs":        fmt.Sprintf("%s:", provider),
+			"dir":       dir,
+			"_async":    "false",
+			"recursive": "false",
+		}
+		req := RCRequest{
+			Command: "vfs/refresh",
+			Args:    refreshArgs,
+		}
+		_, err := m.makeRequest(req, true)
+		if err != nil {
+			m.logger.ErrorContext(ctx, "Failed to refresh directory", "err", err, "provider", provider, "dir", dir)
+			return fmt.Errorf("failed to refresh directory %s for provider %s: %w", dir, provider, err)
+		}
 	}
 	return nil
 }

--- a/pkg/rclonecli/vfs_client.go
+++ b/pkg/rclonecli/vfs_client.go
@@ -117,81 +117,90 @@ func (c *rcloneRcClient) RefreshDir(ctx context.Context, provider string, dirs [
 		return fmt.Errorf("invalid RC URL configuration: %w", err)
 	}
 
-	// Use similar logic to Manager's RefreshDir but with vfs/refresh endpoint
-	refreshArgs := map[string]any{
-		"_async":    "false", // Use async refresh
-		"recursive": "false", // Non-recursive by default
-	}
+	var errs []error
 
-	// Add filesystem specification if provider is provided
-	if provider != "" {
-		refreshArgs["fs"] = fmt.Sprintf("%s:", provider)
-	}
-
-	// Add directories to refresh
-	for i, dir := range dirs {
-		if dir != "" {
-			if i == 0 {
-				refreshArgs["dir"] = dir
-			} else {
-				refreshArgs[fmt.Sprintf("dir%d", i+1)] = dir
-			}
+	// Issue a vfs/forget call for each directory to ensure all parents/children are forgotten
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
 		}
-	}
-
-	forgetArgs := make(map[string]any)
-	for k, v := range refreshArgs {
-		if k != "recursive" {
-			forgetArgs[k] = v
+		forgetArgs := map[string]any{
+			"dir": dir,
 		}
-	}
+		if provider != "" {
+			forgetArgs["fs"] = fmt.Sprintf("%s:", provider)
+		}
 
-	forgetPayload, err := json.Marshal(forgetArgs)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", baseUrl+"/vfs/forget", bytes.NewBuffer(forgetPayload))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		forgetPayload, err := json.Marshal(forgetArgs)
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
-		return fmt.Errorf("unexpected status code: %d, error: %s", resp.StatusCode, string(body))
-	}
 
-	refreshPayload, err := json.Marshal(refreshArgs)
-	if err != nil {
-		return err
-	}
-
-	req, err = http.NewRequestWithContext(ctx, "POST", baseUrl+"/vfs/refresh", bytes.NewBuffer(refreshPayload))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err = c.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
+		req, err := http.NewRequestWithContext(ctx, "POST", baseUrl+"/vfs/forget", bytes.NewBuffer(forgetPayload))
 		if err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
-		return fmt.Errorf("unexpected status code: %d, error: %s", resp.StatusCode, string(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			errs = append(errs, fmt.Errorf("vfs/forget failed for %s: status %d, error: %s", dir, resp.StatusCode, string(body)))
+			continue
+		}
+		resp.Body.Close()
+	}
+
+	// Issue a vfs/refresh call for each directory to ensure all parents/children are refreshed
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		refreshArgs := map[string]any{
+			"dir":       dir,
+			"_async":    "false", // Run synchronously to ensure cache is ready
+			"recursive": "false", // Non-recursive by default
+		}
+		if provider != "" {
+			refreshArgs["fs"] = fmt.Sprintf("%s:", provider)
+		}
+
+		refreshPayload, err := json.Marshal(refreshArgs)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "POST", baseUrl+"/vfs/refresh", bytes.NewBuffer(refreshPayload))
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			errs = append(errs, fmt.Errorf("vfs/refresh failed for %s: status %d, error: %s", dir, resp.StatusCode, string(body)))
+			continue
+		}
+		resp.Body.Close()
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("VFS sync completed with %d errors; first error: %w", len(errs), errs[0])
 	}
 
 	return nil


### PR DESCRIPTION
This pull request improves the VFS cache refresh and forget logic:
- Loops and sends separate vfs/forget for each directory.
- Loops and sends separate vfs/refresh for each directory.
- Changes _async and recursive parameters to string 'false' for rclone type strictness.
- Implements error resilience in VFS RefreshDir to prevent single-directory halts.