### PR TITLE
fix(health): harden record lifecycle and stop pending/repair records stranding

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -607,7 +607,10 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 					metadataStr = &str
 				}
 
-				if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr); err == nil && relinked {
+				// Download events carry a freshly imported copy: relink with revalidation so
+			// the new file gets health-checked (repair budget is preserved). Rename events
+			// carry no new content and must not disturb repair/corrupted state.
+			if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
 					attrs := []any{
 						"event", req.EventType,
 						"instance", req.InstanceName,

--- a/internal/database/health_fixes_test.go
+++ b/internal/database/health_fixes_test.go
@@ -1,0 +1,335 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Fix A: corrupted is terminal at the query level, and backfill never re-arms it ---
+
+// TestGetUnhealthyFiles_ExcludesCorrupted verifies that a 'corrupted' record is never
+// selected for checking even when it has a due scheduled_check_at and retry budget left,
+// so no re-arm vector (e.g. an unconditional release-date backfill) can resurrect it.
+func TestGetUnhealthyFiles_ExcludesCorrupted(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, max_retries, scheduled_check_at)
+		VALUES ('corrupted.mkv', 'corrupted', 2, 3, ?), ('pending.mkv', 'pending', 0, 3, ?)
+	`, past, past)
+	require.NoError(t, err)
+
+	files, err := repo.GetUnhealthyFiles(ctx, 10, "NONE", "", 3)
+	require.NoError(t, err)
+
+	paths := map[string]bool{}
+	for _, f := range files {
+		paths[f.FilePath] = true
+	}
+	assert.False(t, paths["corrupted.mkv"], "corrupted record must not be selected for checking")
+	assert.True(t, paths["pending.mkv"], "pending record must still be selected (control)")
+}
+
+// TestBackfillReleaseDates_DoesNotRearmTerminal verifies the status-gated backfill:
+// release_date is filled for every record, but scheduled_check_at is only (re)scheduled
+// for non-terminal/non-repair records. A corrupted record's NULL schedule must survive.
+func TestBackfillReleaseDates_DoesNotRearmTerminal(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, scheduled_check_at, release_date)
+		VALUES ('dead.mkv', 'corrupted', NULL, NULL), ('alive.mkv', 'pending', NULL, NULL)
+	`)
+	require.NoError(t, err)
+
+	dead, err := repo.GetFileHealth(ctx, "dead.mkv")
+	require.NoError(t, err)
+	alive, err := repo.GetFileHealth(ctx, "alive.mkv")
+	require.NoError(t, err)
+
+	future := time.Now().UTC().Add(48 * time.Hour)
+	relDate := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	err = repo.BackfillReleaseDates(ctx, []BackfillUpdate{
+		{ID: dead.ID, ReleaseDate: relDate, ScheduledCheckAt: future},
+		{ID: alive.ID, ReleaseDate: relDate, ScheduledCheckAt: future},
+	})
+	require.NoError(t, err)
+
+	dead, err = repo.GetFileHealth(ctx, "dead.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, dead.ReleaseDate, "release_date must be backfilled even for corrupted records")
+
+	alive, err = repo.GetFileHealth(ctx, "alive.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, alive.ReleaseDate)
+
+	// GetFileHealth does not project scheduled_check_at, so read it directly.
+	assert.False(t, scheduledCheckAt(t, repo, "dead.mkv").Valid,
+		"backfill must NOT re-arm a corrupted record's terminal NULL schedule")
+	assert.True(t, scheduledCheckAt(t, repo, "alive.mkv").Valid,
+		"pending record must be (re)scheduled by backfill")
+}
+
+// scheduledCheckAt reads the raw scheduled_check_at column (not projected by GetFileHealth).
+func scheduledCheckAt(t *testing.T, repo *HealthRepository, filePath string) sql.NullString {
+	t.Helper()
+	var v sql.NullString
+	require.NoError(t, repo.db.QueryRowContext(context.Background(),
+		"SELECT scheduled_check_at FROM file_health WHERE file_path = ?", filePath).Scan(&v))
+	return v
+}
+
+// --- Fix B: status-conditional bulk updates close the TOCTOU window ---
+
+// TestUpdateHealthStatusBulk_ExpectedStatusGuard verifies that a guarded write only lands
+// when the record still holds the expected status, so a concurrent transition (e.g. a
+// webhook relink moving repair_triggered -> pending) is not clobbered.
+func TestUpdateHealthStatusBulk_ExpectedStatusGuard(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('rescued.mkv', 'pending', 1, 3), ('still_repair.mkv', 'repair_triggered', 1, 3)
+	`)
+	require.NoError(t, err)
+
+	repairStatus := HealthStatusRepairTriggered
+	now := time.Now().UTC()
+	err = repo.UpdateHealthStatusBulk(ctx, []HealthStatusUpdate{
+		{Type: UpdateTypeRepairRetry, FilePath: "rescued.mkv", ScheduledCheckAt: now, ExpectedStatus: &repairStatus},
+		{Type: UpdateTypeRepairRetry, FilePath: "still_repair.mkv", ScheduledCheckAt: now, ExpectedStatus: &repairStatus},
+	})
+	require.NoError(t, err)
+
+	rescued, err := repo.GetFileHealth(ctx, "rescued.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusPending, rescued.Status, "guard must prevent clobbering a concurrently-rescued record")
+	assert.Equal(t, 1, rescued.RepairRetryCount, "guarded no-op must not increment the repair budget")
+
+	still, err := repo.GetFileHealth(ctx, "still_repair.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusRepairTriggered, still.Status)
+	assert.Equal(t, 2, still.RepairRetryCount, "guard must allow the write when status still matches")
+}
+
+// TestUpdateHealthStatusBulk_NoGuardAppliesRegardless verifies that without ExpectedStatus
+// the write applies regardless of current status (preserving the legacy unguarded path).
+func TestUpdateHealthStatusBulk_NoGuardAppliesRegardless(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, max_retries)
+		VALUES ('any.mkv', 'pending', 0, 3)
+	`)
+	require.NoError(t, err)
+
+	err = repo.UpdateHealthStatusBulk(ctx, []HealthStatusUpdate{
+		{Type: UpdateTypeRetry, FilePath: "any.mkv", ScheduledCheckAt: time.Now().UTC()},
+	})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "any.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.RetryCount, "unguarded write must apply")
+}
+
+// --- Fix C: relink refuses an ambiguous blanket reset across colliding basenames ---
+
+func TestRelinkFileByFilename_RefusesAmbiguousCollision(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('tv/ShowA/01.mkv', 'repair_triggered', 1, 3), ('tv/ShowB/01.mkv', 'repair_triggered', 1, 3)
+	`)
+	require.NoError(t, err)
+
+	// Incoming Download whose path matches NEITHER existing record exactly: must refuse.
+	relinked, err := repo.RelinkFileByFilename(ctx, "01.mkv", "tv/ShowC/01.mkv", "/lib/ShowC/01.mkv", nil, true)
+	require.NoError(t, err)
+	assert.False(t, relinked, "a basename matching multiple unrelated records must not be blanket-relinked")
+
+	for _, p := range []string{"tv/ShowA/01.mkv", "tv/ShowB/01.mkv"} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		assert.Equal(t, HealthStatusRepairTriggered, h.Status, "%s must be untouched", p)
+		assert.Equal(t, 1, h.RepairRetryCount, "%s repair budget must be untouched", p)
+	}
+}
+
+func TestRelinkFileByFilename_CollisionResolvedByExactPath(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('tv/ShowA/01.mkv', 'repair_triggered', 1, 3), ('tv/ShowB/01.mkv', 'repair_triggered', 2, 3)
+	`)
+	require.NoError(t, err)
+
+	// Incoming Download whose path matches ShowA exactly: relink only that one.
+	relinked, err := repo.RelinkFileByFilename(ctx, "01.mkv", "tv/ShowA/01.mkv", "/lib/ShowA/01.mkv", nil, true)
+	require.NoError(t, err)
+	assert.True(t, relinked)
+
+	a, err := repo.GetFileHealth(ctx, "tv/ShowA/01.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusPending, a.Status, "exact-match target is revalidated to pending")
+	assert.Equal(t, 1, a.RepairRetryCount, "repair budget preserved across the Download relink")
+
+	b, err := repo.GetFileHealth(ctx, "tv/ShowB/01.mkv")
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusRepairTriggered, b.Status, "the colliding sibling must be untouched")
+	assert.Equal(t, 2, b.RepairRetryCount)
+}
+
+// --- Fix D: prefix deletes escape LIKE metacharacters ---
+
+func TestDeleteHealthRecordsByPrefix_EscapesWildcards(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status) VALUES
+			('tv/Show_S01_1080p/e01.mkv', 'pending'),
+			('tv/ShowXS01X1080p/e01.mkv', 'pending'),
+			('tv/100%Real/e01.mkv', 'pending'),
+			('tv/100ZZReal/e01.mkv', 'pending')
+	`)
+	require.NoError(t, err)
+
+	n, err := repo.DeleteHealthRecordsByPrefix(ctx, "tv/Show_S01_1080p")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "underscore prefix must match only its own subtree")
+
+	survivor, err := repo.GetFileHealth(ctx, "tv/ShowXS01X1080p/e01.mkv")
+	require.NoError(t, err)
+	assert.NotNil(t, survivor, "'_' wildcard must not over-delete an unrelated sibling")
+
+	n, err = repo.DeleteHealthRecordsByPrefix(ctx, "tv/100%Real")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "percent prefix must match only its own subtree")
+
+	survivor, err = repo.GetFileHealth(ctx, "tv/100ZZReal/e01.mkv")
+	require.NoError(t, err)
+	assert.NotNil(t, survivor, "'%' wildcard must not over-delete an unrelated sibling")
+}
+
+// --- Fix E: failed-import cleanup spares prior successful import's records ---
+
+func TestDeleteUnvalidatedHealthRecordsByPrefix_PreservesValidated(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, library_path, status) VALUES
+			('tv/Pack/e01.mkv', 'tv/Pack/e01.mkv', 'pending'),
+			('tv/Pack/e02.mkv', '/lib/Pack/e02.mkv', 'healthy'),
+			('tv/Pack/e03.mkv', '/lib/Pack/e03.mkv', 'pending'),
+			('tv/Pack/e04.mkv', 'tv/Pack/e04.mkv', 'repair_triggered')
+	`)
+	require.NoError(t, err)
+
+	n, err := repo.DeleteUnvalidatedHealthRecordsByPrefix(ctx, "tv/Pack")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n, "only the unvalidated placeholder record may be deleted")
+
+	gone, err := repo.GetFileHealth(ctx, "tv/Pack/e01.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, gone, "pending placeholder (library_path == file_path) is removed")
+
+	for _, p := range []string{"tv/Pack/e02.mkv", "tv/Pack/e03.mkv", "tv/Pack/e04.mkv"} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		assert.NotNil(t, h, "%s belongs to a prior successful import and must survive", p)
+	}
+}
+
+// --- Fix F: every writer normalizes a leading slash so UNIQUE(file_path) holds ---
+
+func TestRegisterCorruptedFile_NormalizesLeadingSlash(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, repo.RegisterCorruptedFile(ctx, "/tv/Slashed/e01.mkv", nil, "boom"))
+
+	h, err := repo.GetFileHealth(ctx, "tv/Slashed/e01.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h, "record must be stored without the leading slash")
+}
+
+func TestAddHealthCheck_NormalizesLeadingSlash(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	require.NoError(t, repo.AddHealthCheck(ctx, "/tv/Slashed/e02.mkv", now, now, nil))
+
+	h, err := repo.GetFileHealth(ctx, "tv/Slashed/e02.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h, "record must be stored without the leading slash")
+}
+
+// --- Fix G: bulk checking transition ---
+
+func TestSetFilesCheckingBulk(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status) VALUES ('a.mkv', 'pending'), ('b.mkv', 'pending')
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.SetFilesCheckingBulk(ctx, []string{"a.mkv", "/b.mkv"}))
+
+	for _, p := range []string{"a.mkv", "b.mkv"} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		assert.Equal(t, HealthStatusChecking, h.Status, "%s must be marked checking", p)
+	}
+}
+
+// --- Fix I: batch upsert preserves the per-title repair budget on conflict ---
+
+func TestBatchAddFileToHealthCheck_PreservesRepairBudget(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count, max_repair_retries)
+		VALUES ('tv/Pack/old.mkv', 'repair_triggered', 2, 2, 3)
+	`)
+	require.NoError(t, err)
+
+	lib1 := "tv/Pack/old.mkv"
+	lib2 := "tv/Pack/new.mkv"
+	err = repo.BatchAddFileToHealthCheck(ctx, []HealthCheckUpsert{
+		{FilePath: "tv/Pack/old.mkv", LibraryPath: &lib1, Priority: HealthPriorityNext, MaxRetries: 3, MaxRepairRetries: 3},
+		{FilePath: "/tv/Pack/new.mkv", LibraryPath: &lib2, Priority: HealthPriorityNext, MaxRetries: 3, MaxRepairRetries: 3},
+	})
+	require.NoError(t, err)
+
+	old, err := repo.GetFileHealth(ctx, "tv/Pack/old.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, old)
+	assert.Equal(t, HealthStatusPending, old.Status, "re-import upsert resets to pending")
+	assert.Equal(t, 0, old.RetryCount, "retry_count resets for the new copy")
+	assert.Equal(t, 2, old.RepairRetryCount, "repair budget must survive the batched re-import upsert")
+
+	fresh, err := repo.GetFileHealth(ctx, "tv/Pack/new.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, fresh, "new path normalized and inserted")
+	assert.Equal(t, HealthStatusPending, fresh.Status)
+}

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -279,7 +279,10 @@ func (r *HealthRepository) SetPriority(ctx context.Context, id int64, priority H
 	return nil
 }
 
-// GetFilesForRepairNotification returns files that need repair notification (repair_triggered status)
+// GetFilesForRepairNotification returns files that need repair notification (repair_triggered status).
+// Records whose repair_retry_count has reached max_repair_retries are returned too: the worker
+// finalizes them as corrupted (prepareRepairNotificationUpdate). Filtering them out here would
+// leave them permanently stuck in repair_triggered — no other query ever selects that status.
 func (r *HealthRepository) GetFilesForRepairNotification(ctx context.Context, limit int) ([]*FileHealth, error) {
 	query := `
 		SELECT id, file_path, status, last_checked, last_error, retry_count, max_retries,
