### PR TITLE
fix(fuse): prevent async read deadlock

### DIFF
--- a/internal/fuse/backend/asyncbuffer.go
+++ b/internal/fuse/backend/asyncbuffer.go
@@ -165,6 +165,7 @@ func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64
 	}
 
 	a.mu.Lock()
+	a.markSourceDoneIfCanceledLocked()
 	if a.closed {
 		a.mu.Unlock()
 		return a.src.ReadAtContext(ctx, p, off)
@@ -298,6 +299,7 @@ func (a *AsyncReadBuffer) fill() {
 			a.cond.Wait()
 		}
 		if a.closed || a.ctx.Err() != nil {
+			a.markSourceDoneIfCanceledLocked()
 			a.mu.Unlock()
 			return
 		}
@@ -306,6 +308,7 @@ func (a *AsyncReadBuffer) fill() {
 			a.cond.Wait()
 		}
 		if a.closed || a.ctx.Err() != nil {
+			a.markSourceDoneIfCanceledLocked()
 			a.mu.Unlock()
 			return
 		}
@@ -357,6 +360,14 @@ func (a *AsyncReadBuffer) fill() {
 		}
 		a.cond.Broadcast()
 		a.mu.Unlock()
+	}
+}
+
+func (a *AsyncReadBuffer) markSourceDoneIfCanceledLocked() {
+	if err := a.ctx.Err(); err != nil && a.streaming && !a.srcDone {
+		a.srcErr = err
+		a.srcDone = true
+		a.cond.Broadcast()
 	}
 }
 

--- a/internal/fuse/backend/asyncbuffer_test.go
+++ b/internal/fuse/backend/asyncbuffer_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"runtime"
 	"sync"
@@ -247,6 +248,42 @@ func TestAsyncReadBuffer_CloseDuringFill(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Close() hung")
+	}
+}
+
+func TestAsyncReadBuffer_CanceledFillContextDoesNotHangFrontierRead(t *testing.T) {
+	SetAsyncBufferBudget(0)
+	data := testData(4 * 1024 * 1024)
+	parentCtx, cancel := context.WithCancel(context.Background())
+	src := &countingSource{data: data}
+	a := NewAsyncReadBuffer(parentCtx, src, 256*1024, int64(len(data)), nil)
+	defer a.Close()
+
+	p := make([]byte, 1024)
+	for i := range armThreshold {
+		off := int64(i * len(p))
+		if _, err := a.ReadAtContext(context.Background(), p, off); err != nil {
+			t.Fatalf("seed read %d: %v", i, err)
+		}
+	}
+
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		readCtx, readCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer readCancel()
+		_, err := a.ReadAtContext(readCtx, p, int64(armThreshold*len(p)))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("frontier read after fill cancellation returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("frontier read hung after fill context cancellation")
 	}
 }
 

--- a/internal/fuse/backend/hanwen/file.go
+++ b/internal/fuse/backend/hanwen/file.go
@@ -32,7 +32,7 @@ type File struct {
 	size          int64
 	uid           uint32
 	gid           uint32
-	asyncBufSize  int  // per-handle read-ahead buffer size in bytes; 0 = disabled
+	asyncBufSize  int // per-handle read-ahead buffer size in bytes; 0 = disabled
 	noModTime     bool
 }
 
@@ -91,10 +91,8 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 	// stays in passthrough mode until sustained sequential reads are observed,
 	// so header probes and seek/scrub bursts never allocate it.
 	var asyncBuf *backend.AsyncReadBuffer
-	if f.asyncBufSize > 0 && f.size > int64(f.asyncBufSize) {
-		if rac, ok := aferoFile.(readAtContexter); ok {
-			asyncBuf = backend.NewAsyncReadBuffer(ctx, rac, f.asyncBufSize, f.size, f.logger)
-		}
+	if rac, ok := aferoFile.(readAtContexter); ok {
+		asyncBuf = newHandleAsyncBuffer(ctx, rac, f.asyncBufSize, f.size, f.logger)
 	}
 
 	handle := NewHandle(aferoFile, f.logger, f.path, stream, f.streamTracker, asyncBuf)
@@ -112,4 +110,17 @@ func (f *File) Open(ctx context.Context, flags uint32) (fs.FileHandle, uint32, s
 func (f *File) Read(ctx context.Context, fh fs.FileHandle, dest []byte, off int64) (fuse.ReadResult, syscall.Errno) {
 	handle := fh.(*Handle)
 	return handle.Read(ctx, dest, off)
+}
+
+func newHandleAsyncBuffer(
+	openCtx context.Context,
+	src readAtContexter,
+	asyncBufSize int,
+	fileSize int64,
+	logger *slog.Logger,
+) *backend.AsyncReadBuffer {
+	if asyncBufSize <= 0 || fileSize <= int64(asyncBufSize) {
+		return nil
+	}
+	return backend.NewAsyncReadBuffer(context.WithoutCancel(openCtx), src, asyncBufSize, fileSize, logger)
 }

--- a/internal/fuse/backend/hanwen/handle_test.go
+++ b/internal/fuse/backend/hanwen/handle_test.go
@@ -187,6 +187,37 @@ func TestHandle_Read_ContextCanceled(t *testing.T) {
 	mockFile.AssertExpectations(t)
 }
 
+func TestNewHandleAsyncBufferIgnoresOpenContextCancellation(t *testing.T) {
+	openCtx, cancelOpen := context.WithCancel(context.Background())
+	cancelOpen()
+
+	src := &readAtDepthFile{}
+	asyncBuf := newHandleAsyncBuffer(openCtx, src, 256*1024, 4*1024*1024, slog.Default())
+	require.NotNil(t, asyncBuf)
+	defer asyncBuf.Close()
+
+	p := make([]byte, 1024)
+	for i := 0; i < 3; i++ {
+		off := int64(i * len(p))
+		if _, err := asyncBuf.ReadAtContext(context.Background(), p, off); err != nil {
+			t.Fatalf("seed read %d: %v", i, err)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := asyncBuf.ReadAtContext(context.Background(), p, 3*int64(len(p)))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("async buffer was tied to the canceled open context")
+	}
+}
+
 // readAtDepthFile counts overlapping ReadAtContext calls to verify serialization.
 type readAtDepthFile struct {
 	mu        sync.Mutex


### PR DESCRIPTION
## Summary
- detach hanwen async read-ahead buffers from the FUSE Open request context
- wake frontier readers when the async buffer fill context is canceled instead of hanging
- add regression tests for canceled fill contexts and hanwen handle-lifetime buffering

## Test Plan
- go test ./...
- go test ./internal/fuse/backend
- go test ./internal/usenet

Note: GOOS=linux go test ./internal/fuse/backend/hanwen could not run on this macOS host because the Linux cross-build fails in nntppool/rapidyenc.

Fix #647 