### PR TITLE
fix(health): only update scheduled_check_at during backfill if status is healthy

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1424,7 +1424,7 @@ func (r *HealthRepository) BackfillReleaseDates(ctx context.Context, updates []B
 	stmt, err := tx.PrepareContext(ctx, `
 		UPDATE file_health
 		SET release_date = ?,
-		    scheduled_check_at = ?,
+		    scheduled_check_at = CASE WHEN status = 'healthy' THEN ? ELSE scheduled_check_at END,
 		    updated_at = datetime('now')
 		WHERE id = ?
 	`)


### PR DESCRIPTION
This pull request resolves the backfill limbo loop bug. It prevents the release date backfiller from pushing out scheduled_check_at for pending or retrying items, ensuring they receive immediate health checks, while only scheduled_check_at for healthy items is pushed out.