@@ -288,7 +291,6 @@ func (r *HealthRepository) GetFilesForRepairNotification(ctx context.Context, li
 		, metadata
 		FROM file_health
 		WHERE status = 'repair_triggered'
-		  AND repair_retry_count < max_repair_retries
 		  AND (scheduled_check_at IS NULL OR scheduled_check_at <= datetime('now'))
 		ORDER BY last_checked ASC
 		LIMIT ?
@@ -594,8 +596,13 @@ func (r *HealthRepository) AddFileToHealthCheck(ctx context.Context, filePath st
 	return r.AddFileToHealthCheckWithMetadata(ctx, filePath, libraryPath, maxRetries, maxRepairRetries, sourceNzbPath, priority, nil, nil, nil)
 }
 
-// AddFileToHealthCheckWithMetadata adds a file to the health database for checking with metadata
+// AddFileToHealthCheckWithMetadata adds a file to the health database for checking with metadata.
+// On conflict (re-import over an existing record) the record is reset to pending for
+// re-validation, but repair_retry_count is intentionally preserved: it is the per-title
+// repair budget, so a re-download of a broken release cannot reset its own escalation
+// counter. A successful health check resets it to 0.
 func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context, filePath string, libraryPath *string, maxRetries int, maxRepairRetries int, sourceNzbPath *string, priority HealthPriority, releaseDate *time.Time, metadata *string, indexer *string) error {
+	filePath = strings.TrimPrefix(filePath, "/")
 	var releaseDateStr any = nil
 	if releaseDate != nil {
 		releaseDateStr = releaseDate.UTC().Format("2006-01-02 15:04:05")
@@ -609,7 +616,6 @@ func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context,
 		library_path = COALESCE(excluded.library_path, library_path),
 		status = excluded.status,
 		retry_count = 0,
-		repair_retry_count = 0,
 		last_error = NULL,
 		error_details = NULL,
 		max_retries = excluded.max_retries,
@@ -1522,7 +1528,16 @@ func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newP
 
 // RelinkFileByFilename updates the file_path and library_path for a record that matches by filename.
 // This is typically called by webhooks during renames or downloads to provide a definitive library path.
-func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string) (bool, error) {
+//
+// revalidate controls what happens to records in repair_triggered/corrupted state:
+//   - true (Download events — a re-downloaded copy was just imported): reset the record to
+//     pending with an immediate check so the fresh copy is validated instead of being
+//     destroyed by the next repair re-trigger. retry_count restarts for the new copy, but
+//     repair_retry_count is preserved as the per-title repair budget so repeatedly broken
+//     re-downloads still escalate to corrupted instead of looping forever.
+//   - false (Rename events — no new content): preserve repair/corrupted state so a library
+//     reorganization cannot wipe repair progress.
+func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
 	filePath = strings.TrimPrefix(filePath, "/")
 	query := `
 		UPDATE file_health
@@ -1537,6 +1552,21 @@ func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, f
 		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
 		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
 	`
+	if revalidate {
+		query = `
+			UPDATE file_health
+			SET file_path = ?,
+			    library_path = ?,
+			    status = 'pending',
+			    retry_count = 0,
+			    last_error = NULL,
+			    error_details = NULL,
+			    metadata = COALESCE(?, metadata),
+			    updated_at = datetime('now'),
+			    scheduled_check_at = datetime('now')
+			WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
+		`
+	}
 
 	likePattern := "%/" + filename
 	res, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, likePattern, filename, likePattern, libraryPath)

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -23,9 +23,32 @@ func NewHealthRepository(db *sql.DB, d Dialect) *HealthRepository {
 	}
 }
 
