### PR TITLE
feat(queue): default sort to newest-first and pin active items to top

### DIFF
--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -77,7 +77,7 @@ export function QueuePage() {
 	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(
 		"created_at",
 	);
-	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
 
 	const queryClient = useQueryClient();
 
@@ -110,11 +110,16 @@ export function QueuePage() {
 
 	const enrichedQueueData = useMemo(() => {
 		if (!queueData) return undefined;
-		return queueData.map((item) => ({
+		const enriched = queueData.map((item) => ({
 			...item,
 			percentage: liveProgress[item.id]?.percentage ?? item.percentage,
 			stage: liveProgress[item.id]?.stage,
 		}));
+		return enriched.sort((a, b) => {
+			const aActive = a.status === QueueStatus.PROCESSING ? 0 : 1;
+			const bActive = b.status === QueueStatus.PROCESSING ? 0 : 1;
+			return aActive - bActive;
+		});
 	}, [queueData, liveProgress]);
 
 	const { data: stats } = useQueueStats();


### PR DESCRIPTION
## Summary

- Change default queue sort order from ascending to descending so newly added items appear at the top
- Pin `PROCESSING` (active) items above all others via client-side sort so active imports are always immediately visible

## Test plan

- [ ] Open the queue page — items should be sorted newest-first by default
- [ ] Start an import — the active item should jump to the top of the list regardless of creation time
- [ ] Manually change the sort column/order — the active-first pinning should still apply within the new sort