### PR TITLE
feat(ci): publish Docker images to DockerHub (laris11/altmount)

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -10,6 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DOCKERHUB_IMAGE: laris11/altmount
 
 jobs:
   test:
@@ -140,12 +141,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Container Registry
+      - name: Log in to Container Registry (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Container Registry (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Normalize image name
         id: normalize
@@ -161,7 +168,9 @@ jobs:
           file: docker/Dockerfile.ci
           platforms: linux/amd64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}:dev-amd64-temp
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}:dev-amd64-temp
+            ${{ env.DOCKERHUB_IMAGE }}:dev-amd64-temp
           cache-from: type=gha,scope=dev-amd64
           cache-to: type=gha,mode=max,scope=dev-amd64
           provenance: false
@@ -190,12 +199,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to Container Registry
+      - name: Log in to Container Registry (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Container Registry (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Normalize image name
         id: normalize
@@ -211,7 +226,9 @@ jobs:
           file: docker/Dockerfile.ci
           platforms: linux/arm64
           push: true
-          tags: ${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}:dev-arm64-temp
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}:dev-arm64-temp
+            ${{ env.DOCKERHUB_IMAGE }}:dev-arm64-temp
           cache-from: type=gha,scope=dev-arm64
           cache-to: type=gha,mode=max,scope=dev-arm64
           provenance: false
@@ -228,12 +245,18 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Log in to Container Registry
+      - name: Log in to Container Registry (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Container Registry (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Normalize image name
         id: normalize
@@ -243,31 +266,36 @@ jobs:
         id: timestamp
         run: echo "timestamp=$(TZ='America/New_York' date +'%Y%m%d-%H%M')" >> $GITHUB_OUTPUT
 
-      - name: Create and push manifest
+      - name: Create and push manifest (GHCR)
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}
           AMD64_IMAGE="${IMAGE}:dev-amd64-temp"
           ARM64_IMAGE="${IMAGE}:dev-arm64-temp"
           TIMESTAMP_TAG="dev_${{ steps.timestamp.outputs.timestamp }}"
 
-          echo "AMD64 Image: $AMD64_IMAGE"
-          echo "ARM64 Image: $ARM64_IMAGE"
-          echo "Creating multi-arch manifest: ${IMAGE}:dev"
-          echo "Creating multi-arch manifest: ${IMAGE}:${TIMESTAMP_TAG}"
-
-          docker manifest create ${IMAGE}:dev \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
+          docker manifest create ${IMAGE}:dev $AMD64_IMAGE $ARM64_IMAGE
           docker manifest push ${IMAGE}:dev
 
-          docker manifest create ${IMAGE}:${TIMESTAMP_TAG} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
+          docker manifest create ${IMAGE}:${TIMESTAMP_TAG} $AMD64_IMAGE $ARM64_IMAGE
           docker manifest push ${IMAGE}:${TIMESTAMP_TAG}
+
+      - name: Create and push manifest (DockerHub)
+        run: |
+          DH=${{ env.DOCKERHUB_IMAGE }}
+          AMD64_IMAGE="${DH}:dev-amd64-temp"
+          ARM64_IMAGE="${DH}:dev-arm64-temp"
+          TIMESTAMP_TAG="dev_${{ steps.timestamp.outputs.timestamp }}"
+
+          docker manifest create ${DH}:dev $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:dev
+
+          docker manifest create ${DH}:${TIMESTAMP_TAG} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:${TIMESTAMP_TAG}
 
       - name: Clean up temporary tags
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ steps.normalize.outputs.image_name }}
-
           docker manifest rm ${IMAGE}:dev-amd64-temp || true
           docker manifest rm ${IMAGE}:dev-arm64-temp || true
+          docker manifest rm ${{ env.DOCKERHUB_IMAGE }}:dev-amd64-temp || true
+          docker manifest rm ${{ env.DOCKERHUB_IMAGE }}:dev-arm64-temp || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ on:
         default: false
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+  DOCKERHUB_IMAGE: laris11/altmount
 
 jobs:
   test:
