### PR TITLE
fix(health): fallback to SceneName to blocklist when import event is missing

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,123 @@
+name: Build Windows CLI
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'main'
+
+jobs:
+  build-frontend:
+    name: Build Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ${{ inputs.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v5
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend
+        working-directory: frontend
+        env:
+          npm_package_version: ${{ inputs.branch }}-${{ github.sha }}
+          GIT_COMMIT: ${{ github.sha }}
+        run: bun run build
+
+      - name: Upload frontend build
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist
+          retention-days: 1
+
+  build-windows-exe:
+    name: Build Windows .exe
+    runs-on: ubuntu-latest
+    needs: build-frontend
+    steps:
+      - name: Checkout ${{ inputs.branch }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install MinGW cross-compiler
+        run: sudo apt-get install -y gcc-mingw-w64-x86-64
+
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-build
+          path: frontend/dist/
+
+      - name: Get version info
+        id: version
+        run: |
+          VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+          COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+          TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "commit=$COMMIT" >> $GITHUB_OUTPUT
+          echo "timestamp=$TIMESTAMP" >> $GITHUB_OUTPUT
+
+      - name: Build Windows .exe
+        env:
+          CGO_ENABLED: "1"
+          GOOS: windows
+          GOARCH: amd64
+          CC: x86_64-w64-mingw32-gcc
+        run: |
+          go build \
+            -trimpath \
+            -tags=cli \
+            -ldflags="-s -w \
+              -X 'github.com/javi11/altmount/internal/version.Version=${{ steps.version.outputs.version }}' \
+              -X 'github.com/javi11/altmount/internal/version.GitCommit=${{ steps.version.outputs.commit }}' \
+              -X 'github.com/javi11/altmount/internal/version.Timestamp=${{ steps.version.outputs.timestamp }}'" \
+            -o altmount-windows-amd64.exe \
+            ./cmd/altmount/main.go
+
+      - name: Upload Windows .exe artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: altmount-windows-amd64-${{ steps.version.outputs.version }}
+          path: altmount-windows-amd64.exe
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Build summary
+        run: |
+          echo "## ✅ Windows Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Branch | \`${{ inputs.branch }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Version | \`${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commit | \`${{ steps.version.outputs.commit }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Artifact | \`altmount-windows-amd64-${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> ⚠️ **WinFsp** must be installed on the target Windows machine: https://winfsp.dev/" >> $GITHUB_STEP_SUMMARY

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -84,6 +84,12 @@ type ArrsWebhookRequest struct {
 		SceneName string `json:"sceneName"`
 		Path      string `json:"path"`
 	} `json:"episodeFile"`
+	Episodes []struct {
+		Id            int64  `json:"id"`
+		EpisodeNumber int    `json:"episodeNumber"`
+		SeasonNumber  int    `json:"seasonNumber"`
+		Title         string `json:"title"`
+	} `json:"episodes,omitempty"`
 	DeletedFiles ArrsDeletedFiles `json:"deletedFiles,omitempty"`
 	DownloadId   string           `json:"downloadId,omitempty"`
 	Release      *struct {
@@ -125,6 +131,16 @@ func (req ArrsWebhookRequest) ToMetadata() model.WebhookMetadata {
 			SceneName: req.EpisodeFile.SceneName,
 		}
 	}
+
+	if len(req.Episodes) > 0 {
+		meta.Episodes = make([]model.EpisodeMetadata, len(req.Episodes))
+		for i, ep := range req.Episodes {
+			meta.Episodes[i] = model.EpisodeMetadata{
+				Id: ep.Id,
+			}
+		}
+	}
+
 
 	if req.Artist.Id > 0 {
 		meta.Artist = &model.ArtistMetadata{
@@ -598,15 +614,39 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 			// Handle Rename and Download specifically: try to find and re-link old record
 			if req.EventType == "Rename" || req.EventType == "Download" {
 				fileName := filepath.Base(normalizedPath)
-				// Try to find a record with the same filename but currently under /complete/
-				// or with a NULL library_path
 				var metadataStr *string
-				metaBytes, err := json.Marshal(req.ToMetadata())
+				webMeta := req.ToMetadata()
+				metaBytes, err := json.Marshal(webMeta)
 				if err == nil {
 					str := string(metaBytes)
 					metadataStr = &str
 				}
 
+				// Try to find and relink by metadata IDs (e.g. series ID/TVDB ID/episode ID or movie ID/TMDB ID) first
+				if relinked, err := s.healthRepo.RelinkFileByMetadata(c.Context(), &webMeta, normalizedPath, path, metadataStr); err == nil && relinked {
+					attrs := []any{
+						"event", req.EventType,
+						"instance", req.InstanceName,
+						"new_library_path", path,
+					}
+					if req.Series.Id > 0 {
+						attrs = append(attrs, "series_id", req.Series.Id)
+					}
+					if req.EpisodeFile.Id > 0 {
+						attrs = append(attrs, "episode_file_id", req.EpisodeFile.Id)
+					}
+					if req.Movie.Id > 0 {
+						attrs = append(attrs, "movie_id", req.Movie.Id)
+					}
+					if req.MovieFile.Id > 0 {
+						attrs = append(attrs, "movie_file_id", req.MovieFile.Id)
+					}
+
+					slog.InfoContext(c.Context(), "Successfully re-linked health record using metadata IDs during webhook", attrs...)
+					continue // Successfully re-linked, no need to add new
+				}
+
+				// Fall back to filename-based matching
 				if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr); err == nil && relinked {
 					attrs := []any{
 						"event", req.EventType,

--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -623,7 +623,7 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 				}
 
 				// Try to find and relink by metadata IDs (e.g. series ID/TVDB ID/episode ID or movie ID/TMDB ID) first
-				if relinked, err := s.healthRepo.RelinkFileByMetadata(c.Context(), &webMeta, normalizedPath, path, metadataStr); err == nil && relinked {
+				if relinked, err := s.healthRepo.RelinkFileByMetadata(c.Context(), &webMeta, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
 					attrs := []any{
 						"event", req.EventType,
 						"instance", req.InstanceName,
@@ -647,7 +647,10 @@ func (s *Server) handleArrsWebhook(c *fiber.Ctx) error {
 				}
 
 				// Fall back to filename-based matching
-				if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr); err == nil && relinked {
+				// Download events carry a freshly imported copy: relink with revalidation so
+				// the new file gets health-checked (repair budget is preserved). Rename events
+				// carry no new content and must not disturb repair/corrupted state.
+				if relinked, err := s.healthRepo.RelinkFileByFilename(c.Context(), fileName, normalizedPath, path, metadataStr, req.EventType == "Download"); err == nil && relinked {
 					attrs := []any{
 						"event", req.EventType,
 						"instance", req.InstanceName,

--- a/internal/api/provider_speedtest_handler.go
+++ b/internal/api/provider_speedtest_handler.go
@@ -88,6 +88,9 @@ func (s *Server) handleTestProviderSpeed(c *fiber.Ctx) error {
 		}
 	}
 	speed := wireBps / 1024 / 1024 // bytes/sec → MB/s
+	if speed < 0 {
+		speed = 0
+	}
 
 	// Update provider config with speed test result
 	now := time.Now()

--- a/internal/arrs/model/metadata.go
+++ b/internal/arrs/model/metadata.go
@@ -44,6 +44,10 @@ type BookFileMetadata struct {
 	Id int64 `json:"id,omitempty"`
 }
 
+type EpisodeMetadata struct {
+	Id int64 `json:"id,omitempty"`
+}
+
 type WebhookMetadata struct {
 	EventType    string               `json:"eventType,omitempty"`
 	InstanceName string               `json:"instanceName,omitempty"`
@@ -51,6 +55,7 @@ type WebhookMetadata struct {
 	MovieFile    *MovieFileMetadata   `json:"movieFile,omitempty"`
 	Series       *SeriesMetadata      `json:"series,omitempty"`
 	EpisodeFile  *EpisodeFileMetadata `json:"episodeFile,omitempty"`
+	Episodes     []EpisodeMetadata    `json:"episodes,omitempty"`
 	Artist       *ArtistMetadata      `json:"artist,omitempty"`
 	Album        *AlbumMetadata       `json:"album,omitempty"`
 	TrackFile    *TrackFileMetadata   `json:"trackFile,omitempty"`
@@ -58,3 +63,4 @@ type WebhookMetadata struct {
 	Book         *BookMetadata        `json:"book,omitempty"`
 	BookFile     *BookFileMetadata    `json:"bookFile,omitempty"`
 }
+

--- a/internal/arrs/scanner/discovery.go
+++ b/internal/arrs/scanner/discovery.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/javi11/altmount/internal/arrs/model"
 	"golift.io/starr"
+	"golift.io/starr/sonarr"
 )
 
 var (
@@ -153,6 +154,20 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbNa
 				if (libraryPath != "" && ef.Path == libraryPath) ||
 					(cleanNzbName != "" && strings.EqualFold(ef.SceneName, cleanNzbName)) ||
 					(ef.Path == filePath) {
+					var episodes []model.EpisodeMetadata
+					eps, err := client.GetSeriesEpisodesContext(ctx, &sonarr.GetEpisode{
+						SeriesID: show.ID,
+					})
+					if err == nil {
+						for _, ep := range eps {
+							if ep.EpisodeFileID == ef.ID {
+								episodes = append(episodes, model.EpisodeMetadata{
+									Id: ep.ID,
+								})
+							}
+						}
+					}
+
 					metadata := &model.WebhookMetadata{
 						EventType:    "StrictDiscovery",
 						InstanceName: instanceName,
@@ -164,6 +179,7 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbNa
 							Id:        ef.ID,
 							SceneName: ef.SceneName,
 						},
+						Episodes: episodes,
 					}
 					return metadata, nil
 				}

--- a/internal/arrs/scanner/discovery.go
+++ b/internal/arrs/scanner/discovery.go
@@ -78,6 +78,18 @@ func (m *Manager) runStrictDiscovery(ctx context.Context, inst *model.ConfigInst
 	return nil, fmt.Errorf("unsupported type")
 }
 
+func (m *Manager) normalizeTitle(title string) string {
+	t := strings.ToLower(title)
+	t = strings.ReplaceAll(t, ".", "")
+	t = strings.ReplaceAll(t, " ", "")
+	t = strings.ReplaceAll(t, "-", "")
+	t = strings.ReplaceAll(t, "_", "")
+	t = strings.ReplaceAll(t, "&", "")
+	t = strings.ReplaceAll(t, "(", "")
+	t = strings.ReplaceAll(t, ")", "")
+	return t
+}
+
 func (m *Manager) discoverRadarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
 	instanceConfig, _ := m.instances.FindConfigInstance("radarr", instanceName)
 	client, _ := m.clients.GetOrCreateRadarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
@@ -85,8 +97,19 @@ func (m *Manager) discoverRadarrStrict(ctx context.Context, filePath, cleanNzbNa
 	// 1. Check Library (Active Files)
 	movies, err := m.data.GetMovies(ctx, client, instanceName)
 	if err == nil {
+		normalizedNzb := m.normalizeTitle(cleanNzbName)
+		normalizedPath := m.normalizeTitle(filePath)
+
 		for _, movie := range movies {
 			if movie.HasFile && movie.MovieFile != nil {
+				// Optimization: only pull files for movies that might match
+				normalizedTitle := m.normalizeTitle(movie.Title)
+				if !strings.Contains(normalizedNzb, normalizedTitle) &&
+					!strings.Contains(normalizedPath, normalizedTitle) &&
+					(libraryPath == "" || !strings.Contains(libraryPath, movie.Path)) {
+					continue
+				}
+
 				// Strict Match Conditions:
 				// - Library Path matches
 				// - OR Scene Name matches (NZB Name)
@@ -138,11 +161,21 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbNa
 	// 1. Check Library (Active Files)
 	series, err := m.data.GetSeries(ctx, client, instanceName)
 	if err == nil {
+		normalizedNzb := m.normalizeTitle(cleanNzbName)
+		normalizedPath := m.normalizeTitle(filePath)
+
 		for _, show := range series {
 			// Optimization: only pull files for shows that might contain this file
-			if !strings.Contains(strings.ToLower(cleanNzbName), strings.ToLower(show.CleanTitle)) &&
-				!strings.Contains(strings.ToLower(filePath), strings.ToLower(show.Path)) &&
-				(libraryPath == "" || !strings.Contains(strings.ToLower(libraryPath), strings.ToLower(show.Path))) {
+			// Use normalized titles to handle "Law.And.Order" vs "Law & Order" (laworder)
+			normalizedTitle := m.normalizeTitle(show.Title)
+			normalizedClean := strings.ToLower(show.CleanTitle)
+
+			if !strings.Contains(normalizedNzb, normalizedTitle) &&
+				!strings.Contains(normalizedNzb, normalizedClean) &&
+				!strings.Contains(normalizedPath, normalizedTitle) &&
+				!strings.Contains(normalizedPath, normalizedClean) &&
+				!strings.Contains(filePath, show.Path) &&
+				(libraryPath == "" || !strings.Contains(libraryPath, show.Path)) {
 				continue
 			}
 

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -553,6 +553,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 
 	var targetMovie *radarr.Movie
 	var targetMovieFileID int64
+	var sceneName string
 	var err error
 
 	// ID-Based Precision: If we have the exact movie ID and file ID from metadata, use them directly
@@ -561,6 +562,8 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 			"movie_id", metadata.Movie.Id,
 			"movie_file_id", metadata.MovieFile.Id)
 
+		sceneName = metadata.MovieFile.SceneName
+		
 		movies, err := m.data.GetMovies(ctx, client, instanceName)
 		if err != nil {
 			return fmt.Errorf("failed to get movies from Radarr for ID lookup: %w", err)
@@ -640,6 +643,10 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 					}
 				}
 			}
+			
+			if targetMovieFileID > 0 {
+				sceneName = movie.MovieFile.SceneName
+			}
 		}
 	}
 
@@ -666,7 +673,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	// If we found the movie and have a file ID, try to blocklist and delete the file
 	if targetMovieFileID > 0 {
 		// Try to blocklist the release associated with this file
-		if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, targetMovieFileID); err != nil {
+		if err := m.blocklistRadarrMovieFile(ctx, client, targetMovie.ID, targetMovieFileID, sceneName); err != nil {
 			slog.WarnContext(ctx, "Failed to blocklist Radarr release", "error", err)
 		}
 
@@ -721,6 +728,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 	var targetSeriesID int64
 	var targetSeriesTitle string
 	var targetEpisodeFileID int64
+	var sceneName string
 	var err error
 
 	// ID-Based Precision: If we have exact IDs from metadata, use them
@@ -731,6 +739,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 
 		targetSeriesID = metadata.Series.Id
 		targetEpisodeFileID = metadata.EpisodeFile.Id
+		sceneName = metadata.EpisodeFile.SceneName
 		targetSeriesTitle = "Known Series (ID Based)" // Title is just for logging
 	}
 
@@ -841,6 +850,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 
 		if targetEpisodeFile != nil {
 			targetEpisodeFileID = targetEpisodeFile.ID
+			sceneName = targetEpisodeFile.SceneName
 		}
 	}
 
@@ -872,7 +882,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 			episodeFiles, err := m.data.GetEpisodeFiles(ctx, client, instanceName, targetSeriesID)
 			if err == nil {
 				for _, ef := range episodeFiles {
-					if ef.Path == filePath || (metadata != nil && ef.SceneName == metadata.EpisodeFile.SceneName) {
+					if ef.Path == filePath || (sceneName != "" && ef.SceneName == sceneName) {
 						slog.InfoContext(ctx, "Smart Repair Guard: Episode already has a different healthy file (likely upgraded). Skipping repair.",
 							"old_file_id", targetEpisodeFileID,
 							"new_file_id", ef.ID)
@@ -888,7 +898,7 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 				"episode_file_id", targetEpisodeFileID)
 
 			// Try to blocklist the release associated with this file
-			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, targetEpisodeFileID); err != nil {
+			if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, targetEpisodeFileID, episodeIDs, sceneName); err != nil {
 				slog.WarnContext(ctx, "Failed to blocklist Sonarr release", "error", err)
 			}
 
@@ -1002,8 +1012,8 @@ func (m *Manager) failSonarrQueueItemByPath(ctx context.Context, client *sonarr.
 }
 
 // blocklistRadarrMovieFile finds the history event for the given file and marks it as failed (blocklisting the release)
-func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.Radarr, movieID int64, fileID int64) error {
-	slog.DebugContext(ctx, "Attempting to find and blocklist release for movie file", "movie_id", movieID, "file_id", fileID)
+func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.Radarr, movieID int64, fileID int64, sceneName string) error {
+	slog.DebugContext(ctx, "Attempting to find and blocklist release for movie file", "movie_id", movieID, "file_id", fileID, "scene_name", sceneName)
 
 	// Fetch history for this specific movie
 	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
@@ -1019,14 +1029,40 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 
 	// 1. Find the import event to get the downloadId
 	for _, record := range history.Records {
-		if record.Data.FileID == targetFileID && (record.EventType == "movieFileImported" || record.EventType == "downloadFolderImported") {
-			downloadID = record.DownloadID
-			break
+		if record.EventType == "movieFileImported" || record.EventType == "downloadFolderImported" {
+			if record.Data.FileID == targetFileID {
+				downloadID = record.DownloadID
+				break
+			}
 		}
 	}
 
 	if downloadID == "" {
-		slog.WarnContext(ctx, "Could not find import event in Radarr history for file", "movie_id", movieID, "file_id", fileID)
+		slog.WarnContext(ctx, "Could not find import event in Radarr history for file, attempting to find latest grabbed event directly", "movie_id", movieID, "file_id", fileID)
+		
+		// Precision Fallback: Find the grabbed event matching the SceneName or MovieID
+		for _, record := range history.Records {
+			if record.EventType == "grabbed" && record.MovieID == movieID {
+				if sceneName != "" && strings.Contains(strings.ToLower(record.SourceTitle), strings.ToLower(sceneName)) {
+					slog.InfoContext(ctx, "Found grabbed history record using SceneName precision fallback, marking as failed to blocklist release",
+						"history_id", record.ID, "source_title", record.SourceTitle)
+					if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+						return fmt.Errorf("failed to fail Radarr grab event %d: %w", record.ID, failErr)
+					}
+					return nil
+				}
+				
+				// Without an exact SceneName match, we blindly grab the first grabbed event matching the movieID as a fallback
+				slog.InfoContext(ctx, "Found latest grabbed history record using MovieID fallback, marking as failed to blocklist release",
+					"history_id", record.ID, "movie_id", movieID)
+				if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+					return fmt.Errorf("failed to fail Radarr grab event %d: %w", record.ID, failErr)
+				}
+				return nil
+			}
+		}
+
+		slog.WarnContext(ctx, "Could not find ANY grab event in Radarr history for this movie", "movie_id", movieID)
 		return nil
 	}
 
@@ -1047,8 +1083,8 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 }
 
 // blocklistSonarrEpisodeFile finds the grabbed history event for the given file and marks it as failed (blocklisting the release)
-func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr.Sonarr, seriesID int64, fileID int64) error {
-	slog.DebugContext(ctx, "Attempting to find and blocklist release for episode file", "series_id", seriesID, "file_id", fileID)
+func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr.Sonarr, seriesID int64, fileID int64, episodeIDs []int64, sceneName string) error {
+	slog.DebugContext(ctx, "Attempting to find and blocklist release for episode file", "series_id", seriesID, "file_id", fileID, "scene_name", sceneName)
 
 	// Fetch history for this specific series
 	req := &starr.PageReq{PageSize: 100, SortKey: "date", SortDir: starr.SortDescend}
@@ -1064,14 +1100,55 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 
 	// 1. Find the import event to get the downloadId
 	for _, record := range history.Records {
-		if record.Data.FileID == targetFileID && record.EventType == "downloadFolderImported" {
-			downloadID = record.DownloadID
-			break
+		if record.EventType == "downloadFolderImported" {
+			if record.Data.FileID == targetFileID {
+				downloadID = record.DownloadID
+				break
+			}
+			
+			// Fallback: Sonarr history might not expose fileId in data consistently. Match by EpisodeID.
+			for _, epID := range episodeIDs {
+				if record.EpisodeID == epID {
+					slog.DebugContext(ctx, "Found import event using EpisodeID fallback", "episode_id", epID, "download_id", record.DownloadID)
+					downloadID = record.DownloadID
+					break
+				}
+			}
+			if downloadID != "" {
+				break
+			}
 		}
 	}
 
 	if downloadID == "" {
-		slog.WarnContext(ctx, "Could not find import event in Sonarr history for file", "series_id", seriesID, "file_id", fileID)
+		slog.WarnContext(ctx, "Could not find import event in Sonarr history for file, attempting to find grabbed event directly", "series_id", seriesID, "file_id", fileID)
+		
+		// Precision Fallback: Find the grabbed event matching the SceneName
+		for _, record := range history.Records {
+			if record.EventType == "grabbed" {
+				if sceneName != "" && strings.Contains(strings.ToLower(record.SourceTitle), strings.ToLower(sceneName)) {
+					slog.InfoContext(ctx, "Found grabbed history record using SceneName precision fallback, marking as failed to blocklist release",
+						"history_id", record.ID, "source_title", record.SourceTitle)
+					if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+						return fmt.Errorf("failed to fail Sonarr grab event %d: %w", record.ID, failErr)
+					}
+					return nil
+				}
+
+				for _, epID := range episodeIDs {
+					if record.EpisodeID == epID {
+						slog.InfoContext(ctx, "Found latest grabbed history record using EpisodeID fallback, marking as failed to blocklist release",
+							"history_id", record.ID, "episode_id", epID)
+						if failErr := client.FailContext(ctx, record.ID); failErr != nil {
+							return fmt.Errorf("failed to fail Sonarr grab event %d: %w", record.ID, failErr)
+						}
+						return nil
+					}
+				}
+			}
+		}
+		
+		slog.WarnContext(ctx, "Could not find ANY grab event in Sonarr history for this episode", "series_id", seriesID)
 		return nil
 	}
 

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1834,33 +1834,33 @@ func (r *HealthRepository) relinkOrMergeRecordTx(ctx context.Context, tx *dialec
 		}
 
 		var mergedSourceNzb *string
-		if sourceSourceNzb != nil {
-			mergedSourceNzb = sourceSourceNzb
-		} else {
+		if conflictingSourceNzb != nil {
 			mergedSourceNzb = conflictingSourceNzb
+		} else {
+			mergedSourceNzb = sourceSourceNzb
 		}
 
 		var mergedIndexer *string
-		if sourceIndexer != nil {
-			mergedIndexer = sourceIndexer
-		} else {
+		if conflictingIndexer != nil {
 			mergedIndexer = conflictingIndexer
+		} else {
+			mergedIndexer = sourceIndexer
 		}
 
 		var mergedReleaseDate *time.Time
-		if sourceReleaseDate != nil {
-			mergedReleaseDate = sourceReleaseDate
-		} else {
+		if conflictingReleaseDate != nil {
 			mergedReleaseDate = conflictingReleaseDate
+		} else {
+			mergedReleaseDate = sourceReleaseDate
 		}
 
 		var mergedMetadata *string
 		if metadataStr != nil {
 			mergedMetadata = metadataStr
-		} else if sourceMetadata != nil {
-			mergedMetadata = sourceMetadata
-		} else {
+		} else if conflictingMetadata != nil {
 			mergedMetadata = conflictingMetadata
+		} else {
+			mergedMetadata = sourceMetadata
 		}
 
 		var query string

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -823,19 +823,22 @@ func (r *HealthRepository) DeleteHealthRecordsBulk(ctx context.Context, filePath
 		return nil
 	}
 
-	// SQLite parameter limit typically is 999. Batch delete in chunks of 500.
-	const batchSize = 500
+	// SQLite parameter limit typically is 999. Batch delete in chunks of 250 (500 placeholders).
+	const batchSize = 250
 	var totalRowsAffected int64
 
 	for i := 0; i < len(filePaths); i += batchSize {
 		end := min(i+batchSize, len(filePaths))
 		chunk := filePaths[i:end]
 
-		placeholders := make([]string, len(chunk))
-		args := make([]any, len(chunk))
+		placeholders := make([]string, len(chunk)*2)
+		args := make([]any, len(chunk)*2)
 		for j, path := range chunk {
-			placeholders[j] = "?"
-			args[j] = strings.TrimPrefix(path, "/")
+			placeholders[j*2] = "?"
+			placeholders[j*2+1] = "?"
+			trimmed := strings.TrimPrefix(path, "/")
+			args[j*2] = trimmed
+			args[j*2+1] = "/" + trimmed
 		}
 
 		query := fmt.Sprintf(`DELETE FROM file_health WHERE file_path IN (%s)`, strings.Join(placeholders, ","))

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -213,13 +213,16 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		  AND status NOT IN ('repair_triggered', 'checking')
 		  AND (
 			  ? = 'NONE' 
+			  OR (metadata IS NOT NULL AND metadata != '')
 			  OR (library_path IS NOT NULL AND library_path LIKE ?)
 			  OR (last_error LIKE '%failed to unmarshal metadata%')
 			  OR (last_error LIKE '%failed to read file metadata%')
 			  OR (last_error LIKE '%no ARR instance found%')
 			  OR (last_error LIKE '%missing % checked segments%')
 		  )
-		ORDER BY priority DESC, scheduled_check_at ASC
+		ORDER BY priority DESC, 
+		         (CASE WHEN status = 'pending' THEN 0 ELSE 1 END) ASC, 
+		         scheduled_check_at ASC
 		LIMIT ?
 	`
 

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -282,7 +282,10 @@ func (r *HealthRepository) SetPriority(ctx context.Context, id int64, priority H
 	return nil
 }
 
-// GetFilesForRepairNotification returns files that need repair notification (repair_triggered status)
+// GetFilesForRepairNotification returns files that need repair notification (repair_triggered status).
+// Records whose repair_retry_count has reached max_repair_retries are returned too: the worker
+// finalizes them as corrupted (prepareRepairNotificationUpdate). Filtering them out here would
+// leave them permanently stuck in repair_triggered — no other query ever selects that status.
 func (r *HealthRepository) GetFilesForRepairNotification(ctx context.Context, limit int) ([]*FileHealth, error) {
 	query := `
 		SELECT id, file_path, status, last_checked, last_error, retry_count, max_retries,
@@ -291,7 +294,6 @@ func (r *HealthRepository) GetFilesForRepairNotification(ctx context.Context, li
 		, metadata
 		FROM file_health
 		WHERE status = 'repair_triggered'
-		  AND repair_retry_count < max_repair_retries
 		  AND (scheduled_check_at IS NULL OR scheduled_check_at <= datetime('now'))
 		ORDER BY last_checked ASC
 		LIMIT ?
@@ -597,8 +599,13 @@ func (r *HealthRepository) AddFileToHealthCheck(ctx context.Context, filePath st
 	return r.AddFileToHealthCheckWithMetadata(ctx, filePath, libraryPath, maxRetries, maxRepairRetries, sourceNzbPath, priority, nil, nil, nil)
 }
 
-// AddFileToHealthCheckWithMetadata adds a file to the health database for checking with metadata
+// AddFileToHealthCheckWithMetadata adds a file to the health database for checking with metadata.
+// On conflict (re-import over an existing record) the record is reset to pending for
+// re-validation, but repair_retry_count is intentionally preserved: it is the per-title
+// repair budget, so a re-download of a broken release cannot reset its own escalation
+// counter. A successful health check resets it to 0.
 func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context, filePath string, libraryPath *string, maxRetries int, maxRepairRetries int, sourceNzbPath *string, priority HealthPriority, releaseDate *time.Time, metadata *string, indexer *string) error {
+	filePath = strings.TrimPrefix(filePath, "/")
 	var releaseDateStr any = nil
 	if releaseDate != nil {
 		releaseDateStr = releaseDate.UTC().Format("2006-01-02 15:04:05")
@@ -612,7 +619,6 @@ func (r *HealthRepository) AddFileToHealthCheckWithMetadata(ctx context.Context,
 		library_path = COALESCE(excluded.library_path, library_path),
 		status = excluded.status,
 		retry_count = 0,
-		repair_retry_count = 0,
 		last_error = NULL,
 		error_details = NULL,
 		max_retries = excluded.max_retries,
@@ -1528,22 +1534,41 @@ func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newP
 
 // RelinkFileByFilename updates the file_path and library_path for a record that matches by filename.
 // This is typically called by webhooks during renames or downloads to provide a definitive library path.
-func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string) (bool, error) {
+//
+// revalidate controls what happens to records in repair_triggered/corrupted state:
+//   - true (Download events — a re-downloaded copy was just imported): reset the record to
+//     pending with an immediate check so the fresh copy is validated instead of being
+//     destroyed by the next repair re-trigger. retry_count restarts for the new copy, but
+//     repair_retry_count is preserved as the per-title repair budget so repeatedly broken
+//     re-downloads still escalate to corrupted instead of looping forever.
+//   - false (Rename events — no new content): preserve repair/corrupted state so a library
+//     reorganization cannot wipe repair progress.
+func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
 	filePath = strings.TrimPrefix(filePath, "/")
 	query := `
 		UPDATE file_health
 		SET file_path = ?,
 		    library_path = ?,
-		    status = 'pending',
-		    retry_count = 0,
-		    repair_retry_count = 0,
-		    last_error = NULL,
-		    error_details = NULL,
-		    metadata = COALESCE(?, metadata),
 		    updated_at = datetime('now'),
-		    scheduled_check_at = datetime('now')
+		    metadata = COALESCE(?, metadata),
+		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
 		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
 	`
+	if revalidate {
+		query = `
+			UPDATE file_health
+			SET file_path = ?,
+			    library_path = ?,
+			    status = 'pending',
+			    retry_count = 0,
+			    last_error = NULL,
+			    error_details = NULL,
+			    metadata = COALESCE(?, metadata),
+			    updated_at = datetime('now'),
+			    scheduled_check_at = datetime('now')
+			WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
+		`
+	}
 
 	likePattern := "%/" + filename
 	res, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, likePattern, filename, likePattern, libraryPath)
@@ -1713,7 +1738,16 @@ func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string,
 }
 
 // RelinkFileByMetadata matches repair_triggered or corrupted records by metadata and updates them to pending.
-func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *model.WebhookMetadata, filePath, libraryPath string, metadataStr *string) (bool, error) {
+//
+// revalidate controls what happens to records in repair_triggered/corrupted state:
+//   - true (Download events — a re-downloaded copy was just imported): reset the record to
+//     pending with an immediate check so the fresh copy is validated instead of being
+//     destroyed by the next repair re-trigger. retry_count restarts for the new copy, but
+//     repair_retry_count is preserved as the per-title repair budget so repeatedly broken
+//     re-downloads still escalate to corrupted instead of looping forever.
+//   - false (Rename events — no new content): preserve repair/corrupted state so a library
+//     reorganization cannot wipe repair progress.
+func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *model.WebhookMetadata, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
 	filePath = strings.TrimPrefix(filePath, "/")
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT id, file_path, library_path, status, metadata
@@ -1755,16 +1789,26 @@ func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *mo
 			UPDATE file_health
 			SET file_path = ?,
 			    library_path = ?,
-			    status = 'pending',
-			    retry_count = 0,
-			    repair_retry_count = 0,
-			    last_error = NULL,
-			    error_details = NULL,
 			    metadata = COALESCE(?, metadata),
 			    updated_at = datetime('now'),
-			    scheduled_check_at = datetime('now')
+			    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
 			WHERE id = ?
 		`
+		if revalidate {
+			query = `
+				UPDATE file_health
+				SET file_path = ?,
+				    library_path = ?,
+				    status = 'pending',
+				    retry_count = 0,
+				    last_error = NULL,
+				    error_details = NULL,
+				    metadata = COALESCE(?, metadata),
+				    updated_at = datetime('now'),
+				    scheduled_check_at = datetime('now')
+				WHERE id = ?
+			`
+		}
 		_, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, id)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to update matched health record", "id", id, "error", err)

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -824,6 +824,36 @@ func (r *HealthRepository) ResetStalePendingFiles(ctx context.Context) error {
 	if rows > 0 {
 		slog.InfoContext(ctx, "Reset stale pending files", "count", rows)
 	}
+
+	// Fix files stuck in pending status with scheduled_check_at set to the distant future
+	// (usually by the backfill release dates worker when status check was not restricted).
+	// We only reset them if they have retry_count = 0 (never checked/no legitimate retry delay)
+	// and scheduled_check_at is more than 24 hours in the future relative to now.
+	var stuckQuery string
+	if r.dialect.IsPostgres() {
+		stuckQuery = `UPDATE file_health
+		               SET scheduled_check_at = NOW(),
+		                   updated_at = NOW()
+		               WHERE status = ? 
+		                 AND retry_count = 0 
+		                 AND scheduled_check_at > NOW() + INTERVAL '24 hours'`
+	} else {
+		stuckQuery = `UPDATE file_health
+		               SET scheduled_check_at = datetime('now'),
+		                   updated_at = datetime('now')
+		               WHERE status = ? 
+		                 AND retry_count = 0 
+		                 AND scheduled_check_at > datetime('now', '+24 hours')`
+	}
+	stuckResult, err := r.db.ExecContext(ctx, stuckQuery, HealthStatusPending)
+	if err != nil {
+		return fmt.Errorf("failed to reset stuck pending files: %w", err)
+	}
+	stuckRows, _ := stuckResult.RowsAffected()
+	if stuckRows > 0 {
+		slog.InfoContext(ctx, "Reset stuck pending files (scheduled in distant future)", "count", stuckRows)
+	}
+
 	return nil
 }
 
@@ -1330,7 +1360,7 @@ func (r *HealthRepository) BackfillReleaseDates(ctx context.Context, updates []B
 	stmt, err := tx.PrepareContext(ctx, `
 		UPDATE file_health
 		SET release_date = ?,
-		    scheduled_check_at = ?,
+		    scheduled_check_at = CASE WHEN status = 'healthy' THEN ? ELSE scheduled_check_at END,
 		    updated_at = datetime('now')
 		WHERE id = ?
 	`)

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -3,10 +3,13 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
+
+	"github.com/javi11/altmount/internal/arrs/model"
 )
 
 // HealthRepository handles file health database operations
@@ -1528,13 +1531,14 @@ func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, f
 		UPDATE file_health
 		SET file_path = ?,
 		    library_path = ?,
-		    status = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN status ELSE 'pending' END,
-		    retry_count = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN retry_count ELSE 0 END,
-		    last_error = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN last_error ELSE NULL END,
-		    error_details = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN error_details ELSE NULL END,
+		    status = 'pending',
+		    retry_count = 0,
+		    repair_retry_count = 0,
+		    last_error = NULL,
+		    error_details = NULL,
 		    metadata = COALESCE(?, metadata),
 		    updated_at = datetime('now'),
-		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
+		    scheduled_check_at = datetime('now')
 		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
 	`
 
@@ -1704,3 +1708,127 @@ func (r *HealthRepository) UpdateFileMetadata(ctx context.Context, id int64, met
 func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string, status string, errMsg string, downloadID string) error {
 	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }
+
+// RelinkFileByMetadata matches repair_triggered or corrupted records by metadata and updates them to pending.
+func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *model.WebhookMetadata, filePath, libraryPath string, metadataStr *string) (bool, error) {
+	filePath = strings.TrimPrefix(filePath, "/")
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, file_path, library_path, status, metadata
+		FROM file_health
+		WHERE status IN ('pending', 'repair_triggered', 'corrupted')
+		  AND metadata IS NOT NULL
+	`)
+	if err != nil {
+		return false, fmt.Errorf("failed to query non-healthy records: %w", err)
+	}
+	defer rows.Close()
+
+	var matchedIDs []int64
+	for rows.Next() {
+		var id int64
+		var dbFP, dbLP, dbStatus string
+		var dbMetaStr string
+		if err := rows.Scan(&id, &dbFP, &dbLP, &dbStatus, &dbMetaStr); err != nil {
+			continue
+		}
+
+		var dbMeta model.WebhookMetadata
+		if err := json.Unmarshal([]byte(dbMetaStr), &dbMeta); err != nil {
+			continue
+		}
+
+		if r.matchMetadata(&dbMeta, webMeta) {
+			matchedIDs = append(matchedIDs, id)
+		}
+	}
+
+	if len(matchedIDs) == 0 {
+		return false, nil
+	}
+
+	// Update each matched record
+	for _, id := range matchedIDs {
+		query := `
+			UPDATE file_health
+			SET file_path = ?,
+			    library_path = ?,
+			    status = 'pending',
+			    retry_count = 0,
+			    repair_retry_count = 0,
+			    last_error = NULL,
+			    error_details = NULL,
+			    metadata = COALESCE(?, metadata),
+			    updated_at = datetime('now'),
+			    scheduled_check_at = datetime('now')
+			WHERE id = ?
+		`
+		_, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, id)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to update matched health record", "id", id, "error", err)
+		}
+	}
+	return true, nil
+}
+
+// matchMetadata matches two WebhookMetadata objects by their IDs.
+func (r *HealthRepository) matchMetadata(dbMeta, webMeta *model.WebhookMetadata) bool {
+	if dbMeta == nil || webMeta == nil {
+		return false
+	}
+
+	// 1. Check if both are Movie/Radarr
+	if dbMeta.Movie != nil && webMeta.Movie != nil {
+		if dbMeta.Movie.Id > 0 && webMeta.Movie.Id > 0 && dbMeta.Movie.Id == webMeta.Movie.Id {
+			return true
+		}
+		if dbMeta.Movie.TmdbId > 0 && webMeta.Movie.TmdbId > 0 && dbMeta.Movie.TmdbId == webMeta.Movie.TmdbId {
+			return true
+		}
+	}
+
+	// 2. Check if both are Series/Sonarr
+	if dbMeta.Series != nil && webMeta.Series != nil {
+		seriesMatch := false
+		if dbMeta.Series.Id > 0 && webMeta.Series.Id > 0 && dbMeta.Series.Id == webMeta.Series.Id {
+			seriesMatch = true
+		} else if dbMeta.Series.TvdbId > 0 && webMeta.Series.TvdbId > 0 && dbMeta.Series.TvdbId == webMeta.Series.TvdbId {
+			seriesMatch = true
+		}
+
+		if seriesMatch {
+			// Check if EpisodeFile matches
+			if dbMeta.EpisodeFile != nil && webMeta.EpisodeFile != nil {
+				if dbMeta.EpisodeFile.Id > 0 && webMeta.EpisodeFile.Id > 0 && dbMeta.EpisodeFile.Id == webMeta.EpisodeFile.Id {
+					return true
+				}
+			}
+			// Check if any Episode ID matches
+			if len(dbMeta.Episodes) > 0 && len(webMeta.Episodes) > 0 {
+				for _, dbEp := range dbMeta.Episodes {
+					for _, webEp := range webMeta.Episodes {
+						if dbEp.Id > 0 && webEp.Id > 0 && dbEp.Id == webEp.Id {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 3. Check if both are Album/Lidarr
+	if dbMeta.Album != nil && webMeta.Album != nil {
+		if dbMeta.Album.Id > 0 && webMeta.Album.Id > 0 && dbMeta.Album.Id == webMeta.Album.Id {
+			return true
+		}
+	}
+
+	// 4. Check if both are Book/Readarr
+	if dbMeta.Book != nil && webMeta.Book != nil {
+		if dbMeta.Book.Id > 0 && webMeta.Book.Id > 0 && dbMeta.Book.Id == webMeta.Book.Id {
+			return true
+		}
+	}
+
+	return false
+}
+

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1579,43 +1579,48 @@ func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newP
 //     reorganization cannot wipe repair progress.
 func (r *HealthRepository) RelinkFileByFilename(ctx context.Context, filename, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
 	filePath = strings.TrimPrefix(filePath, "/")
-	query := `
-		UPDATE file_health
-		SET file_path = ?,
-		    library_path = ?,
-		    updated_at = datetime('now'),
-		    metadata = COALESCE(?, metadata),
-		    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
-		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
-	`
-	if revalidate {
-		query = `
-			UPDATE file_health
-			SET file_path = ?,
-			    library_path = ?,
-			    status = 'pending',
-			    retry_count = 0,
-			    last_error = NULL,
-			    error_details = NULL,
-			    metadata = COALESCE(?, metadata),
-			    updated_at = datetime('now'),
-			    scheduled_check_at = datetime('now')
-			WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
-		`
-	}
-
 	likePattern := "%/" + filename
-	res, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, likePattern, filename, likePattern, libraryPath)
+
+	// Query to find all matched IDs
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id FROM file_health
+		WHERE (file_path LIKE ? OR file_path = ? OR library_path LIKE ? OR library_path = ?)
+	`, likePattern, filename, likePattern, libraryPath)
 	if err != nil {
-		return false, fmt.Errorf("failed to relink file by filename: %w", err)
+		return false, fmt.Errorf("failed to query records for filename relink: %w", err)
+	}
+	defer rows.Close()
+
+	var matchedIDs []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return false, err
+		}
+		matchedIDs = append(matchedIDs, id)
 	}
 
-	rows, err := res.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("failed to get rows affected: %w", err)
+	if len(matchedIDs) == 0 {
+		return false, nil
 	}
 
-	return rows > 0, nil
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	for _, id := range matchedIDs {
+		if err := r.relinkOrMergeRecordTx(ctx, tx, id, filePath, libraryPath, metadataStr, revalidate); err != nil {
+			return false, fmt.Errorf("failed to merge/relink record %d: %w", id, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return true, nil
 }
 
 // GetSystemState retrieves a persistent state value
@@ -1771,6 +1776,180 @@ func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string,
 	return logIndexerImport(ctx, r.db, indexer, status, errMsg, downloadID)
 }
 
+// relinkOrMergeRecordTx merges details or updates a matched health record under a transaction,
+// resolving any UNIQUE constraint violations on file_path.
+func (r *HealthRepository) relinkOrMergeRecordTx(ctx context.Context, tx *dialectAwareTx, id int64, filePath, libraryPath string, metadataStr *string, revalidate bool) error {
+	filePath = strings.TrimPrefix(filePath, "/")
+
+	// 1. Fetch source/matched record info
+	var sourceRepairRetry int
+	var sourceSourceNzb *string
+	var sourceIndexer *string
+	var sourceReleaseDate *time.Time
+	var sourceMetadata *string
+	err := tx.QueryRowContext(ctx, `
+		SELECT repair_retry_count, source_nzb_path, indexer, release_date, metadata
+		FROM file_health
+		WHERE id = ?
+	`, id).Scan(&sourceRepairRetry, &sourceSourceNzb, &sourceIndexer, &sourceReleaseDate, &sourceMetadata)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil // Source record no longer exists, nothing to do
+		}
+		return err
+	}
+
+	// 2. Check if a record with the new file_path already exists
+	var conflictingID int64
+	var conflictingRepairRetry int
+	var conflictingSourceNzb *string
+	var conflictingIndexer *string
+	var conflictingReleaseDate *time.Time
+	var conflictingMetadata *string
+	var conflictExists bool = true
+
+	err = tx.QueryRowContext(ctx, `
+		SELECT id, repair_retry_count, source_nzb_path, indexer, release_date, metadata
+		FROM file_health
+		WHERE file_path = ?
+	`, filePath).Scan(&conflictingID, &conflictingRepairRetry, &conflictingSourceNzb, &conflictingIndexer, &conflictingReleaseDate, &conflictingMetadata)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			conflictExists = false
+		} else {
+			return err
+		}
+	}
+
+	// If the conflicting record is the exact same record as the source, just update it normally
+	if conflictExists && conflictingID == id {
+		conflictExists = false
+	}
+
+	if conflictExists {
+		// Merge details into the conflicting record, then delete the source record
+		mergedRepairRetry := sourceRepairRetry
+		if conflictingRepairRetry > mergedRepairRetry {
+			mergedRepairRetry = conflictingRepairRetry
+		}
+
+		var mergedSourceNzb *string
+		if sourceSourceNzb != nil {
+			mergedSourceNzb = sourceSourceNzb
+		} else {
+			mergedSourceNzb = conflictingSourceNzb
+		}
+
+		var mergedIndexer *string
+		if sourceIndexer != nil {
+			mergedIndexer = sourceIndexer
+		} else {
+			mergedIndexer = conflictingIndexer
+		}
+
+		var mergedReleaseDate *time.Time
+		if sourceReleaseDate != nil {
+			mergedReleaseDate = sourceReleaseDate
+		} else {
+			mergedReleaseDate = conflictingReleaseDate
+		}
+
+		var mergedMetadata *string
+		if metadataStr != nil {
+			mergedMetadata = metadataStr
+		} else if sourceMetadata != nil {
+			mergedMetadata = sourceMetadata
+		} else {
+			mergedMetadata = conflictingMetadata
+		}
+
+		var query string
+		var args []any
+		if revalidate {
+			query = `
+				UPDATE file_health
+				SET library_path = ?,
+				    status = 'pending',
+				    retry_count = 0,
+				    last_error = NULL,
+				    error_details = NULL,
+				    metadata = ?,
+				    repair_retry_count = ?,
+				    source_nzb_path = ?,
+				    indexer = ?,
+				    release_date = ?,
+				    updated_at = datetime('now'),
+				    scheduled_check_at = datetime('now')
+				WHERE id = ?
+			`
+			args = []any{libraryPath, mergedMetadata, mergedRepairRetry, mergedSourceNzb, mergedIndexer, mergedReleaseDate, conflictingID}
+		} else {
+			query = `
+				UPDATE file_health
+				SET library_path = ?,
+				    metadata = ?,
+				    repair_retry_count = ?,
+				    source_nzb_path = ?,
+				    indexer = ?,
+				    release_date = ?,
+				    updated_at = datetime('now'),
+				    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
+				WHERE id = ?
+			`
+			args = []any{libraryPath, mergedMetadata, mergedRepairRetry, mergedSourceNzb, mergedIndexer, mergedReleaseDate, conflictingID}
+		}
+
+		_, err = tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+
+		// Delete the source record (since its path was obsolete and its history is merged)
+		_, err = tx.ExecContext(ctx, "DELETE FROM file_health WHERE id = ?", id)
+		if err != nil {
+			return err
+		}
+	} else {
+		// No conflict: just rename the source record
+		var query string
+		var args []any
+		if revalidate {
+			query = `
+				UPDATE file_health
+				SET file_path = ?,
+				    library_path = ?,
+				    status = 'pending',
+				    retry_count = 0,
+				    last_error = NULL,
+				    error_details = NULL,
+				    metadata = COALESCE(?, metadata),
+				    updated_at = datetime('now'),
+				    scheduled_check_at = datetime('now')
+				WHERE id = ?
+			`
+			args = []any{filePath, libraryPath, metadataStr, id}
+		} else {
+			query = `
+				UPDATE file_health
+				SET file_path = ?,
+				    library_path = ?,
+				    metadata = COALESCE(?, metadata),
+				    updated_at = datetime('now'),
+				    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
+				WHERE id = ?
+			`
+			args = []any{filePath, libraryPath, metadataStr, id}
+		}
+
+		_, err = tx.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // RelinkFileByMetadata matches repair_triggered or corrupted records by metadata and updates them to pending.
 //
 // revalidate controls what happens to records in repair_triggered/corrupted state:
@@ -1817,37 +1996,23 @@ func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *mo
 		return false, nil
 	}
 
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to start transaction: %w", err)
+	}
+	defer tx.Rollback()
+
 	// Update each matched record
 	for _, id := range matchedIDs {
-		query := `
-			UPDATE file_health
-			SET file_path = ?,
-			    library_path = ?,
-			    metadata = COALESCE(?, metadata),
-			    updated_at = datetime('now'),
-			    scheduled_check_at = CASE WHEN status IN ('repair_triggered', 'corrupted') THEN scheduled_check_at ELSE datetime('now') END
-			WHERE id = ?
-		`
-		if revalidate {
-			query = `
-				UPDATE file_health
-				SET file_path = ?,
-				    library_path = ?,
-				    status = 'pending',
-				    retry_count = 0,
-				    last_error = NULL,
-				    error_details = NULL,
-				    metadata = COALESCE(?, metadata),
-				    updated_at = datetime('now'),
-				    scheduled_check_at = datetime('now')
-				WHERE id = ?
-			`
-		}
-		_, err := r.db.ExecContext(ctx, query, filePath, libraryPath, metadataStr, id)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to update matched health record", "id", id, "error", err)
+		if err := r.relinkOrMergeRecordTx(ctx, tx, id, filePath, libraryPath, metadataStr, revalidate); err != nil {
+			return false, fmt.Errorf("failed to relink/merge matched record %d: %w", id, err)
 		}
 	}
+
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
 	return true, nil
 }
 

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -213,6 +213,7 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		  AND status NOT IN ('repair_triggered', 'checking')
 		  AND (
 			  ? = 'NONE' 
+			  OR status = 'pending'
 			  OR (metadata IS NOT NULL AND metadata != '')
 			  OR (library_path IS NOT NULL AND library_path LIKE ?)
 			  OR (last_error LIKE '%failed to unmarshal metadata%')

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -529,3 +529,36 @@ func TestRelinkFileByMetadata(t *testing.T) {
 	assert.Nil(t, oldH)
 }
 
+func TestResetStalePendingFiles_ResetsStuckPending(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "movies/stuck.mkv"
+	futureTime := time.Now().UTC().Add(48 * time.Hour).Truncate(time.Second)
+
+	// Add a record scheduled in the distant future with status = 'pending' and retry_count = 0
+	err := repo.UpdateFileHealthScheduled(ctx, filePath, HealthStatusPending, nil, nil, nil, false, futureTime)
+	require.NoError(t, err)
+
+	// Verify it has the future scheduled time
+	hBefore, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, hBefore)
+	assert.Equal(t, HealthStatusPending, hBefore.Status)
+	assert.Equal(t, 0, hBefore.RetryCount)
+	
+	// Now run ResetStalePendingFiles
+	err = repo.ResetStalePendingFiles(ctx)
+	require.NoError(t, err)
+
+	// Verify scheduled_check_at was reset to the present/past
+	hAfter, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, hAfter)
+	
+	got := queryScheduledCheckAt(t, repo, filePath)
+	require.NotNil(t, got)
+	assert.True(t, got.Before(time.Now().UTC().Add(1*time.Minute)), "stuck file scheduled time should be reset to now (got %v)", got)
+}
+
+

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -272,8 +272,8 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	err := repo.UpdateFileHealth(ctx, oldPath, HealthStatusHealthy, nil, nil, nil, false)
 	require.NoError(t, err)
 
-	// 2. Perform Relink
-	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, libPath, nil)
+	// 2. Perform Relink (Rename semantics — no new content)
+	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, libPath, nil, false)
 	require.NoError(t, err)
 	assert.True(t, relinked, "Should have relinked the healthy record")
 
@@ -282,7 +282,7 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, libPath, *h.LibraryPath)
-	assert.Equal(t, HealthStatusPending, h.Status, "Status should be reset to pending for re-verification")
+	assert.Equal(t, HealthStatusHealthy, h.Status, "Status should remain healthy under rename semantics")
 
 	// Verify old path is gone (since it was updated)
 	oldH, err := repo.GetFileHealth(ctx, oldPath)
@@ -294,9 +294,158 @@ func TestRelinkFileByFilename_UpdatesAnyStatus(t *testing.T) {
 	err = repo.UpdateFileHealth(ctx, corruptedFile, HealthStatusCorrupted, nil, nil, nil, false)
 	require.NoError(t, err)
 
-	relinked, err = repo.RelinkFileByFilename(ctx, "Matrix.mkv", corruptedFile, "/lib/Matrix.mkv", nil)
+	relinked, err = repo.RelinkFileByFilename(ctx, "Matrix.mkv", corruptedFile, "/lib/Matrix.mkv", nil, false)
 	require.NoError(t, err)
 	assert.True(t, relinked)
+}
+
+// TestRelinkFileByFilename_RenamePreservesRepairState verifies that a Rename relink
+// (revalidate=false) does not disturb repair_triggered state: status, counters, errors
+// and schedule must survive a library reorganization.
+func TestRelinkFileByFilename_RenamePreservesRepairState(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E01/Show.S01E01.mkv"
+	lastErr := "missing 7 segments"
+	future := time.Now().UTC().Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count,
+			max_repair_retries, last_error, scheduled_check_at)
+		VALUES (?, 'repair_triggered', 2, 1, 3, ?, ?)
+	`, filePath, lastErr, future)
+	require.NoError(t, err)
+
+	relinked, err := repo.RelinkFileByFilename(ctx, "Show.S01E01.mkv", filePath, "/lib/Show.S01E01.mkv", nil, false)
+	require.NoError(t, err)
+	require.True(t, relinked)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusRepairTriggered, h.Status, "Rename must not reset repair status")
+	assert.Equal(t, 2, h.RetryCount)
+	assert.Equal(t, 1, h.RepairRetryCount)
+	require.NotNil(t, h.LastError)
+	assert.Equal(t, lastErr, *h.LastError)
+}
+
+// TestRelinkFileByFilename_DownloadRevalidatesRepairState verifies that a Download relink
+// (revalidate=true — a re-downloaded copy was just imported) resets the record to pending
+// for immediate re-validation while preserving repair_retry_count as the per-title repair
+// budget. This is the exit path from the repair loop: without it, the repair worker
+// destroys the fresh import on its next tick.
+func TestRelinkFileByFilename_DownloadRevalidatesRepairState(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E02/Show.S01E02.mkv"
+	future := time.Now().UTC().Add(30 * time.Minute).Format("2006-01-02 15:04:05")
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count,
+			max_repair_retries, last_error, error_details, scheduled_check_at)
+		VALUES (?, 'repair_triggered', 2, 1, 3, 'missing segments', 'details', ?)
+	`, filePath, future)
+	require.NoError(t, err)
+
+	before := time.Now().UTC()
+	relinked, err := repo.RelinkFileByFilename(ctx, "Show.S01E02.mkv", filePath, "/lib/Show.S01E02.mkv", nil, true)
+	require.NoError(t, err)
+	require.True(t, relinked)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status, "Download must reset status so the new copy is validated")
+	assert.Equal(t, 0, h.RetryCount, "retry_count restarts for the new copy")
+	assert.Equal(t, 1, h.RepairRetryCount, "repair budget must be preserved so bad re-downloads still escalate")
+	assert.Nil(t, h.LastError)
+	assert.Nil(t, h.ErrorDetails)
+
+	// scheduled_check_at must be pulled back from the future to now.
+	var raw string
+	err = repo.db.QueryRowContext(ctx,
+		"SELECT scheduled_check_at FROM file_health WHERE file_path = ?", filePath).Scan(&raw)
+	require.NoError(t, err)
+	var scheduled time.Time
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if parsed, e := time.Parse(layout, raw); e == nil {
+			scheduled = parsed.UTC()
+			break
+		}
+	}
+	assert.True(t, scheduled.Before(before.Add(time.Minute)),
+		"scheduled_check_at should be ~now, got %v", scheduled)
+}
+
+// TestGetFilesForRepairNotification_ReturnsExhausted verifies that records whose repair
+// budget is spent are still returned, so the worker can finalize them as corrupted.
+// Filtering them out would leave them stuck in repair_triggered forever: no other
+// query selects that status.
+func TestGetFilesForRepairNotification_ReturnsExhausted(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	pastTime := time.Now().UTC().Add(-1 * time.Hour)
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (
+			file_path, status, repair_retry_count, max_repair_retries, scheduled_check_at, last_checked
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`, "exhausted_repair.mkv", "repair_triggered", 3, 3, pastTime, time.Now().UTC())
+	require.NoError(t, err)
+
+	files, err := repo.GetFilesForRepairNotification(ctx, 10)
+	require.NoError(t, err)
+
+	found := false
+	for _, f := range files {
+		if f.FilePath == "exhausted_repair.mkv" {
+			found = true
+		}
+	}
+	assert.True(t, found, "exhausted repair records must be returned for finalization as corrupted")
+}
+
+// TestAddFileToHealthCheck_ConflictPreservesRepairBudget verifies that a re-import upsert
+// over an existing record resets it to pending for re-validation but does NOT reset
+// repair_retry_count: a re-download of a broken release must not refill its own repair
+// budget, or genuinely dead releases would be re-downloaded forever.
+func TestAddFileToHealthCheck_ConflictPreservesRepairBudget(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	filePath := "tv/Show.S01E03/Show.S01E03.mkv"
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, retry_count, repair_retry_count, max_repair_retries)
+		VALUES (?, 'repair_triggered', 2, 2, 3)
+	`, filePath)
+	require.NoError(t, err)
+
+	err = repo.AddFileToHealthCheckWithMetadata(ctx, filePath, &filePath, 3, 3, nil, HealthPriorityNext, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 0, h.RetryCount, "retry_count resets for the new copy")
+	assert.Equal(t, 2, h.RepairRetryCount, "repair budget must survive the re-import upsert")
+}
+
+// TestAddFileToHealthCheck_NormalizesLeadingSlash verifies the upsert strips a leading
+// slash so import-side paths ("/tv/...") and webhook-side paths ("tv/...") cannot create
+// duplicate rows for the same virtual file.
+func TestAddFileToHealthCheck_NormalizesLeadingSlash(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	slashed := "/tv/Show.S01E04/Show.S01E04.mkv"
+	err := repo.AddFileToHealthCheckWithMetadata(ctx, slashed, &slashed, 3, 3, nil, HealthPriorityNext, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "tv/Show.S01E04/Show.S01E04.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h, "record must be stored without the leading slash")
 }
 
 // TestAddFileToHealthCheckWithMetadata_StoresLibraryPath verifies that new files
@@ -361,7 +510,7 @@ func TestRelinkFileByMetadata(t *testing.T) {
 	require.NoError(t, err)
 	webMetaStr := string(webMetaBytes)
 
-	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr)
+	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr, true)
 	require.NoError(t, err)
 	assert.True(t, relinked, "Should successfully relink by metadata IDs")
 

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -561,4 +561,104 @@ func TestResetStalePendingFiles_ResetsStuckPending(t *testing.T) {
 	assert.True(t, got.Before(time.Now().UTC().Add(1*time.Minute)), "stuck file scheduled time should be reset to now (got %v)", got)
 }
 
+func TestRelinkFileByMetadata_ConflictMerge(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// 1. Setup old record with metadata and repair history
+	oldPath := "complete/tv/show.S01E01.mkv"
+	libraryPath := "/mnt/library/tv/show.S01E01.mkv"
+	dbMeta := `{"eventType":"Download","instanceName":"Sonarr","series":{"id":100,"tvdbId":200},"episodeFile":{"id":300},"episodes":[{"id":400}]}`
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries, metadata, library_path)
+		VALUES (?, 'repair_triggered', 2, 3, ?, ?)
+	`, oldPath, dbMeta, libraryPath)
+	require.NoError(t, err)
+
+	// 2. Setup conflicting record at the target path
+	newPath := "tv/show/Season 01/show.S01E01.mkv"
+	newLibPath := "/mnt/library/tv/show/Season 01/show.S01E01.mkv"
+	_, err = repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries, metadata, library_path)
+		VALUES (?, 'corrupted', 1, 3, ?, ?)
+	`, newPath, dbMeta, newLibPath)
+	require.NoError(t, err)
+
+	// 3. Relink
+	webMeta := model.WebhookMetadata{
+		EventType:    "Download",
+		InstanceName: "Sonarr",
+		Series: &model.SeriesMetadata{
+			Id:     100,
+			TvdbId: 200,
+		},
+		Episodes: []model.EpisodeMetadata{
+			{Id: 400},
+		},
+	}
+	webMetaBytes, err := json.Marshal(webMeta)
+	require.NoError(t, err)
+	webMetaStr := string(webMetaBytes)
+
+	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr, true)
+	require.NoError(t, err)
+	assert.True(t, relinked)
+
+	// 4. Verify conflicting/new record is merged and updated
+	h, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 2, h.RepairRetryCount, "Should carry over the maximum repair retry count (2)")
+	assert.Equal(t, 0, h.RetryCount)
+
+	// Verify old record is deleted
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+
+func TestRelinkFileByFilename_ConflictMerge(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	fileName := "Matrix.mkv"
+	oldPath := "complete/Matrix.mkv"
+	newPath := "Movies/Matrix/Matrix.mkv"
+	newLibPath := "/lib/Matrix.mkv"
+
+	// 1. Setup old record with repair history
+	_, err := repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES (?, 'repair_triggered', 3, 3)
+	`, oldPath)
+	require.NoError(t, err)
+
+	// 2. Setup conflicting record at the target path
+	_, err = repo.db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES (?, 'healthy', 1, 3)
+	`, newPath)
+	require.NoError(t, err)
+
+	// 3. Relink
+	relinked, err := repo.RelinkFileByFilename(ctx, fileName, newPath, newLibPath, nil, true)
+	require.NoError(t, err)
+	assert.True(t, relinked)
+
+	// 4. Verify record at new path is updated and merged
+	h, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, HealthStatusPending, h.Status)
+	assert.Equal(t, 3, h.RepairRetryCount, "Should carry over the maximum repair retry count (3)")
+	assert.Equal(t, 0, h.RetryCount)
+
+	// Verify old path is gone
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+
+
 

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -3,9 +3,11 @@ package database
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/javi11/altmount/internal/arrs/model"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -319,3 +321,62 @@ func TestAddFileToHealthCheckWithMetadata_StoresLibraryPath(t *testing.T) {
 	assert.Equal(t, libraryPath, *h.LibraryPath)
 	assert.Equal(t, filePath, h.FilePath)
 }
