### PR TITLE
fix(health): skip immediate health check on import when health is disabled

### DIFF
--- a/internal/importer/postprocessor/health_scheduler.go
+++ b/internal/importer/postprocessor/health_scheduler.go
@@ -28,6 +28,13 @@ func (c *Coordinator) ScheduleHealthCheck(ctx context.Context, item *database.Im
 		return nil // Health checks not configured
 	}
 
+	// Health checking disabled: don't queue immediate checks or resolve repairs on
+	// import — both are health-system concerns. Records queued here would only sit
+	// as pending forever since the worker refuses to run when disabled.
+	if !c.configGetter().GetHealthEnabled() {
+		return nil
+	}
+
 	// Expand directory entries into per-file paths, and fall back to the
 	// resulting path for legacy callers (single-file imports resolve to the
 	// same thing).

--- a/internal/importer/postprocessor/health_scheduler_test.go
+++ b/internal/importer/postprocessor/health_scheduler_test.go
@@ -56,6 +56,10 @@ func setupSchedulerTest(t *testing.T, mutate ...func(*config.Config)) (*Coordina
 	ms := metadata.NewMetadataService(t.TempDir())
 
 	cfg := config.DefaultConfig()
+	// Health checking is disabled by default; enable it so the scheduling path runs.
+	// (Tests that exercise the disabled guard override this via a mutator below.)
+	healthEnabled := true
+	cfg.Health.Enabled = &healthEnabled
 	// Directory repair resolution is opt-in (defaults to false); enable it so the
 	// stale-repair cleanup path is exercised.
 	resolveRepairs := true
@@ -165,6 +169,41 @@ func TestScheduleHealthCheck_PlainPathsUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	assert.Equal(t, database.HealthStatusPending, h.Status)
+}
+
+// TestScheduleHealthCheck_DisabledQueuesNothing verifies that with health checking
+// disabled in config, an import schedules no health records and does not resolve
+// pending repairs — the whole health subsystem is off, so records queued here would
+// only sit as "pending" forever (the worker refuses to run when disabled).
+func TestScheduleHealthCheck_DisabledQueuesNothing(t *testing.T) {
+	coordinator, ms, repo, db := setupSchedulerTest(t, func(cfg *config.Config) {
+		disabled := false
+		cfg.Health.Enabled = &disabled
+	})
+	ctx := context.Background()
+
+	filePath := "/tv/Disabled.S01E01.mkv"
+	writeTestMetadata(t, ms, filePath)
+
+	// A stale repair record that would normally be resolved by an import.
+	_, err := db.Exec(`
+		INSERT INTO file_health (file_path, status, repair_retry_count, max_repair_retries)
+		VALUES ('tv/old-broken.mkv', 'repair_triggered', 1, 3)
+	`)
+	require.NoError(t, err)
+
+	err = coordinator.ScheduleHealthCheck(ctx, nil, filePath, []string{filePath})
+	require.NoError(t, err)
+
+	// No health record must be queued for the imported file.
+	h, err := repo.GetFileHealth(ctx, "tv/Disabled.S01E01.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, h, "no health record may be queued when health checking is disabled")
+
+	// Repair resolution must be skipped too — the stale record stays untouched.
+	stale, err := repo.GetFileHealth(ctx, "tv/old-broken.mkv")
+	require.NoError(t, err)
+	require.NotNil(t, stale, "pending repair must not be resolved when health checking is disabled")
 }
 
 // TestScheduleHealthCheck_SkipsSidecarsUnderSymlinkStrategy verifies that under


### PR DESCRIPTION
## Problem

When health checking is disabled in config (`health.enabled: false`), successfully imported items were still queued for an immediate health check. Records were written to the `file_health` table as `pending` and stayed there forever — the health worker correctly refuses to process them (`internal/health/worker.go:128`), but they should never have been queued in the first place.

This affected the **default** install, since health checking is disabled by default (`internal/config/manager.go:1439`).

## Root cause

`Coordinator.ScheduleHealthCheck` is called unconditionally after every successful import (`coordinator.go:133`). The scheduler only guarded on `c.healthRepo == nil` (a dependency check) and never checked `cfg.GetHealthEnabled()`, so it queued records and resolved pending repairs regardless of the config flag.

## Change

- **`health_scheduler.go`**: Added an early-return guard on `c.configGetter().GetHealthEnabled()` right after the `healthRepo == nil` check — before any path expansion, record building, batch upsert, or pending-repair resolution. Skipping repair resolution when disabled is intentional and consistent: both are health-subsystem concerns.
- **`health_scheduler_test.go`**: Added `TestScheduleHealthCheck_DisabledQueuesNothing` (asserts no records queued and stale repairs untouched when disabled). Set `Health.Enabled = true` in the shared `setupSchedulerTest` helper so the existing scheduling tests run with health on — their actual intent. They previously passed only because of the bug, since `DefaultConfig()` disables health.

## Verification

- `go test ./internal/importer/postprocessor/... -run HealthCheck -race` — pass
- `go build ./...` — clean
- `go test ./internal/importer/...` — all green

## Reviewer notes

This fixes the **import-time** trigger specifically. A separate library-sync path can also register health records; that was out of scope for this report ("imported items sent to immediate health check") but may be worth a follow-up check on whether it's also gated on `health.enabled`.