### PR TITLE
feat(fuse): add no_mod_time option to suppress unstable virtual filesystem mtimes

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -978,6 +978,7 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 		max_read_ahead_mb: 128,
 		async_buffer_size_mb: 16,
 		async_buffer_max_total_mb: 256,
+		no_mod_time: false,
 	});
 
 	useEffect(() => {
@@ -1139,6 +1140,20 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 							/>
 							<span className="label-text text-xs">Allow other users to access mount</span>
 						</label>
+					</fieldset>
+					<fieldset className="fieldset">
+						<legend className="fieldset-legend">Compatibility</legend>
+						<label className="label cursor-pointer justify-start gap-3">
+							<input
+								type="checkbox"
+								className="checkbox checkbox-primary checkbox-sm"
+								checked={formData.no_mod_time ?? false}
+								onChange={(e) => updateField({ no_mod_time: e.target.checked })}
+								disabled={isRunning}
+							/>
+							<span className="label-text text-xs">Suppress modification times (report epoch for all files)</span>
+						</label>
+						<p className="label">Enable when media servers misinterpret virtual filesystem mtimes as file changes</p>
 					</fieldset>
 				</div>
 			</div>

--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -1151,9 +1151,8 @@ function FuseMountSubSection({ config, isRunning, onFormDataChange }: FuseSubSec
 								onChange={(e) => updateField({ no_mod_time: e.target.checked })}
 								disabled={isRunning}
 							/>
-							<span className="label-text text-xs">Suppress modification times (report epoch for all files)</span>
+							<span className="label-text text-xs">Suppress modification times</span>
 						</label>
-						<p className="label">Enable when media servers misinterpret virtual filesystem mtimes as file changes</p>
 					</fieldset>
 				</div>
 			</div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -228,6 +228,7 @@ export interface FuseConfig {
 	max_read_ahead_mb: number;
 	async_buffer_size_mb: number;
 	async_buffer_max_total_mb: number;
+	no_mod_time: boolean;
 }
 
 // Import strategy type

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -127,10 +127,9 @@ type FuseConfig struct {
 	// cap, additional streams run unbuffered. 0 = unlimited.
 	AsyncBufferMaxTotalMB int    `yaml:"async_buffer_max_total_mb" mapstructure:"async_buffer_max_total_mb" json:"async_buffer_max_total_mb"`
 	Backend               string `yaml:"backend" mapstructure:"backend" json:"backend"` // "hanwen" or "cgo" (empty = platform default)
-	// NoModTime makes the FUSE layer report epoch (zero) for all file and directory
-	// modification times. Prevents media servers (e.g. Jellyfin 10.11.x) from
-	// treating rclone/altmount files as perpetually modified due to unstable mtimes
-	// on virtual filesystems.
+	// NoModTime reports epoch for all timestamps (mtime, ctime, atime); prevents
+	// media servers re-scanning on unstable VFS mtimes. Note: tools like find -atime
+	// will not see meaningful access times on this mount.
 	NoModTime bool `yaml:"no_mod_time" mapstructure:"no_mod_time" json:"no_mod_time"`
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -127,6 +127,11 @@ type FuseConfig struct {
 	// cap, additional streams run unbuffered. 0 = unlimited.
 	AsyncBufferMaxTotalMB int    `yaml:"async_buffer_max_total_mb" mapstructure:"async_buffer_max_total_mb" json:"async_buffer_max_total_mb"`
 	Backend               string `yaml:"backend" mapstructure:"backend" json:"backend"` // "hanwen" or "cgo" (empty = platform default)
+	// NoModTime makes the FUSE layer report epoch (zero) for all file and directory
+	// modification times. Prevents media servers (e.g. Jellyfin 10.11.x) from
+	// treating rclone/altmount files as perpetually modified due to unstable mtimes
+	// on virtual filesystems.
+	NoModTime bool `yaml:"no_mod_time" mapstructure:"no_mod_time" json:"no_mod_time"`
 }
 
 // APIConfig represents REST API configuration

--- a/internal/fuse/backend/hanwen/backend.go
+++ b/internal/fuse/backend/hanwen/backend.go
@@ -51,7 +51,7 @@ func (b *Backend) Mount(ctx context.Context, onReady func()) error {
 	b.cleanup()
 
 	asyncBufSize := b.cfg.FuseConfig.AsyncBufferSizeMB * 1024 * 1024
-	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker, asyncBufSize)
+	root := NewDir(b.cfg.NzbFs, "", b.logger, b.cfg.UID, b.cfg.GID, b.cfg.StreamTracker, asyncBufSize, b.cfg.FuseConfig.NoModTime)
 
 	attrTimeout := time.Duration(b.cfg.FuseConfig.AttrTimeoutSeconds) * time.Second
 	entryTimeout := time.Duration(b.cfg.FuseConfig.EntryTimeoutSeconds) * time.Second

--- a/internal/fuse/backend/hanwen/dir.go
+++ b/internal/fuse/backend/hanwen/dir.go
@@ -37,7 +37,8 @@ type Dir struct {
 	isRootDir     bool
 	uid           uint32
 	gid           uint32
-	asyncBufSize  int // read-ahead buffer size in bytes, propagated to File nodes
+	asyncBufSize  int  // read-ahead buffer size in bytes, propagated to File nodes
+	noModTime     bool
 }
 
 // NewDir creates a new directory node for the FUSE filesystem.
@@ -48,6 +49,7 @@ func NewDir(
 	uid, gid uint32,
 	st backend.StreamTracker,
 	asyncBufSize int,
+	noModTime bool,
 ) *Dir {
 	return &Dir{
 		nzbfs:         nzbfs,
@@ -58,6 +60,7 @@ func NewDir(
 		uid:           uid,
 		gid:           gid,
 		asyncBufSize:  asyncBufSize,
+		noModTime:     noModTime,
 	}
 }
 
@@ -82,7 +85,7 @@ func (d *Dir) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut) 
 		return translateError(err)
 	}
 
-	fillAttr(info, &out.Attr, d.uid, d.gid)
+	fillAttr(info, &out.Attr, d.uid, d.gid, d.noModTime)
 	out.Ino = d.Inode.StableAttr().Ino
 	return 0
 }
@@ -122,7 +125,7 @@ func (d *Dir) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.Ent
 		return nil, syscall.EIO
 	}
 
-	fillAttr(info, &out.Attr, d.uid, d.gid)
+	fillAttr(info, &out.Attr, d.uid, d.gid, d.noModTime)
 
 	node := &Dir{
 		nzbfs:         d.nzbfs,
@@ -132,6 +135,7 @@ func (d *Dir) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.Ent
 		uid:           d.uid,
 		gid:           d.gid,
 		asyncBufSize:  d.asyncBufSize,
+		noModTime:     d.noModTime,
 	}
 
 	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
@@ -149,7 +153,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		return nil, translateError(err)
 	}
 