+
+func TestRelinkFileByMetadata(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// 1. Set up a record with status repair_triggered and metadata JSON
+	oldPath := "complete/tv/show.S01E01.mkv"
+	libraryPath := "/mnt/library/tv/show.S01E01.mkv"
+	dbMeta := `{"eventType":"Download","instanceName":"Sonarr","series":{"id":100,"tvdbId":200},"episodeFile":{"id":300},"episodes":[{"id":400}]}`
+
+	err := repo.AddFileToHealthCheckWithMetadata(ctx, oldPath, &libraryPath, 3, 3, nil, HealthPriorityNormal, nil, &dbMeta, nil)
+	require.NoError(t, err)
+
+	// Update its status to repair_triggered
+	err = repo.UpdateFileHealth(ctx, oldPath, HealthStatusRepairTriggered, nil, nil, nil, false)
+	require.NoError(t, err)
+
+	// Verify it's repair_triggered
+	hOld, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Equal(t, HealthStatusRepairTriggered, hOld.Status)
+
+	// 2. Perform Relink by Metadata
+	newPath := "tv/show/Season 01/show.S01E01.mkv"
+	newLibPath := "/mnt/library/tv/show/Season 01/show.S01E01.mkv"
+	webMeta := model.WebhookMetadata{
+		EventType:    "Download",
+		InstanceName: "Sonarr",
+		Series: &model.SeriesMetadata{
+			Id:     100,
+			TvdbId: 200,
+		},
+		Episodes: []model.EpisodeMetadata{
+			{Id: 400},
+		},
+	}
+	webMetaBytes, err := json.Marshal(webMeta)
+	require.NoError(t, err)
+	webMetaStr := string(webMetaBytes)
+
+	relinked, err := repo.RelinkFileByMetadata(ctx, &webMeta, newPath, newLibPath, &webMetaStr)
+	require.NoError(t, err)
+	assert.True(t, relinked, "Should successfully relink by metadata IDs")
+
+	// 3. Verify the old record got updated to the new paths and reset to pending
+	hNew, err := repo.GetFileHealth(ctx, newPath)
+	require.NoError(t, err)
+	require.NotNil(t, hNew)
+	assert.Equal(t, HealthStatusPending, hNew.Status)
+	assert.Equal(t, newLibPath, *hNew.LibraryPath)
+	assert.Equal(t, 0, hNew.RetryCount)
+	assert.Equal(t, 0, hNew.RepairRetryCount)
+
+	// Verify old path is gone
+	oldH, err := repo.GetFileHealth(ctx, oldPath)
+	require.NoError(t, err)
+	assert.Nil(t, oldH)
+}
+

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -1036,6 +1037,9 @@ type DryRunResult struct {
 	WouldCleanup           bool
 }
 