+// normalizeHealthPath canonicalizes a virtual file path before it is written to or
+// matched against file_health. file_path carries a UNIQUE constraint, so a leading
+// slash ("/tv/x" vs "tv/x") from one caller would otherwise split a single virtual
+// file across two rows and silently defeat the repair_retry_count budget that the
+// repair state machine relies on. Every method that writes or matches on file_path
+// funnels through here.
+func normalizeHealthPath(p string) string {
+	return strings.TrimPrefix(p, "/")
+}
+
+// escapeLikePrefix escapes the LIKE metacharacters in a literal prefix so it can be
+// safely concatenated into a "prefix/%" pattern. Release/folder names routinely
+// contain '_' (matches any single char) and occasionally '%' (matches any run), which
+// would otherwise over-match unrelated siblings. Callers must pair the result with an
+// explicit `ESCAPE '\'` clause. The backslash is escaped first so it cannot double-escape
+// a subsequently-inserted escape character.
+func escapeLikePrefix(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	s = strings.ReplaceAll(s, "%", "\\%")
+	s = strings.ReplaceAll(s, "_", "\\_")
+	return s
+}
+
 // UpdateFileHealth updates or inserts a file health record
 func (r *HealthRepository) UpdateFileHealth(ctx context.Context, filePath string, status HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		INSERT INTO file_health (file_path, status, last_checked, last_error, source_nzb_path, error_details, retry_count, max_retries, repair_retry_count, created_at, updated_at, scheduled_check_at, priority)
 		VALUES (?, ?, datetime('now'), ?, ?, ?, CASE WHEN ? THEN 1 ELSE 0 END, 2, 0, datetime('now'), datetime('now'), datetime('now'), CASE WHEN ? THEN 2 ELSE 0 END)
@@ -53,7 +76,7 @@ func (r *HealthRepository) UpdateFileHealth(ctx context.Context, filePath string
 // UpdateFileHealthScheduled is like UpdateFileHealth but uses an explicit scheduledAt time
 // instead of datetime('now') for the scheduled_check_at column.
 func (r *HealthRepository) UpdateFileHealthScheduled(ctx context.Context, filePath string, status HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	scheduledAtStr := scheduledAt.UTC().Format("2006-01-02 15:04:05")
 	query := `
 		INSERT INTO file_health (file_path, status, last_checked, last_error, source_nzb_path, error_details, retry_count, max_retries, repair_retry_count, created_at, updated_at, scheduled_check_at, priority)
@@ -119,7 +142,7 @@ func scanFileHealth(s rowScanner) (*FileHealth, error) {
 
 // GetFileHealth retrieves health record for a specific file
 func (r *HealthRepository) GetFileHealth(ctx context.Context, filePath string) (*FileHealth, error) {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	health, err := scanFileHealth(r.db.QueryRowContext(ctx, fileHealthSelectColumns+"WHERE file_path = ?", filePath))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -155,7 +178,7 @@ func (r *HealthRepository) GetFileHealthByID(ctx context.Context, id int64) (*Fi
 
 // IncrementStreamingFailureCount increments the streaming failure count and returns whether masking/repair threshold was reached
 func (r *HealthRepository) IncrementStreamingFailureCount(ctx context.Context, filePath string, threshold int) (bool, bool, error) {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		UPDATE file_health
 		SET streaming_failure_count = streaming_failure_count + 1,
@@ -177,7 +200,7 @@ func (r *HealthRepository) IncrementStreamingFailureCount(ctx context.Context, f
 
 // UnmaskFile removes the mask from a file and resets the failure count
 func (r *HealthRepository) UnmaskFile(ctx context.Context, filePath string) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		UPDATE file_health
 		SET is_masked = FALSE,
@@ -207,7 +230,11 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		WHERE scheduled_check_at IS NOT NULL
 		  AND scheduled_check_at <= datetime('now')
 		  AND retry_count < ?
-		  AND status NOT IN ('repair_triggered', 'checking')
+		  -- 'corrupted' is terminal: enforce it at the query level so no re-arm vector
+		  -- (e.g. an unconditional release-date backfill writing scheduled_check_at) can
+		  -- pull a finalized record back into the check queue. 'repair_triggered' and
+		  -- 'checking' are owned by other queries / an in-flight cycle.
+		  AND status NOT IN ('repair_triggered', 'checking', 'corrupted')
 		  AND (
 			  ? = 'NONE' 
 			  OR (library_path IS NOT NULL AND library_path LIKE ?)
@@ -476,7 +503,7 @@ func (r *HealthRepository) DeleteHealthRecordByID(ctx context.Context, id int64)
 
 // DeleteHealthRecord removes a specific health record from the database
 func (r *HealthRepository) DeleteHealthRecord(ctx context.Context, filePath string) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `DELETE FROM file_health WHERE file_path = ?`
 
 	result, err := r.db.ExecContext(ctx, query, filePath)
@@ -521,8 +548,8 @@ func (r *HealthRepository) DeleteHealthRecordsByLibraryPathPrefix(ctx context.Co
 		return nil, 0, nil
 	}
 
-	likePattern := libraryPathPrefix + "/%"
-	query := `DELETE FROM file_health WHERE library_path = ? OR library_path LIKE ? RETURNING file_path`
+	likePattern := escapeLikePrefix(libraryPathPrefix) + "/%"
+	query := `DELETE FROM file_health WHERE library_path = ? OR library_path LIKE ? ESCAPE '\' RETURNING file_path`
 	rows, err := r.db.QueryContext(ctx, query, libraryPathPrefix, likePattern)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to delete health records by library_path prefix %s: %w", libraryPathPrefix, err)
@@ -544,15 +571,20 @@ func (r *HealthRepository) DeleteHealthRecordsByLibraryPathPrefix(ctx context.Co
 	return filePaths, int64(len(filePaths)), nil
 }
 
-// DeleteHealthRecordsByPrefix removes health records that start with the given prefix
+// DeleteHealthRecordsByPrefix removes ALL health records at or under the given virtual
+// path prefix. Used by the webhook directory-delete handler, where the whole subtree is
+// genuinely gone and every record (including healthy/relinked ones) must be removed.
+// For failed-import rollback use DeleteUnvalidatedHealthRecordsByPrefix instead.
 func (r *HealthRepository) DeleteHealthRecordsByPrefix(ctx context.Context, prefix string) (int64, error) {
-	prefix = strings.TrimPrefix(prefix, "/")
+	prefix = normalizeHealthPath(prefix)
 	if prefix == "" {
 		return 0, nil
 	}
 
-	query := `DELETE FROM file_health WHERE file_path = ? OR file_path LIKE ?`
-	likePattern := prefix + "/%"
+	// LIKE metacharacters in the prefix must be escaped: a release folder containing '_'
+	// or '%' would otherwise over-match and delete unrelated siblings' records.
+	query := `DELETE FROM file_health WHERE file_path = ? OR file_path LIKE ? ESCAPE '\'`
+	likePattern := escapeLikePrefix(prefix) + "/%"
 
 	result, err := r.db.ExecContext(ctx, query, prefix, likePattern)
 	if err != nil {
@@ -562,8 +594,39 @@ func (r *HealthRepository) DeleteHealthRecordsByPrefix(ctx context.Context, pref
 	return result.RowsAffected()
 }
 
+// DeleteUnvalidatedHealthRecordsByPrefix removes only the still-unvalidated placeholder
+// records at or under the prefix — those an ARR webhook has not yet relinked to a real
+// library path (library_path NULL or still equal to the virtual file_path) and that are
+// not in a terminal/repair state. This is the failed-import rollback path: the nzbFolder
+// is deterministic per release (not unique per queue item), so a failed re-import of a
+// release that previously imported successfully shares the subtree. Scoping to unvalidated
+// records protects the prior successful import's healthy/relinked/repair_triggered/corrupted
+// records (and the repair budget they carry) from being wiped by an unrelated failed attempt.
+func (r *HealthRepository) DeleteUnvalidatedHealthRecordsByPrefix(ctx context.Context, prefix string) (int64, error) {
+	prefix = normalizeHealthPath(prefix)
+	if prefix == "" {
+		return 0, nil
+	}
+
+	query := `
+		DELETE FROM file_health
+		WHERE (file_path = ? OR file_path LIKE ? ESCAPE '\')
+		  AND status IN ('pending', 'checking')
+		  AND (library_path IS NULL OR library_path = file_path)
+	`
+	likePattern := escapeLikePrefix(prefix) + "/%"
+
+	result, err := r.db.ExecContext(ctx, query, prefix, likePattern)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete unvalidated health records by prefix %s: %w", prefix, err)
+	}
+
+	return result.RowsAffected()
+}
+
 // RegisterCorruptedFile adds or updates a file as corrupted and schedules it for immediate check/repair
 func (r *HealthRepository) RegisterCorruptedFile(ctx context.Context, filePath string, libraryPath *string, errorMessage string) error {
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		INSERT INTO file_health (
 			file_path, library_path, status, last_error, error_details,
@@ -602,7 +665,7 @@ func (r *HealthRepository) AddFileToHealthCheck(ctx context.Context, filePath st
 // repair budget, so a re-download of a broken release cannot reset its own escalation
 // counter. A successful health check resets it to 0.
 func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context, filePath string, libraryPath *string, maxRetries int, maxRepairRetries int, sourceNzbPath *string, priority HealthPriority, releaseDate *time.Time, metadata *string, indexer *string) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	var releaseDateStr any = nil
 	if releaseDate != nil {
 		releaseDateStr = releaseDate.UTC().Format("2006-01-02 15:04:05")
@@ -633,6 +696,90 @@ func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context,
 
 	if err != nil {
 		return fmt.Errorf("failed to add file to health check: %w", err)
+	}
+
+	return nil
+}
+
+// HealthCheckUpsert is one record for BatchAddFileToHealthCheck.
+type HealthCheckUpsert struct {
+	FilePath         string
+	LibraryPath      *string
+	SourceNzbPath    *string
+	Indexer          *string
+	Priority         HealthPriority
+	MaxRetries       int
+	MaxRepairRetries int
+	ReleaseDate      *time.Time
+	Metadata         *string
+}
+
+// BatchAddFileToHealthCheck upserts many health records in a few multi-row statements
+// instead of one transaction per file. It has the SAME conflict semantics as
+// AddFileToHealthCheckWithMetadata (reset to pending for re-validation, repair_retry_count
+// preserved as the per-title budget). Used by the import post-processor, where a single
+// archive/season-pack import can expand to hundreds of per-file checks.
+func (r *HealthRepository) BatchAddFileToHealthCheck(ctx context.Context, records []HealthCheckUpsert) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	// 9 bound params per row; keep batches under SQLite's ~999 parameter limit.
+	const batchSize = 100
+
+	for i := 0; i < len(records); i += batchSize {
+		end := min(i+batchSize, len(records))
+		if err := r.batchUpsertFileHealthCheck(ctx, records[i:end]); err != nil {
+			return fmt.Errorf("failed to upsert health-check batch at index %d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// batchUpsertFileHealthCheck performs a single multi-row upsert.
+func (r *HealthRepository) batchUpsertFileHealthCheck(ctx context.Context, records []HealthCheckUpsert) error {
+	valueStrings := make([]string, len(records))
+	args := make([]any, 0, len(records)*9)
+
+	for i, rec := range records {
+		// status, retry_count and repair_retry_count are literals so excluded.status is
+		// always 'pending' (matching the single-row upsert's bound HealthStatusPending).
+		valueStrings[i] = "(?, ?, 'pending', datetime('now'), 0, ?, 0, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), datetime('now'))"
+
+		var releaseDateStr any = nil
+		if rec.ReleaseDate != nil {
+			releaseDateStr = rec.ReleaseDate.UTC().Format("2006-01-02 15:04:05")
+		}
+
+		args = append(args,
+			normalizeHealthPath(rec.FilePath), rec.LibraryPath,
+			rec.MaxRetries, rec.MaxRepairRetries,
+			rec.SourceNzbPath, rec.Priority, releaseDateStr, rec.Metadata, rec.Indexer)
+	}
+
+	query := fmt.Sprintf(`
+		INSERT INTO file_health (file_path, library_path, status, last_checked, retry_count, max_retries, repair_retry_count, max_repair_retries, source_nzb_path, priority, release_date, metadata, indexer, created_at, updated_at, scheduled_check_at)
+		VALUES %s
+		ON CONFLICT(file_path) DO UPDATE SET
+			library_path = COALESCE(excluded.library_path, library_path),
+			status = excluded.status,
+			retry_count = 0,
+			last_error = NULL,
+			error_details = NULL,
+			max_retries = excluded.max_retries,
+			max_repair_retries = excluded.max_repair_retries,
+			source_nzb_path = COALESCE(excluded.source_nzb_path, source_nzb_path),
+			priority = excluded.priority,
+			release_date = COALESCE(excluded.release_date, release_date),
+			metadata = COALESCE(excluded.metadata, metadata),
+			indexer = COALESCE(excluded.indexer, indexer),
+			updated_at = datetime('now'),
+			scheduled_check_at = datetime('now')
+	`, strings.Join(valueStrings, ","))
+
+	if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("failed to batch upsert file health checks: %w", err)
 	}
 
 	return nil
@@ -779,6 +926,45 @@ func (r *HealthRepository) SetFileChecking(ctx context.Context, filePath string)
 	_, err := r.db.ExecContext(ctx, query, HealthStatusChecking, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to set file status to checking: %w", err)
+	}
+
+	return nil
+}
+
+// SetFilesCheckingBulk marks many files 'checking' in as few writes as possible. The
+// health cycle calls this once for the whole batch instead of issuing one UPDATE per
+// file, which under SQLite's single writer would serialize N transactions against each
+// other and the final bulk status write. Crash recovery is unchanged: ResetFileAllChecking
+// at worker startup re-arms any record stranded in 'checking'.
+func (r *HealthRepository) SetFilesCheckingBulk(ctx context.Context, filePaths []string) error {
+	if len(filePaths) == 0 {
+		return nil
+	}
+
+	// SQLite parameter limit is typically 999; leave room for the status arg.
+	const batchSize = 500
+
+	for i := 0; i < len(filePaths); i += batchSize {
+		end := min(i+batchSize, len(filePaths))
+		chunk := filePaths[i:end]
+
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)+1)
+		args = append(args, HealthStatusChecking)
+		for j, p := range chunk {
+			placeholders[j] = "?"
+			args = append(args, normalizeHealthPath(p))
+		}
+
+		query := fmt.Sprintf(`
+			UPDATE file_health
+			SET status = ?, updated_at = datetime('now')
+			WHERE file_path IN (%s)
+		`, strings.Join(placeholders, ","))
+
+		if _, err := r.db.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf("failed to bulk set files checking (batch at %d): %w", i, err)
+		}
 	}
 
 	return nil
@@ -977,6 +1163,7 @@ func (r *HealthRepository) AddHealthCheck(
 	scheduledCheckAt time.Time,
 	sourceNzbPath *string,
 ) error {
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		INSERT INTO file_health (
 			file_path, status, last_checked, retry_count, max_retries,
@@ -1002,7 +1189,7 @@ func (r *HealthRepository) AddHealthCheck(
 
 // UpdateScheduledCheckTime updates the scheduled check time for a file
 func (r *HealthRepository) UpdateScheduledCheckTime(ctx context.Context, filePath string, nextCheckTime time.Time) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		UPDATE file_health
 		SET status = ?,
@@ -1071,13 +1258,16 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	}
 	defer tx.Rollback()
 
-	// Prepare common statements
+	// Prepare common statements. Each carries an optional status guard:
+	// `AND (status = ? OR ? = '')` — when the caller binds a non-empty expected status the
+	// write only lands if the record is still in that status (closing the TOCTOU window);
+	// when it binds the empty string the guard is a no-op and the write matches by path alone.
 	stmtHealthy, err := tx.PrepareContext(ctx, `
-		UPDATE file_health 
-		SET status = 'healthy', scheduled_check_at = ?, retry_count = 0, 
-		    repair_retry_count = 0, last_error = NULL, error_details = NULL, 
+		UPDATE file_health
+		SET status = 'healthy', scheduled_check_at = ?, retry_count = 0,
+		    repair_retry_count = 0, last_error = NULL, error_details = NULL,
 		    updated_at = datetime('now'), last_checked = datetime('now')
-		WHERE file_path = ?
+		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare healthy statement: %w", err)
@@ -1085,11 +1275,11 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	defer stmtHealthy.Close()
 
 	stmtRetry, err := tx.PrepareContext(ctx, `
-		UPDATE file_health 
-		SET retry_count = retry_count + 1, last_error = ?, error_details = ?, 
-		    status = 'pending', scheduled_check_at = ?, 
+		UPDATE file_health
+		SET retry_count = retry_count + 1, last_error = ?, error_details = ?,
+		    status = 'pending', scheduled_check_at = ?,
 		    updated_at = datetime('now'), last_checked = datetime('now')
-		WHERE file_path = ?
+		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare retry statement: %w", err)
@@ -1102,7 +1292,7 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 		    error_details = ?, status = 'repair_triggered',
 		    updated_at = datetime('now'), last_checked = datetime('now'),
 			scheduled_check_at = ?
-		WHERE file_path = ?
+		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare repair statement: %w", err)
@@ -1115,7 +1305,7 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 		SET last_error = ?, error_details = ?, status = 'repair_triggered',
 		    updated_at = datetime('now'), last_checked = datetime('now'),
 		    scheduled_check_at = ?
-		WHERE file_path = ?
+		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare repair trigger statement: %w", err)
@@ -1123,11 +1313,11 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 	defer stmtRepairTrigger.Close()
 
 	stmtCorrupted, err := tx.PrepareContext(ctx, `
-		UPDATE file_health 
-		SET status = 'corrupted', last_error = ?, error_details = ?, 
+		UPDATE file_health
+		SET status = 'corrupted', last_error = ?, error_details = ?,
 		    scheduled_check_at = NULL,
 		    updated_at = datetime('now'), last_checked = datetime('now')
-		WHERE file_path = ?
+		WHERE file_path = ? AND (status = ? OR ? = '')
 	`)
 	if err != nil {
 		return fmt.Errorf("failed to prepare corrupted statement: %w", err)
@@ -1139,17 +1329,23 @@ func (r *HealthRepository) UpdateHealthStatusBulk(ctx context.Context, updates [
 			continue
 		}
 		filePath := update.FilePath
+		// expected is the empty string for an unguarded write, or the status the record
+		// must still hold for a guarded write to land (see HealthStatusUpdate.ExpectedStatus).
+		expected := ""
+		if update.ExpectedStatus != nil {
+			expected = string(*update.ExpectedStatus)
+		}
 		switch update.Type {
 		case UpdateTypeHealthy:
-			_, err = stmtHealthy.ExecContext(ctx, update.ScheduledCheckAt, filePath)
+			_, err = stmtHealthy.ExecContext(ctx, update.ScheduledCheckAt, filePath, expected, expected)
 		case UpdateTypeRetry:
-			_, err = stmtRetry.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath)
+			_, err = stmtRetry.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
 		case UpdateTypeRepairTrigger:
-			_, err = stmtRepairTrigger.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath)
+			_, err = stmtRepairTrigger.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
 		case UpdateTypeRepairRetry:
-			_, err = stmtRepair.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath)
+			_, err = stmtRepair.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, update.ScheduledCheckAt, filePath, expected, expected)
 		case UpdateTypeCorrupted:
-			_, err = stmtCorrupted.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, filePath)
+			_, err = stmtCorrupted.ExecContext(ctx, update.ErrorMessage, update.ErrorDetails, filePath, expected, expected)
 		}
 
 		if err != nil {
@@ -1180,6 +1376,13 @@ type HealthStatusUpdate struct {
 	ErrorDetails     *string
 	ScheduledCheckAt time.Time
 	Skip             bool // if true, skip this record in the bulk update (e.g. record already deleted)
+	// ExpectedStatus, when non-nil, makes the write conditional on the record still being
+	// in that status (the status the worker based its decision on). It closes the TOCTOU
+	// window where a concurrent webhook relink, re-import upsert or manual recheck lands
+	// between the cycle's read and its write: if the status changed underneath us the
+	// guarded UPDATE matches no rows and the concurrent actor's decision wins instead of
+	// being silently clobbered (last-writer-wins re-entering the repair loop).
+	ExpectedStatus *HealthStatus
 }
 
 // BackfillRecord represents a record used for metadata backfilling
@@ -1317,10 +1520,18 @@ func (r *HealthRepository) BackfillReleaseDates(ctx context.Context, updates []B
 	}
 	defer tx.Rollback()
 
+	// Backfill release_date for every selected record, but never re-arm a terminal or
+	// in-flight record's schedule: a 'corrupted' record's only terminal guard is a NULL
+	// scheduled_check_at, and a 'repair_triggered' record's schedule is the repair
+	// back-off. Only pending/healthy/checking records get their next check rescheduled
+	// from the freshly-derived release date.
 	stmt, err := tx.PrepareContext(ctx, `
 		UPDATE file_health
 		SET release_date = ?,
-		    scheduled_check_at = ?,
+		    scheduled_check_at = CASE
+		        WHEN status IN ('corrupted', 'repair_triggered') THEN scheduled_check_at
+		        ELSE ?
+		    END,
 		    updated_at = datetime('now')
 		WHERE id = ?
 	`)
@@ -1394,7 +1605,7 @@ func (r *HealthRepository) batchInsertAutomaticHealthChecks(ctx context.Context,
 		}
 
 		args = append(args,
-			record.FilePath, record.LibraryPath, HealthStatusHealthy,
+			normalizeHealthPath(record.FilePath), record.LibraryPath, HealthStatusHealthy,
 			record.MaxRetries, record.MaxRepairRetries,
 			record.SourceNzbPath, releaseDateStr, scheduledCheckAtStr)
 	}
@@ -1468,7 +1679,7 @@ func (r *HealthRepository) ResolvePendingRepairsInDirectory(ctx context.Context,
 
 // UpdateLibraryPath updates the library_path for a specific file
 func (r *HealthRepository) UpdateLibraryPath(ctx context.Context, filePath string, libraryPath string) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 	query := `
 		UPDATE file_health
 		SET library_path = ?,
@@ -1538,48 +1749,106 @@ func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newP
 //   - false (Rename events — no new content): preserve repair/corrupted state so a library
 //     reorganization cannot wipe repair progress.
 func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
-	filePath = strings.TrimPrefix(filePath, "/")
-	query := `
-		UPDATE file_health
-		SET file_path = ?,
-		    library_path = ?,
-		    status = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN status ELSE 'pending' END,
-		    retry_count = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN retry_count ELSE 0 END,
-		    last_error = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN last_error ELSE NULL END,
-		    error_details = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN error_details ELSE NULL END,
-		    metadata = COALESCE(?, metadata),
-		    updated_at = datetime('now'),
-		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
-		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
-	`
-	if revalidate {
-		query = `
-			UPDATE file_health
-			SET file_path = ?,
-			    library_path = ?,
-			    status = 'pending',
-			    retry_count = 0,
-			    last_error = NULL,
-			    error_details = NULL,
-			    metadata = COALESCE(?, metadata),
-			    updated_at = datetime('now'),
-			    scheduled_check_at = datetime('now')
-			WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
-		`
+	filePath = normalizeHealthPath(filePath)
+
+	// A single Download/Rename webhook concerns exactly one imported file. Matching by
+	// bare basename ("%/"+filename) can collide across unrelated titles (01.mkv,
+	// sample.mkv, track01.flac); a blanket UPDATE would force-reset every match and
+	// overwrite their paths. So resolve the target record(s) first and only act when the
+	// target is unambiguous — never reset rows belonging to a different release.
+	likePattern := "%/" + escapeLikePrefix(filename)
+	const matchWhere = `(file_path LIKE ? ESCAPE '\' OR file_path = ? OR library_path LIKE ? ESCAPE '\' OR library_path = ?)`
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to begin relink transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	ids, err := scanIDs(tx.QueryContext(ctx,
+		`SELECT id FROM file_health WHERE `+matchWhere, likePattern, filename, likePattern, libraryPath))
+	if err != nil {
+		return false, fmt.Errorf("failed to resolve relink target: %w", err)
+	}
+	if len(ids) == 0 {
+		return false, nil
 	}
 
-	likePattern := "%/" + filename
-	res, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, likePattern, filename, likePattern, libraryPath)
-	if err != nil {
+	targetID := ids[0]
+	if len(ids) > 1 {
+		// Collision: only proceed if exactly one record matches the incoming path
+		// precisely; otherwise refuse and leave every matched row intact.
+		exactIDs, err := scanIDs(tx.QueryContext(ctx,
+			`SELECT id FROM file_health WHERE file_path = ? OR library_path = ?`, filePath, libraryPath))
+		if err != nil {
+			return false, fmt.Errorf("failed to resolve exact relink target: %w", err)
+		}
+		if len(exactIDs) != 1 {
+			slog.WarnContext(ctx, "Refusing ambiguous relink — filename matches multiple records",
+				"filename", filename, "matches", len(ids), "exact_matches", len(exactIDs))
+			return false, nil
+		}
+		slog.WarnContext(ctx, "Filename collision on relink — scoping to the exact path match",
+			"filename", filename, "matches", len(ids))
+		targetID = exactIDs[0]
+	}
+
+	// revalidate (Download — fresh content) resets the record to pending for immediate
+	// re-validation; the non-revalidate (Rename — no new content) branch preserves
+	// repair/corrupted state. Both preserve repair_retry_count (the per-title budget).
+	setClause := `
+		file_path = ?,
+		library_path = ?,
+		status = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN status ELSE 'pending' END,
+		retry_count = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN retry_count ELSE 0 END,
+		last_error = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN last_error ELSE NULL END,
+		error_details = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN error_details ELSE NULL END,
+		metadata = COALESCE(?, metadata),
+		updated_at = datetime('now'),
+		scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END`
+	if revalidate {
+		setClause = `
+		file_path = ?,
+		library_path = ?,
+		status = 'pending',
+		retry_count = 0,
+		last_error = NULL,
+		error_details = NULL,
+		metadata = COALESCE(?, metadata),
+		updated_at = datetime('now'),
+		scheduled_check_at = datetime('now')`
+	}
+
+	if _, err := tx.ExecContext(ctx, `UPDATE file_health SET `+setClause+` WHERE id = ?`,
+		filePath, libraryPath, metadataStr, targetID); err != nil {
 		return false, fmt.Errorf("failed to relink file by filename: %w", err)
 	}
 
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("failed to get rows affected: %w", err)
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("failed to commit relink: %w", err)
 	}
 
-	return rows > 0, nil
+	return true, nil
+}
+
+// scanIDs reads an id column from a query result, always closing the rows. It centralizes
+// the "collect matching ids before writing" pattern so a read cursor is never left open
+// across a write on the same transaction.
+func scanIDs(rows *sql.Rows, queryErr error) ([]int64, error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 // GetSystemState retrieves a persistent state value

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -270,8 +270,8 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	err := repo.UpdateFileHealth(ctx, oldPath, HealthStatusHealthy, nil, nil, nil, false)
 	require.NoError(t, err)
 
-	// 2. Perform Relink
-	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, libPath, nil)
+	// 2. Perform Relink (Rename semantics — no new content)
+	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, libPath, nil, false)
 	require.NoError(t, err)
 	assert.True(t, relinked, "Should have relinked the healthy record")
 
@@ -292,9 +292,158 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	err = repo.UpdateFileHealth(ctx, corruptedFile, HealthStatusCorrupted, nil, nil, nil, false)
 	require.NoError(t, err)
 
-	relinked, err = repo.RelinkFileByFilename(ctx, "Matrix.mkv", corruptedFile, "/lib/Matrix.mkv", nil)
+	relinked, err = repo.RelinkFileByFilename(ctx, "Matrix.mkv", corruptedFile, "/lib/Matrix.mkv", nil, false)
 	require.NoError(t, err)
 	assert.True(t, relinked)
+}
+
+// TestRelinkFileByFilename_RenamePreservesRepairState verifies that a Rename relink
+// (revalidate=false) does not disturb repair_triggered state: status, counters, errors
+// and schedule must survive a library reorganization.
+func TestRelinkFileByFilename_RenamePreservesRepairState(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E01/Show.S01E01.mkv"
+	lastErr := "missing 7 segments"
+	future := time.Now().UTC().Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count,
+			max_repair_retries, last_error, scheduled_check_at)
+		VALUES (?, 'repair_triggered', 2, 1, 3, ?, ?)
+	`, filePath, lastErr, future)
+	require.NoError(t, err)
+
+	relinked, err := repo.RelinkFileByFilename(ctx, "Show.S01E01.mkv", filePath, "/lib/Show.S01E01.mkv", nil, false)
+	require.NoError(t, err)
+	require.True(t, relinked)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusRepairTriggered, h.Status, "Rename must not reset repair status")
+	assert.Equal(t, 2, h.RetryCount)
+	assert.Equal(t, 1, h.RepairRetryCount)
+	require.NotNil(t, h.LastError)
+	assert.Equal(t, lastErr, *h.LastError)
+}
+
+// TestRelinkFileByFilename_DownloadRevalidatesRepairState verifies that a Download relink
+// (revalidate=true — a re-downloaded copy was just imported) resets the record to pending
+// for immediate re-validation while preserving repair_retry_count as the per-title repair
+// budget. This is the exit path from the repair loop: without it, the repair worker
+// destroys the fresh import on its next tick.
+func TestRelinkFileByFilename_DownloadRevalidatesRepairState(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E02/Show.S01E02.mkv"
+	future := time.Now().UTC().Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count,
+			max_repair_retries, last_error, error_details, scheduled_check_at)
+		VALUES (?, 'repair_triggered', 2, 1, 3, 'missing segments', 'details', ?)
+	`, filePath, future)
+	require.NoError(t, err)
+
+	before := time.Now().UTC()
+	relinked, err := repo.RelinkFileByFilename(ctx, "Show.S01E02.mkv", filePath, "/lib/Show.S01E02.mkv", nil, true)
+	require.NoError(t, err)
+	require.True(t, relinked)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status, "Download must reset status so the new copy is validated")
+	assert.Equal(t, 0, h.RetryCount, "retry_count restarts for the new copy")
+	assert.Equal(t, 1, h.RepairRetryCount, "repair budget must be preserved so bad re-downloads still escalate")
+	assert.Nil(t, h.LastError)
+	assert.Nil(t, h.ErrorDetails)
+
+	// scheduled_check_at must be pulled back from the future to now.
+	var raw string
+	err = repo.db.QueryRowContext(ctx,
+		"SELECT scheduled_check_at FROM file_health WHERE file_path = ?", filePath).Scan(&raw)
+	require.NoError(t, err)
+	var scheduled time.Time
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if parsed, e := time.Parse(layout, raw); e == nil {
+			scheduled = parsed.UTC()
+			break
+		}
+	}
+	assert.True(t, scheduled.Before(before.Add(time.Minute)),
+		"scheduled_check_at should be ~now, got %v", scheduled)
+}
+
+// TestGetFilesForRepairNotification_ReturnsExhausted verifies that records whose repair
+// budget is spent are still returned, so the worker can finalize them as corrupted.
+// Filtering them out would leave them stuck in repair_triggered forever: no other
+// query selects that status.
+func TestGetFilesForRepairNotification_ReturnsExhausted(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	pastTime := time.Now().UTC().Add(-1 * time.Hour)
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (
+			file_path, status, repair_retry_count, max_repair_retries, scheduled_check_at, last_checked
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`, "exhausted_repair.mkv", "repair_triggered", 3, 3, pastTime, time.Now().UTC())
+	require.NoError(t, err)
+
+	files, err := repo.GetFilesForRepairNotification(ctx, 10)
+	require.NoError(t, err)
+
+	found := false
+	for _, f := range files {
+		if f.FilePath == "exhausted_repair.mkv" {
+			found = true
+		}
+	}
+	assert.True(t, found, "exhausted repair records must be returned for finalization as corrupted")
+}
+
+// TestAddFileToHealthCheck_ConflictPreservesRepairBudget verifies that a re-import upsert
+// over an existing record resets it to pending for re-validation but does NOT reset
+// repair_retry_count: a re-download of a broken release must not refill its own repair
+// budget, or genuinely dead releases would be re-downloaded forever.
+func TestAddFileToHealthCheck_ConflictPreservesRepairBudget(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E03/Show.S01E03.mkv"
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count, max_repair_retries)
+		VALUES (?, 'repair_triggered', 2, 2, 3)
+	`, filePath)
+	require.NoError(t, err)
+
+	err = repo.AddFileToHealthCheckWithMetadata(ctx, filePath, &filePath, 3, 3, nil, HealthPriorityNext, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 0, h.RetryCount, "retry_count resets for the new copy")
+	assert.Equal(t, 2, h.RepairRetryCount, "repair budget must survive the re-import upsert")
+}
+
+// TestAddFileToHealthCheck_NormalizesLeadingSlash verifies the upsert strips a leading
+// slash so import-side paths ("/tv/...") and webhook-side paths ("tv/...") cannot create
+// duplicate rows for the same virtual file.
+func TestAddFileToHealthCheck_NormalizesLeadingSlash(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	slashed := "/tv/Show.S01E04/Show.S01E04.mkv"
+	err := repo.AddFileToHealthCheckWithMetadata(ctx, slashed, &slashed, 3, 3, nil, HealthPriorityNext, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "tv/Show.S01E04/Show.S01E04.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h, "record must be stored without the leading slash")
 }
 
 // TestAddFileToHealthCheckWithMetadata_StoresLibraryPath verifies that new files

--- a/internal/database/migrations/postgres/031_add_file_health_due_index.sql
+++ b/internal/database/migrations/postgres/031_add_file_health_due_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Covers the per-tick GetUnhealthyFiles hot query: the WHERE filters on
+-- scheduled_check_at and the result is "ORDER BY priority DESC, scheduled_check_at ASC".
+-- Without a matching index PostgreSQL sorts every due row each cycle. The partial
+-- predicate keeps the index small (only schedulable rows) and lets the range scan +
+-- ordering + LIMIT be satisfied directly from the index.
+CREATE INDEX IF NOT EXISTS idx_file_health_due
+    ON file_health(priority DESC, scheduled_check_at ASC)
+    WHERE scheduled_check_at IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_file_health_due;
+-- +goose StatementEnd

--- a/internal/database/migrations/sqlite/031_add_file_health_due_index.sql
+++ b/internal/database/migrations/sqlite/031_add_file_health_due_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Covers the per-tick GetUnhealthyFiles hot query: the WHERE filters on
+-- scheduled_check_at and the result is "ORDER BY priority DESC, scheduled_check_at ASC".
+-- Without a matching index SQLite builds a temporary B-tree to sort every due row each
+-- cycle. The partial predicate keeps the index small (only schedulable rows) and lets the
+-- range scan + ordering + LIMIT be satisfied directly from the index.
+CREATE INDEX IF NOT EXISTS idx_file_health_due
+    ON file_health(priority DESC, scheduled_check_at ASC)
+    WHERE scheduled_check_at IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_file_health_due;
+-- +goose StatementEnd

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -326,6 +326,102 @@ func TestE2E_FileRepairTriggered_FullRetryFlow(t *testing.T) {
 	assert.NoError(t, readErr)
 }
 
+// TestE2E_RepairBudgetExhausted_PendingFileMarkedCorrupted verifies the terminal state:
+// a pending file that fails its last health retry while its repair budget is already
+// spent (repair_retry_count == max_repair_retries, preserved across re-import upserts
+// and webhook relinks) is marked corrupted instead of triggering yet another ARR rescan.
+// Without this guard, a genuinely dead release loops forever: rescan → re-download →
+// re-import resets to pending → check fails → rescan...
+func TestE2E_RepairBudgetExhausted_PendingFileMarkedCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	tempDir := t.TempDir()
+	env := newRepairTestEnv(t, tempDir, nil)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e05.mkv"
+	libraryPath := "/media/library/show.s01e05.mkv"
+	maxRetries := 3
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	// Pending file at its last health retry, with the repair budget already spent.
+	insertFileHealth(t, env.db, filePath, libraryPath, maxRetries-1, maxRetries)
+	_, err := env.db.Exec(
+		`UPDATE file_health SET repair_retry_count = 3, max_repair_retries = 3 WHERE file_path = ?`,
+		filePath,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	// ARR must NOT be called — no more re-downloads for this title.
+	env.mockARRs.mu.Lock()
+	callCount := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Equal(t, 0, callCount, "exhausted repair budget must not trigger another ARR rescan")
+
+	// Status must be terminal corrupted.
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status)
+
+	// Metadata hidden in the safety folder (this path follows a real failed check).
+	original, readErr := env.metadataService.ReadFileMetadata(filePath)
+	assert.Nil(t, original, "metadata should be moved to the safety folder")
+	assert.NoError(t, readErr)
+}
+
+// TestE2E_ExhaustedRepairTriggered_SweptToCorrupted verifies that records already in
+// repair_triggered with a spent repair budget are picked up by the repair-notification
+// pass and finalized as corrupted (previously they were filtered out of every query and
+// stuck in repair_triggered forever). The sweep must be non-destructive: no ARR call and
+// no metadata move, since no fresh check has failed.
+func TestE2E_ExhaustedRepairTriggered_SweptToCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	tempDir := t.TempDir()
+	env := newRepairTestEnv(t, tempDir, nil)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e06.mkv"
+	libraryPath := "/media/library/show.s01e06.mkv"
+
+	// Metadata exists (e.g. a re-import landed after the last repair re-trigger).
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	_, err := env.db.Exec(`
+		INSERT INTO file_health
+			(file_path, library_path, status, retry_count, max_retries,
+			 repair_retry_count, max_repair_retries, scheduled_check_at)
+		VALUES (?, ?, 'repair_triggered', 2, 3, 3, 3, datetime('now', '-1 second'))
+	`, filePath, libraryPath)
+	require.NoError(t, err)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	env.mockARRs.mu.Lock()
+	callCount := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Equal(t, 0, callCount, "sweep must not trigger ARR rescans")
+
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status,
+		"exhausted repair_triggered record must be finalized as corrupted, not stuck")
+
+	// Metadata must be left in place — the sweep has not re-validated content.
+	original, readErr := env.metadataService.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "sweep must not move metadata of a possibly-good copy")
+}
+
 // TestE2E_FileRepairTriggered_ARRReturnsAlreadySatisfied verifies that when ARR returns
 // ErrEpisodeAlreadySatisfied the health record is deleted (zombie cleanup).
 func TestE2E_FileRepairTriggered_ARRReturnsAlreadySatisfied(t *testing.T) {

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -456,25 +456,7 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	switch fh.Status {
 	case database.HealthStatusRepairTriggered:
 		if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
-			update.Type = database.UpdateTypeCorrupted
-			update.Status = database.HealthStatusCorrupted
-			sideEffect = func() error {
-				slog.ErrorContext(ctx, "File permanently marked as corrupted after repair retries exhausted", "file_path", fh.FilePath)
-
-				// Ensure metadata is hidden in the safety folder
-				hw.moveMetadataToSafetyFolder(ctx, fh)
-
-				// Log failure against the indexer if known
-				if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
-					errMsg := "Permanently corrupted"
-					if errorMsg != nil {
-						errMsg = *errorMsg
-					}
-					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg), "")
-				}
-
-				return nil
-			}
+			sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
 		} else {
 			// Calculate repair back-off
 			interval := hw.configGetter().GetRepairInterval()
@@ -508,6 +490,15 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	default:
 		// Regular health check phase
 		if fh.RetryCount >= hw.configGetter().GetMaxRetries()-1 {
+			// Repair budget exhausted: this title was already re-downloaded
+			// max_repair_retries times (the counter survives webhook relinks and
+			// re-import upserts by design). Triggering yet another rescan would
+			// re-download the same broken release forever, so finalize as corrupted.
+			if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
+				sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
+				return update, sideEffect
+			}
+
 			update.Type = database.UpdateTypeRepairTrigger
 			update.Status = database.HealthStatusRepairTriggered
 
@@ -551,6 +542,32 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	return update, sideEffect
 }
 