-	fillAttr(info, &out.Attr, d.uid, d.gid)
+	fillAttr(info, &out.Attr, d.uid, d.gid, d.noModTime)
 
 	if info.IsDir() {
 		node := &Dir{
@@ -160,6 +164,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 			uid:           d.uid,
 			gid:           d.gid,
 			asyncBufSize:  d.asyncBufSize,
+			noModTime:     d.noModTime,
 		}
 		return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFDIR}), 0
 	}
@@ -173,6 +178,7 @@ func (d *Dir) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fs.
 		uid:           d.uid,
 		gid:           d.gid,
 		asyncBufSize:  d.asyncBufSize,
+		noModTime:     d.noModTime,
 	}
 	return d.NewInode(ctx, node, fs.StableAttr{Mode: fuse.S_IFREG}), 0
 }

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -32,7 +32,8 @@ type File struct {
 	size          int64
 	uid           uint32
 	gid           uint32
-	asyncBufSize  int // per-handle read-ahead buffer size in bytes; 0 = disabled
+	asyncBufSize  int  // per-handle read-ahead buffer size in bytes; 0 = disabled
+	noModTime     bool
 }
 
 // Getattr implements fs.NodeGetattrer.
@@ -45,7 +46,7 @@ func (f *File) Getattr(ctx context.Context, fh fs.FileHandle, out *fuse.AttrOut)
 		return translateError(err)
 	}
 
-	fillAttr(info, &out.Attr, f.uid, f.gid)
+	fillAttr(info, &out.Attr, f.uid, f.gid, f.noModTime)
 	out.Ino = f.Inode.StableAttr().Ino
 	return 0
 }

--- a/internal/fuse/backend/hanwen/utils.go
+++ b/internal/fuse/backend/hanwen/utils.go
@@ -61,11 +61,20 @@ func mapError(err error, logger *slog.Logger, ctx context.Context, msg string, a
 }
 
 // fillAttr populates FUSE attributes from os.FileInfo.