+// sampleProofPattern matches filenames containing "sample" or "proof" as a standalone word.
+var sampleProofPattern = regexp.MustCompile(`(?i)(^|[^a-zA-Z0-9])(sample|proof)(?:[^a-zA-Z0-9]|$)`)
+
 // getAllMetadataFiles collects all .meta files from the filesystem
 func (lsw *LibrarySyncWorker) getAllMetadataFiles(ctx context.Context) ([]string, error) {
 	cfg := lsw.configGetter()
@@ -1062,6 +1066,25 @@ func (lsw *LibrarySyncWorker) getAllMetadataFiles(ctx context.Context) ([]string
 
 		// Only include .meta files
 		if !d.IsDir() && strings.HasSuffix(d.Name(), ".meta") {
+			nameWithoutMeta := strings.TrimSuffix(d.Name(), ".meta")
+			if sampleProofPattern.MatchString(nameWithoutMeta) {
+				// Convert to mount relative path to query lite cache
+				mountRelPath := lsw.metaPathToMountRelativePath(path)
+				
+				// Default sample limit is 200MB, but for high-bitrate 4K / Remux releases, sample clips can be larger (up to 600MB)
+				sampleLimit := int64(200 * 1024 * 1024)
+				lowerName := strings.ToLower(nameWithoutMeta)
+				if strings.Contains(lowerName, "2160p") || strings.Contains(lowerName, "4k") || strings.Contains(lowerName, "uhd") || strings.Contains(lowerName, "remux") {
+					sampleLimit = int64(600 * 1024 * 1024)
+				}
+
+				lite, err := lsw.metadataService.ReadFileMetadataLite(mountRelPath)
+				if err == nil && lite != nil && lite.FileSize <= sampleLimit {
+					// Skip sample files
+					slog.DebugContext(ctx, "Library Sync: Skipping sample file", "path", mountRelPath, "size", lite.FileSize, "limit", sampleLimit)
+					return nil
+				}
+			}
 			metaFiles = append(metaFiles, path)
 			count++
 			if count%1000 == 0 {

--- a/internal/health/library_sync_test.go
+++ b/internal/health/library_sync_test.go
@@ -226,3 +226,158 @@ func TestFindFilesToDelete_NormalizesBackslashes(t *testing.T) {
 	require.Len(t, toDelete, 1)
 	assert.Equal(t, "complete/orphan.mkv", toDelete[0])
 }
+
+func TestSyncLibrary_FiltersSampleFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	// Setup temporary directory for metadata
+	tempDir, err := os.MkdirTemp("", "altmount_test_metadata")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Setup in-memory database
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared")
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Initialize database schema
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL
+		);
+		CREATE TABLE IF NOT EXISTS system_state (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+	`)
+	require.NoError(t, err)
+
+	healthRepo := database.NewHealthRepository(db, database.DialectSQLite)
+	metadataService := metadata.NewMetadataService(tempDir)
+
+	// Setup configuration
+	healthEnabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &healthEnabled
+	cfg.Health.LibrarySyncIntervalMinutes = 60
+	cfg.Health.LibrarySyncConcurrency = 2
+	cfg.Metadata.RootPath = tempDir
+	cfg.Import.ImportStrategy = config.ImportStrategyNone
+	cfg.MountPath = "/mnt/test"
+
+	configManager := config.NewManager(cfg, "")
+
+	worker := NewLibrarySyncWorker(
+		metadataService,
+		healthRepo,
+		configManager.GetConfig,
+		configManager,
+		&MockRcloneClient{},
+	)
+
+	// Create a real file metadata (large)
+	realFileName := filepath.Join("movies", "movie_real.mkv")
+	realMeta := metadataService.CreateFileMetadata(
+		500*1024*1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil,
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	err = metadataService.WriteFileMetadata(realFileName, realMeta)
+	require.NoError(t, err)
+
+	// Create a sample file metadata (small, matches sample name)
+	sampleFileName := filepath.Join("movies", "movie_real.sample.mkv")
+	sampleMeta := metadataService.CreateFileMetadata(
+		100*1024*1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil,
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	err = metadataService.WriteFileMetadata(sampleFileName, sampleMeta)
+	require.NoError(t, err)
+
+	// Create a fake movie that contains "sample" in name but is large (800MB, should not be filtered)
+	fakeMovieName := filepath.Join("movies", "The.Sample.Movie.2024.mkv")
+	fakeMovieMeta := metadataService.CreateFileMetadata(
+		800*1024*1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil,
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	err = metadataService.WriteFileMetadata(fakeMovieName, fakeMovieMeta)
+	require.NoError(t, err)
+
+	// Create a 4K sample file (450MB, matches sample name and has 2160p, should be skipped since limit is 600MB for 4K)
+	sample4KName := filepath.Join("movies", "movie_2160p.sample.mkv")
+	sample4KMeta := metadataService.CreateFileMetadata(
+		450*1024*1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil,
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	err = metadataService.WriteFileMetadata(sample4KName, sample4KMeta)
+	require.NoError(t, err)
+
+	// Create a 4K real movie containing "sample" but is larger than 600MB (800MB, has 2160p, should not be skipped)
+	real4KSampleName := filepath.Join("movies", "The.Sample.Movie.2160p.mkv")
+	real4KSampleMeta := metadataService.CreateFileMetadata(
+		800*1024*1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil,
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	err = metadataService.WriteFileMetadata(real4KSampleName, real4KSampleMeta)
+	require.NoError(t, err)
+
+	// Run SyncLibrary
+	ctx := context.Background()
+	result := worker.SyncLibrary(ctx, false)
+	assert.Nil(t, result)
+
+	// Check that real and large movies are added, but sample movies are skipped (count = 3)
+	count, err := healthRepo.CountHealthItems(ctx, nil, nil, "")
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Let's assert exactly which files are in the database
+	items, err := healthRepo.ListHealthItems(ctx, nil, 10, 0, nil, "", "", "")
+	require.NoError(t, err)
+	
+	foundReal := false
+	foundFakeMovie := false
+	foundSample := false
+	foundSample4K := false
+	foundReal4KSample := false
+
+	for _, item := range items {
+		if item.FilePath == "movies/movie_real.mkv" {
+			foundReal = true
+		} else if item.FilePath == "movies/The.Sample.Movie.2024.mkv" {
+			foundFakeMovie = true
+		} else if item.FilePath == "movies/movie_real.sample.mkv" {
+			foundSample = true
+		} else if item.FilePath == "movies/movie_2160p.sample.mkv" {
+			foundSample4K = true
+		} else if item.FilePath == "movies/The.Sample.Movie.2160p.mkv" {
+			foundReal4KSample = true
+		}
+	}
+
+	assert.True(t, foundReal, "Should find movie_real.mkv")
+	assert.True(t, foundFakeMovie, "Should find The.Sample.Movie.2024.mkv")
+	assert.True(t, foundReal4KSample, "Should find The.Sample.Movie.2160p.mkv")
+	assert.False(t, foundSample, "Should NOT find movie_real.sample.mkv")
+	assert.False(t, foundSample4K, "Should NOT find movie_2160p.sample.mkv")
+}

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -326,6 +326,102 @@ func TestE2E_FileRepairTriggered_FullRetryFlow(t *testing.T) {
 	assert.NoError(t, readErr)
 }
 
+// TestE2E_RepairBudgetExhausted_PendingFileMarkedCorrupted verifies the terminal state:
+// a pending file that fails its last health retry while its repair budget is already
+// spent (repair_retry_count == max_repair_retries, preserved across re-import upserts
+// and webhook relinks) is marked corrupted instead of triggering yet another ARR rescan.
+// Without this guard, a genuinely dead release loops forever: rescan → re-download →
+// re-import resets to pending → check fails → rescan...
+func TestE2E_RepairBudgetExhausted_PendingFileMarkedCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	tempDir := t.TempDir()
+	env := newRepairTestEnv(t, tempDir, nil)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e05.mkv"
+	libraryPath := "/media/library/show.s01e05.mkv"
+	maxRetries := 3
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	// Pending file at its last health retry, with the repair budget already spent.
+	insertFileHealth(t, env.db, filePath, libraryPath, maxRetries-1, maxRetries)
+	_, err := env.db.Exec(
+		`UPDATE file_health SET repair_retry_count = 3, max_repair_retries = 3 WHERE file_path = ?`,
+		filePath,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	// ARR must NOT be called — no more re-downloads for this title.
+	env.mockARRs.mu.Lock()
+	callCount := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Equal(t, 0, callCount, "exhausted repair budget must not trigger another ARR rescan")
+
+	// Status must be terminal corrupted.
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status)
+
+	// Metadata hidden in the safety folder (this path follows a real failed check).
+	original, readErr := env.metadataService.ReadFileMetadata(filePath)
+	assert.Nil(t, original, "metadata should be moved to the safety folder")
+	assert.NoError(t, readErr)
+}
+
+// TestE2E_ExhaustedRepairTriggered_SweptToCorrupted verifies that records already in
+// repair_triggered with a spent repair budget are picked up by the repair-notification
+// pass and finalized as corrupted (previously they were filtered out of every query and
+// stuck in repair_triggered forever). The sweep must be non-destructive: no ARR call and
+// no metadata move, since no fresh check has failed.
+func TestE2E_ExhaustedRepairTriggered_SweptToCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	tempDir := t.TempDir()
+	env := newRepairTestEnv(t, tempDir, nil)
+
+	ctx := context.Background()
+	filePath := "series/show.s01e06.mkv"
+	libraryPath := "/media/library/show.s01e06.mkv"
+
+	// Metadata exists (e.g. a re-import landed after the last repair re-trigger).
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	_, err := env.db.Exec(`
+		INSERT INTO file_health
+			(file_path, library_path, status, retry_count, max_retries,
+			 repair_retry_count, max_repair_retries, scheduled_check_at)
+		VALUES (?, ?, 'repair_triggered', 2, 3, 3, 3, datetime('now', '-1 second'))
+	`, filePath, libraryPath)
+	require.NoError(t, err)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	env.mockARRs.mu.Lock()
+	callCount := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Equal(t, 0, callCount, "sweep must not trigger ARR rescans")
+
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status,
+		"exhausted repair_triggered record must be finalized as corrupted, not stuck")
+
+	// Metadata must be left in place — the sweep has not re-validated content.
+	original, readErr := env.metadataService.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "sweep must not move metadata of a possibly-good copy")
+}
+
 // TestE2E_FileRepairTriggered_ARRReturnsAlreadySatisfied verifies that when ARR returns
 // ErrEpisodeAlreadySatisfied the health record is deleted (zombie cleanup).
 func TestE2E_FileRepairTriggered_ARRReturnsAlreadySatisfied(t *testing.T) {

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -411,45 +411,6 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 		sideEffect = func() error {
 			slog.InfoContext(ctx, "File is healthy", "file_path", fh.FilePath)
 
-			// Discovery: If the file is healthy but missing rich metadata (IDs), attempt to discover it now.
-			// This gradually backfills your library as health checks occur.
-			needsDiscovery := false
-			if fh.Metadata == nil || *fh.Metadata == "" {
-				needsDiscovery = true
-			} else {
-				var dbMeta model.WebhookMetadata
-				if err := json.Unmarshal([]byte(*fh.Metadata), &dbMeta); err == nil {
-					if dbMeta.Series != nil && len(dbMeta.Episodes) == 0 {
-						needsDiscovery = true
-					}
-				}
-			}
-
-			if needsDiscovery {
-				slog.DebugContext(ctx, "Missing metadata or episode IDs for healthy file, attempting discovery", "file_path", fh.FilePath)
-				relativePath := strings.TrimPrefix(fh.FilePath, "complete/")
-				nzbName := ""
-				if fh.SourceNzbPath != nil {
-					nzbName = filepath.Base(*fh.SourceNzbPath)
-				}
-				libPath := ""
-				if fh.LibraryPath != nil {
-					libPath = *fh.LibraryPath
-				}
-				metadata, err := hw.arrsService.DiscoverFileMetadata(ctx, fh.FilePath, relativePath, nzbName, libPath)
-				if err == nil && metadata != nil {
-					metaBytes, err := json.Marshal(metadata)
-					if err == nil {
-						slog.InfoContext(ctx, "Successfully discovered metadata during health check",
-							"file_path", fh.FilePath,
-							"instance", metadata.InstanceName)
-						if err := hw.healthRepo.UpdateFileMetadata(ctx, fh.ID, metaBytes); err != nil {
-							slog.ErrorContext(ctx, "Failed to save discovered metadata", "error", err)
-						}
-					}
-				}
-			}
-
 			return hw.metadataService.UpdateFileStatus(fh.FilePath, metapb.FileStatus_FILE_STATUS_HEALTHY)
 		}
 
@@ -787,6 +748,9 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 				slog.ErrorContext(ctx, "Failed to set file checking status", "file_path", fh.FilePath, "error", err)
 				return
 			}
+
+			// Proactively discover metadata if missing (IDs first priority)
+			fh.Metadata = hw.ensureMetadata(ctx, fh)
 
 			// Perform check
 			opts := CheckOptions{}
@@ -1141,7 +1105,7 @@ func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileH
 		return item.Metadata
 	}
 
-	slog.InfoContext(ctx, "Emergency ID discovery: Missing metadata for corrupted file, attempting discovery before repair", "file_path", item.FilePath)
+	slog.DebugContext(ctx, "Missing metadata or episode IDs, attempting discovery during health check", "file_path", item.FilePath)
 	relativePath := strings.TrimPrefix(item.FilePath, "complete/")
 	nzbName := ""
 	if item.SourceNzbPath != nil {
@@ -1156,17 +1120,16 @@ func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileH
 		metaBytes, err := json.Marshal(metadata)
 		if err == nil {
 			str := string(metaBytes)
-			slog.InfoContext(ctx, "Successfully discovered metadata during emergency discovery",
+			slog.InfoContext(ctx, "Successfully discovered metadata during health check",
 				"file_path", item.FilePath,
 				"instance", metadata.InstanceName)
 			if err := hw.healthRepo.UpdateFileMetadata(ctx, item.ID, metaBytes); err != nil {
-				slog.ErrorContext(ctx, "Failed to save discovered metadata during emergency discovery", "error", err)
+				slog.ErrorContext(ctx, "Failed to save discovered metadata", "error", err)
 			}
 			return &str
 		}
 	}
 
-	slog.WarnContext(ctx, "Emergency ID discovery failed, falling back to path-based repair", "file_path", item.FilePath)
 	return nil
 }
 

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -413,8 +413,20 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 
 			// Discovery: If the file is healthy but missing rich metadata (IDs), attempt to discover it now.
 			// This gradually backfills your library as health checks occur.
+			needsDiscovery := false
 			if fh.Metadata == nil || *fh.Metadata == "" {
-				slog.DebugContext(ctx, "Missing metadata for healthy file, attempting discovery", "file_path", fh.FilePath)
+				needsDiscovery = true
+			} else {
+				var dbMeta model.WebhookMetadata
+				if err := json.Unmarshal([]byte(*fh.Metadata), &dbMeta); err == nil {
+					if dbMeta.Series != nil && len(dbMeta.Episodes) == 0 {
+						needsDiscovery = true
+					}
+				}
+			}
+
+			if needsDiscovery {
+				slog.DebugContext(ctx, "Missing metadata or episode IDs for healthy file, attempting discovery", "file_path", fh.FilePath)
 				relativePath := strings.TrimPrefix(fh.FilePath, "complete/")
 				nzbName := ""
 				if fh.SourceNzbPath != nil {
@@ -1093,7 +1105,19 @@ func (hw *HealthWorker) retriggerFileRepair(ctx context.Context, item *database.
 }
 
 func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileHealth) *string {
-	if item.Metadata != nil && *item.Metadata != "" {
+	needsDiscovery := false
+	if item.Metadata == nil || *item.Metadata == "" {
+		needsDiscovery = true
+	} else {
+		var dbMeta model.WebhookMetadata
+		if err := json.Unmarshal([]byte(*item.Metadata), &dbMeta); err == nil {
+			if dbMeta.Series != nil && len(dbMeta.Episodes) == 0 {
+				needsDiscovery = true
+			}
+		}
+	}
+
+	if !needsDiscovery {
 		return item.Metadata
 	}
 

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -468,25 +468,7 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	switch fh.Status {
 	case database.HealthStatusRepairTriggered:
 		if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
-			update.Type = database.UpdateTypeCorrupted
-			update.Status = database.HealthStatusCorrupted
-			sideEffect = func() error {
-				slog.ErrorContext(ctx, "File permanently marked as corrupted after repair retries exhausted", "file_path", fh.FilePath)
-
-				// Ensure metadata is hidden in the safety folder
-				hw.moveMetadataToSafetyFolder(ctx, fh)
-
-				// Log failure against the indexer if known
-				if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
-					errMsg := "Permanently corrupted"
-					if errorMsg != nil {
-						errMsg = *errorMsg
-					}
-					_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg), "")
-				}
-
-				return nil
-			}
+			sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
 		} else {
 			// Calculate repair back-off
 			interval := hw.configGetter().GetRepairInterval()
@@ -520,6 +502,15 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	default:
 		// Regular health check phase
 		if fh.RetryCount >= hw.configGetter().GetMaxRetries()-1 {
+			// Repair budget exhausted: this title was already re-downloaded
+			// max_repair_retries times (the counter survives webhook relinks and
+			// re-import upserts by design). Triggering yet another rescan would
+			// re-download the same broken release forever, so finalize as corrupted.
+			if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
+				sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
+				return update, sideEffect
+			}
+
 			update.Type = database.UpdateTypeRepairTrigger
 			update.Status = database.HealthStatusRepairTriggered
 
@@ -563,6 +554,32 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	return update, sideEffect
 }
 
+// markCorruptedRepairExhausted fills update with the terminal corrupted state for a file
+// whose repair budget is spent after a failed health check, and returns the side effect
+// (hide metadata in the safety folder, log the failure against the indexer).
+func (hw *HealthWorker) markCorruptedRepairExhausted(ctx context.Context, fh *database.FileHealth, update *database.HealthStatusUpdate, errorMsg *string) func() error {
+	update.Type = database.UpdateTypeCorrupted
+	update.Status = database.HealthStatusCorrupted
+
+	return func() error {
+		slog.ErrorContext(ctx, "File permanently marked as corrupted after repair retries exhausted", "file_path", fh.FilePath)
+
+		// Ensure metadata is hidden in the safety folder
+		hw.moveMetadataToSafetyFolder(ctx, fh)
+
+		// Log failure against the indexer if known
+		if fh.Indexer != nil && *fh.Indexer != "" && *fh.Indexer != database.IndexerUnknown {
+			errMsg := "Permanently corrupted"
+			if errorMsg != nil {
+				errMsg = *errorMsg
+			}
+			_ = hw.healthRepo.LogIndexerImport(ctx, *fh.Indexer, "failed", fmt.Sprintf("Health check permanently corrupted: %s", errMsg), "")
+		}
+
+		return nil
+	}
+}
+
 // prepareRepairNotificationUpdate builds the update and side effect for a file already in
 // repair_triggered state. It re-triggers ARR directly without calling CheckFile, since the
 // metadata has already been moved to the corrupted folder.
@@ -572,7 +589,10 @@ func (hw *HealthWorker) prepareRepairNotificationUpdate(ctx context.Context, fh 
 	}
 
 	if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
-		// Retries exhausted — give up and mark corrupted.
+		// Retries exhausted — give up and mark corrupted. Deliberately no metadata
+		// move here: unlike the failed-check path, this sweep has not re-validated
+		// the file's content, and a re-import may have just landed a good copy. The
+		// user can recheck from the Health page; a failed check will then hide it.
 		update.Type = database.UpdateTypeCorrupted
 		update.Status = database.HealthStatusCorrupted
 		sideEffect := func() error {

--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -3,10 +3,17 @@ package postprocessor
 import (
 	"context"
 	"log/slog"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/javi11/altmount/internal/database"
 )
+
+// maxDirExpansionDepth bounds the recursive walk of "DIR:" written-path entries.
+// Import folders are shallow (an NZB folder, occasionally a Blu-ray structure from
+// ISO expansion), so this is a safety net, not an expected limit.
+const maxDirExpansionDepth = 8
 
 // ScheduleHealthCheck schedules an immediate health check for an imported file.
 // Multi-file imports (e.g. season packs) schedule one check per written virtual
@@ -19,9 +26,10 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return nil // Health checks not configured
 	}
 
-	// Prefer the explicit per-file list; fall back to the resulting path for
-	// legacy callers (single-file imports resolve to the same thing).
-	paths := writtenPaths
+	// Expand directory entries into per-file paths, and fall back to the
+	// resulting path for legacy callers (single-file imports resolve to the
+	// same thing).
+	paths := c.expandWrittenPaths(writtenPaths)
 	if len(paths) == 0 {
 		paths = []string{resultingPath}
 	}
@@ -65,6 +73,12 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 	if scheduled > 0 {
 		slog.InfoContext(ctx, "Scheduled immediate health check for imported files",
 			"path", resultingPath, "files", scheduled)
+	} else {
+		// A successful import that schedules nothing means the file will only be
+		// covered by library sync much later — and any pending repair in its
+		// directory stays unresolved. Surface it instead of failing silently.
+		slog.WarnContext(ctx, "No health checks scheduled for import - no readable file metadata found",
+			"path", resultingPath, "written_paths", len(writtenPaths))
 	}
 
 	// Resolve pending repairs in the affected directories if configured
@@ -76,6 +90,48 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return lastErr
 	}
 	return nil
+}
+
+// expandWrittenPaths resolves "DIR:"-prefixed entries (whole-directory imports such
+// as RAR/7z archives, which only report their NZB folder) into the per-file virtual
+// paths beneath them by walking the metadata tree. Plain file entries pass through
+// unchanged. Without this, archive imports would schedule no health checks at all:
+// ReadFileMetadata("DIR:...") finds nothing and the loop above skips silently.
+func (c *Coordinator) expandWrittenPaths(writtenPaths []string) []string {
+	var out []string
+	for _, p := range writtenPaths {
+		dir, isDir := strings.CutPrefix(p, "DIR:")
+		if !isDir {
+			out = append(out, p)
+			continue
+		}
+		out = append(out, c.listMetadataFilesRecursive(dir, 0)...)
+	}
+	return out
+}
+
+// listMetadataFilesRecursive returns the virtual file paths of all metadata files
+// under virtualDir, recursing into subdirectories up to maxDirExpansionDepth.
+func (c *Coordinator) listMetadataFilesRecursive(virtualDir string, depth int) []string {
+	if depth > maxDirExpansionDepth || c.metadataService == nil {
+		return nil
+	}
+
+	dirs, files, err := c.metadataService.ListDirectoryAll(virtualDir)
+	if err != nil {
+		c.log.Warn("Failed to list metadata directory for health check scheduling",
+			"dir", virtualDir, "error", err)
+		return nil
+	}
+
+	var out []string
+	for _, f := range files {
+		out = append(out, path.Join(virtualDir, f))
+	}
+	for _, d := range dirs {
+		out = append(out, c.listMetadataFilesRecursive(path.Join(virtualDir, d.Name()), depth+1)...)
+	}
+	return out
 }
 
 // resolvePendingRepairsInDir resolves pending repairs in the given directory

--- a/internal/importer/postprocessor/health_scheduler_test.go
+++ b/internal/importer/postprocessor/health_scheduler_test.go
@@ -1,0 +1,164 @@
+package postprocessor
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupSchedulerTest builds a Coordinator with a real MetadataService (temp dir)
+// and a real HealthRepository (in-memory sqlite) so ScheduleHealthCheck can be
+// exercised end to end.
+func setupSchedulerTest(t *testing.T) (*Coordinator, *metadata.MetadataService, *database.HealthRepository, *sql.DB) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file::memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			priority INTEGER DEFAULT 0,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	repo := database.NewHealthRepository(db, database.DialectSQLite)
+	ms := metadata.NewMetadataService(t.TempDir())
+
+	cfg := config.DefaultConfig()
+	// Directory repair resolution is opt-in (defaults to false); enable it so the
+	// stale-repair cleanup path is exercised.
+	resolveRepairs := true
+	cfg.Health.ResolveRepairOnImport = &resolveRepairs
+	configManager := config.NewManager(cfg, "")
+
+	coordinator := NewCoordinator(Config{
+		ConfigGetter:    configManager.GetConfig,
+		MetadataService: ms,
+		HealthRepo:      repo,
+	})
+
+	return coordinator, ms, repo, db
+}
+
+// writeTestMetadata writes a minimal valid metadata file for the given virtual path.
+func writeTestMetadata(t *testing.T, ms *metadata.MetadataService, virtualPath string) {
+	t.Helper()
+	seg := &metapb.SegmentData{
+		Id:          "article-001@test.example.com",
+		SegmentSize: 1024,
+		StartOffset: 0,
+		EndOffset:   1023,
+	}
+	meta := ms.CreateFileMetadata(
+		1024, "source.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		[]*metapb.SegmentData{seg},
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+}
+
+// TestScheduleHealthCheck_ExpandsDirWrittenPaths verifies that "DIR:" written-path
+// entries (RAR/7z archive imports report only their NZB folder) are expanded into
+// per-file health checks, and that pending repairs in that directory are resolved.
+// Before this, archive imports scheduled nothing: the literal "DIR:..." path had no
+// metadata, so the import-side exit from the repair loop never fired.
+func TestScheduleHealthCheck_ExpandsDirWrittenPaths(t *testing.T) {
+	coordinator, ms, repo, db := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	nzbFolder := "/tv/Show.S01E01.1080p-GRP"
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E01.1080p-GRP.mkv")
+	writeTestMetadata(t, ms, nzbFolder+"/Show.S01E01.1080p-GRP.en.srt")
+
+	// A stale repair record in the same directory — the new import replaces it.
+	_, err := db.Exec(`
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('tv/Show.S01E01.1080p-GRP/old-broken.mkv', 'repair_triggered', 1, 3)
+	`)
+	require.NoError(t, err)
+
+	err = coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	// Both extracted files must have pending health records.
+	for _, p := range []string{
+		"tv/Show.S01E01.1080p-GRP/Show.S01E01.1080p-GRP.mkv",
+		"tv/Show.S01E01.1080p-GRP/Show.S01E01.1080p-GRP.en.srt",
+	} {
+		h, err := repo.GetFileHealth(ctx, p)
+		require.NoError(t, err)
+		require.NotNil(t, h, "expected a health record for %s", p)
+		assert.Equal(t, database.HealthStatusPending, h.Status)
+	}
+
+	// The stale repair record in the directory must be resolved (deleted).
+	stale, err := repo.GetFileHealth(ctx, "tv/Show.S01E01.1080p-GRP/old-broken.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, stale, "pending repair in the import directory must be resolved by the new import")
+}
+
+// TestScheduleHealthCheck_ExpandsNestedDirs verifies recursion into subdirectories
+// (e.g. Blu-ray structures produced by ISO expansion inside an archive).
+func TestScheduleHealthCheck_ExpandsNestedDirs(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	nzbFolder := "/movies/Film.2024.1080p-GRP"
+	nested := nzbFolder + "/BDMV/STREAM/00001.m2ts"
+	writeTestMetadata(t, ms, nested)
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, nzbFolder, []string{"DIR:" + nzbFolder})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "movies/Film.2024.1080p-GRP/BDMV/STREAM/00001.m2ts")
+	require.NoError(t, err)
+	require.NotNil(t, h, "nested files must be discovered through recursive expansion")
+	assert.Equal(t, database.HealthStatusPending, h.Status)
+}
+
+// TestScheduleHealthCheck_PlainPathsUnchanged verifies non-DIR entries keep working.
+func TestScheduleHealthCheck_PlainPathsUnchanged(t *testing.T) {
+	coordinator, ms, repo, _ := setupSchedulerTest(t)
+	ctx := context.Background()
+
+	filePath := "/tv/Single.S01E01.mkv"
+	writeTestMetadata(t, ms, filePath)
+
+	err := coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath})
+	require.NoError(t, err)
+
+	h, err := repo.GetFileHealth(ctx, "tv/Single.S01E01.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	assert.Equal(t, database.HealthStatusPending, h.Status)
+}


### PR DESCRIPTION
Fixes a silent failure where Sonarr/Radarr would redownload the exact same corrupted release over and over because the `downloadFolderImported` history record couldn't be mapped by file ID (e.g., if it was already deleted or renamed). We now securely fall back to matching the most recent `grabbed` event by SceneName or EpisodeID/MovieID to successfully blocklist the corrupted release.