### PR TITLE
fix(importer): reconstruct multi-volume RAR sets with reposted/rollover volumes

### DIFF
--- a/internal/api/file_handlers.go
+++ b/internal/api/file_handlers.go
@@ -326,7 +326,7 @@ type BatchExportRequest struct {
 
 // Archive detection patterns
 var (
-	rarPattern      = regexp.MustCompile(`(?i)\.r(ar|\d+)$|\.part\d+\.rar$`)
+	rarPattern      = regexp.MustCompile(`(?i)\.(?:rar|r\d+|[r-z]\d{2})$|\.part\d+\.rar$`)
 	sevenZipPattern = regexp.MustCompile(`(?i)\.7z$|\.7z\.\d+$`)
 	archiveExts     = []string{".rar", ".7z", ".zip", ".tar", ".gz", ".bz2", ".arj", ".arc"}
 )

--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -440,7 +440,11 @@ func GroupArchivesByBaseName(files []parser.ParsedFile) [][]parser.ParsedFile {
 	for _, k := range keys {
 		groups = append(groups, groupMap[k])
 	}
-	return groups
+
+	// A single physical RAR set whose first volume was reposted under a different
+	// base name (e.g. movie.repost.part01.rar alongside movie.r00..) splits into
+	// multiple groups above; fold it back into one set so the whole archive maps.
+	return reconcileRepostedFirstVolume(groups)
 }
 
 // normalizeArchiveReleaseFilename aligns the filename to the NZB basename while keeping the original extension.

--- a/internal/importer/archive/rar/aggregator_test.go
+++ b/internal/importer/archive/rar/aggregator_test.go
@@ -17,6 +17,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestGroupArchivesByBaseNameOldStyleRollover is a regression test for old-style
+// multi-volume RAR sets that roll over past .r99 into .s00…/.t00…/… . Every volume
+// must land in a SINGLE group so the full set is handed to rardecode together;
+// before the fix, .sNN..zNN failed SetKey and each became its own singleton group,
+// starving rardecode of the continuation volumes and truncating the extracted file.
+func TestGroupArchivesByBaseNameOldStyleRollover(t *testing.T) {
+	names := oldRollSet("movie", 12) // movie.rar, .r00..r99, .s00..s12 (114 volumes)
+	files := make([]parser.ParsedFile, len(names))
+	for i, n := range names {
+		files[i] = parser.ParsedFile{Filename: n}
+	}
+
+	groups := GroupArchivesByBaseName(files)
+
+	if len(groups) != 1 {
+		t.Fatalf("GroupArchivesByBaseName produced %d groups; want 1 (all volumes in one set)", len(groups))
+	}
+	if len(groups[0]) != len(names) {
+		t.Errorf("group has %d volumes; want %d (no volume dropped)", len(groups[0]), len(names))
+	}
+}
+
 // mockRarProcessor is a test double for the Processor interface that returns
 // pre-configured contents without hitting Usenet.
 type mockRarProcessor struct {
@@ -316,22 +338,22 @@ func TestProcessArchivePreservesInternalFolderStructure(t *testing.T) {
 			}
 
 			err := ProcessArchive(ctx, ProcessArchiveOptions{
-				VirtualDir:              tt.virtualDir,
-				ArchiveFiles:            []parser.ParsedFile{{Filename: "archive.rar"}},
-				Password:                "",
-				ReleaseDate:             0,
-				NzbPath:                 tt.nzbPath,
-				Processor:               proc,
-				MetadataService:         svc,
+				VirtualDir:             tt.virtualDir,
+				ArchiveFiles:           []parser.ParsedFile{{Filename: "archive.rar"}},
+				Password:               "",
+				ReleaseDate:            0,
+				NzbPath:                tt.nzbPath,
+				Processor:              proc,
+				MetadataService:        svc,
 				PoolManager:            nil,
 				ArchiveProgressTracker: nil,
 				AllowedFileExtensions:  nil,
 				ExtractedFiles:         extracted,
-				MaxPrefetch:             1,
-				ReadTimeout:             30 * time.Second,
-				ExpandBlurayIso:         false,
-				FilterSamples:           false,
-				RenameToNzbName:         tt.renameToNzbName,
+				MaxPrefetch:            1,
+				ReadTimeout:            30 * time.Second,
+				ExpandBlurayIso:        false,
+				FilterSamples:          false,
+				RenameToNzbName:        tt.renameToNzbName,
 			})
 			require.NoError(t, err)
 

--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -324,6 +324,17 @@ func (rh *rarProcessor) parseRarFilename(filename string) (base string, part int
 		}
 	}
 
+	// Pattern 3b: old-style rollover volumes .s##..z## (continuation after .r99).
+	// The extension letter rolls r→s→…→z, so the part number stays contiguous:
+	// .r00=0, .r99=99, .s00=100, …, .z99=899 — keeping volumes correctly ordered.
+	if matches := RollVolPattern.FindStringSubmatch(filename); len(matches) > 3 {
+		base = matches[1]
+		letter := strings.ToLower(matches[2])[0]
+		if nn := archive.ParseInt(matches[3]); nn >= 0 {
+			return base, int(letter-'r')*100 + nn
+		}
+	}
+
 	// Pattern 4: filename.### (numeric extensions like .001, .002)
 	if matches := NumericPattern.FindStringSubmatch(filename); len(matches) > 2 {
 		base = matches[1]
@@ -500,6 +511,9 @@ func isRarArchiveFile(filename string) bool {
 		return true
 	}
 	if RPattern.MatchString(lower) {
+		return true
+	}
+	if RollVolPattern.MatchString(lower) {
 		return true
 	}
 	return false

--- a/internal/importer/archive/rar/reconcile_test.go
+++ b/internal/importer/archive/rar/reconcile_test.go
@@ -1,0 +1,83 @@
+package rar
+
+import (
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/javi11/altmount/internal/importer/parser"
+)
+
+// TestGroupArchivesReconcilesRepostedFirstVolume reproduces the real-world failure
+// where one physical RAR set has its first volume reposted under a different base
+// name (Zero.Effect...monkee.repost.part01.rar) while every continuation volume keeps
+// the original base (Zero.Effect...monkee.r00..r99 / .s00..s12, with no plain .rar).
+//
+// Grouping by base name splits this into the lone part01.rar group plus continuation
+// groups, so only part01.rar (the one volume with a real archive header) ever gets
+// mapped — exactly one ~100k volume, which is why streaming reported far fewer bytes
+// than the file size. The reconciliation must fold everything into one set and rename
+// the reposted first volume to <base>.rar so rardecode follows the whole sequence.
+func TestGroupArchivesReconcilesRepostedFirstVolume(t *testing.T) {
+	const base = "Zero.Effect.1998.1080p.AMZN.WEBRip.DD5.1.x264-monkee"
+
+	var names []string
+	names = append(names, base+".repost.part01.rar") // reposted first volume, different base
+	for i := 0; i <= 99; i++ {
+		names = append(names, fmt.Sprintf("%s.r%02d", base, i))
+	}
+	for i := 0; i <= 12; i++ {
+		names = append(names, fmt.Sprintf("%s.s%02d", base, i))
+	}
+
+	files := make([]parser.ParsedFile, len(names))
+	for i, n := range names {
+		files[i] = parser.ParsedFile{Filename: n, OriginalIndex: i}
+	}
+
+	groups := GroupArchivesByBaseName(files)
+
+	if len(groups) != 1 {
+		t.Fatalf("got %d groups; want 1 (single physical RAR set)", len(groups))
+	}
+	g := groups[0]
+	if len(g) != len(names) {
+		t.Fatalf("merged group has %d volumes; want %d (no volume dropped)", len(g), len(names))
+	}
+
+	// The reposted first volume must be renamed to <continuation-base>.rar so the set
+	// shares one base and rardecode's old-style volume following reaches every part.
+	want := base + ".rar"
+	if g[0].Filename != want {
+		t.Errorf("first volume = %q; want %q", g[0].Filename, want)
+	}
+	if g[1].Filename != base+".r00" {
+		t.Errorf("second volume = %q; want %q (continuations ordered by volume number)", g[1].Filename, base+".r00")
+	}
+	if last := g[len(g)-1].Filename; last != base+".s12" {
+		t.Errorf("last volume = %q; want %q", last, base+".s12")
+	}
+
+	rh := &rarProcessor{log: slog.Default()}
+	gnames := make([]string, len(g))
+	for i, f := range g {
+		gnames[i] = f.Filename
+	}
+	first, err := rh.getFirstRarPart(gnames)
+	if err != nil || first != want {
+		t.Errorf("getFirstRarPart = %q, err=%v; want %q", first, err, want)
+	}
+}
+
+// TestReconcileLeavesSeparateArchivesAlone guards the conservative gate: two genuinely
+// independent archives (each with its own first volume) must NOT be merged.
+func TestReconcileLeavesSeparateArchivesAlone(t *testing.T) {
+	files := []parser.ParsedFile{
+		{Filename: "MovieA.rar"}, {Filename: "MovieA.r00"}, {Filename: "MovieA.r01"},
+		{Filename: "MovieB.rar"}, {Filename: "MovieB.r00"}, {Filename: "MovieB.r01"},
+	}
+	groups := GroupArchivesByBaseName(files)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups; want 2 (two independent archives must stay separate)", len(groups))
+	}
+}

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -169,6 +169,153 @@ func groupHasVolumeGap(files []parser.ParsedFile) bool {
 	return false
 }
 
+// groupHasFirstVolume reports whether a RAR group contains the volume that begins
+// an archive (the one carrying the main header): the plain .rar for the roll
+// scheme, .part01.rar for the part scheme, or .001 for the numeric scheme. A group
+// made only of continuation volumes (.r00.., .s00.., .002..) returns false — it
+// cannot start an archive on its own.
+func groupHasFirstVolume(files []parser.ParsedFile) bool {
+	for _, f := range files {
+		s, n, ok := rarVolumeNumber(f.Filename)
+		if !ok {
+			continue
+		}
+		start := 1
+		if s == schemeRoll {
+			start = 0
+		}
+		if n == start {
+			return true
+		}
+	}
+	return false
+}
+
+// orphanFirstVolumeName derives the name the missing first volume would have for a
+// set of continuation volumes, preserving the original base name's case so
+// rardecode's name-based volume following matches the real continuation files.
+func orphanFirstVolumeName(orphan string, scheme rarScheme) (string, bool) {
+	switch scheme {
+	case schemeRoll:
+		if m := RollVolPattern.FindStringSubmatch(orphan); len(m) > 1 {
+			return m[1] + ".rar", true
+		}
+		if m := RPattern.FindStringSubmatch(orphan); len(m) > 1 {
+			return m[1] + ".rar", true
+		}
+	case schemeNumeric:
+		if m := NumericPattern.FindStringSubmatch(orphan); len(m) > 1 {
+			return m[1] + ".001", true
+		}
+	}
+	return "", false
+}
+
+// baseExtends reports whether one base name is the other extended by a "."-delimited
+// suffix (or they are equal) — the signal that a reposted first volume belongs to the
+// same release as its continuations (e.g. "movie.x264" and "movie.x264.repost").
+func baseExtends(a, b string) bool {
+	if a == b {
+		return true
+	}
+	long, short := a, b
+	if len(b) > len(a) {
+		long, short = b, a
+	}
+	return strings.HasPrefix(long, short) && long[len(short)] == '.'
+}
+
+// reconcileRepostedFirstVolume handles a single physical RAR set whose first volume
+// was reposted under a different base name (e.g. movie.repost.part01.rar) while its
+// continuation volumes keep the original base (movie.r00, movie.r01, …). Grouping by
+// base name splits these apart, isolating the only volume with a real archive header
+// from its continuations, so only that one volume ever gets mapped.
+//
+// When EXACTLY ONE group is a lone first volume and every other group is pure
+// continuations sharing one roll/numeric scheme, those continuations can only belong
+// to that first volume. We rename the first volume to the continuations' first-volume
+// name (so the whole set shares one base and rardecode follows it natively) and merge
+// everything into a single group ordered by volume number. The guards are deliberately
+// strict: any ambiguity (zero or multiple starters, a multi-volume starter, a
+// part-scheme or unrecognized orphan, mixed orphan schemes) leaves grouping untouched.
+func reconcileRepostedFirstVolume(groups [][]parser.ParsedFile) [][]parser.ParsedFile {
+	if len(groups) < 2 {
+		return groups
+	}
+
+	starterIdx := -1
+	for i, g := range groups {
+		if groupHasFirstVolume(g) {
+			if starterIdx >= 0 {
+				return groups // more than one group can start → genuinely separate archives
+			}
+			starterIdx = i
+		}
+	}
+	if starterIdx < 0 || len(groups[starterIdx]) != 1 {
+		return groups // no anchor, or the starter is itself a multi-volume set
+	}
+
+	var orphans []parser.ParsedFile
+	orphanScheme := schemeUnknown
+	orphanBase := ""
+	for i, g := range groups {
+		if i == starterIdx {
+			continue
+		}
+		base, ok := SetKey(g[0].Filename)
+		if !ok {
+			return groups
+		}
+		if orphanBase == "" {
+			orphanBase = base
+		} else if base != orphanBase {
+			return groups // orphans from different releases → not one set
+		}
+		for _, f := range g {
+			s, _, ok := rarVolumeNumber(f.Filename)
+			if !ok || s == schemePart {
+				return groups // unrecognized or part-scheme orphan → too risky to merge
+			}
+			if orphanScheme == schemeUnknown {
+				orphanScheme = s
+			} else if s != orphanScheme {
+				return groups // mixed orphan schemes → ambiguous
+			}
+		}
+		orphans = append(orphans, g...)
+	}
+	if len(orphans) == 0 {
+		return groups
+	}
+
+	// Only merge when the reposted first volume clearly belongs to the same release:
+	// its base must be the continuations' base extended by a ".<suffix>" (e.g.
+	// "movie" → "movie.repost"). Unrelated bases (a continuation set plus a different
+	// single-part archive in the same NZB) are left as separate groups.
+	starterBase, ok := SetKey(groups[starterIdx][0].Filename)
+	if !ok || !baseExtends(starterBase, orphanBase) {
+		return groups
+	}
+
+	// Order continuations by volume ordinal (contiguous across the r→s rollover).
+	sort.SliceStable(orphans, func(a, b int) bool {
+		_, na, _ := rarVolumeNumber(orphans[a].Filename)
+		_, nb, _ := rarVolumeNumber(orphans[b].Filename)
+		return na < nb
+	})
+
+	firstName, ok := orphanFirstVolumeName(orphans[0].Filename, orphanScheme)
+	if !ok {
+		return groups
+	}
+
+	starter := groups[starterIdx][0]
+	starter.Filename = firstName
+	merged := append([]parser.ParsedFile{starter}, orphans...)
+	return [][]parser.ParsedFile{merged}
+}
+
 // normalizeRarPartFilename normalizes RAR part numbers while preserving padding width
 // If allFilesNoExt is true, uses baseFilename for all parts with .rXX extension
 // where XX is the 0-based part number (index) with zero-padding based on totalFiles

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -18,9 +18,15 @@ var (
 	// NumericPattern matches filename.### (numeric extensions like .001, .002)
 	NumericPattern = regexp.MustCompile(`^(.+)\.(\d+)$`)
 	// RPattern matches filename.r## or filename.r### (e.g., movie.r00, movie.r01)
-	RPattern             = regexp.MustCompile(`^(.+)\.r(\d+)$`)
+	RPattern = regexp.MustCompile(`^(.+)\.r(\d+)$`)
+	// RollVolPattern matches old-style continuation volumes whose extension letter
+	// rolls after .r99 (r→s→…→z), always with two digits — e.g. movie.s00 is the
+	// volume right after movie.r99. Mirrors rardecode's nextOldVolName. The leading
+	// .rar is volume 0; .r00 is volume 1. Group 1 is the base, 2 the letter, 3 the digits.
+	RollVolPattern       = regexp.MustCompile(`(?i)^(.+)\.([r-z])(\d{2})$`)
 	partPatternNumber    = regexp.MustCompile(`\.part(\d+)\.rar$`)
 	rPatternNumber       = regexp.MustCompile(`\.r(\d+)$`)
+	rollVolPatternNumber = regexp.MustCompile(`(?i)\.([r-z])(\d{2})$`)
 	numericPatternNumber = regexp.MustCompile(`\.(\d+)$`)
 )
 
@@ -43,6 +49,10 @@ func SetKey(filename string) (string, bool) {
 	}
 	// Pattern 3: filename.r##
 	if m := RPattern.FindStringSubmatch(lower); len(m) > 1 {
+		return m[1], true
+	}
+	// Pattern 3b: old-style rollover volumes .s##..z## (continuation after .r99)
+	if m := RollVolPattern.FindStringSubmatch(lower); len(m) > 1 {
 		return m[1], true
 	}
 	// Pattern 4: filename.### (numeric)
@@ -89,6 +99,15 @@ func rarVolumeNumber(filename string) (rarScheme, int, bool) {
 	}
 	if strings.HasSuffix(lower, ".rar") {
 		return schemeRoll, 0, true
+	}
+	// Old-style continuation volumes .r00..z99. The extension letter rolls after
+	// .r99 (r→s→…→z), so the ordinal must stay contiguous across the boundary:
+	// .r00=1, .r99=100, .s00=101, …, .z99=900. (.rar=0 is handled above.)
+	if m := rollVolPatternNumber.FindStringSubmatch(lower); len(m) > 2 {
+		letter := m[1][0]
+		if nn := archive.ParseInt(m[2]); nn >= 0 {
+			return schemeRoll, 1 + int(letter-'r')*100 + nn, true
+		}
 	}
 	if m := rPatternNumber.FindStringSubmatch(lower); len(m) > 1 {
 		if n := archive.ParseInt(m[1]); n >= 0 {

--- a/internal/importer/archive/rar/utils_test.go
+++ b/internal/importer/archive/rar/utils_test.go
@@ -1,6 +1,7 @@
 package rar
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/javi11/altmount/internal/importer/parser"
@@ -18,6 +19,10 @@ func TestSetKey(t *testing.T) {
 		{"plain rar", "movie.rar", "movie", true},
 		{"old roll r00", "movie.r00", "movie", true},
 		{"old roll r15", "movie.r15", "movie", true},
+		{"old roll rollover s00", "movie.s00", "movie", true},
+		{"old roll rollover s12", "movie.s12", "movie", true},
+		{"old roll rollover z99", "movie.z99", "movie", true},
+		{"old roll rollover uppercase", "Movie.Name.S00", "movie.name", true},
 		{"numeric", "archive.001", "archive", true},
 		{"7z numeric", "archive.7z.001", "archive.7z", true},
 		{"strips directory", "sub/dir/movie.part02.rar", "movie", true},
@@ -57,6 +62,8 @@ func TestGroupHasVolumeGap(t *testing.T) {
 		{"old roll contiguous", files("m.rar", "m.r00", "m.r01"), false},
 		{"old roll missing first volume", files("m.r00", "m.r01"), true},
 		{"old roll interior gap", files("m.rar", "m.r00", "m.r02"), true},
+		{"old roll full rollover into s contiguous", files(oldRollSet("m", 12)...), false},
+		{"old roll rollover missing s00", files(oldRollSetSkip("m", 12, "m.s00")...), true},
 		{"numeric contiguous", files("a.001", "a.002", "a.003"), false},
 		{"numeric gap", files("a.001", "a.003"), true},
 		{"numeric missing first", files("a.002", "a.003"), true},
@@ -72,4 +79,61 @@ func TestGroupHasVolumeGap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRarVolumeNumber(t *testing.T) {
+	tests := []struct {
+		name       string
+		filename   string
+		wantScheme rarScheme
+		wantNum    int
+		wantOK     bool
+	}{
+		{"first volume .rar", "movie.rar", schemeRoll, 0, true},
+		{"old roll r00", "movie.r00", schemeRoll, 1, true},
+		{"old roll r99", "movie.r99", schemeRoll, 100, true},
+		// Old-style naming rolls .r99 -> .s00, so s00 must be the volume right after
+		// r99 (contiguous ordinal) — otherwise gap detection misfires.
+		{"old roll rollover s00", "movie.s00", schemeRoll, 101, true},
+		{"old roll rollover s12", "movie.s12", schemeRoll, 113, true},
+		{"old roll rollover z99", "movie.z99", schemeRoll, 900, true},
+		{"old roll rollover uppercase", "Movie.S00", schemeRoll, 101, true},
+		{"part scheme", "movie.part02.rar", schemePart, 2, true},
+		{"numeric scheme", "archive.003", schemeNumeric, 3, true},
+		{"not a volume", "movie.mkv", schemeUnknown, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, n, ok := rarVolumeNumber(tt.filename)
+			if s != tt.wantScheme || n != tt.wantNum || ok != tt.wantOK {
+				t.Errorf("rarVolumeNumber(%q) = (%v, %d, %t); want (%v, %d, %t)",
+					tt.filename, s, n, ok, tt.wantScheme, tt.wantNum, tt.wantOK)
+			}
+		})
+	}
+}
+
+// oldRollSet returns a full old-style multi-volume RAR set name list:
+// base.rar, base.r00..base.r99, base.s00..base.s{sCount}.
+func oldRollSet(base string, sCount int) []string {
+	names := []string{base + ".rar"}
+	for i := 0; i <= 99; i++ {
+		names = append(names, fmt.Sprintf("%s.r%02d", base, i))
+	}
+	for i := 0; i <= sCount; i++ {
+		names = append(names, fmt.Sprintf("%s.s%02d", base, i))
+	}
+	return names
+}
+
+// oldRollSetSkip returns oldRollSet with the named volume removed, simulating a gap.
+func oldRollSetSkip(base string, sCount int, skip string) []string {
+	all := oldRollSet(base, sCount)
+	out := all[:0:0]
+	for _, n := range all {
+		if n != skip {
+			out = append(out, n)
+		}
+	}
+	return out
 }

--- a/internal/importer/archive/sevenzip/processor.go
+++ b/internal/importer/archive/sevenzip/processor.go
@@ -55,6 +55,7 @@ var (
 var (
 	rarPartPattern    = rar.PartPattern
 	rarRPattern       = rar.RPattern
+	rarRollPattern    = rar.RollVolPattern
 	rarNumericPattern = rar.NumericPattern
 )
 
@@ -660,6 +661,9 @@ func isRarArchiveFile(filename string) bool {
 	if rarRPattern.MatchString(lower) {
 		return true
 	}
+	if rarRollPattern.MatchString(lower) {
+		return true
+	}
 	return false
 }
 
@@ -689,6 +693,15 @@ func parseRarFilename(filename string) (base string, part int) {
 		base = matches[1]
 		if partNum := archive.ParseInt(matches[2]); partNum >= 0 {
 			return base, partNum
+		}
+	}
+
+	// Pattern 3b: old-style rollover volumes .s##..z## (continuation after .r99).
+	if matches := rarRollPattern.FindStringSubmatch(filename); len(matches) > 3 {
+		base = matches[1]
+		letter := strings.ToLower(matches[2])[0]
+		if nn := archive.ParseInt(matches[3]); nn >= 0 {
+			return base, int(letter-'r')*100 + nn
 		}
 	}
 

--- a/internal/importer/parser/fileinfo/detector.go
+++ b/internal/importer/parser/fileinfo/detector.go
@@ -20,8 +20,10 @@ var (
 		".mkv": true, ".mk3d": true, ".ts": true, ".wtv": true, ".m2ts": true,
 	}
 
-	// RAR file pattern: .rar or .r00, .r01, etc.
-	rarPattern = regexp.MustCompile(`(?i)\.r(ar|\d+)$|\.part\d+\.rar$`)
+	// RAR file pattern: .rar, .r00/.r01…, the old-style rollover continuation
+	// volumes .s00…/.t00…/… up to .z99 (the extension letter rolls r→s→…→z after
+	// .r99), and .partNN.rar.
+	rarPattern = regexp.MustCompile(`(?i)\.(?:rar|r\d+|[r-z]\d{2})$|\.part\d+\.rar$`)
 
 	// 7z file pattern: .7z or .7z.001, .7z.002, etc.
 	sevenZipPattern = regexp.MustCompile(`(?i)\.7z(\.(\d+))?$`)

--- a/internal/importer/parser/fileinfo/detector_test.go
+++ b/internal/importer/parser/fileinfo/detector_test.go
@@ -1,0 +1,33 @@
+package fileinfo
+
+import "testing"
+
+func TestIsRarFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{"plain rar", "movie.rar", true},
+		{"old roll r00", "movie.r00", true},
+		{"old roll r99", "movie.r99", true},
+		// Old-style naming rolls .r99 -> .s00 -> ... -> .z99; these continuation
+		// volumes must be recognized as RAR parts or they get dropped from the set.
+		{"old roll rollover s00", "movie.s00", true},
+		{"old roll rollover s12", "movie.s12", true},
+		{"old roll rollover z99", "movie.z99", true},
+		{"part rar", "movie.part01.rar", true},
+		{"uppercase rollover", "MOVIE.S00", true},
+		{"plain media file", "movie.mkv", false},
+		{"par2", "movie.par2", false},
+		{"nfo", "movie.nfo", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRarFile(tt.filename); got != tt.want {
+				t.Errorf("IsRarFile(%q) = %t; want %t", tt.filename, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/importer/utils/file_extensions.go
+++ b/internal/importer/utils/file_extensions.go
@@ -11,8 +11,9 @@ import (
 // popular/likely file extensions, adapted to Go.
 
 var (
-	// Pattern to detect RAR files
-	rarPattern = regexp.MustCompile(`(?i)\.r(ar|\d+)$|\.part\d+\.rar$`)
+	// Pattern to detect RAR files, including old-style rollover continuation
+	// volumes (.s00…/.t00…/… up to .z99 — the extension letter rolls r→s→…→z after .r99).
+	rarPattern = regexp.MustCompile(`(?i)\.(?:rar|r\d+|[r-z]\d{2})$|\.part\d+\.rar$`)
 	// Pattern to detect 7zip files
 	sevenZipPattern = regexp.MustCompile(`(?i)\.7z$|\.7z\.\d+$`)
 )


### PR DESCRIPTION
## Problem

Streaming an extracted `.mkv` failed with:

```
[createUsenetReader] No segments to download start=0 end=11575329534
  available_bytes=102400000 expected_file_size=11575329535
```

The release is **one physical multi-volume RAR set** with two quirks that broke import:

1. **Reposted first volume under a different base name.** The only volume with a real RAR header is `…x264-monkee.repost.part01.rar`, while every continuation keeps the original base: `…x264-monkee.r00`…`.r99` then the old-style rollover `…x264-monkee.s00`…`.s12`. There is no plain `…x264-monkee.rar`.
2. **Old-style letter rollover** past `.r99` into `.s00`…`.z99`, which AltMount didn't recognize at all.

`GroupArchivesByBaseName` split this single set by base name, isolating `part01.rar` (base `…monkee.repost`) from its continuations (base `…monkee`). Only the `part01.rar` group had a usable archive header, so `rardecode` mapped **just that one volume** = exactly `102400000` bytes (one `-v100000k` volume), truncating the ~11.5 GB `.mkv`.

Confirmed with a deterministic reproduction at the grouping seam (15 groups pre-fix; the `part01.rar` group analyzed alone).

## Fix

Two composing changes:

- **`.sNN`…`.zNN` rollover recognition** (`utils.go` `RollVolPattern`/`rarVolumeNumber`, `detector.go`, `file_extensions.go`, `file_handlers.go`, sevenzip): the continuation letter rolls `r→s→…→z` after `.r99`. `rarVolumeNumber` now returns a **contiguous** ordinal across the boundary (`.r99`=100, `.s00`=101) so the continuations group and order correctly.
- **Reposted-first-volume reconciliation** (`utils.go` `reconcileRepostedFirstVolume`, wired into `GroupArchivesByBaseName`): when exactly one group is a lone first volume and the others are pure continuations sharing one scheme **and** a base the first volume's base merely extends by a `.<suffix>` (the repost signal), fold them into one set, rename the first volume to `<base>.rar`, and order continuations by volume number. `rardecode` then follows the whole archive natively via `nextOldVolName`.

Conservative guards keep genuinely separate archives untouched (unrelated bases, multiple first volumes, multi-volume starters) — verified by the existing `TestGroupArchivesByBaseName` (a continuation set + an unrelated single-part archive stays 2 groups).

## Tests

- `TestGroupArchivesReconcilesRepostedFirstVolume` — the real Zero.Effect shape (114 volumes) collapses to one group with the first volume renamed to `<base>.rar`.
- `TestReconcileLeavesSeparateArchivesAlone` + existing `TestGroupArchivesByBaseName` — unrelated archives stay separate.
- `IsRarFile`/`SetKey`/`rarVolumeNumber`/`groupHasVolumeGap` rollover cases.

`go build ./...`, `go test -race ./internal/importer/...`, and `./internal/api/` all pass.

## Validation needed

This fixes import-time grouping/ordering. The byte-level RAR reconstruction across the renamed sequence relies on `rardecode` following `<base>.rar` → `.r00` → … (which it does for normal old-style sets); it can't be exercised offline without the real volumes. **Please re-import this NZB** (existing metadata is partial and won't self-heal) and confirm streaming works end-to-end.