### PR TITLE
feat(importer): make NZB compression configurable and number only on collision (#679)

### DIFF
--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -288,6 +288,27 @@ export function ImportConfigSection({
 						<label className="label cursor-pointer items-start justify-start gap-4">
 							<input
 								type="checkbox"
+								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
+								checked={formData.compress_nzb ?? true}
+								disabled={isReadOnly}
+								onChange={(e) => handleInputChange("compress_nzb", e.target.checked)}
+							/>
+							<div className="min-w-0 flex-1">
+								<span className="block whitespace-normal break-words font-bold text-xs">
+									Compress Stored NZBs
+								</span>
+								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
+									Gzip-compress persisted NZBs as .nzb.gz to save disk space. When disabled, NZBs
+									are kept as plain .nzb files in their category folders.
+								</span>
+							</div>
+						</label>
+
+						<div className="divider text-base-content/70" />
+
+						<label className="label cursor-pointer items-start justify-start gap-4">
+							<input
+								type="checkbox"
 								className="checkbox checkbox-error checkbox-sm mt-1 shrink-0"
 								checked={formData.delete_completed_nzb ?? false}
 								disabled={isReadOnly}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -253,6 +253,7 @@ export interface ImportConfig {
 	failed_item_retention_hours?: number | null;
 	history_retention_days?: number | null;
 	delete_completed_nzb?: boolean;
+	compress_nzb?: boolean;
 }
 
 // Log configuration
@@ -464,6 +465,7 @@ export interface ImportUpdateRequest {
 	allow_nested_rar_extraction?: boolean;
 	rename_to_nzb_name?: boolean;
 	filter_sample_files?: boolean;
+	compress_nzb?: boolean;
 }
 
 // Log update request

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -155,6 +155,7 @@ type ImportAPIResponse struct {
 	AllowNestedRarExtraction *bool `json:"allow_nested_rar_extraction,omitempty"`
 	RenameToNzbName          *bool `json:"rename_to_nzb_name,omitempty"`
 	FilterSampleFiles        *bool `json:"filter_sample_files,omitempty"`
+	CompressNzb              *bool `json:"compress_nzb,omitempty"`
 }
 
 // SABnzbdAPIResponse sanitizes SABnzbd config for API responses
@@ -417,6 +418,7 @@ func ToImportAPIResponse(importConfig config.ImportConfig) ImportAPIResponse {
 		AllowNestedRarExtraction: importConfig.AllowNestedRarExtraction,
 		RenameToNzbName:          importConfig.RenameToNzbName,
 		FilterSampleFiles:        importConfig.FilterSampleFiles,
+		CompressNzb:              importConfig.CompressNzb,
 	}
 }
 

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -319,6 +319,7 @@ type ImportConfig struct {
 	FailedItemRetentionHours           *int           `yaml:"failed_item_retention_hours" mapstructure:"failed_item_retention_hours" json:"failed_item_retention_hours,omitempty"`
 	HistoryRetentionDays               *int           `yaml:"history_retention_days" mapstructure:"history_retention_days" json:"history_retention_days,omitempty"`
 	DeleteCompletedNzb                 *bool          `yaml:"delete_completed_nzb" mapstructure:"delete_completed_nzb" json:"delete_completed_nzb,omitempty"`
+	CompressNzb                        *bool          `yaml:"compress_nzb" mapstructure:"compress_nzb" json:"compress_nzb,omitempty"`
 }
 
 // ShouldDeleteCompletedNzb returns whether the NZB file should be removed from
@@ -333,6 +334,15 @@ func (c *Config) ShouldDeleteCompletedNzb() bool {
 		return *c.Metadata.DeleteCompletedNzb
 	}
 	return false
+}
+
+// ShouldCompressNzb reports whether persisted NZBs should be gzip-compressed
+// (.nzb.gz). Defaults to true when unset to preserve legacy behavior.
+func (c *Config) ShouldCompressNzb() bool {
+	if c.Import.CompressNzb != nil {
+		return *c.Import.CompressNzb
+	}
+	return true
 }
 
 // LogConfig represents logging configuration with rotation support
@@ -1452,6 +1462,7 @@ func DefaultConfig(configDir ...string) *Config {
 	failedItemRetentionHours := 24  // Default: auto-remove failed items after 24 hours
 	historyRetentionDays := 90      // Default: auto-remove import history after 90 days (3 months)
 	isoAnalyzeTimeoutSeconds := 120 // Default: 120s hard cap per ISO analyse (prevents stuck NNTP from stalling import for 9+ minutes)
+	compressNzb := true             // Default: gzip-compress persisted NZBs (.nzb.gz)
 	metadataBackupEnabled := false
 	failureMaskingEnabled := false
 	repairEnabled := true
@@ -1590,6 +1601,7 @@ func DefaultConfig(configDir ...string) *Config {
 			WatchIntervalSeconds:     &watchIntervalSeconds,
 			FailedItemRetentionHours: &failedItemRetentionHours,
 			HistoryRetentionDays:     &historyRetentionDays,
+			CompressNzb:              &compressNzb,
 		},
 		Log: LogConfig{
 			File:       logPath, // Default log file path

--- a/internal/importer/migration.go
+++ b/internal/importer/migration.go
@@ -71,6 +71,12 @@ func migrateNzbsToGz(ctx context.Context, nzbDir, sentinelPath string, updater f
 // runNzbCompressionMigration is a one-time background task that compresses legacy
 // plain .nzb files in the persistent .nzbs/ directory to .nzb.gz.
 func (s *Service) runNzbCompressionMigration(ctx context.Context) {
+	// Skip when compression is disabled: the user wants plain .nzb files, so don't
+	// rewrite them to .nzb.gz behind their back.
+	if !s.configGetter().ShouldCompressNzb() {
+		return
+	}
+
 	nzbDir := s.GetNzbFolder()
 	sentinelPath := filepath.Join(nzbDir, migrationSentinelFile)
 

--- a/internal/importer/persistent_path_test.go
+++ b/internal/importer/persistent_path_test.go
@@ -1,0 +1,32 @@
+package importer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/altmount/internal/nzbfile"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPersistentNzbPath verifies that a persisted NZB lands directly in its category
+// folder with a clean filename when the destination is free, and is namespaced with the
+// queue item ID as a filename prefix when the plain path is already taken.
+func TestPersistentNzbPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "Movies")
+	base := "Abbott Elementary (2021)"
+
+	// Free destination: no number, file sits directly in the category folder.
+	free := func(string) bool { return false }
+	p1 := persistentNzbPath(dir, base, nzbfile.GzExtension, 42, free)
+	assert.Equal(t, filepath.Join(dir, base+nzbfile.GzExtension), p1)
+
+	// Plain extension when compression is disabled.
+	plain := persistentNzbPath(dir, base, ".nzb", 42, free)
+	assert.Equal(t, filepath.Join(dir, base+".nzb"), plain)
+
+	// Collision: namespace with the queue item ID as a filename prefix, staying in nzbDir.
+	taken := func(string) bool { return true }
+	p2 := persistentNzbPath(dir, base, nzbfile.GzExtension, 202, taken)
+	assert.Equal(t, filepath.Join(dir, "202-"+base+nzbfile.GzExtension), p2)
+	assert.NotEqual(t, p1, p2)
+}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -680,6 +680,40 @@ func uniqueFailedNzbPath(failedDir, srcNzbPath string, itemID int64) string {
 	return newPath
 }
 
+// persistentNzbPath returns the destination path for a successfully imported NZB inside
+// nzbDir. It prefers the clean filename directly in nzbDir and only namespaces it with the
+// queue item ID as a filename prefix (nzbDir/<id>-<name><ext>) when the plain destination is
+// reported taken by isTaken, guaranteeing a unique path for the UNIQUE import_queue.nzb_path
+// column. Mirrors uniqueFailedNzbPath.
+func persistentNzbPath(nzbDir, baseName, ext string, itemID int64, isTaken func(string) bool) string {
+	plain := filepath.Join(nzbDir, baseName+ext)
+	if !isTaken(plain) {
+		return plain
+	}
+	return filepath.Join(nzbDir, fmt.Sprintf("%d-%s%s", itemID, baseName, ext))
+}
+
+// copyFile copies the contents of src to dst, creating dst.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	return out.Close()
+}
+
 // sanitizeFilename replaces invalid characters in filenames
 func sanitizeFilename(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
@@ -960,41 +994,75 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 		return nil
 	}
 
-	// Store each NZB in a per-ID subfolder to guarantee uniqueness without
-	// polluting the user-visible filename (which is exposed via the SABnzbd
-	// history API and parsed by Sonarr/Radarr — a trailing `_<id>` would
-	// break their release-group parser).
 	if item.ID == 0 {
 		return fmt.Errorf("cannot persist NZB without queue ID (row must be inserted first)")
 	}
-	nzbDir = filepath.Join(nzbDir, strconv.FormatInt(item.ID, 10))
+
 	if err := os.MkdirAll(nzbDir, 0755); err != nil {
 		return fmt.Errorf("failed to create persistent NZB directory: %w", err)
 	}
+
+	// Pick the destination extension based on the compression setting: gzip-compressed
+	// NZBs keep the .nzb.gz extension, plain NZBs keep .nzb so they read transparently.
+	compress := cfg.ShouldCompressNzb()
+	ext := nzbfile.GzExtension
+	if !compress {
+		ext = ".nzb"
+	}
+
 	base := nzbtrim.TrimNzbExtension(sanitizeFilename(filepath.Base(item.NzbPath)))
-	newPath := filepath.Join(nzbDir, base+nzbfile.GzExtension)
 
-	s.log.DebugContext(ctx, "Moving and compressing NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath)
-
-	// Try rename to a temp path first (works only on same filesystem), then compress.
-	// For cross-device moves, compress directly from source.
-	tmpPath := newPath + ".tmp"
-	err := os.Rename(item.NzbPath, tmpPath)
-	if err == nil {
-		// Same filesystem: compress the tmp file to the final .nzb.gz path
-		if compErr := nzbfile.Compress(tmpPath, newPath); compErr != nil {
-			_ = os.Rename(tmpPath, item.NzbPath) // attempt to restore on failure
-			return fmt.Errorf("failed to compress NZB: %w", compErr)
+	// Save directly into the category folder using the clean filename. Only when that
+	// destination is already taken do we namespace it with the queue item ID as a filename
+	// prefix (<id>-<name>) — this drops the numeric folder in the common case while still
+	// guaranteeing a unique path on collision for the UNIQUE import_queue.nzb_path column.
+	taken := func(p string) bool {
+		if _, err := os.Stat(p); err == nil {
+			return true
 		}
-		_ = os.Remove(tmpPath)
+		// DeleteCompletedNzb can remove the file while leaving the UNIQUE nzb_path row,
+		// so also treat a path owned by a different queue item as taken.
+		if existing, err := s.database.Repository.GetQueueItemByNzbPath(ctx, p); err == nil && existing != nil && existing.ID != item.ID {
+			return true
+		}
+		return false
+	}
+	newPath := persistentNzbPath(nzbDir, base, ext, item.ID, taken)
+
+	s.log.DebugContext(ctx, "Moving NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath, "compress", compress)
+
+	if compress {
+		// Try rename to a temp path first (works only on same filesystem), then compress.
+		// For cross-device moves, compress directly from source.
+		tmpPath := newPath + ".tmp"
+		err := os.Rename(item.NzbPath, tmpPath)
+		if err == nil {
+			// Same filesystem: compress the tmp file to the final .nzb.gz path
+			if compErr := nzbfile.Compress(tmpPath, newPath); compErr != nil {
+				_ = os.Rename(tmpPath, item.NzbPath) // attempt to restore on failure
+				return fmt.Errorf("failed to compress NZB: %w", compErr)
+			}
+			_ = os.Remove(tmpPath)
+		} else {
+			// Cross-device: compress directly from source to destination
+			s.log.DebugContext(ctx, "Rename failed, compressing directly from source", "error", err, "src", item.NzbPath, "dst", newPath)
+			if compErr := nzbfile.Compress(item.NzbPath, newPath); compErr != nil {
+				return fmt.Errorf("failed to compress NZB: %w", compErr)
+			}
+			if err := os.Remove(item.NzbPath); err != nil {
+				s.log.WarnContext(ctx, "Failed to remove source NZB after compression", "path", item.NzbPath, "error", err)
+			}
+		}
 	} else {
-		// Cross-device: compress directly from source to destination
-		s.log.DebugContext(ctx, "Rename failed, compressing directly from source", "error", err, "src", item.NzbPath, "dst", newPath)
-		if compErr := nzbfile.Compress(item.NzbPath, newPath); compErr != nil {
-			return fmt.Errorf("failed to compress NZB: %w", compErr)
-		}
-		if err := os.Remove(item.NzbPath); err != nil {
-			s.log.WarnContext(ctx, "Failed to remove source NZB after compression", "path", item.NzbPath, "error", err)
+		// Plain mode: move the NZB as-is (rename, with cross-device copy+remove fallback).
+		if err := os.Rename(item.NzbPath, newPath); err != nil {
+			s.log.DebugContext(ctx, "Rename failed, copying NZB to persistent storage", "error", err, "src", item.NzbPath, "dst", newPath)
+			if copyErr := copyFile(item.NzbPath, newPath); copyErr != nil {
+				return fmt.Errorf("failed to copy NZB to persistent storage: %w", copyErr)
+			}
+			if err := os.Remove(item.NzbPath); err != nil {
+				s.log.WarnContext(ctx, "Failed to remove source NZB after copy", "path", item.NzbPath, "error", err)
+			}
 		}
 	}
 

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -986,7 +986,7 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 	compress := cfg.ShouldCompressNzb()
 	ext := nzbfile.GzExtension
 	if !compress {
-		ext = ".nzb"
+		ext = nzbfile.PlainExtension
 	}
 
 	base := nzbtrim.TrimNzbExtension(sanitizeFilename(filepath.Base(item.NzbPath)))

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -693,27 +693,6 @@ func persistentNzbPath(nzbDir, baseName, ext string, itemID int64, isTaken func(
 	return filepath.Join(nzbDir, fmt.Sprintf("%d-%s%s", itemID, baseName, ext))
 }
 
-// copyFile copies the contents of src to dst, creating dst.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(out, in); err != nil {
-		out.Close()
-		_ = os.Remove(dst)
-		return err
-	}
-	return out.Close()
-}
-
 // sanitizeFilename replaces invalid characters in filenames
 func sanitizeFilename(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
@@ -1054,15 +1033,11 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 			}
 		}
 	} else {
-		// Plain mode: move the NZB as-is (rename, with cross-device copy+remove fallback).
+		// Plain mode: move the NZB as-is. If the rename fails (e.g. cross-device), leave the
+		// source untouched and abort — the caller can retry rather than risk a partial copy.
 		if err := os.Rename(item.NzbPath, newPath); err != nil {
-			s.log.DebugContext(ctx, "Rename failed, copying NZB to persistent storage", "error", err, "src", item.NzbPath, "dst", newPath)
-			if copyErr := copyFile(item.NzbPath, newPath); copyErr != nil {
-				return fmt.Errorf("failed to copy NZB to persistent storage: %w", copyErr)
-			}
-			if err := os.Remove(item.NzbPath); err != nil {
-				s.log.WarnContext(ctx, "Failed to remove source NZB after copy", "path", item.NzbPath, "error", err)
-			}
+			s.log.ErrorContext(ctx, "Failed to move NZB to persistent storage", "error", err, "src", item.NzbPath, "dst", newPath)
+			return fmt.Errorf("failed to move NZB to persistent storage: %w", err)
 		}
 	}
 

--- a/internal/nzbfile/nzbfile.go
+++ b/internal/nzbfile/nzbfile.go
@@ -13,6 +13,9 @@ import (
 // GzExtension is the persistent storage extension for gzip-compressed NZB files.
 const GzExtension = ".nzb.gz"
 
+// PlainExtension is the persistent storage extension for uncompressed NZB files.
+const PlainExtension = ".nzb"
+
 // IsGzipped reports whether path points to a gzip-compressed NZB by suffix.
 func IsGzipped(path string) bool {
 	return strings.HasSuffix(strings.ToLower(path), GzExtension)


### PR DESCRIPTION
## What & why

Closes #679. Users reported that persisted NZBs were saved as numbered entries (`1`, `2`, `3`…) and only as gzip `.nzb.gz`, rather than as plain `.nzb` in their category folders (Movies, Series, corrupted, etc.). Two behaviors in `internal/importer` caused this:

1. **Forced numbering** — `ensurePersistentNzb` always nested every successful NZB under a per-queue-ID subfolder `.nzbs/{category}/{id}/`. The `{id}` was the "number" users saw.
2. **Always gzip** — every NZB was compressed to `.nzb.gz`, with a startup migration also rewriting any plain `.nzb`. There was no opt-out.

## Changes

- **Configurable compression**: new `import.compress_nzb` option (`*bool`, default `true` = unchanged behavior) with a `ShouldCompressNzb()` accessor. When disabled, NZBs are moved as plain `.nzb` (rename with copy+remove fallback) instead of gzip-compressed. The one-time gzip migration early-returns while compression is off so it won't rewrite plain files behind the user's back. Reads already tolerate both extensions via `nzbfile.Open`/`ResolveOnDisk`.
- **Number only on collision**: NZBs now save directly to `.nzbs/{category}/{name}{ext}`. The per-ID disambiguation only kicks in when the destination is already taken, applied as an `{id}-{name}` filename prefix (kept in the category folder), mirroring the existing failed-path convention (`uniqueFailedNzbPath`). The collision check is both disk- and DB-aware so the UNIQUE `import_queue.nzb_path` constraint still holds even after `DeleteCompletedNzb` removes a file. Extracted into a testable `persistentNzbPath` helper.
- **End-to-end wiring**: Go config struct + default + accessor, `ImportAPIResponse` field + mapping, frontend `ImportConfig`/`ImportUpdateRequest` types, and a "Compress Stored NZBs" toggle in `WorkersConfigSection.tsx`.

The failed path (`.nzbs/failed/{category}/`) already numbered only on collision and needed no change.

## Reviewer notes

- Default is `compress_nzb: true`, so existing installs are unaffected; users opt into plain `.nzb`.
- The `{id}-` filename prefix on collision is a deliberate choice (per request) consistent with the failed-folder behavior.

## Testing

- New `TestPersistentNzbPath` covers free-destination (clean name) and collision (prefixed) cases for both extensions.
- `go test -race ./internal/importer/... ./internal/config/... ./internal/api/...` and `go vet` pass.
- Frontend `bun run check` (biome) passes.