-func fillAttr(info os.FileInfo, out *fuse.Attr, uid, gid uint32) {
+// When noModTime is true all timestamps are reported as Unix epoch so that
+// media servers (e.g. Jellyfin 10.11.x) never see a file as "modified" due
+// to unstable mtimes on virtual/cloud filesystems.
+func fillAttr(info os.FileInfo, out *fuse.Attr, uid, gid uint32, noModTime bool) {
 	out.Size = uint64(info.Size())
-	out.Mtime = uint64(info.ModTime().Unix())
-	out.Ctime = uint64(info.ModTime().Unix())
-	out.Atime = uint64(info.ModTime().Unix())
+	if noModTime {
+		out.Mtime = 0
+		out.Ctime = 0
+		out.Atime = 0
+	} else {
+		out.Mtime = uint64(info.ModTime().Unix())
+		out.Ctime = uint64(info.ModTime().Unix())
+		out.Atime = uint64(info.ModTime().Unix())
+	}
 	out.Uid = uid
 	out.Gid = gid
 

--- a/internal/fuse/backend/hanwen/utils.go
+++ b/internal/fuse/backend/hanwen/utils.go
@@ -61,9 +61,9 @@ func mapError(err error, logger *slog.Logger, ctx context.Context, msg string, a
 }
 
 // fillAttr populates FUSE attributes from os.FileInfo.
-// When noModTime is true all timestamps are reported as Unix epoch so that
-// media servers (e.g. Jellyfin 10.11.x) never see a file as "modified" due
-// to unstable mtimes on virtual/cloud filesystems.
+// When noModTime is true all three timestamps (mtime, ctime, atime) are reported
+// as Unix epoch so that media servers (e.g. Jellyfin 10.11.x) never see a file
+// as "modified" due to unstable mtimes on virtual/cloud filesystems.
 func fillAttr(info os.FileInfo, out *fuse.Attr, uid, gid uint32, noModTime bool) {
 	out.Size = uint64(info.Size())
 	if noModTime {


### PR DESCRIPTION
## Problem

Virtual filesystems (NFS, FUSE-backed cloud mounts, segment-cache layers) can report inconsistent or rapidly-changing modification times for files whose content has not actually changed. This happens because: 

- Segment caches update file metadata as segments are fetched, changing the stored mtime
- Directory nodes have no natural mtime and previously returned `time.Now()` on every `Getattr` call
- Some underlying storage backends don't preserve mtimes accurately across mounts/remounts

Media servers and indexing tools that rely on mtime to detect file changes will incorrectly treat these files as modified on every scan, triggering unnecessary re-indexing, metadata re-extraction, and in some cases entering re-processing loops that stall the entire scan.

## Solution

Adds a `no_mod_time: true` option to `FuseConfig`. When enabled, the FUSE layer reports Unix epoch (zero) for all `mtime`, `ctime`, and `atime` values instead of the underlying virtual filesystem value.

This gives any consumer of the mount a stable, consistent timestamp. Since the files themselves are read-only (NZB archives on Usenet don't change), reporting epoch is semantically accurate — the content never changes, so the mtime should never change either.

### Changes

- **`internal/config/manager.go`**: adds `NoModTime bool` (`no_mod_time` in YAML/JSON) to `FuseConfig`
- **`internal/fuse/backend/hanwen/utils.go`**: `fillAttr` accepts `noModTime bool`; returns zero timestamps when set
- **`internal/fuse/backend/hanwen/dir.go`**: `Dir` carries `noModTime`, propagated to all child `Dir` and `File` nodes created during `Lookup` and `Mkdir`
- **`internal/fuse/backend/hanwen/file.go`**: `File` carries `noModTime`, applied in `Getattr`
- **`internal/fuse/backend/hanwen/backend.go`**: passes `FuseConfig.NoModTime` to `NewDir` at mount time
- **`frontend/src/types/config.ts`**: adds `no_mod_time` to `FuseConfig` interface
- **`frontend/src/components/config/MountConfigSection.tsx`**: adds "Suppress modification times" checkbox to the FUSE Compatibility section

### Configuration

```yaml
fuse:
  no_mod_time: true
```

Defaults to `false` — no behaviour change for existing configurations.

### Notes

- The flag is named to mirror the equivalent option in rclone (`--no-modtime`) for familiarity
- Only the hanwen (Linux) backend is affected; the cgofuse backend has its own attr path
- On first mount after enabling, consumers that already stored a non-zero mtime will see one mtime transition (stored value → epoch); after that all stats return epoch and no further changes are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)