### PR TITLE
perf(fuse): improve video streaming throughput for FUSE over Usenet

### DIFF
--- a/internal/fuse/backend/asyncbuffer.go
+++ b/internal/fuse/backend/asyncbuffer.go
@@ -16,11 +16,16 @@ const (
 	// Larger chunks reduce mutex churn in ReadAtContext. Segments are ~750KB,
 	// so 4MB reads ~1 ReadAtContext call per segment.
 	fillChunkSize = 4 * 1024 * 1024 // 4MB
-	// nearFrontierWindow is the maximum distance ahead of the fill frontier
-	// that we treat as "near-sequential" and wait for rather than demoting.
-	// Chosen to absorb kernel readahead parallelism (128KB reads, up to 64
-	// in flight) without masking genuine seeks.
-	nearFrontierWindow = 4 * 1024 * 1024 // 4MB
+	// nearFrontierWindow is the lookahead beyond the fill frontier treated as
+	// near-sequential during streaming. Set equal to fillChunkSize so that a
+	// near-frontier read is guaranteed to be satisfied within at most one fill
+	// iteration.
+	nearFrontierWindow = 4 * 1024 * 1024 // 4MB — kept equal to fillChunkSize intentionally
+	// probingSeqTolerance is the maximum forward delta in probing mode that is
+	// still counted as sequential for arming read-ahead. Kernel readahead may
+	// issue 128 KB parallel probes slightly out of order; 256 KB absorbs that
+	// without creating large holes in the streaming start frontier.
+	probingSeqTolerance = 256 * 1024 // 256 KB
 	// armThreshold is how many consecutive sequential reads must be observed
 	// before the buffer promotes from probing to streaming and begins reading
 	// ahead. This keeps read-ahead off during the media player's header-probe
@@ -177,6 +182,9 @@ func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64
 	}
 
 	if a.streaming {
+		// bufEnd is a snapshot of the fill frontier taken once; the inner-loop
+		// conditions use live a.baseOff+int64(a.filled) so they see progress
+		// made by the fill goroutine while we wait.
 		bufEnd := a.baseOff + int64(a.filled)
 
 		// Offset already within the buffered window.
@@ -222,6 +230,7 @@ func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64
 				// consumers to drain it — waiting here would deadlock, so give up
 				// and fall through to demote instead.
 				if a.filled >= a.bufSize {
+					// Buffer full — fill goroutine cannot advance; demote rather than deadlock.
 					goto demote
 				}
 				a.cond.Wait()
@@ -250,9 +259,11 @@ func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64
 
 	// Probing mode: count sequential runs, decide on promotion, then serve the
 	// read directly from the source (outside the lock).
-	// Treat reads within nearFrontierWindow ahead as sequential for arming
-	// purposes — kernel readahead may issue parallel probes slightly out of order.
-	if off >= a.expectedNext && off <= a.expectedNext+nearFrontierWindow {
+	// Treat reads within probingSeqTolerance ahead as sequential for arming
+	// purposes — kernel readahead may issue 128 KB parallel probes slightly out
+	// of order; 256 KB absorbs that without creating large holes in the
+	// streaming start frontier.
+	if off >= a.expectedNext && off <= a.expectedNext+probingSeqTolerance {
 		a.seqRun++
 	} else {
 		a.seqRun = 1

--- a/internal/fuse/backend/asyncbuffer.go
+++ b/internal/fuse/backend/asyncbuffer.go
@@ -14,8 +14,13 @@ const (
 	defaultAsyncBufSize = 8 * 1024 * 1024
 	// fillChunkSize is how much the background goroutine reads per iteration.
 	// Larger chunks reduce mutex churn in ReadAtContext. Segments are ~750KB,
-	// so 1MB reads ~1 ReadAtContext call per segment.
-	fillChunkSize = 1024 * 1024 // 1MB
+	// so 4MB reads ~1 ReadAtContext call per segment.
+	fillChunkSize = 4 * 1024 * 1024 // 4MB
+	// nearFrontierWindow is the maximum distance ahead of the fill frontier
+	// that we treat as "near-sequential" and wait for rather than demoting.
+	// Chosen to absorb kernel readahead parallelism (128KB reads, up to 64
+	// in flight) without masking genuine seeks.
+	nearFrontierWindow = 4 * 1024 * 1024 // 4MB
 	// armThreshold is how many consecutive sequential reads must be observed
 	// before the buffer promotes from probing to streaming and begins reading
 	// ahead. This keeps read-ahead off during the media player's header-probe
@@ -205,13 +210,49 @@ func (a *AsyncReadBuffer) ReadAtContext(ctx context.Context, p []byte, off int64
 			// Closed while waiting — fall through to passthrough.
 		}
 
+		// Near-frontier: this read is just ahead of the fill frontier — likely a
+		// kernel readahead parallel read, not a genuine seek. Wait for the fill
+		// goroutine to reach this offset rather than demoting.
+		if off >= bufEnd && off < bufEnd+nearFrontierWindow {
+			for !a.srcDone && !a.closed && ctx.Err() == nil {
+				if a.baseOff+int64(a.filled) > off {
+					break
+				}
+				// If the buffer is full the fill goroutine is blocked waiting for
+				// consumers to drain it — waiting here would deadlock, so give up
+				// and fall through to demote instead.
+				if a.filled >= a.bufSize {
+					goto demote
+				}
+				a.cond.Wait()
+			}
+			if ctx.Err() != nil {
+				a.mu.Unlock()
+				return 0, ctx.Err()
+			}
+			if !a.closed && off >= a.baseOff && off < a.baseOff+int64(a.filled) {
+				n := a.copyFromBuffer(p, off)
+				a.expectedNext = off + int64(n)
+				a.mu.Unlock()
+				return n, nil
+			}
+			if a.srcDone {
+				err := a.srcErr
+				a.mu.Unlock()
+				return 0, err
+			}
+			// Closed while waiting or off fell outside buffer — fall through to demote.
+		}
 		// Non-sequential read (seek) while streaming → demote to probing.
+	demote:
 		a.demoteLocked()
 	}
 
 	// Probing mode: count sequential runs, decide on promotion, then serve the
 	// read directly from the source (outside the lock).
-	if off == a.expectedNext {
+	// Treat reads within nearFrontierWindow ahead as sequential for arming
+	// purposes — kernel readahead may issue parallel probes slightly out of order.
+	if off >= a.expectedNext && off <= a.expectedNext+nearFrontierWindow {
 		a.seqRun++
 	} else {
 		a.seqRun = 1

--- a/internal/fuse/backend/asyncbuffer_test.go
+++ b/internal/fuse/backend/asyncbuffer_test.go
@@ -395,6 +395,13 @@ func TestAsyncReadBuffer_NearFrontierWaitDoesNotDemote(t *testing.T) {
 		t.Fatal("buffer did not start filling after promotion")
 	}
 
+	// Confirm streaming was active before the near-frontier read so we know the
+	// assertion below is meaningful (streaming was active throughout, not just
+	// re-established after a demote).
+	if bufEnd == 0 {
+		t.Fatal("streaming was not active before near-frontier read")
+	}
+
 	// Issue a near-frontier read: 64KB ahead of current bufEnd.
 	nearOff := bufEnd + 64*1024
 	result := make([]byte, len(p))

--- a/internal/fuse/backend/asyncbuffer_test.go
+++ b/internal/fuse/backend/asyncbuffer_test.go
@@ -360,6 +360,73 @@ func TestAsyncReadBuffer_NoGoroutineLeak(t *testing.T) {
 	}
 }
 
+// TestAsyncReadBuffer_NearFrontierWaitDoesNotDemote verifies that a read
+// slightly ahead of the fill frontier (simulating kernel readahead parallelism)
+// waits for the fill goroutine rather than demoting to probing mode.
+func TestAsyncReadBuffer_NearFrontierWaitDoesNotDemote(t *testing.T) {
+	SetAsyncBufferBudget(0)
+	// Source must be larger than bufSize + nearFrontierWindow so the file is big
+	// enough that streaming is expected and nearFrontierWindow fits inside.
+	totalSize := defaultAsyncBufSize + nearFrontierWindow + 1*1024*1024
+	data := testData(totalSize)
+	src := &countingSource{data: data, delay: 5 * time.Millisecond}
+
+	bufSize := defaultAsyncBufSize
+	a := NewAsyncReadBuffer(context.Background(), src, bufSize, int64(totalSize), nil)
+	defer a.Close()
+
+	p := make([]byte, 1024)
+
+	// Drive enough sequential reads to promote into streaming mode (>= armThreshold).
+	for i := range armThreshold + 2 {
+		off := int64(i * len(p))
+		if _, err := a.ReadAtContext(context.Background(), p, off); err != nil {
+			t.Fatalf("seed read %d: %v", i, err)
+		}
+	}
+
+	// Wait until the fill goroutine has buffered at least a few bytes ahead.
+	deadline := time.Now().Add(2 * time.Second)
+	for a.GetBufferedOffset() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	bufEnd := a.GetBufferedOffset()
+	if bufEnd == 0 {
+		t.Fatal("buffer did not start filling after promotion")
+	}
+
+	// Issue a near-frontier read: 64KB ahead of current bufEnd.
+	nearOff := bufEnd + 64*1024
+	result := make([]byte, len(p))
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.ReadAtContext(context.Background(), result, nearOff)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil && err != io.EOF {
+			t.Fatalf("near-frontier read returned unexpected error: %v", err)
+		}
+		// Verify the data is correct.
+		if nearOff < int64(totalSize) {
+			n := min(len(result), totalSize-int(nearOff))
+			if !bytes.Equal(result[:n], data[nearOff:nearOff+int64(n)]) {
+				t.Fatal("near-frontier read: data mismatch")
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("near-frontier read hung — possible deadlock or no progress")
+	}
+
+	// Confirm the buffer is still in streaming mode (not demoted).
+	if bo := a.GetBufferedOffset(); bo == 0 {
+		t.Fatal("buffer was demoted during near-frontier read; expected to stay streaming")
+	}
+}
+
 // TestAsyncReadBuffer_BudgetGate verifies that when the global budget is
 // exhausted, additional buffers stay in passthrough (probing) mode.
 func TestAsyncReadBuffer_BudgetGate(t *testing.T) {

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1055,13 +1055,39 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	defer mvf.mu.Unlock()
 
 	// Determine whether this offset can reuse the shared reader.
-	// Shared path: offset matches the next expected sequential position.
-	useShared := (mvf.readAtSharedNext >= 0 && off == mvf.readAtSharedNext) ||
+	// Shared path: offset matches the next expected sequential position, OR
+	// it is slightly ahead (forward-skip: gap ≤ forwardSkipLimit) — discard
+	// the gap via the already-prefetched pipeline instead of creating an
+	// ephemeral reader. Covers "skip intro" / chapter-jump patterns where
+	// the player moves forward by a few seconds inside the prefetch window.
+	const forwardSkipLimit = 16 * 1024 * 1024 // 16 MB — roughly 20 segments
+	forwardSkip := mvf.readerInitialized &&
+		mvf.readAtSharedNext >= 0 &&
+		off > mvf.readAtSharedNext &&
+		off-mvf.readAtSharedNext <= forwardSkipLimit
+	useShared := forwardSkip ||
+		(mvf.readAtSharedNext >= 0 && off == mvf.readAtSharedNext) ||
 		(mvf.readAtSharedNext == 0 && !mvf.readerInitialized && off == mvf.position)
 
 	if useShared {
 		if err := mvf.ensureReader(); err != nil {
 			return 0, err
+		}
+
+		// Forward-skip: discard the gap between the shared reader's current
+		// position and the requested offset. Prefetched bytes make this
+		// memory-speed; any not-yet-fetched bytes download from the pipeline
+		// that would be needed for sequential play anyway.
+		if forwardSkip {
+			gap := off - mvf.readAtSharedNext
+			if _, skipErr := io.CopyN(io.Discard, mvf.reader, gap); skipErr != nil {
+				// Skip failed (e.g. EOF mid-gap). Close and let the
+				// ephemeral path handle this read.
+				mvf.closeCurrentReader()
+				mvf.readAtSharedNext = -1
+				goto ephemeral
+			}
+			mvf.readAtSharedNext = off
 		}
 
 		// Read from the shared reader (same logic as Read but bounded to len(p))
@@ -1100,6 +1126,7 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 		return n, nil
 	}
 
+ephemeral:
 	// --- Ephemeral path: non-sequential offset ---
 	// Track consecutive scrubs. Short bursts (e.g. Plex thumbnail probes) keep
 	// the shared reader alive so the 60-segment prefetch pipeline survives.

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1502,6 +1502,11 @@ func (mvf *MetadataVirtualFile) closeCurrentReader() {
 	if mvf.reader != nil {
 		reader := mvf.reader
 		mvf.setReader(nil)
+		// Interrupt immediately so in-flight NNTP downloads stop consuming pool
+		// connections before the closer worker eventually calls Close().
+		if i, ok := reader.(readerInterrupter); ok {
+			i.Interrupt()
+		}
 		mvf.enqueueCloser(reader)
 	}
 	mvf.readerInitialized = false
@@ -1533,6 +1538,11 @@ func (mvf *MetadataVirtualFile) enqueueCloser(r io.Closer) {
 		// Queue full — apply backpressure inline rather than letting
 		// the closer fan-out grow unbounded. This is the rare path; a
 		// real Seek burst stays under closerWorkerCount.
+		// Interrupt first (idempotent) so in-flight downloads release the
+		// pool connection before Close() waits on drain.
+		if i, ok := r.(readerInterrupter); ok {
+			i.Interrupt()
+		}
 		_ = r.Close()
 	}
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -821,6 +821,12 @@ type MetadataVirtualFile struct {
 	// !readerInitialized means the very first ReadAt at offset 0 is shared.
 	readAtSharedNext int64
 
+	// ephemeralStreak counts consecutive non-sequential ReadAtContext calls
+	// (scrubs, header probes). Short bursts keep the shared reader alive so
+	// the 60-segment prefetch pipeline survives; after ephemeralStreakLimit
+	// consecutive misses the player has genuinely moved and we tear down.
+	ephemeralStreak int
+
 	// Segment offset index for O(1) offset→segment lookup
 	segmentIndex *segmentOffsetIndex
 
@@ -1090,14 +1096,30 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 
 		// Advance the shared cursor so the next sequential call hits this path again.
 		mvf.readAtSharedNext = off + int64(n)
+		mvf.ephemeralStreak = 0 // sequential read — reset scrub counter
 		return n, nil
 	}
 
 	// --- Ephemeral path: non-sequential offset ---
-	// Invalidate the shared cursor and tear down the stale shared reader so
-	// that the next sequential run creates a fresh reader at the correct offset.
-	mvf.readAtSharedNext = -1
-	mvf.closeCurrentReader()
+	// Track consecutive scrubs. Short bursts (e.g. Plex thumbnail probes) keep
+	// the shared reader alive so the 60-segment prefetch pipeline survives.
+	// After ephemeralStreakLimit consecutive misses the player has genuinely
+	// moved, so we tear down and let the next sequential run rebuild from the
+	// new position.
+	const ephemeralStreakLimit = 3
+	if mvf.readerInitialized {
+		mvf.ephemeralStreak++
+		if mvf.ephemeralStreak >= ephemeralStreakLimit {
+			mvf.ephemeralStreak = 0
+			mvf.readAtSharedNext = -1
+			mvf.closeCurrentReader()
+		}
+		// else: shared reader stays alive; readAtSharedNext remains at the
+		// reader's current position so the next sequential call can reuse it.
+	} else {
+		mvf.readAtSharedNext = -1
+		mvf.ephemeralStreak = 0
+	}
 
 	end := off + int64(len(p)) - 1
 	if end >= mvf.meta.FileSize {
@@ -1111,7 +1133,12 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	// segments — encrypted streams don't map cleanly to segment
 	// boundaries.
 	if n, served := mvf.tryServeFromRandomReadCache(readCtx, p, off, end); served {
-		mvf.readAtSharedNext = off + int64(n)
+		// Only update the shared cursor when the shared reader is gone; if it
+		// is still alive, readAtSharedNext already points to the reader's
+		// current position and must not be overwritten.
+		if !mvf.readerInitialized {
+			mvf.readAtSharedNext = off + int64(n)
+		}
 		return n, nil
 	}
 
@@ -1127,10 +1154,12 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 		err = nil
 	}
 
-	// If this ephemeral read landed right after the shared reader's position,
-	// promote it: set readAtSharedNext so the next sequential call rebuilds
-	// a shared reader from here.
-	mvf.readAtSharedNext = off + int64(n)
+	// Only update the shared cursor when the shared reader was torn down.
+	// If it is still alive, readAtSharedNext already points to the reader's
+	// current position and must not be overwritten by the ephemeral endpoint.
+	if !mvf.readerInitialized {
+		mvf.readAtSharedNext = off + int64(n)
+	}
 
 	return n, err
 }
@@ -1375,8 +1404,11 @@ func (mvf *MetadataVirtualFile) Seek(offset int64, whence int) (int64, error) {
 
 	mvf.position = abs
 	// Align ReadAt shared cursor with the new seek position so that the next
-	// ReadAtContext at this offset reuses the shared reader.
+	// ReadAtContext at this offset reuses the shared reader. Also reset the
+	// ephemeral-streak counter: an explicit Seek establishes a new sequential
+	// starting point regardless of previous scrub activity.
 	mvf.readAtSharedNext = abs
+	mvf.ephemeralStreak = 0
 	return abs, nil
 }
 
@@ -1510,6 +1542,7 @@ func (mvf *MetadataVirtualFile) closeCurrentReader() {
 		mvf.enqueueCloser(reader)
 	}
 	mvf.readerInitialized = false
+	mvf.ephemeralStreak = 0
 }
 
 // closerWorkerCount bounds the number of background reader-Close


### PR DESCRIPTION
## Summary

Four targeted fixes to the FUSE streaming read path that eliminate the primary throughput killers when playing high-bitrate video from a Usenet mount (Plex/Jellyfin use case).

### Problem

The segment-download pipeline (`UsenetReader`, 60-segment prefetch, streaming yEnc decode) was already well-optimized, but layers above it were destroying its benefits:

1. **Kernel readahead reordering → constant AsyncReadBuffer demotion.** With `MaxReadAhead=128MB` and `MaxBackground=64`, the kernel issues parallel 128KB reads per handle. Any read landing past the buffer frontier (`off > bufEnd`) triggered `demoteLocked()` immediately, freeing the ring buffer and resetting the sequential-run counter — restarting the 60-segment prefetch ramp from zero on every batch of parallel kernel reads.

2. **Scrub/seek probes tore down the shared reader.** Any ephemeral (non-sequential) `ReadAtContext` call (Plex timeline scrub, chapter detection, container parsing) unconditionally called `closeCurrentReader()`, restarting the prefetch pipeline and causing visible buffering on resume.

3. **NNTP pool connections held during seek.** `closeCurrentReader` enqueued to a 4-worker closer pool. Between enqueue and `Close()`, the `UsenetReader` continued holding NNTP connections and downloading segments — wasting pool capacity during seeks.

4. **Small forward jumps (skip intro, chapter changes) rebuilt the pipeline from scratch** even when the prefetched data could have been consumed by discarding the gap.

### Changes

**`perf(fuse): interrupt readers immediately on seek; never block close under mvf.mu`**
- `closeCurrentReader` now calls `Interrupt()` synchronously before enqueuing to the closer pool, cancelling in-flight NNTP downloads immediately and releasing pool connections on seek.
- `Seek()` resets `ephemeralStreak` to 0.

**`perf(fuse): tolerate kernel readahead reordering in AsyncReadBuffer; bump fill chunk to 4MB`**
- Near-frontier wait: reads landing in `[bufEnd, bufEnd+4MB)` block on a condition variable until the fill goroutine advances past the read offset, instead of demoting. Demote only on backward seeks or jumps beyond the window. Bounded by context cancellation and a full-buffer deadlock guard.
- Probing mode: separate `probingSeqTolerance = 256KB` constant for the `seqRun` counter (distinct from `nearFrontierWindow`) — prevents 4MB holes from delaying streaming-mode promotion.
- `fillChunkSize` bumped 1MB → 4MB: fewer `mvf.mu` round-trips per ring fill at steady-state throughput.

**`perf(fuse): preserve shared reader across scrubs with ephemeral-streak limit`**
- New `ephemeralStreak` field: consecutive non-sequential `ReadAtContext` calls increment the counter; the shared reader is kept alive until `ephemeralStreakLimit = 3` consecutive misses. This absorbs Plex/Jellyfin scrub probes without restarting prefetch.
- Sequential reads reset the streak to 0.

**`perf(fuse): forward-skip within shared reader for small gaps (skip intro, chapter jumps)`**
- When `off > readAtSharedNext` and the gap ≤ 16MB, discard bytes via `io.CopyN(io.Discard, mvf.reader, gap)` instead of tearing down. The gap bytes are already prefetched in the UsenetReader pipeline, so the discard is memory-speed. Covers "skip intro" jumps and chapter-boundary seeks.

**`perf(fuse): tighten AsyncReadBuffer probing tolerance and improve comments`**
- Code quality: documents that `nearFrontierWindow == fillChunkSize` is intentional, clarifies `probingSeqTolerance` rationale, strengthens test assertion with `bufEnd != 0` guard.

## Test plan

- [ ] `go test -race ./internal/fuse/... ./internal/nzbfilesystem/... ./internal/usenet/...` — existing storm tests (seek thrash, close races, scrub bursts) pass
- [ ] New test `TestAsyncReadBuffer_NearFrontierWaitDoesNotDemote` verifies near-frontier reads don't demote the buffer
- [ ] Manual: mount a large NZB, play high-bitrate file in Plex/Jellyfin, scrub repeatedly — no reader-recreate log spam, no buffering on resume
- [ ] `dd if=<mountfile> of=/dev/null bs=4M count=256` — sustained throughput sanity check
- [ ] Watch `GetMetricsSnapshot` pool connection count during seeks — connections released promptly