### PR TITLE
fix(fuse): drain async read-ahead after closing source to stop timeout warning

### DIFF
--- a/internal/fuse/backend/asyncbuffer.go
+++ b/internal/fuse/backend/asyncbuffer.go
@@ -33,11 +33,14 @@ const (
 	// sequential run), addressing the seek-thrashing that got earlier versions
 	// of this buffer reverted.
 	armThreshold = 3
-	// closeDrainTimeout bounds how long Close waits for the fill goroutine to
-	// exit. ctx cancellation propagates into the source read, so this is a
-	// safety net rather than the normal path.
-	closeDrainTimeout = 5 * time.Second
 )
+
+// closeDrainTimeout bounds how long Wait blocks for the fill goroutine to exit.
+// Callers are expected to close/interrupt the source between Shutdown and Wait
+// so the goroutine exits promptly; this timeout is only a safety net against a
+// source whose read cannot be unblocked. It is a var (not a const) so tests can
+// shorten it.
+var closeDrainTimeout = 5 * time.Second
 
 // readAtContexter matches nzbfilesystem.MetadataVirtualFile.ReadAtContext.
 type readAtContexter interface {
@@ -135,10 +138,11 @@ type AsyncReadBuffer struct {
 	seqRun       int   // consecutive sequential reads observed while probing
 	accounted    bool  // holds an accounted slot in the global budget
 
-	started   bool // fill goroutine launched
-	closed    bool
-	closeOnce sync.Once
-	wg        sync.WaitGroup
+	started      bool // fill goroutine launched
+	closed       bool
+	shutdownOnce sync.Once
+	waitOnce     sync.Once
+	wg           sync.WaitGroup
 }
 
 // NewAsyncReadBuffer creates an async read-ahead buffer wrapping src. The fill
@@ -458,22 +462,42 @@ func (a *AsyncReadBuffer) GetBufferedOffset() int64 {
 	return a.baseOff + int64(a.filled)
 }
 
-// Close stops the fill goroutine and releases resources. It does NOT close the
-// underlying source — the FUSE handle owns that lifecycle. Close drains the
-// fill goroutine with a bounded wait: ctx cancellation propagates into the
-// source read, so the goroutine normally exits promptly; the timeout is a
-// safety net against a wedged source.
-func (a *AsyncReadBuffer) Close() {
-	a.closeOnce.Do(func() {
+// Shutdown signals the fill goroutine to stop without waiting for it to exit.
+// It cancels the buffer's context and marks the buffer closed so the goroutine
+// exits at its next lock acquisition without issuing another source read.
+//
+// Shutdown does NOT close the underlying source — the FUSE handle owns that
+// lifecycle. Because a sequential source read blocks on the source's own
+// context (not this buffer's), the caller MUST close/interrupt the source
+// between Shutdown and Wait; otherwise an in-flight read cannot be unblocked
+// and Wait falls back to its bounded safety-net timeout. Idempotent.
+func (a *AsyncReadBuffer) Shutdown() {
+	a.shutdownOnce.Do(func() {
 		a.cancel()
 
 		a.mu.Lock()
 		a.closed = true
 		a.srcDone = true
+		a.cond.Broadcast()
+		a.mu.Unlock()
+	})
+}
+
+// Wait drains the fill goroutine and releases resources. It must be called
+// after Shutdown (and after the underlying source has been closed/interrupted)
+// so the goroutine exits promptly. The bounded wait is a safety net against a
+// wedged source: with the source interrupted first it returns near-instantly.
+// Idempotent.
+func (a *AsyncReadBuffer) Wait() {
+	a.waitOnce.Do(func() {
+		// Defensive: ensure the stop signal was delivered even if a caller
+		// invokes Wait without a preceding Shutdown.
+		a.Shutdown()
+
+		a.mu.Lock()
+		started := a.started
 		accounted := a.accounted
 		a.accounted = false
-		a.cond.Broadcast()
-		started := a.started
 		a.mu.Unlock()
 
 		if started {
@@ -512,4 +536,14 @@ func (a *AsyncReadBuffer) Close() {
 		a.buf = nil
 		a.mu.Unlock()
 	})
+}
+
+// Close stops the fill goroutine and releases resources in a single call. It is
+// equivalent to Shutdown followed by Wait. Callers that own the underlying
+// source should prefer Shutdown → close source → Wait so an in-flight source
+// read is unblocked promptly; Close on its own relies on the bounded safety-net
+// timeout when a source read is wedged.
+func (a *AsyncReadBuffer) Close() {
+	a.Shutdown()
+	a.Wait()
 }

--- a/internal/fuse/backend/asyncbuffer_test.go
+++ b/internal/fuse/backend/asyncbuffer_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -484,5 +486,152 @@ func TestAsyncReadBuffer_BudgetGate(t *testing.T) {
 	}
 	if a2.GetBufferedOffset() == 0 {
 		t.Fatal("a2 should promote after a1 released budget")
+	}
+}
+
+// blockingSource models a source whose read-ahead read blocks on its OWN
+// lifecycle (e.g. the UsenetReader's context) rather than the per-read context
+// the async buffer passes in. Small probe reads are served immediately so the
+// buffer can promote; the first large read-ahead read parks until interrupt()
+// is called — modeling MetadataVirtualFile.Close interrupting an in-flight
+// sequential read. The passed ctx is intentionally ignored on the blocking
+// path, reproducing the cancellation-ownership gap behind the timeout warning.
+type blockingSource struct {
+	data     []byte
+	blockMin int // reads with len(p) >= blockMin block
+
+	blocked    chan struct{} // closed once a read has parked
+	release    chan struct{} // closed by interrupt() to unblock the read
+	blockOnce  sync.Once
+	signalOnce sync.Once
+}
+
+func newBlockingSource(data []byte, blockMin int) *blockingSource {
+	return &blockingSource{
+		data:     data,
+		blockMin: blockMin,
+		blocked:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *blockingSource) ReadAtContext(_ context.Context, p []byte, off int64) (int, error) {
+	if len(p) >= b.blockMin {
+		b.signalOnce.Do(func() { close(b.blocked) })
+		<-b.release // ignore the passed ctx — only an external interrupt unblocks
+		return 0, io.ErrClosedPipe
+	}
+	if off >= int64(len(b.data)) {
+		return 0, io.EOF
+	}
+	return copy(p, b.data[off:]), nil
+}
+
+// interrupt unblocks the parked read, modeling the underlying source being
+// closed by the FUSE handle between Shutdown and Wait.
+func (b *blockingSource) interrupt() { b.blockOnce.Do(func() { close(b.release) }) }
+
+// warnRecorder is a slog.Handler that records whether the drain-timeout warning
+// was emitted.
+type warnRecorder struct {
+	mu  sync.Mutex
+	got bool
+}
+
+func (w *warnRecorder) Enabled(context.Context, slog.Level) bool { return true }
+
+func (w *warnRecorder) Handle(_ context.Context, r slog.Record) error {
+	if strings.Contains(r.Message, "did not exit within timeout") {
+		w.mu.Lock()
+		w.got = true
+		w.mu.Unlock()
+	}
+	return nil
+}
+
+func (w *warnRecorder) WithAttrs([]slog.Attr) slog.Handler { return w }
+func (w *warnRecorder) WithGroup(string) slog.Handler      { return w }
+
+func (w *warnRecorder) warned() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.got
+}
+
+// promoteBlockingSource drives armThreshold sequential reads to promote the
+// buffer, then waits for the fill goroutine to park inside the source read.
+func promoteBlockingSource(t *testing.T, a *AsyncReadBuffer, src *blockingSource) {
+	t.Helper()
+	p := make([]byte, 1024)
+	for i := range armThreshold {
+		if _, err := a.ReadAtContext(context.Background(), p, int64(i*len(p))); err != nil {
+			t.Fatalf("seed read %d: %v", i, err)
+		}
+	}
+	select {
+	case <-src.blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fill goroutine did not start a read-ahead read")
+	}
+}
+
+// TestAsyncReadBuffer_ShutdownThenSourceCloseDrainsPromptly reproduces the
+// Handle.Release ordering (Shutdown → close source → Wait) and verifies the
+// fill goroutine drains promptly without logging the timeout warning — the
+// regression that caused "async read buffer fill goroutine did not exit within
+// timeout" on every Release with read-ahead in flight.
+func TestAsyncReadBuffer_ShutdownThenSourceCloseDrainsPromptly(t *testing.T) {
+	SetAsyncBufferBudget(0)
+	prev := closeDrainTimeout
+	closeDrainTimeout = 2 * time.Second
+	defer func() { closeDrainTimeout = prev }()
+
+	rec := &warnRecorder{}
+	data := testData(4 * 1024 * 1024)
+	src := newBlockingSource(data, 4096)
+	a := NewAsyncReadBuffer(context.Background(), src, 256*1024, int64(len(data)), slog.New(rec))
+
+	promoteBlockingSource(t, a, src)
+
+	// Real Release ordering: signal stop, then unblock the source, then drain.
+	a.Shutdown()
+	src.interrupt()
+
+	start := time.Now()
+	a.Wait()
+	if d := time.Since(start); d >= closeDrainTimeout {
+		t.Fatalf("Wait took %v, expected a prompt drain well under the %v timeout", d, closeDrainTimeout)
+	}
+	if rec.warned() {
+		t.Fatal("timeout warning was logged despite the source being interrupted before Wait")
+	}
+}
+
+// TestAsyncReadBuffer_WaitWithoutSourceCloseHitsSafetyNet verifies the bounded
+// drain remains a safety net: when the source read cannot be unblocked, Wait
+// blocks until closeDrainTimeout and logs the warning.
+func TestAsyncReadBuffer_WaitWithoutSourceCloseHitsSafetyNet(t *testing.T) {
+	SetAsyncBufferBudget(0)
+	prev := closeDrainTimeout
+	closeDrainTimeout = 200 * time.Millisecond
+	defer func() { closeDrainTimeout = prev }()
+
+	rec := &warnRecorder{}
+	data := testData(4 * 1024 * 1024)
+	src := newBlockingSource(data, 4096)
+	a := NewAsyncReadBuffer(context.Background(), src, 256*1024, int64(len(data)), slog.New(rec))
+	defer src.interrupt() // let the parked goroutine exit after the test
+
+	promoteBlockingSource(t, a, src)
+
+	// Close without interrupting the source: the read stays wedged, so the drain
+	// must fall back to the bounded safety-net timeout and log the warning.
+	start := time.Now()
+	a.Close()
+	if d := time.Since(start); d < closeDrainTimeout {
+		t.Fatalf("Close returned in %v, expected it to block until the %v safety-net timeout", d, closeDrainTimeout)
+	}
+	if !rec.warned() {
+		t.Fatal("expected timeout warning when the source read is wedged")
 	}
 }

--- a/internal/fuse/backend/cgofuse/fs.go
+++ b/internal/fuse/backend/cgofuse/fs.go
@@ -135,13 +135,19 @@ func (f *FS) closeHandle(h *openHandle) {
 	if h.stream != nil && f.cfg.StreamTracker != nil {
 		f.cfg.StreamTracker.Remove(h.stream.ID)
 	}
-	// Stop read-ahead before closing the underlying file so the fill goroutine
-	// is drained first.
+	// Signal the fill goroutine to stop, then close the underlying file to
+	// unblock any in-flight source read, then drain the goroutine. A sequential
+	// source read blocks on the source's own context, not the async buffer's,
+	// so the file must be closed between Shutdown and Wait — otherwise Wait
+	// would stall on the wedged read until its safety-net timeout.
 	if h.asyncBuf != nil {
-		h.asyncBuf.Close()
+		h.asyncBuf.Shutdown()
 	}
 	if h.file != nil {
 		_ = h.file.Close()
+	}
+	if h.asyncBuf != nil {
+		h.asyncBuf.Wait()
 	}
 }
 

--- a/internal/fuse/backend/hanwen/handle.go
+++ b/internal/fuse/backend/hanwen/handle.go
@@ -119,16 +119,23 @@ func (h *Handle) Release(ctx context.Context) syscall.Errno {
 		h.stream = nil
 	}
 
-	// Stop read-ahead before closing the underlying file so the fill goroutine
-	// is drained first.
+	// Signal the fill goroutine to stop, then close the underlying file to
+	// unblock any in-flight source read, then drain the goroutine. A sequential
+	// source read blocks on the source's own context, not the async buffer's,
+	// so the file must be closed between Shutdown and Wait — otherwise Wait
+	// would stall on the wedged read until its safety-net timeout.
 	if h.asyncBuf != nil {
-		h.asyncBuf.Close()
+		h.asyncBuf.Shutdown()
 	}
 
 	if h.file != nil {
 		if err := h.file.Close(); err != nil {
 			h.logger.ErrorContext(ctx, "Close failed", "path", h.path, "error", err)
 		}
+	}
+
+	if h.asyncBuf != nil {
+		h.asyncBuf.Wait()
 	}
 
 	return 0


### PR DESCRIPTION
## What

Splits `AsyncReadBuffer.Close()` into `Shutdown()` (signal) + `Wait()` (drain) and reorders both FUSE backends' release paths to `Shutdown()` → `file.Close()` → `Wait()`.

## Why

The backends logged `async read buffer fill goroutine did not exit within timeout` (component `fuse-hanwen`) on nearly every file Release with read-ahead in flight, and stalled Release for up to 5s.

**Root cause — cancellation-ownership gap + bad ordering:**
- `AsyncReadBuffer.Close()` cancelled its *own* context and waited up to `closeDrainTimeout` (5s) for the fill goroutine.
- But the fill goroutine blocks in `src.ReadAtContext` → `MetadataVirtualFile.ReadAtContext` (sequential path) → `UsenetReader.Read` → `segment.GetReaderContext(b.ctx)`, which waits on the **UsenetReader's own context `b.ctx`**, not the per-read ctx the buffer passes. Cancelling the buffer ctx cannot unblock it.
- The only thing that cancels `b.ctx` is `file.Close()` (`MetadataVirtualFile.Close` → `UsenetReader.Interrupt/Close`), which ran *after* `Close()` returned. So the drain always timed out and logged the warning.

## How

- `Shutdown()` — cancel ctx, set `closed=true`, broadcast. No wait. Setting `closed` here guarantees the goroutine exits without issuing another read once unblocked.
- `Wait()` — drain the goroutine, release budget, free buffer. Bounded `closeDrainTimeout` retained as a true safety net.
- `Close()` kept as `Shutdown(); Wait()` for compatibility.
- Both release paths (`hanwen/handle.go` Release, `cgofuse/fs.go` closeHandle) now close the underlying file between `Shutdown` and `Wait`, so the in-flight read is unblocked before the drain.
- `closeDrainTimeout` changed from `const` to `var` so tests can shorten it.

Fixes both the **hanwen (linux)** backend (the one in the report) and the **cgofuse (darwin)** backend, which had the identical latent bug.

## Tests

Added two regression tests using a `blockingSource` that ignores the per-read context (modeling the real source):
- `Shutdown → interrupt → Wait` drains promptly with **no** warning logged.
- `Close()` without interrupting the source still hits the bounded safety-net timeout and logs the warning (proving the net remains).

## Verification

- `go test -race ./internal/fuse/...` — pass
- `go build ./...`, `go vet`, `gofmt` — clean
- Note: `hanwen/handle.go` is `//go:build linux` and could not be compiled on the darwin dev host (pre-existing `rapidyenc` cgo cross-compile limitation). It mirrors the verified cgofuse change and uses the same tested `Shutdown`/`Wait` methods — **please confirm the linux build in CI**.

## Reviewer notes

The cgofuse fix is slightly beyond a strict hanwen-only scope, included because it's the same root cause and would otherwise leave the darwin backend with the same defect.