+// markCorruptedRepairExhausted fills update with the terminal corrupted state for a file
+// whose repair budget is spent after a failed health check, and returns the side effect
+// (hide metadata in the safety folder, log the failure against the indexer).
+func (hw *HealthWorker) markCorruptedRepairExhausted(ctx context.Context, fh *database.FileHealth, update *database.HealthStatusUpdate, errorMsg *string) func() error {
+	update.Type = database.UpdateTypeCorrupted
+	update.Status = database.HealthStatusCorrupted
+
+	return func() error {
+		slog.ErrorContext(ctx, "File permanently marked as corrupted after repair retries exhausted", "file_path", fh.FilePath)
+
+		// Ensure metadata is hidden in the safety folder
+		hw.moveMetadataToSafetyFolder(ctx, fh)
+
+		// Log failure against the indexer if known
+		if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
+			errMsg := "Permanently corrupted"
+			if errorMsg != nil {
+				errMsg = *errorMsg
+			}
+			_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg), "")
+		}
+
+		return nil
+	}
+}
+
 // prepareRepairNotificationUpdate builds the update and side effect for a file already in
 // repair_triggered state. It re-triggers ARR directly without calling CheckFile, since the
 // metadata has already been moved to the corrupted folder.
@@ -560,7 +577,10 @@ func (hw *HealthWorker) prepareRepairNotificationUpdate(ctx context.Context, fh 
 	}
 
 	if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
