### PR TITLE
fix(speedtest): match pool provider name, pipeline fallback, report per-provider speed

### DIFF
--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -61,7 +62,20 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 	if err != nil {
 		return RespondInternalError(c, "Speed test failed", err.Error())
 	}
-	speed := result.WireSpeedBps / 1024 / 1024 // bytes/sec → MB/s
+	// Prefer the targeted provider's per-provider wire speed over the
+	// client-wide aggregate. WireSpeedBps divides the whole-client
+	// BytesConsumed delta by elapsed, so on the shared production pool
+	// any concurrent stream or other provider's traffic during the test
+	// window inflates it. result.Providers carries the delta-based,
+	// per-provider speed for exactly the provider we targeted.
+	wireBps := result.WireSpeedBps
+	for _, ps := range result.Providers {
+		if ps.AvgSpeed > 0 {
+			wireBps = ps.AvgSpeed
+			break
+		}
+	}
+	speed := wireBps / 1024 / 1024 // bytes/sec → MB/s
 
 	// Update provider config with speed test result
 	now := time.Now()
@@ -108,9 +122,15 @@ func (s *Server) runProviderSpeedTest(ctx context.Context, p *config.ProviderCon
 	if s.poolManager != nil {
 		if cp, err := s.poolManager.GetPool(); err == nil && cp != nil {
 			if real, ok := cp.(*nntppool.Client); ok {
-				providerName := p.Host
+				// Match the name the production pool registers for this
+				// provider: ToNNTPProvider sets Host = "host:port", and
+				// nntppool's resolveProviderName derives "host:port+user".
+				// Building the lookup from p.Host alone (no port) never
+				// matches, forcing the slow coordinator fallback.
+				host := fmt.Sprintf("%s:%d", p.Host, p.Port)
+				providerName := host
 				if p.Username != "" {
-					providerName = p.Host + "+" + p.Username
+					providerName = host + "+" + p.Username
 				}
 				// Try the production pool first. If the provider isn't
 				// in it, nntppool returns an error and we fall through

--- a/internal/api/speedtest_coordinator.go
+++ b/internal/api/speedtest_coordinator.go
@@ -149,12 +149,21 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 		}
 	}
 
+	// Mirror the production pool (ToNNTPProvider): without Inflight the
+	// nntppool client defaults to depth 1, making the fallback path
+	// latency-bound (one BODY per RTT) instead of pipelined.
+	inflight := p.InflightRequests
+	if inflight <= 0 {
+		inflight = 10
+	}
+
 	client, err := nntppool.NewClient(ctx, []nntppool.Provider{
 		{
 			Host:        host,
 			TLSConfig:   tlsCfg,
 			Auth:        nntppool.Auth{Username: p.Username, Password: p.Password},
 			Connections: p.MaxConnections,
+			Inflight:    inflight,
 			IdleTimeout: 60 * time.Second,
 		},
 	})


### PR DESCRIPTION
## Summary

Fixes three bugs in the per-provider speed test so it reports an accurate number. **These correct the benchmark reading — they do not change real download/stream throughput.**

## Bugs fixed

### Bug 1 — provider-name port mismatch forced the slow path
`provider_speedtest_handler.go` built the pool-lookup name from `p.Host` alone (e.g. `host+user`), but the production pool registers providers as `host:port` (`ToNNTPProvider`), which nntppool's `resolveProviderName` turns into `host:port+user`. `findGroup` requires an exact match, so the lookup never matched and the speed test **always** fell through to the slow coordinator path. Now the name is built as `host:port[+user]`.

### Bug 2 — coordinator fallback ran at pipeline depth 1
`speedtest_coordinator.go` built its fallback client with `Connections` set but no `Inflight`, so nntppool defaulted to 1 — latency-bound, one BODY per RTT. Now sets `Inflight` from the provider's `InflightRequests` (default 10), mirroring the production pool.

### Bug 3 — reported the client-wide aggregate, not the targeted provider
The handler reported `result.WireSpeedBps`, the whole-client `BytesConsumed` delta over elapsed. Latent before — but once Bug 1's fix routes the test through the shared production pool, concurrent streams or other providers inflate it. Now reports the targeted provider's per-provider `AvgSpeed`, falling back to `WireSpeedBps` when no per-provider stat is present.

## Effect
- Speed test routes through the production pipelined path when the provider is active in the pool; the fallback also pipelines (inflight=10).
- The reported number reflects the tested provider's own wire speed, not unrelated pool traffic.

https://claude.ai/code/session_01246WE67MUiTLDKavD9u3re

---
_Generated by [Claude Code](https://claude.ai/code/session_01246WE67MUiTLDKavD9u3re)_