### PR TITLE
fix(validation) report status of checked segments, not just completed

### DIFF
--- a/internal/usenet/validation.go
+++ b/internal/usenet/validation.go
@@ -42,28 +42,31 @@ func ValidateSegmentList(
 	}
 
 	totalToValidate := len(segments)
-	var validatedCount int32
+	var checkedCount int32
 
 	pl := concpool.New().WithErrors().WithFirstError().WithMaxGoroutines(maxConnections)
 	for _, seg := range segments {
 		pl.Go(func() error {
+			// Advance progress for every segment checked, pass or fail, so the
+			// bar reflects validation throughput instead of freezing at the
+			// stage floor (e.g. 30%) when a file is incomplete and no segment
+			// succeeds.
+			if progressTracker != nil {
+				defer func() {
+					count := atomic.AddInt32(&checkedCount, 1)
+					progressTracker.Update(int(count), totalToValidate)
+				}()
+			}
+
 			checkCtx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
-			var err error
-			_, err = usenetPool.Stat(checkCtx, seg.Id)
-			if err == nil {
-				poolManager.IncArticlesDownloaded()
-				poolManager.UpdateDownloadProgress("", 100)
-			}
-			if err != nil {
+			if _, err := usenetPool.Stat(checkCtx, seg.Id); err != nil {
 				return fmt.Errorf("segment with ID %s unreachable: %w", seg.Id, err)
 			}
 
-			if progressTracker != nil {
-				count := atomic.AddInt32(&validatedCount, 1)
-				progressTracker.Update(int(count), totalToValidate)
-			}
+			poolManager.IncArticlesDownloaded()
+			poolManager.UpdateDownloadProgress("", 100)
 
 			return nil
 		})


### PR DESCRIPTION
## Problem

* Have import validation set to 100%

During NZB import, the queue progress bar sits frozen at **"Validating segments 30%"** for the entire validation phase, then jumps straight to completed or failed. For incomplete files (segments missing on the provider) it can appear stuck for seconds to minutes, which is indistinguishable from a hang.

The 30% value is not real progress. It is a fixed **stage marker** set in `internal/importer/processor.go` right before validation begins:

```go
proc.updateProgressWithStage(queueID, 30, "Validating segments")
```

Validation then owns the 30→100% band via a tracker created with `CreateTracker(queueID, 30, 100)`. Real progress within that band is computed in `internal/progress/tracker.go`:

```
percentage = minPercent + (current * (maxPercent - minPercent) / total)
           = 30 + (current * 70 / total)
```

## Root cause

In `ValidateSegmentList`, the progress counter only incremented **after a successful `Stat`**. A failed segment returned early and never reached the update:

```go
_, err = usenetPool.Stat(checkCtx, seg.Id)
...
if err != nil {
    return fmt.Errorf("segment with ID %s unreachable: %w", seg.Id, err) // returns BEFORE progress update
}

if progressTracker != nil {
    count := atomic.AddInt32(&validatedCount, 1) // only reached on success
    progressTracker.Update(int(count), totalToValidate)
}
```

So when a file's articles are missing, `validatedCount` stays at 0 and the math resolves to `30 + 0*70/total = 30%` for the whole run. The bar literally cannot move until a segment succeeds.

This matters because the pool is built with `WithErrors().WithFirstError()` and **no context cancellation**, so it STATs every selected segment even after the first failure. The work is happening; the UI just had no way to reflect it.


## The change

Count every segment that has been **checked** (pass or fail) rather than only successes. The update is moved into a `defer` so it always fires when the goroutine returns, regardless of the `Stat` outcome.

Walkthrough the changes:

1. **`validatedCount` to `checkedCount`.** The counter now tracks segments *checked*, not segments that *passed*. Renamed so the name matches the meaning.
2. **Progress update moved into a `defer` at the top of the closure.** Deferring guarantees it runs on every return path, including the early `return` when `Stat` fails. This is the core of the fix.
3. **Error handling collapsed into a single `if`.** With the success-side side effects (`IncArticlesDownloaded` / `UpdateDownloadProgress`) moved below the error check, the `var err error` / split `if err == nil` / `if err != nil` blocks are no longer needed. The unreachable-segment error return is unchanged.


## Behavior change

| Scenario | Before | After |
|---|---|---|
| Healthy file | 30% until done, then jumps to 100% | climbs 30→100% smoothly as segments are checked |
| Incomplete file | frozen at 30% for the whole run, then fails | climbs toward 100% as it checks, then fails |