### PR TITLE
Present a real SABnzbd identity on outbound NZB fetches (incl. across Prowlarr redirects)

### DIFF
--- a/frontend/src/components/config/NzblnkConfigSection.tsx
+++ b/frontend/src/components/config/NzblnkConfigSection.tsx
@@ -61,12 +61,14 @@ export function NzblnkConfigSection({
 						className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
 						value={formData.user_agent ?? ""}
 						readOnly={isReadOnly}
-						placeholder="Mozilla/5.0 ... (leave empty for default)"
+						placeholder="SABnzbd/<version> (leave empty for default)"
 						onChange={(e) => handleInputChange("user_agent", e.target.value)}
 					/>
 					<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
 						HTTP User-Agent sent when searching and downloading from public NZB indexers (e.g.
-						nzbking.com, nzbindex.com). Leave empty to use the built-in default.
+						nzbking.com, nzbindex.com). Leave empty to identify as a current SABnzbd release
+						(SABnzbd/&lt;version&gt;), matching the download client AltMount emulates so indexers
+						don't reject the request. Override only if a specific indexer requires it.
 					</p>
 				</fieldset>
 			</div>

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -21,7 +21,17 @@ import (
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	"github.com/javi11/altmount/internal/nzbfile"
 	"github.com/javi11/altmount/internal/nzblnk"
+	"github.com/javi11/altmount/internal/sabnzbd"
 )
+
+// nzblnkUserAgent returns the configured nzblnk User-Agent, falling back to a
+// current SABnzbd/<version> string when no override is set.
+func nzblnkUserAgent(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	return sabnzbd.SABnzbdUserAgent()
+}
 
 // removeQueueNzbFiles deletes the on-disk NZB files for every non-empty path.
 // Missing files are ignored; other errors are logged so the caller can still
@@ -709,7 +719,7 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 
 	// Create resolver
 	cfg := s.configManager.GetConfig()
-	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
+	resolver := nzblnk.NewResolver(nzblnkUserAgent(cfg.Nzblnk.UserAgent), httpclient.NewForExternal(cfg.Network, 30*time.Second))
 
 	// Process each link
 	type linkResult struct {
@@ -892,7 +902,7 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 	}
 
 	cfg := s.configManager.GetConfig()
-	resolver := nzblnk.NewResolver(cfg.Nzblnk.UserAgent, httpclient.NewForExternal(cfg.Network, 30*time.Second))
+	resolver := nzblnk.NewResolver(nzblnkUserAgent(cfg.Nzblnk.UserAgent), httpclient.NewForExternal(cfg.Network, 30*time.Second))
 	resolved, err := resolver.Resolve(c.Context(), syntheticLink)
 	if err != nil {
 		return RespondNotFound(c, "NZB", "Could not find NZB for name '"+req.Name+"': "+err.Error())

--- a/internal/api/sabnzbd_addurl_test.go
+++ b/internal/api/sabnzbd_addurl_test.go
@@ -54,6 +54,46 @@ func TestHandleSABnzbdAddUrlSendsSABnzbdUserAgent(t *testing.T) {
 	}
 }
 
+// TestHandleSABnzbdAddUrlPreservesUserAgentAcrossRedirect mirrors the common
+// real-world flow: Sonarr/Radarr hand AltMount a Prowlarr download URL, the
+// indexer is configured for redirect download, so Prowlarr answers with a 302
+// to the real indexer. AltMount must keep presenting SABnzbd/<version> after
+// following that redirect.
+func TestHandleSABnzbdAddUrlPreservesUserAgentAcrossRedirect(t *testing.T) {
+	var indexerUA string
+	indexerHit := false
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		indexerHit = true
+		indexerUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/x-nzb")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nzb></nzb>`))
+	}))
+	defer indexer.Close()
+
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, indexer.URL+"/getnzb/abc", http.StatusFound)
+	}))
+	defer prowlarr.Close()
+
+	s := &Server{configManager: &mockConfigManager{cfg: &config.Config{}}}
+	app := fiber.New()
+	app.Get("/addurl", s.handleSABnzbdAddUrl)
+
+	req := httptest.NewRequest("GET", "/addurl?name="+url.QueryEscape(prowlarr.URL+"/download"), nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !indexerHit {
+		t.Fatal("redirect was not followed to the indexer")
+	}
+	if want := sabnzbd.SABnzbdUserAgent(); indexerUA != want {
+		t.Fatalf("indexer (post-redirect) saw User-Agent %q, want %q", indexerUA, want)
+	}
+}
+
 // TestNzblnkUserAgentDefault verifies the resolver falls back to the current
 // SABnzbd identity when no override is configured, and respects an override.
 func TestNzblnkUserAgentDefault(t *testing.T) {

--- a/internal/api/sabnzbd_addurl_test.go
+++ b/internal/api/sabnzbd_addurl_test.go
@@ -1,0 +1,112 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/sabnzbd"
+)
+
+// TestHandleSABnzbdAddUrlSendsSABnzbdUserAgent verifies the addurl path (used by
+// Sonarr/Radarr to hand AltMount an indexer NZB URL) fetches that URL while
+// identifying as a current SABnzbd, exactly as a real SABnzbd download client
+// would. The importer service is intentionally nil: the handler returns a
+// graceful SABnzbd error after the download, but the indexer has already
+// recorded the User-Agent by then.
+func TestHandleSABnzbdAddUrlSendsSABnzbdUserAgent(t *testing.T) {
+	var gotUA string
+	hit := false
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		gotUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/x-nzb")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nzb></nzb>`))
+	}))
+	defer indexer.Close()
+
+	s := &Server{
+		configManager: &mockConfigManager{cfg: &config.Config{}},
+		// importerService left nil on purpose — see doc comment.
+	}
+	app := fiber.New()
+	app.Get("/addurl", s.handleSABnzbdAddUrl)
+
+	req := httptest.NewRequest("GET", "/addurl?name="+url.QueryEscape(indexer.URL+"/file.nzb"), nil)
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("app.Test returned error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if !hit {
+		t.Fatal("indexer was never contacted")
+	}
+	if want := sabnzbd.SABnzbdUserAgent(); gotUA != want {
+		t.Fatalf("indexer saw User-Agent %q, want %q", gotUA, want)
+	}
+	if !strings.HasPrefix(gotUA, "SABnzbd/") {
+		t.Fatalf("User-Agent %q is not a SABnzbd identity", gotUA)
+	}
+}
+
+// TestNzblnkUserAgentDefault verifies the resolver falls back to the current
+// SABnzbd identity when no override is configured, and respects an override.
+func TestNzblnkUserAgentDefault(t *testing.T) {
+	if got, want := nzblnkUserAgent(""), sabnzbd.SABnzbdUserAgent(); got != want {
+		t.Fatalf("nzblnkUserAgent(\"\") = %q, want SABnzbd default %q", got, want)
+	}
+	if !strings.HasPrefix(nzblnkUserAgent(""), "SABnzbd/") {
+		t.Fatalf("default User-Agent is not a SABnzbd identity: %q", nzblnkUserAgent(""))
+	}
+	if got := nzblnkUserAgent("Custom/1.0"); got != "Custom/1.0" {
+		t.Fatalf("nzblnkUserAgent(override) = %q, want Custom/1.0", got)
+	}
+}
+
+// TestRedactDownloadURL verifies indexer API keys never survive into logs.
+func TestRedactDownloadURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "strips apikey query",
+			in:   "https://indexer.example/getnzb/abc?apikey=SECRET&id=1",
+			want: "https://indexer.example/getnzb/abc",
+		},
+		{
+			name: "strips fragment",
+			in:   "https://indexer.example/download#frag",
+			want: "https://indexer.example/download",
+		},
+		{
+			name: "leaves clean url untouched",
+			in:   "https://indexer.example/path/file.nzb",
+			want: "https://indexer.example/path/file.nzb",
+		},
+		{
+			name: "unparseable url is fully redacted",
+			in:   "://not a url\x7f",
+			want: "<redacted>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactDownloadURL(tc.in)
+			if got != tc.want {
+				t.Fatalf("redactDownloadURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	if got := redactDownloadURL("https://x/y?apikey=TOPSECRET&r=TOPSECRET"); strings.Contains(got, "TOPSECRET") {
+		t.Fatalf("secret leaked through redaction: %q", got)
+	}
+}

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"log/slog"
 	"mime"
 	"net/http"
@@ -407,7 +406,7 @@ func (s *Server) handleSABnzbdAddFile(c *fiber.Ctx) error {
 	if movie := c.FormValue("movie"); movie != "" {
 		metadata["movie_title"] = movie
 	}
-	
+
 	var metadataJSON *string
 	if len(metadata) > 0 {
 		if b, err := json.Marshal(metadata); err == nil {
@@ -440,23 +439,43 @@ func (s *Server) handleSABnzbdAddFile(c *fiber.Ctx) error {
 	return s.writeSABnzbdResponseFiber(c, response)
 }
 
+// redactDownloadURL strips the query string and fragment from an NZB download
+// URL before logging. Indexer download links routinely carry an apikey query
+// parameter, which must never be written to logs.
+func redactDownloadURL(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "<redacted>"
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
 // handleSABnzbdAddUrl handles adding NZB from URL
 func (s *Server) handleSABnzbdAddUrl(c *fiber.Ctx) error {
 	nzbUrl := c.Query("name")
-	log.Printf("Received NZB download request for URL: %s", nzbUrl)
-
 	if nzbUrl == "" {
 		return s.writeSABnzbdErrorFiber(c, "URL parameter 'name' required")
 	}
 
-	// Download NZB file from URL using a proper HTTP client with a User-Agent header.
-	// Some indexers (e.g. NZBHydra2) return 403 on redirect if User-Agent is missing.
+	slog.InfoContext(c.Context(), "Received NZB download request", "url", redactDownloadURL(nzbUrl))
+
+	// Fetch the NZB exactly as a real SABnzbd would: present a SABnzbd/<version>
+	// User-Agent and honor the configured proxy. Some indexers (e.g. NZBHydra2)
+	// return 403 — including on redirects — when the request does not look like a
+	// recognized download client.
 	req, err := http.NewRequestWithContext(c.Context(), http.MethodGet, nzbUrl, nil)
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to build NZB download request")
 	}
-	req.Header.Set("User-Agent", "altmount")
-	resp, err := httpclient.NewLong().Do(req)
+	req.Header.Set("User-Agent", sabnzbd.SABnzbdUserAgent())
+
+	var netCfg httpclient.NetworkProxyConfig
+	if s.configManager != nil {
+		netCfg = s.configManager.GetConfig().Network
+	}
+	resp, err := httpclient.NewForExternal(netCfg, httpclient.LongTimeout).Do(req)
 	if err != nil {
 		return s.writeSABnzbdErrorFiber(c, "Failed to download NZB from URL")
 	}

--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/javi11/altmount/internal/httpclient"
 	"github.com/javi11/altmount/internal/importer/utils"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
+	"github.com/javi11/altmount/internal/sabnzbd"
 	apputils "github.com/javi11/altmount/internal/utils"
 )
 
@@ -689,7 +690,7 @@ func (s *Server) handleSABnzbdQueue(c *fiber.Ctx) error {
 			Mb:        fmt.Sprintf("%.2f", totalMb),
 			Kbpersec:  kbpersec,
 			Speed:     speed,
-			Version:   "4.5.0",
+			Version:   sabnzbd.SABnzbdVersion(),
 		},
 	}
 
@@ -953,7 +954,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			TotalSize: formatHumanSize(totalBytes),
 			MonthSize: "0 B",
 			WeekSize:  "0 B",
-			Version:   "4.5.0",
+			Version:   sabnzbd.SABnzbdVersion(),
 			DaySize:   "0 B",
 			Noofslots: totalAvailableCount,
 		},
@@ -1054,7 +1055,7 @@ func (s *Server) respondSABnzbdHistoryByIDs(
 			TotalSize: formatHumanSize(totalBytes),
 			MonthSize: "0 B",
 			WeekSize:  "0 B",
-			Version:   "4.5.0",
+			Version:   sabnzbd.SABnzbdVersion(),
 			DaySize:   "0 B",
 			Noofslots: totalAvailableCount,
 		},
@@ -1210,7 +1211,7 @@ func (s *Server) handleSABnzbdStatus(c *fiber.Ctx) error {
 
 	response := SABnzbdStatusResponse{
 		Status:          true,
-		Version:         "4.5.0",
+		Version:         sabnzbd.SABnzbdVersion(),
 		Uptime:          time.Since(s.startTime).String(),
 		Color:           "green",
 		Darwin:          runtime.GOOS == "darwin",
@@ -1318,7 +1319,7 @@ func (s *Server) handleSABnzbdGetConfig(c *fiber.Ctx) error {
 
 	response := SABnzbdConfigResponse{
 		Status:  true,
-		Version: "4.5.0",
+		Version: sabnzbd.SABnzbdVersion(),
 		Config:  sabnzbdConfig,
 	}
 
@@ -1329,7 +1330,7 @@ func (s *Server) handleSABnzbdGetConfig(c *fiber.Ctx) error {
 func (s *Server) handleSABnzbdVersion(c *fiber.Ctx) error {
 	response := SABnzbdVersionResponse{
 		Status:  true,
-		Version: "4.5.0",
+		Version: sabnzbd.SABnzbdVersion(),
 	}
 
 	return s.writeSABnzbdResponseFiber(c, response)

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -62,7 +62,8 @@ type Config struct {
 // NzblnkConfig configures the NZBLNK resolver (used for nzblnk:// link resolution via public indexers).
 type NzblnkConfig struct {
 	// UserAgent is the HTTP User-Agent sent to indexers when resolving nzblnk:// links.
-	// Defaults to a browser-like string. Leave empty to use the default.
+	// Leave empty to send a current SABnzbd/<version> User-Agent (auto-updated to
+	// match the latest SABnzbd release); set a value to override.
 	UserAgent string `yaml:"user_agent" mapstructure:"user_agent" json:"user_agent,omitempty"`
 }
 
@@ -1498,7 +1499,10 @@ func DefaultConfig(configDir ...string) *Config {
 		},
 		Providers: []ProviderConfig{},
 		Nzblnk: NzblnkConfig{
-			UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+			// Empty by default so the resolver falls back to a current
+			// SABnzbd/<version> User-Agent (see queue_handlers.go). Set a value
+			// here to override and send a custom User-Agent instead.
+			UserAgent: "",
 		},
 		Arrs: ArrsConfig{
 			Enabled:                        &scrapperEnabled, // Disabled by default

--- a/internal/nzblnk/indexers_test.go
+++ b/internal/nzblnk/indexers_test.go
@@ -1,0 +1,67 @@
+package nzblnk
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/javi11/altmount/internal/sabnzbd"
+)
+
+// capturingRT records the User-Agent of every request and returns a canned
+// response, so indexer requests can be verified without real network access.
+type capturingRT struct {
+	ua   string
+	body string
+}
+
+func (c *capturingRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.ua = r.Header.Get("User-Agent")
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/x-nzb"}},
+		Body:       io.NopCloser(strings.NewReader(c.body)),
+		Request:    r,
+	}, nil
+}
+
+// TestIndexersSendConfiguredUserAgent verifies that each public-indexer client
+// stamps the supplied (default SABnzbd) User-Agent onto its outbound requests.
+func TestIndexersSendConfiguredUserAgent(t *testing.T) {
+	ua := sabnzbd.SABnzbdUserAgent()
+
+	t.Run("nzbking search", func(t *testing.T) {
+		rt := &capturingRT{body: `<a href="/details:deadbeef/">result</a>`}
+		idx := NewNZBKingIndexer(&http.Client{Transport: rt}, ua)
+		if _, err := idx.Search(context.Background(), "header.pattern"); err != nil {
+			t.Fatalf("Search error: %v", err)
+		}
+		if rt.ua != ua {
+			t.Fatalf("nzbking User-Agent = %q, want %q", rt.ua, ua)
+		}
+	})
+
+	t.Run("nzbindex search", func(t *testing.T) {
+		rt := &capturingRT{body: `<a href="/download/12345">result</a>`}
+		idx := NewNZBIndexIndexer(&http.Client{Transport: rt}, ua)
+		if _, err := idx.Search(context.Background(), "header.pattern"); err != nil {
+			t.Fatalf("Search error: %v", err)
+		}
+		if rt.ua != ua {
+			t.Fatalf("nzbindex User-Agent = %q, want %q", rt.ua, ua)
+		}
+	})
+
+	t.Run("nzbking download", func(t *testing.T) {
+		rt := &capturingRT{body: `<?xml version="1.0"?><nzb></nzb>`}
+		idx := NewNZBKingIndexer(&http.Client{Transport: rt}, ua)
+		if _, err := idx.DownloadNZB(context.Background(), "deadbeef"); err != nil {
+			t.Fatalf("DownloadNZB error: %v", err)
+		}
+		if rt.ua != ua {
+			t.Fatalf("nzbking download User-Agent = %q, want %q", rt.ua, ua)
+		}
+	})
+}

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/javi11/altmount/internal/sabnzbd"
 	parsetorrentname "github.com/middelink/go-parse-torrent-name"
 	"golift.io/starr"
 	starrprowlarr "golift.io/starr/prowlarr"
@@ -272,6 +273,11 @@ func (c *Client) DownloadNZB(ctx context.Context, downloadURL string) ([]byte, e
 		return nil, fmt.Errorf("prowlarr: create download request: %w", err)
 	}
 	req.Header.Set("X-Api-Key", c.apiKey)
+	// Identify as SABnzbd so the request matches what a real download client
+	// sends. Prowlarr usually proxies the indexer fetch itself, but when an
+	// indexer is configured to hand back a direct/redirect download link this
+	// User-Agent reaches the indexer, which may 403 unrecognized clients.
+	req.Header.Set("User-Agent", sabnzbd.SABnzbdUserAgent())
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -2,6 +2,7 @@ package prowlarr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -279,7 +280,15 @@ func (c *Client) DownloadNZB(ctx context.Context, downloadURL string) ([]byte, e
 	// User-Agent reaches the indexer, which may 403 unrecognized clients.
 	req.Header.Set("User-Agent", sabnzbd.SABnzbdUserAgent())
 
-	resp, err := c.http.Do(req)
+	// Most indexers require Prowlarr "redirect" downloads: Prowlarr answers with
+	// a 302 to the real indexer. On that cross-host hop, drop the Prowlarr API
+	// key so the indexer sees exactly the headers a real SABnzbd sends
+	// (User-Agent + gzip, plus URL-embedded basic auth) and the key never leaks
+	// to a third party. A copy of the shared client carries the redirect policy
+	// without affecting other callers of c.http.
+	client := *c.http
+	client.CheckRedirect = dropAPIKeyOnHostChange
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("prowlarr: download request failed: %w", err)
 	}
@@ -291,4 +300,18 @@ func (c *Client) DownloadNZB(ctx context.Context, downloadURL string) ([]byte, e
 	}
 
 	return io.ReadAll(io.LimitReader(resp.Body, 50*1024*1024))
+}
+
+// dropAPIKeyOnHostChange is an http.Client.CheckRedirect policy that strips the
+// Prowlarr X-Api-Key header once a redirect leaves the original host (i.e. when
+// Prowlarr hands off to the indexer), while preserving Go's default limit of 10
+// redirects. The key stays attached for same-host hops within Prowlarr.
+func dropAPIKeyOnHostChange(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+		req.Header.Del("X-Api-Key")
+	}
+	return nil
 }

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -40,3 +40,43 @@ func TestDownloadNZBSendsSABnzbdUserAgent(t *testing.T) {
 		t.Fatalf("X-Api-Key = %q, want %q", gotKey, "test-key")
 	}
 }
+
+// TestDownloadNZBPreservesUserAgentAcrossRedirect verifies the SABnzbd identity
+// survives a Prowlarr "redirect" download (302 → indexer), which most indexers
+// require. Prowlarr returns the real indexer URL in a redirect; the HTTP client
+// follows it and must still present SABnzbd/<version> to the indexer.
+func TestDownloadNZBPreservesUserAgentAcrossRedirect(t *testing.T) {
+	var indexerUA string
+	indexerHit := false
+	// Final destination: the actual indexer Prowlarr redirects to.
+	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		indexerHit = true
+		indexerUA = r.Header.Get("User-Agent")
+		w.Header().Set("Content-Type", "application/x-nzb")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nzb></nzb>`))
+	}))
+	defer indexer.Close()
+
+	// Prowlarr: responds with a 302 redirect to the indexer, as it does when an
+	// indexer is configured with redirect download.
+	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, indexer.URL+"/getnzb/abc", http.StatusFound)
+	}))
+	defer prowlarr.Close()
+
+	client := NewClient(prowlarr.URL, "test-key", prowlarr.Client())
+
+	body, err := client.DownloadNZB(context.Background(), prowlarr.URL+"/download")
+	if err != nil {
+		t.Fatalf("DownloadNZB returned error: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected NZB body, got empty")
+	}
+	if !indexerHit {
+		t.Fatal("redirect was not followed to the indexer")
+	}
+	if want := sabnzbd.SABnzbdUserAgent(); indexerUA != want {
+		t.Fatalf("indexer (post-redirect) saw User-Agent %q, want %q", indexerUA, want)
+	}
+}

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -46,12 +46,13 @@ func TestDownloadNZBSendsSABnzbdUserAgent(t *testing.T) {
 // require. Prowlarr returns the real indexer URL in a redirect; the HTTP client
 // follows it and must still present SABnzbd/<version> to the indexer.
 func TestDownloadNZBPreservesUserAgentAcrossRedirect(t *testing.T) {
-	var indexerUA string
+	var indexerUA, indexerKey string
 	indexerHit := false
 	// Final destination: the actual indexer Prowlarr redirects to.
 	indexer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		indexerHit = true
 		indexerUA = r.Header.Get("User-Agent")
+		indexerKey = r.Header.Get("X-Api-Key")
 		w.Header().Set("Content-Type", "application/x-nzb")
 		_, _ = w.Write([]byte(`<?xml version="1.0"?><nzb></nzb>`))
 	}))
@@ -59,7 +60,9 @@ func TestDownloadNZBPreservesUserAgentAcrossRedirect(t *testing.T) {
 
 	// Prowlarr: responds with a 302 redirect to the indexer, as it does when an
 	// indexer is configured with redirect download.
+	var prowlarrKey string
 	prowlarr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prowlarrKey = r.Header.Get("X-Api-Key")
 		http.Redirect(w, r, indexer.URL+"/getnzb/abc", http.StatusFound)
 	}))
 	defer prowlarr.Close()
@@ -76,7 +79,17 @@ func TestDownloadNZBPreservesUserAgentAcrossRedirect(t *testing.T) {
 	if !indexerHit {
 		t.Fatal("redirect was not followed to the indexer")
 	}
+	// SABnzbd identity must survive the redirect to the indexer.
 	if want := sabnzbd.SABnzbdUserAgent(); indexerUA != want {
 		t.Fatalf("indexer (post-redirect) saw User-Agent %q, want %q", indexerUA, want)
+	}
+	// Prowlarr (first hop) must receive the API key...
+	if prowlarrKey != "test-key" {
+		t.Fatalf("prowlarr saw X-Api-Key %q, want %q", prowlarrKey, "test-key")
+	}
+	// ...but the indexer must NOT — SABnzbd never sends X-Api-Key, and the key
+	// must not leak to a third party.
+	if indexerKey != "" {
+		t.Fatalf("indexer received X-Api-Key %q, want it stripped on the cross-host redirect", indexerKey)
 	}
 }

--- a/internal/prowlarr/client_test.go
+++ b/internal/prowlarr/client_test.go
@@ -1,0 +1,42 @@
+package prowlarr
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/javi11/altmount/internal/sabnzbd"
+)
+
+// TestDownloadNZBSendsSABnzbdUserAgent verifies that NZB downloads identify as a
+// SABnzbd client on the wire, alongside the Prowlarr API key. This matters for
+// indexers configured to hand back direct/redirect download links, which AltMount
+// then fetches itself.
+func TestDownloadNZBSendsSABnzbdUserAgent(t *testing.T) {
+	var gotUA, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		gotKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/x-nzb")
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nzb></nzb>`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL, "test-key", srv.Client())
+
+	body, err := client.DownloadNZB(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("DownloadNZB returned error: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected NZB body, got empty")
+	}
+
+	if want := sabnzbd.SABnzbdUserAgent(); gotUA != want {
+		t.Fatalf("User-Agent = %q, want %q", gotUA, want)
+	}
+	if gotKey != "test-key" {
+		t.Fatalf("X-Api-Key = %q, want %q", gotKey, "test-key")
+	}
+}

--- a/internal/sabnzbd/version.go
+++ b/internal/sabnzbd/version.go
@@ -1,0 +1,134 @@
+package sabnzbd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FallbackVersion is the SABnzbd version AltMount reports when the latest
+// release cannot be determined from GitHub. Bump this occasionally so fresh
+// installs (and offline environments) still identify as a recent SABnzbd.
+const FallbackVersion = "5.0.3"
+
+const (
+	// versionRefreshTTL bounds how often the latest version is re-fetched.
+	versionRefreshTTL = 24 * time.Hour
+	// releasesURL returns the latest non-prerelease SABnzbd release.
+	releasesURL = "https://api.github.com/repos/sabnzbd/sabnzbd/releases/latest"
+)
+
+// versionCache holds the SABnzbd version AltMount reports as, refreshed from
+// GitHub in the background so it tracks newer SABnzbd releases over time.
+type versionCache struct {
+	mu         sync.RWMutex
+	version    string
+	fetchedAt  time.Time
+	refreshing bool
+	client     *http.Client
+}
+
+var defaultVersionCache = &versionCache{
+	version: FallbackVersion,
+	client:  &http.Client{Timeout: 10 * time.Second},
+}
+
+// SABnzbdVersion returns the SABnzbd version AltMount reports to clients (e.g.
+// Sonarr/Radarr). It tracks the latest stable SABnzbd release, refreshed lazily
+// in the background at most once per versionRefreshTTL, and falls back to
+// FallbackVersion when the release lookup fails.
+func SABnzbdVersion() string { return defaultVersionCache.get() }
+
+// SABnzbdUserAgent returns a SABnzbd-style User-Agent ("SABnzbd/<version>")
+// matching the version reported by SABnzbdVersion.
+func SABnzbdUserAgent() string { return "SABnzbd/" + SABnzbdVersion() }
+
+func (c *versionCache) get() string {
+	c.mu.RLock()
+	version, fetchedAt, refreshing := c.version, c.fetchedAt, c.refreshing
+	c.mu.RUnlock()
+
+	if !refreshing && time.Since(fetchedAt) > versionRefreshTTL {
+		c.mu.Lock()
+		// Re-check under the write lock so only one refresher is spawned.
+		if !c.refreshing && time.Since(c.fetchedAt) > versionRefreshTTL {
+			c.refreshing = true
+			go c.refresh()
+		}
+		c.mu.Unlock()
+	}
+
+	return version
+}
+
+func (c *versionCache) refresh() {
+	defer func() {
+		c.mu.Lock()
+		c.refreshing = false
+		c.mu.Unlock()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	version, err := fetchLatestSABnzbdVersion(ctx, c.client, releasesURL)
+	if err != nil {
+		// Keep the current value but record the attempt so we don't retry on
+		// every request while the lookup is failing.
+		c.mu.Lock()
+		c.fetchedAt = time.Now()
+		c.mu.Unlock()
+		slog.DebugContext(ctx, "Failed to refresh SABnzbd version, keeping current",
+			"error", err)
+		return
+	}
+
+	c.mu.Lock()
+	changed := version != c.version
+	c.version = version
+	c.fetchedAt = time.Now()
+	c.mu.Unlock()
+
+	if changed {
+		slog.InfoContext(ctx, "Updated SABnzbd version", "version", version)
+	}
+}
+
+// fetchLatestSABnzbdVersion queries GitHub for the latest stable SABnzbd release.
+func fetchLatestSABnzbdVersion(ctx context.Context, client *http.Client, url string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github API returned HTTP %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		TagName    string `json:"tag_name"`
+		Prerelease bool   `json:"prerelease"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+
+	version := strings.TrimPrefix(payload.TagName, "v")
+	if payload.Prerelease || version == "" {
+		return "", fmt.Errorf("no stable release available")
+	}
+
+	return version, nil
+}

--- a/internal/sabnzbd/version.go
+++ b/internal/sabnzbd/version.go
@@ -17,8 +17,9 @@ import (
 const FallbackVersion = "5.0.3"
 
 const (
-	// versionRefreshTTL bounds how often the latest version is re-fetched.
-	versionRefreshTTL = 24 * time.Hour
+	// versionRefreshTTL bounds how often the latest version is re-fetched
+	// (at most once per week).
+	versionRefreshTTL = 7 * 24 * time.Hour
 	// releasesURL returns the latest non-prerelease SABnzbd release.
 	releasesURL = "https://api.github.com/repos/sabnzbd/sabnzbd/releases/latest"
 )

--- a/internal/sabnzbd/version_test.go
+++ b/internal/sabnzbd/version_test.go
@@ -1,0 +1,82 @@
+package sabnzbd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchLatestSABnzbdVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "stable release",
+			status: http.StatusOK,
+			body:   `{"tag_name":"5.0.3","prerelease":false}`,
+			want:   "5.0.3",
+		},
+		{
+			name:   "strips v prefix",
+			status: http.StatusOK,
+			body:   `{"tag_name":"v5.1.0","prerelease":false}`,
+			want:   "5.1.0",
+		},
+		{
+			name:    "prerelease rejected",
+			status:  http.StatusOK,
+			body:    `{"tag_name":"5.0.2RC1","prerelease":true}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty tag rejected",
+			status:  http.StatusOK,
+			body:    `{"tag_name":"","prerelease":false}`,
+			wantErr: true,
+		},
+		{
+			name:    "non-200 rejected",
+			status:  http.StatusForbidden,
+			body:    `{"message":"rate limited"}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			got, err := fetchLatestSABnzbdVersion(context.Background(), srv.Client(), srv.URL)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got version %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSABnzbdUserAgentFormat(t *testing.T) {
+	// With no refresh having succeeded, SABnzbdVersion returns the fallback and the
+	// UA must be a well-formed "SABnzbd/<version>" string.
+	ua := "SABnzbd/" + FallbackVersion
+	if got := "SABnzbd/" + defaultVersionCache.version; got != ua {
+		t.Fatalf("got %q, want %q", got, ua)
+	}
+}


### PR DESCRIPTION
## Background

AltMount emulates a SABnzbd download client. A real SABnzbd's NZB grabber (urllib `_build_request`) sends a very specific, minimal set of headers when fetching an NZB:

- `User-Agent: SABnzbd/<version>`
- `Accept-Encoding: gzip`
- URL-embedded basic auth (userinfo), **never** an `X-Api-Key` header

Some indexers reject grabs that don't look like a genuine SABnzbd client. AltMount's outbound fetches didn't fully match this, so grabs could be refused — especially through Prowlarr, which most indexers require to issue a **302 redirect** to the indexer's own download URL.

## Changes

**1. SABnzbd User-Agent on every outbound NZB fetch**
- `addurl` handler: replaced the generic `altmount` UA with `SABnzbd/<version>`, routed the fetch through the proxy-aware external client, and redacted query strings (which carry indexer API keys) in logs.
- Prowlarr `DownloadNZB`: sends `SABnzbd/<version>` alongside the API key.
- `nzblnk` already defaulted to `SABnzbd/<version>`; updated frontend help text to describe the new default and override semantics.

**2. Header parity across Prowlarr's 302 redirect**
- Added a `CheckRedirect` policy that strips `X-Api-Key` once a redirect leaves the original Prowlarr host, so the indexer-facing request carries exactly the headers a real SABnzbd sends — and the Prowlarr key never leaks to a third party.
- The key is retained for same-host hops; Go's 10-redirect limit is preserved.
- Go already adds `Accept-Encoding: gzip` (transport compression) and derives basic auth from URL userinfo, covering the remaining SABnzbd headers.

**3. Weekly version refresh**
- `versionRefreshTTL` changed from 24h → 7 days, so the latest SABnzbd version is fetched at most once per week.

## Testing
- Wire-level tests covering all three outbound paths (`addurl`, Prowlarr `DownloadNZB`, `nzblnk`) plus URL/API-key redaction.
- Redirect tests proving the `SABnzbd/<version>` UA survives a Prowlarr 302 download redirect, and that `X-Api-Key` is dropped on cross-host redirects, for both the Prowlarr client and the `addurl` handler.
