### PR TITLE
fix(arrs): route multi-instance categories like radarr-abc to the correct ARR type

### DIFF
--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -14,7 +14,7 @@ import (
 	"golift.io/starr/radarr"
 	"golift.io/starr/readarr"
 	"golift.io/starr/sonarr"
-	)
+)
 
 type Manager struct {
 	configGetter  config.ConfigGetter
@@ -169,7 +169,7 @@ func (m *Manager) RegisterInstance(ctx context.Context, arrURL, apiKey string) (
 
 	// Determine category based on ARR type
 	var category string
-	
+
 	// Check if instance already exists in config to respect pre-configured category
 	existingInstances := m.GetAllInstances()
 	found := false
@@ -246,7 +246,7 @@ func (m *Manager) RegisterInstance(ctx context.Context, arrURL, apiKey string) (
 	}
 
 	// Create category for this ARR type
-	m.ensureCategoryExistsInConfig(ctx, newConfig, category)
+	m.ensureCategoryExistsInConfig(ctx, newConfig, category, arrType)
 
 	// Update and save configuration
 	if err := m.configManager.UpdateConfig(newConfig); err != nil {
@@ -442,14 +442,24 @@ func (m *Manager) categoryUsedByOtherInstance(arrType, category string) bool {
 	return false
 }
 
-// ensureCategoryExistsInConfig ensures a category exists in the provided config
-func (m *Manager) ensureCategoryExistsInConfig(ctx context.Context, cfg *config.Config, category string) {
+// ensureCategoryExistsInConfig ensures a category exists in the provided config.
+// arrType ("radarr", "sonarr", "lidarr", "readarr", "whisparr", "sportarr") is
+// recorded on the category so post-process notifications can route to the
+// correct ARR type without relying on category-name heuristics. If the category
+// already exists but has no Type set, it is backfilled from arrType.
+func (m *Manager) ensureCategoryExistsInConfig(ctx context.Context, cfg *config.Config, category string, arrType string) {
 	if category == "" {
 		category = "default"
 	}
 
-	for _, existingCategory := range cfg.SABnzbd.Categories {
+	for i, existingCategory := range cfg.SABnzbd.Categories {
 		if existingCategory.Name == category {
+			if existingCategory.Type == "" && arrType != "" {
+				cfg.SABnzbd.Categories[i].Type = arrType
+				slog.InfoContext(ctx, "Backfilled type on existing category",
+					"category", category,
+					"type", arrType)
+			}
 			slog.DebugContext(ctx, "Category already exists, skipping creation", "category", category)
 			return
 		}
@@ -467,6 +477,7 @@ func (m *Manager) ensureCategoryExistsInConfig(ctx context.Context, cfg *config.
 		Order:    nextOrder,
 		Priority: 0,
 		Dir:      category,
+		Type:     arrType,
 	}
 
 	cfg.SABnzbd.Categories = append(cfg.SABnzbd.Categories, newCategory)
@@ -474,5 +485,6 @@ func (m *Manager) ensureCategoryExistsInConfig(ctx context.Context, cfg *config.
 	slog.InfoContext(ctx, "Created new category",
 		"category", category,
 		"order", nextOrder,
-		"dir", category)
+		"dir", category,
+		"type", arrType)
 }

--- a/internal/arrs/instances/manager_test.go
+++ b/internal/arrs/instances/manager_test.go
@@ -1,0 +1,82 @@
+package instances
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+func TestEnsureCategoryExistsInConfig_NewCategorySetsType(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+
+	m.ensureCategoryExistsInConfig(context.Background(), cfg, "radarr-sqp1", "radarr")
+
+	if len(cfg.SABnzbd.Categories) != 1 {
+		t.Fatalf("want 1 category, got %d", len(cfg.SABnzbd.Categories))
+	}
+	cat := cfg.SABnzbd.Categories[0]
+	if cat.Name != "radarr-sqp1" {
+		t.Errorf("name = %q, want %q", cat.Name, "radarr-sqp1")
+	}
+	if cat.Type != "radarr" {
+		t.Errorf("type = %q, want %q", cat.Type, "radarr")
+	}
+}
+
+func TestEnsureCategoryExistsInConfig_BackfillsTypeOnExisting(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{
+		SABnzbd: config.SABnzbdConfig{
+			Categories: []config.SABnzbdCategory{
+				{Name: "sonarr-4k", Dir: "sonarr-4k"}, // Type missing — pre-fix install
+			},
+		},
+	}
+
+	m.ensureCategoryExistsInConfig(context.Background(), cfg, "sonarr-4k", "sonarr")
+
+	if len(cfg.SABnzbd.Categories) != 1 {
+		t.Fatalf("want 1 category, got %d", len(cfg.SABnzbd.Categories))
+	}
+	if got := cfg.SABnzbd.Categories[0].Type; got != "sonarr" {
+		t.Errorf("type = %q, want %q (should have been backfilled)", got, "sonarr")
+	}
+}
+
+func TestEnsureCategoryExistsInConfig_PreservesExistingType(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{
+		SABnzbd: config.SABnzbdConfig{
+			Categories: []config.SABnzbdCategory{
+				{Name: "shared", Dir: "shared", Type: "radarr"}, // user already set
+			},
+		},
+	}
+
+	// Caller claims it's sonarr; existing user-set value must win.
+	m.ensureCategoryExistsInConfig(context.Background(), cfg, "shared", "sonarr")
+
+	if got := cfg.SABnzbd.Categories[0].Type; got != "radarr" {
+		t.Errorf("type = %q, want %q (existing value must be preserved)", got, "radarr")
+	}
+}
+
+func TestEnsureCategoryExistsInConfig_EmptyCategoryNameDefaultsButNoType(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+
+	m.ensureCategoryExistsInConfig(context.Background(), cfg, "", "radarr")
+
+	if len(cfg.SABnzbd.Categories) != 1 {
+		t.Fatalf("want 1 category, got %d", len(cfg.SABnzbd.Categories))
+	}
+	cat := cfg.SABnzbd.Categories[0]
+	if cat.Name != "default" {
+		t.Errorf("name = %q, want %q", cat.Name, "default")
+	}
+	if cat.Type != "radarr" {
+		t.Errorf("type = %q, want %q", cat.Type, "radarr")
+	}
+}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -646,6 +646,59 @@ func (c *Config) GetDownloadClientBaseURL() string {
 	return fmt.Sprintf("http://%s:%d/sabnzbd", host, c.WebDAV.Port)
 }
 
+// InferARRTypeFromCategory guesses the ARR type ("radarr"/"sonarr"/"lidarr"/
+// "readarr"/"whisparr") from a category name. Uses HasPrefix so multi-instance
+// names like "radarr-sqp1", "sonarr-4k", "sonarr-anime" route correctly.
+// Returns "" when no rule matches. Pure string logic, no side effects.
+func InferARRTypeFromCategory(categoryName string) string {
+	category := strings.ToLower(categoryName)
+	switch {
+	case category == "tv",
+		strings.Contains(category, "tv"),
+		strings.Contains(category, "show"),
+		strings.HasPrefix(category, "sonarr"):
+		return "sonarr"
+	case category == "movies",
+		strings.Contains(category, "movie"),
+		strings.HasPrefix(category, "radarr"):
+		return "radarr"
+	case category == "music",
+		strings.Contains(category, "music"),
+		strings.HasPrefix(category, "lidarr"):
+		return "lidarr"
+	case category == "books",
+		strings.Contains(category, "book"),
+		strings.HasPrefix(category, "readarr"):
+		return "readarr"
+	case category == "adult",
+		strings.HasPrefix(category, "whisparr"):
+		return "whisparr"
+	}
+	return ""
+}
+
+// MigrateCategoryTypes walks SABnzbd.Categories and fills in an empty Type
+// field for any category whose name matches the InferARRTypeFromCategory
+// heuristic. Returns the names of categories that were backfilled so the
+// caller can log and decide whether to persist. Does not touch categories
+// whose Type is already set (preserves user intent) or whose name doesn't
+// match any rule.
+func (c *Config) MigrateCategoryTypes() []string {
+	var backfilled []string
+	for i, cat := range c.SABnzbd.Categories {
+		if cat.Type != "" {
+			continue
+		}
+		inferred := InferARRTypeFromCategory(cat.Name)
+		if inferred == "" {
+			continue
+		}
+		c.SABnzbd.Categories[i].Type = inferred
+		backfilled = append(backfilled, cat.Name)
+	}
+	return backfilled
+}
+
 // Validate validates the configuration
 func (c *Config) Validate() error {
 	if c.WebDAV.Port <= 0 || c.WebDAV.Port > 65535 {
@@ -1854,6 +1907,27 @@ func LoadConfig(configFile string) (*Config, error) {
 		}
 		config.WebDAV.Port = port
 		slog.Info("Using PORT from environment variable", "port", port)
+	}
+
+	// Migrate: backfill SABnzbd category Type field from the name heuristic.
+	// Older installs (and any UI-created category before the type-field UI
+	// shipped) carry no Type. Filling it here makes arr_notifier's explicit
+	// mapping path work without manual yaml edits.
+	if backfilled := config.MigrateCategoryTypes(); len(backfilled) > 0 {
+		slog.Info("Backfilled SABnzbd category types from heuristic",
+			"categories", backfilled,
+			"count", len(backfilled))
+		if targetConfigFile != "" {
+			backupFile := targetConfigFile + ".bak"
+			if data, readErr := os.ReadFile(targetConfigFile); readErr == nil {
+				_ = os.WriteFile(backupFile, data, 0644)
+			}
+			if err := SaveToFile(config, targetConfigFile); err != nil {
+				slog.Warn("Failed to persist category-type backfill — will retry on next startup",
+					"path", targetConfigFile,
+					"error", err)
+			}
+		}
 	}
 
 	// Validate configuration

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -458,3 +458,91 @@ func TestMigrateArrsCleanup_AutoFailureFlag_FalseClearsOnly(t *testing.T) {
 	assert.Equal(t, rules, cfg.Arrs.QueueCleanupRules)
 	assert.Nil(t, cfg.Arrs.CleanupAutomaticImportFailure)
 }
+
+func TestInferARRTypeFromCategory(t *testing.T) {
+	cases := []struct {
+		category string
+		want     string
+	}{
+		// Multi-instance radarr/sonarr names — the original bug.
+		{"radarr-sqp1", "radarr"},
+		{"radarr-anime", "radarr"},
+		{"radarr-anime-v3", "radarr"},
+		{"sonarr-4k", "sonarr"},
+		{"sonarr-anime", "sonarr"},
+		// Exact and contains.
+		{"radarr", "radarr"},
+		{"sonarr", "sonarr"},
+		{"movies", "radarr"},
+		{"tv", "sonarr"},
+		{"shows", "sonarr"},
+		{"music", "lidarr"},
+		{"books", "readarr"},
+		{"adult", "whisparr"},
+		// Case insensitive.
+		{"RADARR-SQP1", "radarr"},
+		// Unknown.
+		{"", ""},
+		{"default", ""},
+		{"asdf-foo", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.category, func(t *testing.T) {
+			assert.Equal(t, tc.want, InferARRTypeFromCategory(tc.category))
+		})
+	}
+}
+
+func TestMigrateCategoryTypes_BackfillsEmpty(t *testing.T) {
+	cfg := &Config{
+		SABnzbd: SABnzbdConfig{
+			Categories: []SABnzbdCategory{
+				{Name: "radarr-sqp1", Dir: "radarr-sqp1"},
+				{Name: "sonarr-anime", Dir: "sonarr-anime"},
+			},
+		},
+	}
+
+	backfilled := cfg.MigrateCategoryTypes()
+
+	assert.ElementsMatch(t, []string{"radarr-sqp1", "sonarr-anime"}, backfilled)
+	assert.Equal(t, "radarr", cfg.SABnzbd.Categories[0].Type)
+	assert.Equal(t, "sonarr", cfg.SABnzbd.Categories[1].Type)
+}
+
+func TestMigrateCategoryTypes_PreservesExistingType(t *testing.T) {
+	cfg := &Config{
+		SABnzbd: SABnzbdConfig{
+			Categories: []SABnzbdCategory{
+				{Name: "radarr-sqp1", Dir: "radarr-sqp1", Type: "sonarr"}, // user override
+			},
+		},
+	}
+
+	backfilled := cfg.MigrateCategoryTypes()
+
+	assert.Empty(t, backfilled, "should not touch user-set Type")
+	assert.Equal(t, "sonarr", cfg.SABnzbd.Categories[0].Type, "user value must survive")
+}
+
+func TestMigrateCategoryTypes_SkipsUnknownNames(t *testing.T) {
+	cfg := &Config{
+		SABnzbd: SABnzbdConfig{
+			Categories: []SABnzbdCategory{
+				{Name: "asdf-custom", Dir: "asdf-custom"}, // heuristic miss
+				{Name: "radarr-sqp1", Dir: "radarr-sqp1"},
+			},
+		},
+	}
+
+	backfilled := cfg.MigrateCategoryTypes()
+
+	assert.Equal(t, []string{"radarr-sqp1"}, backfilled)
+	assert.Equal(t, "", cfg.SABnzbd.Categories[0].Type)
+	assert.Equal(t, "radarr", cfg.SABnzbd.Categories[1].Type)
+}
+
+func TestMigrateCategoryTypes_NoCategories(t *testing.T) {
+	cfg := &Config{}
+	assert.Empty(t, cfg.MigrateCategoryTypes())
+}

--- a/internal/importer/postprocessor/arr_notifier.go
+++ b/internal/importer/postprocessor/arr_notifier.go
@@ -105,7 +105,6 @@ func (c *Coordinator) broadcastToARRType(ctx context.Context, arrsService *arrs.
 		return fmt.Errorf("cannot determine ARR type: category is nil")
 	}
 	categoryName := *item.Category
-	category := strings.ToLower(categoryName)
 	arrType := ""
 
 	cfg := c.configGetter()
@@ -118,19 +117,9 @@ func (c *Coordinator) broadcastToARRType(ctx context.Context, arrsService *arrs.
 		}
 	}
 
-	// Fallback to heuristic if no explicit type is mapped
+	// Fallback to heuristic if no explicit type is mapped.
 	if arrType == "" {
-		if category == "tv" || strings.Contains(category, "tv") || strings.Contains(category, "show") || category == "sonarr" {
-			arrType = "sonarr"
-		} else if category == "movies" || strings.Contains(category, "movie") || category == "radarr" {
-			arrType = "radarr"
-		} else if category == "music" || strings.Contains(category, "music") || category == "lidarr" {
-			arrType = "lidarr"
-		} else if category == "books" || strings.Contains(category, "book") || category == "readarr" {
-			arrType = "readarr"
-		} else if category == "adult" || category == "whisparr" {
-			arrType = "whisparr"
-		}
+		arrType = config.InferARRTypeFromCategory(categoryName)
 	}
 
 	if arrType != "" {
@@ -139,4 +128,11 @@ func (c *Coordinator) broadcastToARRType(ctx context.Context, arrsService *arrs.
 	}
 
 	return fmt.Errorf("could not determine ARR type for category: %s", categoryName)
+}
+
+// inferARRTypeFromCategory is a thin shim around config.InferARRTypeFromCategory
+// kept so the existing table-driven test in this package continues to compile.
+// Prefer calling config.InferARRTypeFromCategory directly from new code.
+func inferARRTypeFromCategory(categoryName string) string {
+	return config.InferARRTypeFromCategory(categoryName)
 }

--- a/internal/importer/postprocessor/arr_notifier_test.go
+++ b/internal/importer/postprocessor/arr_notifier_test.go
@@ -1,0 +1,58 @@
+package postprocessor
+
+import "testing"
+
+func TestInferARRTypeFromCategory(t *testing.T) {
+	cases := []struct {
+		name     string
+		category string
+		want     string
+	}{
+		// Radarr — exact, prefixed, and "movie" contains.
+		{"radarr exact", "radarr", "radarr"},
+		{"radarr-sqp1", "radarr-sqp1", "radarr"},
+		{"radarr-sqp3", "radarr-sqp3", "radarr"},
+		{"radarr-anime", "radarr-anime", "radarr"},
+		{"radarr-anime-v3", "radarr-anime-v3", "radarr"},
+		{"radarr uppercase", "RADARR-SQP1", "radarr"},
+		{"movies", "movies", "radarr"},
+		{"movie4k", "movie4k", "radarr"},
+
+		// Sonarr — exact, prefixed, and "tv"/"show" contains.
+		{"sonarr exact", "sonarr", "sonarr"},
+		{"sonarr-4k", "sonarr-4k", "sonarr"},
+		{"sonarr-anime", "sonarr-anime", "sonarr"},
+		{"tv exact", "tv", "sonarr"},
+		{"tv-shows", "tv-shows", "sonarr"},
+		{"shows", "shows", "sonarr"},
+
+		// Lidarr.
+		{"lidarr exact", "lidarr", "lidarr"},
+		{"lidarr-flac", "lidarr-flac", "lidarr"},
+		{"music", "music", "lidarr"},
+
+		// Readarr.
+		{"readarr exact", "readarr", "readarr"},
+		{"readarr-audiobooks", "readarr-audiobooks", "readarr"},
+		{"books", "books", "readarr"},
+
+		// Whisparr.
+		{"whisparr exact", "whisparr", "whisparr"},
+		{"whisparr-extra", "whisparr-extra", "whisparr"},
+		{"adult", "adult", "whisparr"},
+
+		// Unknown.
+		{"empty", "", ""},
+		{"junk", "asdf-foo", ""},
+		{"default", "default", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := inferARRTypeFromCategory(tc.category)
+			if got != tc.want {
+				t.Errorf("inferARRTypeFromCategory(%q) = %q, want %q", tc.category, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with AI (Claude Code). All code reviewed by a human before submission. Tests written and verified locally.

## Summary

Fixes the `could not determine ARR type for category: <name>` post-process notification failure when users run multiple ARR instances with suffixed categories (e.g. `radarr-abc`, `sonarr-4k`, `sonarr-anime`).

Three complementary changes:

1. **Heuristic (`internal/config/manager.go: InferARRTypeFromCategory`)** — switched the fallback rules from exact equality (`category == "radarr"`) to `strings.HasPrefix`, so any name beginning with `radarr` / `sonarr` / `lidarr` / `readarr` / `whisparr` routes correctly. Helper now lives in `internal/config` so the startup migration below can reuse it without creating an import cycle (`internal/arrs` already imports `internal/config`). `internal/importer/postprocessor/arr_notifier.go` calls the helper via the config package.

2. **Instance manager (`internal/arrs/instances/manager.go`)** — threaded `arrType` through `ensureCategoryExistsInConfig` so newly-created SAB categories have the `Type` field set from the start, and added a backfill that fills `Type` on a previously-created category whose `Type` was left empty when an ARR instance is (re-)registered.

3. **Startup migration (`internal/config/manager.go: MigrateCategoryTypes`)** — on every `LoadConfig`, walk `SABnzbd.Categories` and fill any empty `Type` using the heuristic. When something changes, write a `.bak` next to `config.yaml` and persist the updated file. Handles every existing install on first run without forcing users to edit yaml or re-add ARR instances. User-set `Type` values are never overwritten; names that don't match the heuristic are left alone.

The runtime heuristic in `arr_notifier.go` stays in place as a defence-in-depth fallback for any category whose `Type` couldn't be resolved at load time.

## Why this matters

`SABnzbdCategory.Type` is honored by `arr_notifier.go` but is not exposed in the frontend SAB config form (`frontend/src/components/config/SABnzbdConfigSection.tsx` only edits `name` / `order` / `priority` / `dir`). Before this PR, the only ways to set `Type` were editing `config.yaml` by hand, or hoping your category name was literally `radarr` / `sonarr` / contained `movie` or `tv`. Multi-instance setups (one Radarr per quality profile, etc.) all hit the failure mode.

The startup migration means existing affected installs are auto-healed the first time they boot a build that includes this PR — no manual yaml editing required, and the `.bak` lets users revert if they don't like the change.

## Test plan

- [x] `go test ./internal/config/` — `InferARRTypeFromCategory` (17 cases) + `MigrateCategoryTypes` (backfill, preserves-user-set, skips-unknown, no-categories). All pass.
- [x] `go test ./internal/importer/postprocessor/` — 26-case table-driven test for the heuristic via the postprocessor shim, covering all suffixed names plus the existing keyword cases. All pass.
- [x] `go test ./internal/arrs/instances/` — 4 cases for `ensureCategoryExistsInConfig`: new-category-sets-type, backfills-empty-type-on-existing, preserves-user-set-type, empty-name-defaults-to-`default`-with-type. All pass.
- [x] `go vet ./...` — clean.
- [x] `go build ./...` — clean.
- [ ] Manual: deploy a build with this PR onto an install whose categories have empty `Type`. Confirm the `INFO Backfilled SABnzbd category types from heuristic categories=[...] count=N` log line on first start, `config.yaml.bak` is written, and post-process notification fires (no `could not determine ARR type` log).
- [ ] Manual: register a new ARR instance with a suffixed category (e.g. `radarr-abc`), confirm the SABnzbd category gets `type: radarr` written from the start.