### PR TITLE
fix(importer): skip files with missing yEnc segments instead of importing them corrupt (#681)

### DIFF
--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -347,8 +347,18 @@ func (p *Parser) parseFile(ctx context.Context, meta map[string]string, nzbFilen
 
 		err := p.normalizeSegmentSizesWithYenc(ctx, info.NzbFile.Segments, cachedFirstSegment, nzbStandardPartSize, notFoundIDs)
 		if err != nil {
-			// Log the error but continue with original segment sizes
-			// This ensures processing continues even if yEnc header fetching fails
+			if stderrors.Is(err, nntppool.ErrArticleNotFound) {
+				// A segment required to determine the real (decoded) sizes is missing
+				// from every provider. Importing the file with the NZB's un-normalized
+				// (yEnc-encoded) byte counts would compute wrong segment offsets and
+				// produce a corrupt media file (#681), so skip the whole file. The
+				// caller's aggregation loop logs and continues, so the rest of the
+				// release still imports normally.
+				return nil, fmt.Errorf("failed to normalize segment sizes for %q: %w", info.Filename, err)
+			}
+			// Any other normalization failure (e.g. a present but non-yEnc article that
+			// yields no part size) is non-fatal: the NZB-declared segment sizes remain
+			// the best available source. Log and continue with them, as before.
 			p.log.WarnContext(ctx, "Failed to normalize segment sizes with yEnc headers",
 				"error", err,
 				"segments", len(info.NzbFile.Segments))
@@ -1075,7 +1085,7 @@ func (p *Parser) normalizeSegmentSizesWithYenc(ctx context.Context, segments []n
 	fileSize := firstSegment.FileSize
 	if firstPartSize <= 0 {
 		if _, known404 := notFoundIDs[segments[0].ID]; known404 {
-			return fmt.Errorf("first segment %s is known not found, skipping yEnc normalization", segments[0].ID)
+			return fmt.Errorf("first segment %s is known not found: %w", segments[0].ID, nntppool.ErrArticleNotFound)
 		}
 		// Fetch PartSize from first segment if not in cache. The same headers carry the
 		// total file size, which enables last-part derivation below.
@@ -1104,7 +1114,7 @@ func (p *Parser) normalizeSegmentSizesWithYenc(ctx context.Context, segments []n
 		}
 
 		if _, known404 := notFoundIDs[segments[1].ID]; known404 {
-			return fmt.Errorf("second segment %s is known not found, skipping yEnc normalization", segments[1].ID)
+			return fmt.Errorf("second segment %s is known not found: %w", segments[1].ID, nntppool.ErrArticleNotFound)
 		}
 		// Fetch PartSize from last segment
 		lastPartHeaders, err := p.fetchYencHeaders(ctx, segments[1], nil)
@@ -1129,10 +1139,10 @@ func (p *Parser) normalizeSegmentSizesWithYenc(ctx context.Context, segments []n
 		// Neither a shared part size nor a total file size: both the second and last
 		// segments must be fetched — do it in parallel as before.
 		if _, known404 := notFoundIDs[segments[1].ID]; known404 {
-			return fmt.Errorf("second segment %s is known not found, skipping yEnc normalization", segments[1].ID)
+			return fmt.Errorf("second segment %s is known not found: %w", segments[1].ID, nntppool.ErrArticleNotFound)
 		}
 		if _, known404 := notFoundIDs[segments[lastSegmentIndex].ID]; known404 {
-			return fmt.Errorf("last segment %s is known not found, skipping yEnc normalization", segments[lastSegmentIndex].ID)
+			return fmt.Errorf("last segment %s is known not found: %w", segments[lastSegmentIndex].ID, nntppool.ErrArticleNotFound)
 		}
 		var secondPartHeaders, lastPartHeaders nntppool.YEncMeta
 		g, gctx := errgroup.WithContext(ctx)
@@ -1161,7 +1171,7 @@ func (p *Parser) normalizeSegmentSizesWithYenc(ctx context.Context, segments []n
 		if standardPartSize <= 0 {
 			// No NZB-wide representative — fetch this file's second segment once.
 			if _, known404 := notFoundIDs[segments[1].ID]; known404 {
-				return fmt.Errorf("second segment %s is known not found, skipping yEnc normalization", segments[1].ID)
+				return fmt.Errorf("second segment %s is known not found: %w", segments[1].ID, nntppool.ErrArticleNotFound)
 			}
 			h, err := p.fetchYencHeaders(ctx, segments[1], nil)
 			if err != nil {
@@ -1174,7 +1184,7 @@ func (p *Parser) normalizeSegmentSizesWithYenc(ctx context.Context, segments []n
 			lastPartSize = last
 		} else {
 			if _, known404 := notFoundIDs[segments[lastSegmentIndex].ID]; known404 {
-				return fmt.Errorf("last segment %s is known not found, skipping yEnc normalization", segments[lastSegmentIndex].ID)
+				return fmt.Errorf("last segment %s is known not found: %w", segments[lastSegmentIndex].ID, nntppool.ErrArticleNotFound)
 			}
 			h, err := p.fetchYencHeaders(ctx, segments[lastSegmentIndex], nil)
 			if err != nil {

--- a/internal/importer/parser/parser_parsenzb_test.go
+++ b/internal/importer/parser/parser_parsenzb_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
 	"github.com/javi11/nzbparser"
 )
 
@@ -12,6 +13,11 @@ import (
 // with BrokenFileIndexes never calls Body() for the flagged file index.
 func TestParseNzbBrokenIndexMakesNoBodyCallForBrokenFile(t *testing.T) {
 	fp := fakepool.New()
+	// Serve valid yEnc for the healthy file so it normalizes and is kept;
+	// otherwise it would be skipped for failing normalization (#681).
+	fp.SetBehavior("healthy-seg-0", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: "healthy.mkv", PartSize: 1024},
+	})
 	pm := newFakeFullPoolManager(fp)
 
 	n := &nzbparser.Nzb{
@@ -59,6 +65,11 @@ func TestParseNzbBrokenIndexMakesNoBodyCallForBrokenFile(t *testing.T) {
 // with an empty ParseOptions processes all files normally.
 func TestParseNzbEmptyOptionsNormalBehavior(t *testing.T) {
 	fp := fakepool.New()
+	// Serve valid yEnc so the file normalizes and is processed normally;
+	// without it normalization fails and the file is skipped (#681).
+	fp.SetBehavior("movie-seg-0", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: "movie.mkv", PartSize: 1024},
+	})
 	pm := newFakeFullPoolManager(fp)
 
 	n := &nzbparser.Nzb{

--- a/internal/importer/parser/parser_skip_test.go
+++ b/internal/importer/parser/parser_skip_test.go
@@ -1,0 +1,147 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// TestParseNzbSkipsFileThatFailsNormalization is the regression test for
+// https://github.com/javi11/altmount/issues/681.
+//
+// When a file's segment sizes cannot be normalized — here because the second
+// segment (needed to learn the part size, since the total file size is unknown)
+// returns 430 — the file must be SKIPPED entirely. Importing it with the NZB's
+// un-normalized (yEnc-encoded) byte counts would compute wrong segment offsets
+// and produce a corrupt media file. The other files in the release must still
+// import with normalized (decoded) sizes.
+func TestParseNzbSkipsFileThatFailsNormalization(t *testing.T) {
+	const (
+		firstPartDecoded = 700000
+		lastPartDecoded  = 50000
+		firstPartEncoded = 720000 // NZB raw byte counts carry yEnc overhead
+		lastPartEncoded  = 51000
+	)
+
+	// Realistic, non-obfuscated release names so fileinfo preserves them
+	// (a bare "broken.mkv" would be flagged obfuscated and replaced by the NZB stem).
+	const (
+		brokenName  = "The.Matrix.1999.1080p.BluRay.mkv"
+		healthyName = "Inception.2010.1080p.BluRay.mkv"
+	)
+
+	fp := fakepool.New()
+	// Healthy file: both parts serve valid yEnc headers → normalizes cleanly.
+	fp.SetBehavior("fileB-seg-0", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: healthyName, PartSize: firstPartDecoded},
+	})
+	fp.SetBehavior("fileB-seg-1", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: healthyName, PartSize: lastPartDecoded},
+	})
+	// Failing file: the first part is fine, but the second part — required to
+	// learn the last-part size because FileSize is unknown — returns 430.
+	fp.SetBehavior("fileA-seg-0", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: brokenName, PartSize: firstPartDecoded},
+	})
+	fp.SetBehavior("fileA-seg-1", fakepool.SegmentBehavior{
+		Err: nntppool.ErrArticleNotFound,
+	})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(4))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{
+				Filename: brokenName,
+				Segments: nzbparser.NzbSegments{
+					{Bytes: firstPartEncoded, Number: 1, ID: "fileA-seg-0"},
+					{Bytes: lastPartEncoded, Number: 2, ID: "fileA-seg-1"},
+				},
+			},
+			{
+				Filename: healthyName,
+				Segments: nzbparser.NzbSegments{
+					{Bytes: firstPartEncoded, Number: 1, ID: "fileB-seg-0"},
+					{Bytes: lastPartEncoded, Number: 2, ID: "fileB-seg-1"},
+				},
+			},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1 (broken file skipped, healthy kept)", len(parsed.Files))
+	}
+
+	got := parsed.Files[0]
+	if got.Filename != healthyName {
+		t.Fatalf("kept file = %q, want %q", got.Filename, healthyName)
+	}
+
+	// The kept file must carry NORMALIZED (decoded) sizes, not the raw NZB bytes.
+	if len(got.Segments) != 2 {
+		t.Fatalf("kept file segments = %d, want 2", len(got.Segments))
+	}
+	if got.Segments[0].SegmentSize != firstPartDecoded {
+		t.Errorf("segment[0] size = %d, want %d (normalized, not raw %d)",
+			got.Segments[0].SegmentSize, firstPartDecoded, firstPartEncoded)
+	}
+	if got.Segments[1].SegmentSize != lastPartDecoded {
+		t.Errorf("segment[1] size = %d, want %d (normalized, not raw %d)",
+			got.Segments[1].SegmentSize, lastPartDecoded, lastPartEncoded)
+	}
+
+	// Guard: the skipped file's data must not leak into the parsed release.
+	for _, f := range parsed.Files {
+		if f.Filename == brokenName {
+			t.Errorf("%q appeared in parsed output, want it skipped", brokenName)
+		}
+	}
+}
+
+// TestParseNzbKeepsFileWhenYencHeaderUnavailable pins the scope of the #681 fix:
+// only a MISSING article (430) triggers a skip. When the article is present but
+// carries no usable yEnc part size, the NZB-declared segment sizes remain the best
+// available source, so the file must still be imported (not skipped).
+func TestParseNzbKeepsFileWhenYencHeaderUnavailable(t *testing.T) {
+	const declaredSize = 12345
+
+	fp := fakepool.New()
+	// Article is present (no error) but the fake returns no yEnc part size,
+	// mirroring a non-yEnc / unparseable-header article.
+	fp.SetBehavior("present-seg-0", fakepool.SegmentBehavior{Bytes: make([]byte, 16)})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(2))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{
+				Filename: "Some.Show.S01E01.1080p.mkv",
+				Segments: nzbparser.NzbSegments{
+					{Bytes: declaredSize, Number: 1, ID: "present-seg-0"},
+				},
+			},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1 (present article must not be skipped)", len(parsed.Files))
+	}
+	if got := parsed.Files[0].Segments[0].SegmentSize; got != declaredSize {
+		t.Errorf("segment size = %d, want %d (NZB-declared size preserved)", got, declaredSize)
+	}
+}


### PR DESCRIPTION
## What

Fixes [#681](https://github.com/javi11/altmount/issues/681). When a multi-segment file could not be size-normalized, `parseFile` swallowed the error and imported the file anyway using the NZB's raw **yEnc-encoded** byte counts. Those encoded sizes produce wrong segment offsets → **corrupt media file**.

Now: when normalization fails because a **required segment is missing from all providers** (`errors.Is(err, nntppool.ErrArticleNotFound)`), the file is **skipped**. The existing aggregation loop drops it and continues, so the rest of the release imports normally.

## Why this scope

The reported trigger: the part-size probe fetches a single segment; if that article returns `430` on the provider used, normalization fails for the whole file and the corrupt fallback runs. The corruption only happens when we'd fall back to encoded NZB sizes for a file we can't verify.

The skip is intentionally scoped to **not-found** errors:
- **Missing article (430)** → skip (fixes the corruption).
- **Present but non-yEnc / no usable part size** → keep using the NZB-declared sizes (long-standing, non-corrupting behavior; importer integration battery relies on this).

To make detection uniform, the "known not found" branches in `normalizeSegmentSizesWithYenc` now wrap `ErrArticleNotFound` (`NonRetryableError.Unwrap` lets `errors.Is` traverse the fetch path too).

## Changes

- `internal/importer/parser/parser.go` — scoped skip-on-not-found in `parseFile`; not-found branches in `normalizeSegmentSizesWithYenc` wrap `ErrArticleNotFound`.
- `internal/importer/parser/parser_skip_test.go` (new):
  - `TestParseNzbSkipsFileThatFailsNormalization` — a 430 on a needed segment skips that file; the healthy file is kept with **normalized (decoded)** sizes, not raw encoded values.
  - `TestParseNzbKeepsFileWhenYencHeaderUnavailable` — present-but-no-yEnc article is **not** skipped.
- `internal/importer/parser/parser_parsenzb_test.go` — serve realistic yEnc for healthy single-segment fixtures.

## Reviewer notes

- The skip is per-parse and final. A `430` from a provider that actually *has* the article but isn't tried for the body fetch would now drop the file rather than corrupt it — the safe outcome. Cross-provider / multi-segment-probe *recovery* of such files was deliberately deferred (separate, larger change).

## Verification

- `go test ./internal/importer/parser/... -race` ✅, `go vet` ✅
- `go test ./internal/importer/ -race` (integration battery) ✅
- `make` → exit 0, 0 failures ✅