@@ -178,19 +177,27 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # docker login
-      - name: Docker login
+      - name: Docker login (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker login (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Extract metadata for tags and labels
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=ref,event=tag,suffix=-amd64-temp
             type=semver,pattern={{version}},suffix=-amd64-temp
@@ -241,19 +248,27 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # docker login
-      - name: Docker login
+      - name: Docker login (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Docker login (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Extract metadata for tags and labels
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=ref,event=tag,suffix=-arm64-temp
             type=semver,pattern={{version}},suffix=-arm64-temp
@@ -294,12 +309,18 @@ jobs:
           echo "IMAGE_NAME_LC=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       # docker login
-      - name: Docker login
+      - name: Docker login (GHCR)
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker login (DockerHub)
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract version from tag
       - name: Extract version
@@ -318,67 +339,64 @@ jobs:
           echo "minor=$MINOR" >> $GITHUB_OUTPUT
 
       # Create and push multi-platform manifests using temporary tags
-      - name: Create multi-platform manifest
+      - name: Create multi-platform manifest (GHCR)
         run: |
-          # Use temporary tagged images instead of digests
           AMD64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-amd64-temp"
           ARM64_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-arm64-temp"
+          GHCR="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}"
 
-          echo "AMD64 Image: $AMD64_IMAGE"
-          echo "ARM64 Image: $ARM64_IMAGE"
+          docker manifest create ${GHCR}:v${{ steps.version.outputs.version }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:v${{ steps.version.outputs.version }}
 
-          # Create and push version-specific manifest (v1.2.3)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}
+          docker manifest create ${GHCR}:${{ steps.version.outputs.version }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:${{ steps.version.outputs.version }}
 
-          # Create and push semver version manifest (1.2.3)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.version }}
+          docker manifest create ${GHCR}:v${{ steps.version.outputs.major }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:v${{ steps.version.outputs.major }}
 
-          # Create and push major version manifest (v1)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}
+          docker manifest create ${GHCR}:${{ steps.version.outputs.major }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:${{ steps.version.outputs.major }}
 
-          # Create and push major version manifest (1)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}
+          docker manifest create ${GHCR}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
 
-          # Create and push major.minor version manifest (v1.2)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          docker manifest create ${GHCR}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
 
-          # Create and push major.minor version manifest (1.2)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          docker manifest create ${GHCR}:latest $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${GHCR}:latest
 
-          # Create and push latest manifest (multi-arch)
-          docker manifest create \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest \
-            $AMD64_IMAGE \
-            $ARM64_IMAGE
-          docker manifest push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest
+      - name: Create multi-platform manifest (DockerHub)
+        run: |
+          AMD64_IMAGE="${{ env.DOCKERHUB_IMAGE }}:v${{ steps.version.outputs.version }}-amd64-temp"
+          ARM64_IMAGE="${{ env.DOCKERHUB_IMAGE }}:v${{ steps.version.outputs.version }}-arm64-temp"
+          DH="${{ env.DOCKERHUB_IMAGE }}"
+
+          docker manifest create ${DH}:v${{ steps.version.outputs.version }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:v${{ steps.version.outputs.version }}
+
+          docker manifest create ${DH}:${{ steps.version.outputs.version }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:${{ steps.version.outputs.version }}
+
+          docker manifest create ${DH}:v${{ steps.version.outputs.major }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:v${{ steps.version.outputs.major }}
+
+          docker manifest create ${DH}:${{ steps.version.outputs.major }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:${{ steps.version.outputs.major }}
+
+          docker manifest create ${DH}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+          docker manifest create ${DH}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+          docker manifest create ${DH}:latest $AMD64_IMAGE $ARM64_IMAGE
+          docker manifest push ${DH}:latest
 
       # Clean up temporary tags
       - name: Clean up temporary tags
         run: |
-          # Delete temporary platform-specific tags
           docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-amd64-temp || true
           docker manifest rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:v${{ steps.version.outputs.version }}-arm64-temp || true
+          docker manifest rm ${{ env.DOCKERHUB_IMAGE }}:v${{ steps.version.outputs.version }}-amd64-temp || true
+          docker manifest rm ${{ env.DOCKERHUB_IMAGE }}:v${{ steps.version.outputs.version }}-arm64-temp || true


### PR DESCRIPTION
## Summary

- Adds `docker.io/laris11/altmount` as a secondary registry alongside GHCR in both `release.yml` and `dev-image.yml`
- All multi-arch builds (amd64 + arm64) are pushed to DockerHub with identical tags (`latest`, `vX.Y.Z`, `X.Y.Z`, `vX`, `X`, `vX.Y`, `X.Y`, and dev tags)
- DockerHub login uses `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repository secrets

## Setup required

Add these two secrets to the repository settings before merging:
- `DOCKERHUB_USERNAME` — DockerHub account username (`laris11`)
- `DOCKERHUB_TOKEN` — DockerHub access token (generate at hub.docker.com → Account Settings → Security)

## Test plan

- [ ] Verify `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are set in repo settings
- [ ] Trigger `release.yml` (via a tag push or `workflow_dispatch`) and confirm images appear at `docker.io/laris11/altmount`
- [ ] Confirm dev images appear at `docker.io/laris11/altmount:dev` after a push to `main`

Closes #662