-		// Retries exhausted — give up and mark corrupted.
+		// Retries exhausted — give up and mark corrupted. Deliberately no metadata
+		// move here: unlike the failed-check path, this sweep has not re-validated
+		// the file's content, and a re-import may have just landed a good copy. The
+		// user can recheck from the Health page; a failed check will then hide it.
 		update.Type = database.UpdateTypeCorrupted
 		update.Status = database.HealthStatusCorrupted
 		sideEffect := func() error {

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -758,10 +758,27 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		"total", totalFiles,
 		"max_concurrent_jobs", maxJobs)
 
+	// Transition the whole batch to 'checking' in one write instead of one UPDATE per
+	// file: under SQLite's single writer N per-file transitions would serialize against
+	// each other and the final bulk status write. Crash recovery is unchanged
+	// (ResetFileAllChecking at startup re-arms stranded 'checking' rows).
+	checkingPaths := make([]string, len(unhealthyFiles))
+	for i, fh := range unhealthyFiles {
+		checkingPaths[i] = fh.FilePath
+	}
+	if err := hw.healthRepo.SetFilesCheckingBulk(ctx, checkingPaths); err != nil {
+		slog.ErrorContext(ctx, "Failed to bulk-set files to checking", "count", len(checkingPaths), "error", err)
+	}
+
 	// Process files in parallel with bounded concurrency
 	p := pool.New().WithMaxGoroutines(maxJobs)
 	var results []database.HealthStatusUpdate
 	var resultsMu sync.Mutex
