### PR TITLE
fix(health): match Windows library paths in GetUnhealthyFiles

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -210,7 +210,7 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		  AND status NOT IN ('repair_triggered', 'checking')
 		  AND (
 			  ? = 'NONE' 
-			  OR (library_path IS NOT NULL AND (library_path LIKE ? OR library_path LIKE ?))
+			  OR (library_path IS NOT NULL AND (library_path LIKE ? ESCAPE '!' OR library_path LIKE ? ESCAPE '!'))
 			  OR (last_error LIKE '%failed to unmarshal metadata%')
 			  OR (last_error LIKE '%failed to read file metadata%')
 			  OR (last_error LIKE '%no ARR instance found%')

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -210,7 +210,7 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		  AND status NOT IN ('repair_triggered', 'checking')
 		  AND (
 			  ? = 'NONE' 
-			  OR (library_path IS NOT NULL AND library_path LIKE ?)
+			  OR (library_path IS NOT NULL AND (library_path LIKE ? OR library_path LIKE ?))
 			  OR (last_error LIKE '%failed to unmarshal metadata%')
 			  OR (last_error LIKE '%failed to read file metadata%')
 			  OR (last_error LIKE '%no ARR instance found%')
@@ -220,14 +220,11 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		LIMIT ?
 	`
 
-	// Build the library directory prefix filter (e.g. /my/library/path/%)
-	libraryPrefix := libraryDir
-	if !strings.HasSuffix(libraryPrefix, "/") {
-		libraryPrefix += "/"
-	}
-	libraryPrefix += "%"
-
-	rows, err := r.db.QueryContext(ctx, query, maxRetries, strategy, libraryPrefix, limit)
+	// Build library directory prefix filters. Windows may store library_path with
+	// backslashes even when config paths are normalized with slashes.
+	libraryPrefix := strings.TrimRight(libraryDir, `/\`) + "/%"
+	libraryPrefixAlt := strings.TrimRight(libraryDir, `/\`) + `\%`
+	rows, err := r.db.QueryContext(ctx, query, maxRetries, strategy, libraryPrefix, libraryPrefixAlt, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query files due for check: %w", err)
 	}

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -319,3 +319,20 @@ func TestAddFileToHealthCheckWithMetadata_StoresLibraryPath(t *testing.T) {
 	assert.Equal(t, libraryPath, *h.LibraryPath)
 	assert.Equal(t, filePath, h.FilePath)
 }
+
+func TestGetUnhealthyFiles_MatchesWindowsLibraryPath(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, library_path, status, retry_count, max_retries, scheduled_check_at)
+		VALUES ('tv/Show/Episode.mkv', 'C:\rclone\show-torrents\Show\Season 1\Episode.mkv', 'pending', 0, 3, ?)
+	`, past)
+	require.NoError(t, err)
+
+	files, err := repo.GetUnhealthyFiles(ctx, 10, "SYMLINK", `C:\rclone`, 3)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "tv/Show/Episode.mkv", files[0].FilePath)
+}


### PR DESCRIPTION
## Problem

On Windows, altmount stores `library_path` values in SQLite with backslashes (e.g. `C:\rclone\show-torrents\Show\Season 1\Episode.mkv`). The `GetUnhealthyFiles` query only matched a forward-slash prefix:

```sql
OR (library_path IS NOT NULL AND library_path LIKE ?)
```

Where the bound parameter was `C:/rclone/%`. This never matches a backslash-stored path, so health checks never fire for Windows users — all 9000+ files stay permanently `pending`.

## Fix

Add a second `OR` clause binding the backslash variant:

```sql
OR (library_path IS NOT NULL AND (library_path LIKE ? OR library_path LIKE ?))
```

With parameters `C:/rclone/%` and `C:\rclone\%`.

Also simplifies the prefix-building logic using `strings.TrimRight` to handle both separator styles consistently.

## Impact

**No behavioral change on Linux/macOS** — backslash paths never appear there, so the new clause never matches. Windows users get health checks working correctly.

## Test

Added `TestGetUnhealthyFiles_MatchesWindowsLibraryPath` to `health_repository_test.go` — inserts a record with a Windows-style backslash `library_path` and asserts `GetUnhealthyFiles` returns it.