+
+	// The regular-check writes are based on the record being 'checking' (set just above);
+	// guard them on that status so a concurrent webhook relink / re-import / manual
+	// recheck that lands mid-check is not silently clobbered by a stale check result.
+	checkingStatus := database.HealthStatusChecking
 
 	// Process health check files
 	for _, fileHealth := range unhealthyFiles {
@@ -769,18 +786,12 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		p.Go(func() {
 			slog.InfoContext(ctx, "Checking unhealthy file", "file_path", fh.FilePath)
 
-			// Set checking status
-			err := hw.healthRepo.SetFileChecking(ctx, fh.FilePath)
-			if err != nil {
-				slog.ErrorContext(ctx, "Failed to set file checking status", "file_path", fh.FilePath, "error", err)
-				return
-			}
-
 			// Perform check
 			opts := CheckOptions{}
 			event := hw.healthChecker.CheckFile(ctx, fh.FilePath, opts)
 
 			updatePtr, sideEffect := hw.prepareUpdateForResult(ctx, fh, event)
+			updatePtr.ExpectedStatus = &checkingStatus
 			if sideEffect != nil {
 				if err := sideEffect(); err != nil {
 					slog.ErrorContext(ctx, "Failed to execute side effect for health result", "file_path", fh.FilePath, "error", err)
@@ -808,6 +819,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		})
 	}
 
+	repairStatus := database.HealthStatusRepairTriggered
 	for _, fileHealth := range repairFiles {
 		fh := fileHealth // Capture for closure
 		p.Go(func() {
@@ -818,9 +830,21 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 				fh = latest
 			}
 
+			// If a concurrent actor moved the record out of repair_triggered between the
+			// cycle's read and now (e.g. a Download webhook relinked the fresh copy to
+			// pending, or a manual recheck/delete fired), leave it alone. Re-triggering
+			// would clobber that rescue and re-enter the repair loop — and fire the ARR
+			// re-trigger / metadata-move side effects against a record that no longer needs them.
+			if fh.Status != database.HealthStatusRepairTriggered {
+				slog.InfoContext(ctx, "Skipping repair notification — record left repair_triggered concurrently",
+					"file_path", fh.FilePath, "status", fh.Status)
+				return
+			}
+
 			slog.InfoContext(ctx, "Re-triggering repair for file", "file_path", fh.FilePath)
 
 			updatePtr, sideEffect := hw.prepareRepairNotificationUpdate(ctx, fh)
+			updatePtr.ExpectedStatus = &repairStatus
 
 			if sideEffect != nil {
 				if err := sideEffect(); err != nil {

--- a/internal/importer/cleanup_test.go
+++ b/internal/importer/cleanup_test.go
@@ -2,25 +2,77 @@ package importer
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"testing"
 
+	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // newCleanupTestService creates a minimal Service with a real MetadataService
-// backed by a temp directory. Only the fields needed by cleanupWrittenPaths are set.
+// backed by a temp directory and a real HealthRepository (in-memory sqlite).
+// Only the fields needed by cleanupWrittenPaths are set.
 func newCleanupTestService(t *testing.T) (*Service, *metadata.MetadataService) {
 	t.Helper()
 	ms := metadata.NewMetadataService(t.TempDir())
 	svc := &Service{
 		metadataService: ms,
+		healthRepo:      newCleanupTestHealthRepo(t),
 		log:             slog.Default(),
 	}
 	return svc, ms
+}
+
+// newCleanupTestHealthRepo builds a HealthRepository over an in-memory sqlite DB.
+func newCleanupTestHealthRepo(t *testing.T) *database.HealthRepository {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file::memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			priority INTEGER DEFAULT 0,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	return database.NewHealthRepository(db, database.DialectSQLite)
+}
+
+// addPendingHealthRecord seeds a pending health record the way the import scheduler
+// does (virtual path doubling as the placeholder library path).
+func addPendingHealthRecord(t *testing.T, repo *database.HealthRepository, virtualPath string) {
+	t.Helper()
+	require.NoError(t, repo.AddFileToHealthCheckWithMetadata(
+		context.Background(), virtualPath, &virtualPath, 3, 3, nil,
+		database.HealthPriorityNext, nil, nil, nil))
 }
 
 // writeTestMeta writes a minimal healthy metadata file at virtualPath and returns it.
@@ -108,6 +160,75 @@ func TestCleanupWrittenPaths_EmptyAndNilSlice(t *testing.T) {
 	assert.NotPanics(t, func() {
 		svc.cleanupWrittenPaths(ctx, 4, []string{})
 		svc.cleanupWrittenPaths(ctx, 5, nil)
+	})
+}
+
+// TestCleanupWrittenPaths_DeletesHealthRecordsForDir verifies that rolling back a
+// failed directory import also removes the health records scheduled beneath it —
+// including ones created by an earlier, successful attempt of the same release.
+// Without this they linger in pending forever under SYMLINK/STRM strategies: the
+// placeholder library_path never matches the worker's library filter and no ARR
+// webhook will ever relink a rolled-back import.
+func TestCleanupWrittenPaths_DeletesHealthRecordsForDir(t *testing.T) {
+	svc, ms := newCleanupTestService(t)
+	ctx := context.Background()
+
+	writeTestMeta(t, ms, "tv/Pack.S08.1080p-GRP/e01.mkv")
+	writeTestMeta(t, ms, "tv/Pack.S08.1080p-GRP/e02.mkv")
+	addPendingHealthRecord(t, svc.healthRepo, "tv/Pack.S08.1080p-GRP/e01.mkv")
+	addPendingHealthRecord(t, svc.healthRepo, "tv/Pack.S08.1080p-GRP/e02.mkv")
+	// A record in a sibling release must survive the cleanup.
+	addPendingHealthRecord(t, svc.healthRepo, "tv/Other.S01.1080p-GRP/e01.mkv")
+
+	svc.cleanupWrittenPaths(ctx, 10, []string{"DIR:tv/Pack.S08.1080p-GRP"})
+
+	for _, p := range []string{
+		"tv/Pack.S08.1080p-GRP/e01.mkv",
+		"tv/Pack.S08.1080p-GRP/e02.mkv",
+	} {
+		h, err := svc.healthRepo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		assert.Nil(t, h, "health record %s must be deleted with the rolled-back import", p)
+	}
+
+	h, err := svc.healthRepo.GetFileHealth(ctx, "tv/Other.S01.1080p-GRP/e01.mkv")
+	require.NoError(t, err)
+	assert.NotNil(t, h, "records of unrelated releases must not be touched")
+}
+
+// TestCleanupWrittenPaths_DeletesHealthRecordForFile verifies the single-file variant:
+// a plain written path removes exactly its own health record.
+func TestCleanupWrittenPaths_DeletesHealthRecordForFile(t *testing.T) {
+	svc, ms := newCleanupTestService(t)
+	ctx := context.Background()
+
+	writeTestMeta(t, ms, "movies/Broken.2024.mkv")
+	addPendingHealthRecord(t, svc.healthRepo, "movies/Broken.2024.mkv")
+	addPendingHealthRecord(t, svc.healthRepo, "movies/Keep.2024.mkv")
+
+	svc.cleanupWrittenPaths(ctx, 11, []string{"movies/Broken.2024.mkv"})
+
+	h, err := svc.healthRepo.GetFileHealth(ctx, "movies/Broken.2024.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, h, "health record of the failed file must be deleted")
+
+	h, err = svc.healthRepo.GetFileHealth(ctx, "movies/Keep.2024.mkv")
+	require.NoError(t, err)
+	assert.NotNil(t, h, "other records must not be touched")
+}
+
+// TestCleanupWrittenPaths_NilHealthRepo ensures the cleanup tolerates a Service
+// constructed without a health repository.
+func TestCleanupWrittenPaths_NilHealthRepo(t *testing.T) {
+	ms := metadata.NewMetadataService(t.TempDir())
+	svc := &Service{
+		metadataService: ms,
+		log:             slog.Default(),
+	}
+	writeTestMeta(t, ms, "movies/NoRepo.2024.mkv")
+
+	assert.NotPanics(t, func() {
+		svc.cleanupWrittenPaths(context.Background(), 12, []string{"movies/NoRepo.2024.mkv"})
 	})
 }
 

--- a/internal/importer/cleanup_test.go
+++ b/internal/importer/cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/metadata"
@@ -194,6 +195,46 @@ func TestCleanupWrittenPaths_DeletesHealthRecordsForDir(t *testing.T) {
 	h, err := svc.healthRepo.GetFileHealth(ctx, "tv/Other.S01.1080p-GRP/e01.mkv")
 	require.NoError(t, err)
 	assert.NotNil(t, h, "records of unrelated releases must not be touched")
+}
+
+// TestCleanupWrittenPaths_PreservesPriorSuccessfulImport verifies that a failed re-import
+// into a shared nzbFolder deletes only its own unvalidated placeholder records and leaves
+// a prior successful import's validated records (healthy, or relinked to a real ARR library
+// path) intact. The nzbFolder is deterministic per release, so without scoping a failed
+// re-grab would wipe a still-good library entry's health record.
+func TestCleanupWrittenPaths_PreservesPriorSuccessfulImport(t *testing.T) {
+	svc, ms := newCleanupTestService(t)
+	ctx := context.Background()
+
+	writeTestMeta(t, ms, "tv/Pack.S08.1080p-GRP/e01.mkv")
+
+	// This failed attempt's fresh placeholder — must be deleted.
+	addPendingHealthRecord(t, svc.healthRepo, "tv/Pack.S08.1080p-GRP/e01.mkv")
+
+	// A prior successful import's relinked record (library_path != file_path) — must survive.
+	relinked := "/media/library/Pack/e02.mkv"
+	require.NoError(t, svc.healthRepo.AddFileToHealthCheckWithMetadata(ctx,
+		"tv/Pack.S08.1080p-GRP/e02.mkv", &relinked, 3, 3, nil,
+		database.HealthPriorityNext, nil, nil, nil))
+
+	// A prior successful import's healthy record — must survive.
+	addPendingHealthRecord(t, svc.healthRepo, "tv/Pack.S08.1080p-GRP/e03.mkv")
+	require.NoError(t, svc.healthRepo.MarkAsHealthy(ctx, "tv/Pack.S08.1080p-GRP/e03.mkv", time.Now().Add(time.Hour)))
+
+	svc.cleanupWrittenPaths(ctx, 20, []string{"DIR:tv/Pack.S08.1080p-GRP"})
+
+	gone, err := svc.healthRepo.GetFileHealth(ctx, "tv/Pack.S08.1080p-GRP/e01.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, gone, "the failed attempt's unvalidated placeholder must be deleted")
+
+	for _, p := range []string{
+		"tv/Pack.S08.1080p-GRP/e02.mkv",
+		"tv/Pack.S08.1080p-GRP/e03.mkv",
+	} {
+		h, err := svc.healthRepo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		assert.NotNil(t, h, "validated record %s from a prior successful import must survive", p)
+	}
 }
 
 // TestCleanupWrittenPaths_DeletesHealthRecordForFile verifies the single-file variant:

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -64,15 +64,15 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		indexer = item.Indexer
 	}
 
-	scheduled := 0
 	var lastErr error
 	repairDirs := make(map[string]struct{})
-	for _, path := range paths {
+	records := make([]database.HealthCheckUpsert, 0, len(paths))
+	for _, p := range paths {
 		// Read metadata to get SourceNzbPath needed for health check
-		fileMeta, err := c.metadataService.ReadFileMetadata(path)
+		fileMeta, err := c.metadataService.ReadFileMetadata(p)
 		if err != nil {
 			slog.WarnContext(ctx, "Failed to read metadata for health check scheduling",
-				"path", path,
+				"path", p,
 				"error", err)
 			lastErr = err
 			continue
@@ -81,17 +81,34 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 			continue
 		}
 
-		// Add/Update health record with high priority
-		filePath := path
-		if err := c.healthRepo.AddFileToHealthCheckWithMetadata(ctx, filePath, &filePath, cfg.GetMaxRetries(), cfg.GetMaxRepairRetries(), &fileMeta.SourceNzbPath, database.HealthPriorityNext, nil, nil, indexer); err != nil {
-			slog.ErrorContext(ctx, "Failed to schedule immediate health check for imported file",
-				"path", path,
-				"error", err)
+		// Copy the path and source NZB into per-iteration locals so the pointers stored in
+		// the batch outlive the loop and do not retain the proto message.
+		filePath := p
+		srcNzb := fileMeta.SourceNzbPath
+		records = append(records, database.HealthCheckUpsert{
+			FilePath:         filePath,
+			LibraryPath:      &filePath,
+			SourceNzbPath:    &srcNzb,
+			Indexer:          indexer,
+			Priority:         database.HealthPriorityNext,
+			MaxRetries:       cfg.GetMaxRetries(),
+			MaxRepairRetries: cfg.GetMaxRepairRetries(),
+		})
+		repairDirs[filepath.Dir(p)] = struct{}{}
+	}
+
+	// One batched upsert for the whole import instead of a write transaction per file — a
+	// season pack / archive can expand to hundreds of paths. Conflict semantics match the
+	// single-row upsert (reset to pending, preserve repair_retry_count).
+	scheduled := 0
+	if len(records) > 0 {
+		if err := c.healthRepo.BatchAddFileToHealthCheck(ctx, records); err != nil {
+			slog.ErrorContext(ctx, "Failed to schedule immediate health checks for imported files",
+				"path", resultingPath, "files", len(records), "error", err)
 			lastErr = err
-			continue
+		} else {
+			scheduled = len(records)
 		}
-		scheduled++
-		repairDirs[filepath.Dir(path)] = struct{}{}
 	}
 
 	if scheduled > 0 {

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -3,10 +3,17 @@ package postprocessor
 import (
 	"context"
 	"log/slog"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/javi11/altmount/internal/database"
 )
+
+// maxDirExpansionDepth bounds the recursive walk of "DIR:" written-path entries.
+// Import folders are shallow (an NZB folder, occasionally a Blu-ray structure from
+// ISO expansion), so this is a safety net, not an expected limit.
+const maxDirExpansionDepth = 8
 
 // ScheduleHealthCheck schedules an immediate health check for an imported file.
 // Multi-file imports (e.g. season packs) schedule one check per written virtual
@@ -19,9 +26,10 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return nil // Health checks not configured
 	}
 
-	// Prefer the explicit per-file list; fall back to the resulting path for
-	// legacy callers (single-file imports resolve to the same thing).
-	paths := writtenPaths
+	// Expand directory entries into per-file paths, and fall back to the
+	// resulting path for legacy callers (single-file imports resolve to the
+	// same thing).
+	paths := c.expandWrittenPaths(writtenPaths)
 	if len(paths) == 0 {
 		paths = []string{resultingPath}
 	}
@@ -65,6 +73,12 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 	if scheduled > 0 {
 		slog.InfoContext(ctx, "Scheduled immediate health check for imported files",
 			"path", resultingPath, "files", scheduled)
+	} else {
+		// A successful import that schedules nothing means the file will only be
+		// covered by library sync much later — and any pending repair in its
+		// directory stays unresolved. Surface it instead of failing silently.
+		slog.WarnContext(ctx, "No health checks scheduled for import - no readable file metadata found",
+			"path", resultingPath, "written_paths", len(writtenPaths))
 	}
 
 	// Resolve pending repairs in the affected directories if configured
@@ -76,6 +90,48 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return lastErr
 	}
 	return nil
+}
+
+// expandWrittenPaths resolves "DIR:"-prefixed entries (whole-directory imports such
+// as RAR/7z archives, which only report their NZB folder) into the per-file virtual
+// paths beneath them by walking the metadata tree. Plain file entries pass through
+// unchanged. Without this, archive imports would schedule no health checks at all:
+// ReadFileMetadata("DIR:...") finds nothing and the loop above skips silently.
+func (c *Coordinator) expandWrittenPaths(writtenPaths []string) []string {
+	var out []string
+	for _, p := range writtenPaths {
+		dir, isDir := strings.CutPrefix(p, "DIR:")
+		if !isDir {
+			out = append(out, p)
+			continue
+		}
+		out = append(out, c.listMetadataFilesRecursive(dir, 0)...)
+	}
+	return out
+}
+
+// listMetadataFilesRecursive returns the virtual file paths of all metadata files
+// under virtualDir, recursing into subdirectories up to maxDirExpansionDepth.
+func (c *Coordinator) listMetadataFilesRecursive(virtualDir string, depth int) []string {
+	if depth > maxDirExpansionDepth || c.metadataService == nil {
+		return nil
+	}
+
+	dirs, files, err := c.metadataService.ListDirectoryAll(virtualDir)
+	if err != nil {
+		c.log.Warn("Failed to list metadata directory for health check scheduling",
+			"dir", virtualDir, "error", err)
+		return nil
+	}
+
+	var out []string
+	for _, f := range files {
+		out = append(out, path.Join(virtualDir, f))
+	}
+	for _, d := range dirs {
+		out = append(out, c.listMetadataFilesRecursive(path.Join(virtualDir, d.Name()), depth+1)...)
+	}
+	return out
 }
 
 // resolvePendingRepairsInDir resolves pending repairs in the given directory

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 )
 
 // maxDirExpansionDepth bounds the recursive walk of "DIR:" written-path entries.
@@ -35,6 +37,28 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 	}
 
 	cfg := c.configGetter()
+
+	// Under SYMLINK/STRM strategies a record only becomes checkable once an ARR
+	// Download webhook relinks it to a real library path (GetUnhealthyFiles
+	// filters on library_path), and ARRs only ever import media files. Sidecars
+	// (.nfo, .srt, ...) would sit permanently ineligible in pending until the
+	// next library sync deletes them, so don't schedule them here. Any sidecar
+	// an ARR does copy into the library is still registered — with a real
+	// library path — by the library sync.
+	if cfg.Import.ImportStrategy != config.ImportStrategyNone {
+		media := make([]string, 0, len(paths))
+		for _, p := range paths {
+			if isArrImportableMedia(p) {
+				media = append(media, p)
+			}
+		}
+		if skipped := len(paths) - len(media); skipped > 0 {
+			slog.DebugContext(ctx, "Skipping health checks for sidecar files",
+				"path", resultingPath, "skipped", skipped)
+		}
+		paths = media
+	}
+
 	var indexer *string = nil
 	if item != nil {
 		indexer = item.Indexer
@@ -77,7 +101,7 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		// A successful import that schedules nothing means the file will only be
 		// covered by library sync much later — and any pending repair in its
 		// directory stays unresolved. Surface it instead of failing silently.
-		slog.WarnContext(ctx, "No health checks scheduled for import - no readable file metadata found",
+		slog.WarnContext(ctx, "No health checks scheduled for import - no checkable media files with readable metadata found",
 			"path", resultingPath, "written_paths", len(writtenPaths))
 	}
 
@@ -90,6 +114,24 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return lastErr
 	}
 	return nil
+}
+
+// arrAudioBookExtensions are the non-video media types ARRs import (Lidarr audio,
+// Readarr books). Video extensions are covered by fileinfo.IsVideoFile.
+var arrAudioBookExtensions = map[string]bool{
+	".mp3": true, ".flac": true, ".m4a": true, ".m4b": true, ".aac": true,
+	".ogg": true, ".opus": true, ".wav": true,
+	".epub": true, ".pdf": true, ".cbz": true, ".cbr": true, ".mobi": true, ".azw3": true,
+}
+
+// isArrImportableMedia reports whether the virtual path is a media file an ARR could
+// import into the library — i.e. one that can ever be relinked to a real library path
+// by a Download webhook and so become eligible for health checks under SYMLINK/STRM.
+func isArrImportableMedia(p string) bool {
+	if fileinfo.IsVideoFile(p) {
+		return true
+	}
+	return arrAudioBookExtensions[strings.ToLower(path.Ext(p))]
 }
 
 // expandWrittenPaths resolves "DIR:"-prefixed entries (whole-directory imports such

--- a/internal/importer/postprocessor/health_scheduler_test.go
+++ b/internal/importer/postprocessor/health_scheduler_test.go
@@ -1,0 +1,164 @@
+package postprocessor
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSchedulerTest builds a Coordinator with a real MetadataService (temp dir)
+// and a real HealthRepository (in-memory sqlite) so ScheduleHealthCheck can be
+// exercised end to end.
+func setupSchedulerTest(t *testing.T) (*Coordinator, *metadata.MetadataService, *database.HealthRepository, *sql.DB) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file::memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			priority INTEGER DEFAULT 0,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	repo := database.NewHealthRepository(db, database.DialectSQLite)
+	ms := metadata.NewMetadataService(t.TempDir())
+
+	cfg := config.DefaultConfig()
+	// Directory repair resolution is opt-in (defaults to false); enable it so the
+	// stale-repair cleanup path is exercised.
+	resolveRepairs := true
+	cfg.Health.ResolveRepairOnImport = &resolveRepairs
+	configManager := config.NewManager(cfg, "")
+
+	coordinator := NewCoordinator(Config{
+		ConfigGetter:    configManager.GetConfig,
+		MetadataService: ms,
+		HealthRepo:      repo,
+	})
+
+	return coordinator, ms, repo, db
+}
+
+// writeTestMetadata writes a minimal valid metadata file for the given virtual path.
+func writeTestMetadata(t *testing.T, ms *metadata.MetadataService, virtualPath string) {
+	t.Helper()
+	seg := &metapb.SegmentData{
+		Id:          "article-001@test.example.com",
+		SegmentSize: 1024,
+		StartOffset: 0,
+		EndOffset:   1023,
+	}
+	meta := ms.CreateFileMetadata(
+		1024, "source.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		[]*metapb.SegmentData{seg},
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+}
+
+// TestScheduleHealthCheck_ExpandsDirWrittenPaths verifies that "DIR:" written-path
+// entries (RAR/7z archive imports report only their NZB folder) are expanded into
+// per-file health checks, and that pending repairs in that directory are resolved.
+// Before this, archive imports scheduled nothing: the literal "DIR:..." path had no
+// metadata, so the import-side exit from the repair loop never fired.
+func TestScheduleHealthCheck_ExpandsDirWrittenPaths(t *testing.T) {
+	coordinator, ms, repo, db := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	nzbFolder := "/tv/Show.S01E01.1080p-GRP"
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E01.1080p-GRP.mkv")
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E01.1080p-GRP.en.srt")
+
+	// A stale repair record in the same directory — the new import replaces it.
+	_, err := db.Exec(`
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('tv/Show.S01E01.1080p-GRP/old-broken.mkv', 'repair_triggered', 1, 3)
+	`)
+	require.NoError(t, err)
+
+	err = coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	// Both extracted files must have pending health records.
+	for _, p := range []string{
+		"tv/Show.S01E01.1080p-GRP/Show.S01E01.1080p-GRP.mkv",
+		"tv/Show.S01E01.1080p-GRP/Show.S01E01.1080p-GRP.en.srt",
+	} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		require.NotNil(t, h, "expected a health record for %s", p)
+		assert.Equal(t, database.HealthStatusPending, h.Status)
+	}
+
+	// The stale repair record in the directory must be resolved (deleted).
+	stale, err := repo.GetFileHealth(ctx, "tv/Show.S01E01.1080p-GRP/old-broken.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, stale, "pending repair in the import directory must be resolved by the new import")
+}
+
+// TestScheduleHealthCheck_ExpandsNestedDirs verifies recursion into subdirectories
+// (e.g. Blu-ray structures produced by ISO expansion inside an archive).
+func TestScheduleHealthCheck_ExpandsNestedDirs(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	nzbFolder := "/movies/Film.2024.1080p-GRP"
+	nested := nzbFolder + "/BDMV/STREAM/00001.m2ts"
+	writeTestMetadata(t, ms, nested)
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "movies/Film.2024.1080p-GRP/BDMV/STREAM/00001.m2ts")
+	require.NoError(t, err)
+	require.NotNil(t, h, "nested files must be discovered through recursive expansion")
+	assert.Equal(t, database.HealthStatusPending, h.Status)
+}
+
+// TestScheduleHealthCheck_PlainPathsUnchanged verifies non-DIR entries keep working.
+func TestScheduleHealthCheck_PlainPathsUnchanged(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	filePath := "/tv/Single.S01E01.mkv"
+	writeTestMetadata(t, ms, filePath)
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "tv/Single.S01E01.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, database.HealthStatusPending, h.Status)
+}

--- a/internal/importer/postprocessor/health_scheduler_test.go
+++ b/internal/importer/postprocessor/health_scheduler_test.go
@@ -16,8 +16,9 @@ import (
 
 // setupSchedulerTest builds a Coordinator with a real MetadataService (temp dir)
 // and a real HealthRepository (in-memory sqlite) so ScheduleHealthCheck can be
-// exercised end to end.
-func setupSchedulerTest(t *testing.T) (*Coordinator, *metadata.MetadataService, *database.HealthRepository, *sql.DB) {
+// exercised end to end. Optional mutators adjust the config before the manager
+// is built (e.g. to set an import strategy).
+func setupSchedulerTest(t *testing.T, mutate ...func(*config.Config)) (*Coordinator, *metadata.MetadataService, *database.HealthRepository, *sql.DB) {
 	t.Helper()
 
 	db, err := sql.Open("sqlite3", "file::memory:")
@@ -59,6 +60,9 @@ func setupSchedulerTest(t *testing.T) (*Coordinator, *metadata.MetadataService, 
 	// stale-repair cleanup path is exercised.
 	resolveRepairs := true
 	cfg.Health.ResolveRepairOnImport = &resolveRepairs
+	for _, m := range mutate {
+		m(cfg)
+	}
 	configManager := config.NewManager(cfg, "")
 
 	coordinator := NewCoordinator(Config{
@@ -161,4 +165,64 @@ func TestScheduleHealthCheck_PlainPathsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, database.HealthStatusPending, h.Status)
+}
+
+// TestScheduleHealthCheck_SkipsSidecarsUnderSymlinkStrategy verifies that under
+// SYMLINK/STRM strategies only ARR-importable media files are scheduled. Sidecars
+// (.nfo, .srt, ...) can never be relinked to a real library path by a Download
+// webhook, so their records would sit permanently ineligible for the health worker
+// (GetUnhealthyFiles filters on library_path) and pile up as stuck "pending" until
+// the next library sync deletes them.
+func TestScheduleHealthCheck_SkipsSidecarsUnderSymlinkStrategy(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t, func(cfg *config.Config) {
+		cfg.Import.ImportStrategy = config.ImportStrategySYMLINK
+	})
+	ctx := context.Background()
+
+	nzbFolder := "/tv/Show.S01E02.1080p-GRP"
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E02.1080p-GRP.mkv")
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E02.1080p-GRP.nfo")
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E02.1080p-GRP.en.srt")
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "tv/Show.S01E02.1080p-GRP/Show.S01E02.1080p-GRP.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h, "media file must be scheduled")
+	assert.Equal(t, database.HealthStatusPending, h.Status)
+
+	for _, sidecar := range []string{
+		"tv/Show.S01E02.1080p-GRP/Show.S01E02.1080p-GRP.nfo",
+		"tv/Show.S01E02.1080p-GRP/Show.S01E02.1080p-GRP.en.srt",
+	} {
+		h, err := repo.GetFileHealth(ctx, sidecar)
+		require.NoError(t, err)
+		assert.Nil(t, h, "sidecar %s must not get a permanently-ineligible health record", sidecar)
+	}
+}
+
+// TestScheduleHealthCheck_KeepsSidecarsUnderNoneStrategy verifies that under the NONE
+// strategy (no library filter — every record is eligible as-is) sidecars keep getting
+// health checks, preserving the pre-filter behavior.
+func TestScheduleHealthCheck_KeepsSidecarsUnderNoneStrategy(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	nzbFolder := "/tv/Show.S01E03.1080p-GRP"
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E03.1080p-GRP.mkv")
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E03.1080p-GRP.nfo")
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	for _, p := range []string{
+		"tv/Show.S01E03.1080p-GRP/Show.S01E03.1080p-GRP.mkv",
+		"tv/Show.S01E03.1080p-GRP/Show.S01E03.1080p-GRP.nfo",
+	} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		require.NotNil(t, h, "expected a health record for %s under NONE strategy", p)
+		assert.Equal(t, database.HealthStatusPending, h.Status)
+	}
 }

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1192,17 +1192,23 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 	}
 }
 
-// cleanupHealthRecords removes health records under the given virtual path (a file or a
-// directory) whose metadata was just rolled back by a failed import. Without this, records
-// scheduled mid-import — or by an earlier attempt of the same release — linger in pending
-// forever under SYMLINK/STRM strategies: their placeholder library_path never matches the
-// worker's library filter, and no ARR webhook will ever relink a rolled-back import.
+// cleanupHealthRecords removes the still-unvalidated health records under the given virtual
+// path (a file or a directory) whose metadata was just rolled back by a failed import.
+// Without this, records scheduled mid-import — or by an earlier attempt of the same release —
+// linger in pending forever under SYMLINK/STRM strategies: their placeholder library_path
+// never matches the worker's library filter, and no ARR webhook will ever relink a
+// rolled-back import.
+//
+// It deletes only unvalidated placeholder records (pending/checking, not yet relinked to a
+// real library path). The nzbFolder is deterministic per release rather than unique per
+// queue item, so a failed re-import shares the subtree of a prior successful import; scoping
+// to unvalidated records keeps that prior import's healthy/relinked/repair records intact.
 func (s *Service) cleanupHealthRecords(ctx context.Context, itemID int64, virtualPath string) {
 	if s.healthRepo == nil {
 		return
 	}
 
-	deleted, err := s.healthRepo.DeleteHealthRecordsByPrefix(ctx, virtualPath)
+	deleted, err := s.healthRepo.DeleteUnvalidatedHealthRecordsByPrefix(ctx, virtualPath)
 	if err != nil {
 		s.log.WarnContext(ctx, "Failed to clean up health records after import failure",
 			"queue_id", itemID,

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1158,7 +1158,8 @@ func (s *Service) OnItemClaimed(ctx context.Context, item *database.ImportQueueI
 	}
 }
 
-// cleanupWrittenPaths deletes metadata files/directories written during a failed import.
+// cleanupWrittenPaths deletes metadata files/directories written during a failed import,
+// along with any health records already scheduled for them.
 // Paths prefixed with "DIR:" indicate a whole directory should be removed; others are individual files.
 func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths []string) {
 	for _, p := range paths {
@@ -1174,6 +1175,7 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 					"queue_id", itemID,
 					"dir", dirPath)
 			}
+			s.cleanupHealthRecords(ctx, itemID, dirPath)
 		} else {
 			if delErr := s.metadataService.DeleteFileMetadata(p); delErr != nil {
 				s.log.WarnContext(ctx, "Failed to clean up metadata file after import failure",
@@ -1185,7 +1187,34 @@ func (s *Service) cleanupWrittenPaths(ctx context.Context, itemID int64, paths [
 					"queue_id", itemID,
 					"path", p)
 			}
+			s.cleanupHealthRecords(ctx, itemID, p)
 		}
+	}
+}
+
+// cleanupHealthRecords removes health records under the given virtual path (a file or a
+// directory) whose metadata was just rolled back by a failed import. Without this, records
+// scheduled mid-import — or by an earlier attempt of the same release — linger in pending
+// forever under SYMLINK/STRM strategies: their placeholder library_path never matches the
+// worker's library filter, and no ARR webhook will ever relink a rolled-back import.
+func (s *Service) cleanupHealthRecords(ctx context.Context, itemID int64, virtualPath string) {
+	if s.healthRepo == nil {
+		return
+	}
+
+	deleted, err := s.healthRepo.DeleteHealthRecordsByPrefix(ctx, virtualPath)
+	if err != nil {
+		s.log.WarnContext(ctx, "Failed to clean up health records after import failure",
+			"queue_id", itemID,
+			"path", virtualPath,
+			"error", err)
+		return
+	}
+	if deleted > 0 {
+		s.log.InfoContext(ctx, "Removed health records for rolled-back import",
+			"queue_id", itemID,
+			"path", virtualPath,
+			"records", deleted)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three related fixes to the file-health record lifecycle. Together they stop records from getting stranded in `pending`/`repair_triggered`, give repairs a terminal state so they can't loop forever, and close several races and data-loss vectors in the repository layer. A new index speeds up the per-cycle "what's due?" query.

All changes are scoped to the health subsystem and its importer hooks. No API or config surface changes.

## What's fixed

**1. Break the `repair_triggered` loop; give repairs a terminal state**
- An exhausted `repair_triggered` record is now finalized as `corrupted` instead of being re-armed and swept on every cycle.
- `corrupted` is treated as terminal at the query level — `GetUnhealthyFiles` never re-selects it, so no re-arm vector (e.g. the release-date backfill) can resurrect it.
- The release-date backfill is status-gated: it still fills `release_date` for every record but only (re)schedules `scheduled_check_at` for non-terminal records.

**2. Stop failed imports and sidecars from stranding pending records**
- A failed import no longer leaves placeholder health records behind in `pending`. Cleanup deletes only the unvalidated placeholders (`library_path == file_path`) for the failed path and spares records from a prior successful import.
- The health scheduler skips sidecars under the symlink strategy and keeps them under the `none` strategy, matching how those files are actually materialized.

**3. Harden record lifecycle, close cycle races, and speed up checks**
- **TOCTOU guard:** bulk status updates can now require an `ExpectedStatus`, so a concurrent transition (e.g. a webhook relink moving `repair_triggered -> pending`) is no longer clobbered and the repair budget isn't wrongly decremented.
- **Ambiguous relink refusal:** `RelinkFileByFilename` refuses to blanket-reset when a basename collides across unrelated records, and resolves the collision by exact path when possible — preventing the wrong title's repair state from being reset.
- **`LIKE` wildcard escaping:** prefix deletes escape `_`/`%` so a path like `Show_S01_1080p` or `100%Real` can't silently over-delete unrelated siblings.
- **Path normalization:** every writer normalizes a leading slash so `UNIQUE(file_path)` holds and duplicate records can't be created for the same file.
- **Repair budget preservation:** re-import upserts reset status to `pending` but preserve the per-title repair budget instead of resetting it.
- **Don't destroy on ambiguous ARR miss:** when ARR returns `ErrPathMatchFailed`, the record is marked `corrupted` and its metadata/symlink are preserved rather than deleted — a path-match miss is not a reliable orphan signal. Genuine orphans are still removed by the guarded library-sync pass.
- **New index:** migration `031_add_file_health_due_index` (sqlite + postgres) backs the per-cycle due-check query.

## Migration

`031_add_file_health_due_index` — additive index only, no data migration, safe to roll back.

## Testing

- New unit coverage for each repository-level fix (terminal/backfill, status guard, relink collisions, wildcard escaping, validated-record preservation, normalization, repair-budget preservation).
- New end-to-end repair tests covering exhausted `repair_triggered -> corrupted` finalization and the "never destroy the file on an ambiguous ARR path miss" guarantee.
- `go test ./internal/database/... ./internal/health/... ./internal/importer/...` passes.


Before you get a heart attack looking at the PR size:
  | Category | Added | Removed |
  | --- | ---: | ---: |
  | Actual Code | +602 | −106 |
  | Tests | +974 | −4 |
  | Migrations | +32 | 0 |
  | **Total** | **+1,608** | **−110** |