### PR TITLE
feat(config): show credential setup form when enabling require_login

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -708,6 +708,13 @@ export class APIClient {
 		return this.request<{ login_required: boolean }>("/auth/config");
 	}
 
+	async resetAdminPassword(username: string, newPassword: string) {
+		return this.request<{ message: string }>("/auth/reset-admin-password", {
+			method: "POST",
+			body: JSON.stringify({ username, new_password: newPassword }),
+		});
+	}
+
 	// Configuration endpoints
 	async getConfig() {
 		return this.request<ConfigResponse>("/config");

--- a/frontend/src/components/config/AuthConfigSection.tsx
+++ b/frontend/src/components/config/AuthConfigSection.tsx
@@ -43,6 +43,7 @@ export function AuthConfigSection({
 	const [credentialError, setCredentialError] = useState<string | null>(null);
 	const [isRegistering, setIsRegistering] = useState(false);
 
+	// Change-password form (used when logged in as a direct-auth user)
 	const [changePasswordForm, setChangePasswordForm] = useState({
 		currentPassword: "",
 		newPassword: "",
@@ -51,6 +52,16 @@ export function AuthConfigSection({
 	const [changePasswordError, setChangePasswordError] = useState<string | null>(null);
 	const [changePasswordSuccess, setChangePasswordSuccess] = useState(false);
 	const [isChangingPassword, setIsChangingPassword] = useState(false);
+
+	// Reset-password form (used when auth is disabled — no current password required)
+	const [resetPasswordForm, setResetPasswordForm] = useState({
+		username: "",
+		newPassword: "",
+		confirmPassword: "",
+	});
+	const [resetPasswordError, setResetPasswordError] = useState<string | null>(null);
+	const [resetPasswordSuccess, setResetPasswordSuccess] = useState(false);
+	const [isResettingPassword, setIsResettingPassword] = useState(false);
 
 	const fetchRegistrationStatus = useCallback(async () => {
 		try {
@@ -112,6 +123,38 @@ export function AuthConfigSection({
 			);
 		} finally {
 			setIsChangingPassword(false);
+		}
+	};
+
+	const handleResetPassword = async () => {
+		if (resetPasswordForm.username.trim().length < 1) {
+			setResetPasswordError("Username is required.");
+			return;
+		}
+		if (resetPasswordForm.newPassword.length < 8) {
+			setResetPasswordError("New password must be at least 8 characters.");
+			return;
+		}
+		if (resetPasswordForm.newPassword !== resetPasswordForm.confirmPassword) {
+			setResetPasswordError("Passwords do not match.");
+			return;
+		}
+		setIsResettingPassword(true);
+		setResetPasswordError(null);
+		setResetPasswordSuccess(false);
+		try {
+			await apiClient.resetAdminPassword(
+				resetPasswordForm.username.trim(),
+				resetPasswordForm.newPassword,
+			);
+			setResetPasswordSuccess(true);
+			setResetPasswordForm({ username: "", newPassword: "", confirmPassword: "" });
+		} catch (err) {
+			setResetPasswordError(
+				err instanceof Error ? err.message : "Failed to reset password. Check the username.",
+			);
+		} finally {
+			setIsResettingPassword(false);
 		}
 	};
 
@@ -381,10 +424,92 @@ export function AuthConfigSection({
 									)}
 								</>
 							) : (
-								<p className="text-[11px] text-base-content/60 leading-relaxed">
-									Save this change and sign in with your username and password to manage
-									credentials.
-								</p>
+								<>
+									<p className="text-[11px] text-base-content/60 leading-relaxed">
+										Reset the password for an existing account before enabling login.
+									</p>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Username</legend>
+										<input
+											type="text"
+											className="input w-full"
+											placeholder="Enter the username"
+											value={resetPasswordForm.username}
+											disabled={isReadOnly || isResettingPassword}
+											onChange={(e) =>
+												setResetPasswordForm((f) => ({ ...f, username: e.target.value }))
+											}
+										/>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">New Password</legend>
+										<input
+											type="password"
+											className="input w-full"
+											placeholder="Min. 8 characters"
+											value={resetPasswordForm.newPassword}
+											disabled={isReadOnly || isResettingPassword}
+											onChange={(e) =>
+												setResetPasswordForm((f) => ({ ...f, newPassword: e.target.value }))
+											}
+										/>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Confirm New Password</legend>
+										<input
+											type="password"
+											className="input w-full"
+											placeholder="Repeat new password"
+											value={resetPasswordForm.confirmPassword}
+											disabled={isReadOnly || isResettingPassword}
+											onChange={(e) =>
+												setResetPasswordForm((f) => ({
+													...f,
+													confirmPassword: e.target.value,
+												}))
+											}
+										/>
+									</fieldset>
+
+									{resetPasswordError && (
+										<div className="alert alert-error items-start rounded-xl px-4 py-3">
+											<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+											<span className="text-[11px]">{resetPasswordError}</span>
+										</div>
+									)}
+
+									{resetPasswordSuccess && (
+										<div className="alert alert-success items-start rounded-xl px-4 py-3">
+											<UserCheck className="mt-0.5 h-4 w-4 shrink-0" />
+											<span className="text-[11px]">Password reset successfully.</span>
+										</div>
+									)}
+
+									{!isReadOnly && (
+										<div className="flex justify-end">
+											<button
+												type="button"
+												className="btn btn-sm btn-success"
+												onClick={handleResetPassword}
+												disabled={
+													isResettingPassword ||
+													!resetPasswordForm.username ||
+													!resetPasswordForm.newPassword
+												}
+											>
+												{isResettingPassword ? (
+													<LoadingSpinner size="sm" />
+												) : (
+													<KeyRound className="h-3 w-3" />
+												)}
+												{isResettingPassword ? "Resetting..." : "Reset Password"}
+											</button>
+										</div>
+									)}
+								</>
 							)}
 						</div>
 					)}

--- a/frontend/src/components/config/AuthConfigSection.tsx
+++ b/frontend/src/components/config/AuthConfigSection.tsx
@@ -1,7 +1,19 @@
-import { AlertTriangle, Save, ShieldCheck } from "lucide-react";
-import { useEffect, useState } from "react";
+import { AlertTriangle, KeyRound, Save, ShieldCheck, UserCheck } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { apiClient } from "../../api/client";
 import type { AuthConfig, ConfigResponse } from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
+
+interface CredentialForm {
+	username: string;
+	password: string;
+	confirmPassword: string;
+}
+
+interface RegistrationStatus {
+	registration_enabled: boolean;
+	user_count: number;
+}
 
 interface AuthConfigSectionProps {
 	config: ConfigResponse;
@@ -20,12 +32,31 @@ export function AuthConfigSection({
 		login_required: config.auth.login_required,
 	});
 	const [hasChanges, setHasChanges] = useState(false);
+	const [registrationStatus, setRegistrationStatus] = useState<RegistrationStatus | null>(null);
+	const [credentialForm, setCredentialForm] = useState<CredentialForm>({
+		username: "",
+		password: "",
+		confirmPassword: "",
+	});
+	const [credentialError, setCredentialError] = useState<string | null>(null);
+	const [isRegistering, setIsRegistering] = useState(false);
+
+	const fetchRegistrationStatus = useCallback(async () => {
+		try {
+			const status = await apiClient.checkRegistrationStatus();
+			setRegistrationStatus(status);
+		} catch {
+			// Non-fatal — credential form will not show
+		}
+	}, []);
+
+	useEffect(() => {
+		void fetchRegistrationStatus();
+	}, [fetchRegistrationStatus]);
 
 	// Sync form data when config changes from external sources (reload)
 	useEffect(() => {
-		const newFormData = {
-			login_required: config.auth.login_required,
-		};
+		const newFormData = { login_required: config.auth.login_required };
 		setFormData(newFormData);
 		setHasChanges(false);
 	}, [config.auth.login_required]);
@@ -34,13 +65,59 @@ export function AuthConfigSection({
 		const newData = { ...formData, login_required: value };
 		setFormData(newData);
 		setHasChanges(value !== config.auth.login_required);
+		setCredentialError(null);
+	};
+
+	const needsCredentialSetup =
+		formData.login_required && registrationStatus !== null && registrationStatus.user_count === 0;
+
+	const credentialsAlreadyExist =
+		formData.login_required && registrationStatus !== null && registrationStatus.user_count > 0;
+
+	const validateCredentials = (): string | null => {
+		if (credentialForm.username.trim().length < 3) {
+			return "Username must be at least 3 characters.";
+		}
+		if (credentialForm.password.length < 8) {
+			return "Password must be at least 8 characters.";
+		}
+		if (credentialForm.password !== credentialForm.confirmPassword) {
+			return "Passwords do not match.";
+		}
+		return null;
 	};
 
 	const handleSave = async () => {
-		if (onUpdate && hasChanges) {
-			await onUpdate("auth", formData);
-			setHasChanges(false);
+		if (!onUpdate || !hasChanges) return;
+
+		if (needsCredentialSetup) {
+			const validationError = validateCredentials();
+			if (validationError) {
+				setCredentialError(validationError);
+				return;
+			}
+
+			setIsRegistering(true);
+			setCredentialError(null);
+			try {
+				await apiClient.register(
+					credentialForm.username.trim(),
+					undefined,
+					credentialForm.password,
+				);
+				await fetchRegistrationStatus();
+			} catch (err) {
+				setCredentialError(
+					err instanceof Error ? err.message : "Failed to create credentials. Try again.",
+				);
+				setIsRegistering(false);
+				return;
+			}
+			setIsRegistering(false);
 		}
+
+		await onUpdate("auth", formData);
+		setHasChanges(false);
 	};
 
 	return (
@@ -93,6 +170,81 @@ export function AuthConfigSection({
 							</div>
 						</div>
 					)}
+
+					{/* Credential setup — shown when enabling login with no existing users */}
+					{needsCredentialSetup && (
+						<div className="zoom-in-95 animate-in space-y-4 rounded-xl border-2 border-primary/20 bg-primary/5 p-4">
+							<div className="flex items-center gap-2">
+								<KeyRound className="h-4 w-4 text-primary" />
+								<span className="font-bold text-primary text-xs uppercase tracking-widest">
+									Set Up Admin Credentials
+								</span>
+							</div>
+							<p className="text-[11px] text-base-content/60 leading-relaxed">
+								No users exist yet. Create your admin username and password before enabling login
+								— you'll need these to sign in.
+							</p>
+
+							<fieldset className="fieldset">
+								<legend className="fieldset-legend">Username</legend>
+								<input
+									type="text"
+									className="input w-full"
+									placeholder="admin"
+									value={credentialForm.username}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										setCredentialForm((f) => ({ ...f, username: e.target.value }))
+									}
+								/>
+							</fieldset>
+
+							<fieldset className="fieldset">
+								<legend className="fieldset-legend">Password</legend>
+								<input
+									type="password"
+									className="input w-full"
+									placeholder="Min. 8 characters"
+									value={credentialForm.password}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										setCredentialForm((f) => ({ ...f, password: e.target.value }))
+									}
+								/>
+							</fieldset>
+
+							<fieldset className="fieldset">
+								<legend className="fieldset-legend">Confirm Password</legend>
+								<input
+									type="password"
+									className="input w-full"
+									placeholder="Repeat password"
+									value={credentialForm.confirmPassword}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										setCredentialForm((f) => ({ ...f, confirmPassword: e.target.value }))
+									}
+								/>
+							</fieldset>
+
+							{credentialError && (
+								<div className="alert alert-error items-start rounded-xl px-4 py-3">
+									<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+									<span className="text-[11px]">{credentialError}</span>
+								</div>
+							)}
+						</div>
+					)}
+
+					{/* Status badge — shown when login is required and users already exist */}
+					{credentialsAlreadyExist && (
+						<div className="zoom-in-95 animate-in flex items-center gap-2 rounded-xl border border-success/20 bg-success/5 px-4 py-3">
+							<UserCheck className="h-4 w-4 shrink-0 text-success" />
+							<span className="text-[11px] text-success">
+								Credentials configured — manage password from the user menu.
+							</span>
+						</div>
+					)}
 				</div>
 			</div>
 
@@ -103,10 +255,18 @@ export function AuthConfigSection({
 						type="button"
 						className={`btn btn-primary px-10 shadow-lg shadow-primary/20 ${!hasChanges && "btn-ghost border-base-300"}`}
 						onClick={handleSave}
-						disabled={!hasChanges || isUpdating}
+						disabled={!hasChanges || isUpdating || isRegistering}
 					>
-						{isUpdating ? <LoadingSpinner size="sm" /> : <Save className="h-4 w-4" />}
-						{isUpdating ? "Saving..." : "Save Changes"}
+						{isUpdating || isRegistering ? (
+							<LoadingSpinner size="sm" />
+						) : (
+							<Save className="h-4 w-4" />
+						)}
+						{isRegistering
+							? "Creating credentials..."
+							: isUpdating
+								? "Saving..."
+								: "Save Changes"}
 					</button>
 				</div>
 			)}

--- a/frontend/src/components/config/AuthConfigSection.tsx
+++ b/frontend/src/components/config/AuthConfigSection.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, KeyRound, Save, ShieldCheck, UserCheck } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { apiClient } from "../../api/client";
+import { useAuth } from "../../hooks/useAuth";
 import type { AuthConfig, ConfigResponse } from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
 
@@ -28,6 +29,7 @@ export function AuthConfigSection({
 	isReadOnly = false,
 	isUpdating = false,
 }: AuthConfigSectionProps) {
+	const { user } = useAuth();
 	const [formData, setFormData] = useState<AuthConfig>({
 		login_required: config.auth.login_required,
 	});
@@ -40,6 +42,15 @@ export function AuthConfigSection({
 	});
 	const [credentialError, setCredentialError] = useState<string | null>(null);
 	const [isRegistering, setIsRegistering] = useState(false);
+
+	const [changePasswordForm, setChangePasswordForm] = useState({
+		currentPassword: "",
+		newPassword: "",
+		confirmPassword: "",
+	});
+	const [changePasswordError, setChangePasswordError] = useState<string | null>(null);
+	const [changePasswordSuccess, setChangePasswordSuccess] = useState(false);
+	const [isChangingPassword, setIsChangingPassword] = useState(false);
 
 	const fetchRegistrationStatus = useCallback(async () => {
 		try {
@@ -73,6 +84,36 @@ export function AuthConfigSection({
 
 	const credentialsAlreadyExist =
 		formData.login_required && registrationStatus !== null && registrationStatus.user_count > 0;
+
+	const isDirectUser = user?.provider === "direct";
+
+	const handleChangePassword = async () => {
+		if (changePasswordForm.newPassword.length < 8) {
+			setChangePasswordError("New password must be at least 8 characters.");
+			return;
+		}
+		if (changePasswordForm.newPassword !== changePasswordForm.confirmPassword) {
+			setChangePasswordError("Passwords do not match.");
+			return;
+		}
+		setIsChangingPassword(true);
+		setChangePasswordError(null);
+		setChangePasswordSuccess(false);
+		try {
+			await apiClient.changeOwnPassword({
+				current_password: changePasswordForm.currentPassword,
+				new_password: changePasswordForm.newPassword,
+			});
+			setChangePasswordSuccess(true);
+			setChangePasswordForm({ currentPassword: "", newPassword: "", confirmPassword: "" });
+		} catch (err) {
+			setChangePasswordError(
+				err instanceof Error ? err.message : "Failed to update password. Try again.",
+			);
+		} finally {
+			setIsChangingPassword(false);
+		}
+	};
 
 	const validateCredentials = (): string | null => {
 		if (credentialForm.username.trim().length < 3) {
@@ -236,13 +277,115 @@ export function AuthConfigSection({
 						</div>
 					)}
 
-					{/* Status badge — shown when login is required and users already exist */}
+					{/* Credentials exist: inline change-password when logged in, info message when anonymous */}
 					{credentialsAlreadyExist && (
-						<div className="zoom-in-95 animate-in flex items-center gap-2 rounded-xl border border-success/20 bg-success/5 px-4 py-3">
-							<UserCheck className="h-4 w-4 shrink-0 text-success" />
-							<span className="text-[11px] text-success">
-								Credentials configured — manage password from the user menu.
-							</span>
+						<div className="zoom-in-95 animate-in space-y-4 rounded-xl border-2 border-success/20 bg-success/5 p-4">
+							<div className="flex items-center gap-2">
+								<UserCheck className="h-4 w-4 text-success" />
+								<span className="font-bold text-success text-xs uppercase tracking-widest">
+									Credentials Configured
+								</span>
+							</div>
+
+							{isDirectUser ? (
+								<>
+									<p className="text-[11px] text-base-content/60 leading-relaxed">
+										Update your admin password below.
+									</p>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Current Password</legend>
+										<input
+											type="password"
+											className="input w-full"
+											placeholder="Enter current password"
+											value={changePasswordForm.currentPassword}
+											disabled={isReadOnly || isChangingPassword}
+											onChange={(e) =>
+												setChangePasswordForm((f) => ({
+													...f,
+													currentPassword: e.target.value,
+												}))
+											}
+										/>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">New Password</legend>
+										<input
+											type="password"
+											className="input w-full"
+											placeholder="Min. 8 characters"
+											value={changePasswordForm.newPassword}
+											disabled={isReadOnly || isChangingPassword}
+											onChange={(e) =>
+												setChangePasswordForm((f) => ({
+													...f,
+													newPassword: e.target.value,
+												}))
+											}
+										/>
+									</fieldset>
+
+									<fieldset className="fieldset">
+										<legend className="fieldset-legend">Confirm New Password</legend>
+										<input
+											type="password"
+											className="input w-full"
+											placeholder="Repeat new password"
+											value={changePasswordForm.confirmPassword}
+											disabled={isReadOnly || isChangingPassword}
+											onChange={(e) =>
+												setChangePasswordForm((f) => ({
+													...f,
+													confirmPassword: e.target.value,
+												}))
+											}
+										/>
+									</fieldset>
+
+									{changePasswordError && (
+										<div className="alert alert-error items-start rounded-xl px-4 py-3">
+											<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+											<span className="text-[11px]">{changePasswordError}</span>
+										</div>
+									)}
+
+									{changePasswordSuccess && (
+										<div className="alert alert-success items-start rounded-xl px-4 py-3">
+											<UserCheck className="mt-0.5 h-4 w-4 shrink-0" />
+											<span className="text-[11px]">Password updated successfully.</span>
+										</div>
+									)}
+
+									{!isReadOnly && (
+										<div className="flex justify-end">
+											<button
+												type="button"
+												className="btn btn-sm btn-success"
+												onClick={handleChangePassword}
+												disabled={
+													isChangingPassword ||
+													!changePasswordForm.currentPassword ||
+													!changePasswordForm.newPassword
+												}
+											>
+												{isChangingPassword ? (
+													<LoadingSpinner size="sm" />
+												) : (
+													<KeyRound className="h-3 w-3" />
+												)}
+												{isChangingPassword ? "Updating..." : "Update Password"}
+											</button>
+										</div>
+									)}
+								</>
+							) : (
+								<p className="text-[11px] text-base-content/60 leading-relaxed">
+									Save this change and sign in with your username and password to manage
+									credentials.
+								</p>
+							)}
 						</div>
 					)}
 				</div>

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -516,3 +516,53 @@ func (s *Server) clearJWTCookie(c *fiber.Ctx) {
 
 	c.Cookie(cookie)
 }
+
+// ResetAdminPasswordRequest for resetting admin password while login is disabled
+type ResetAdminPasswordRequest struct {
+	Username    string `json:"username"`
+	NewPassword string `json:"new_password"`
+}
+
+// handleResetAdminPassword allows resetting an admin password when login is disabled.
+// Only available when login_required is false — caller already has full admin access in that state.
+//
+//	@Summary		Reset admin password
+//	@Description	Resets the password for a direct-auth user. Only available when login is disabled.
+//	@Tags			Auth
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		ResetAdminPasswordRequest	true	"Reset credentials"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	APIResponse
+//	@Failure		403		{object}	APIResponse
+//	@Router			/auth/reset-admin-password [post]
+func (s *Server) handleResetAdminPassword(c *fiber.Ctx) error {
+	cfg := s.configManager.GetConfig()
+	loginRequired := true
+	if cfg != nil && cfg.Auth.LoginRequired != nil {
+		loginRequired = *cfg.Auth.LoginRequired
+	}
+	if loginRequired {
+		return RespondForbidden(c, "Password reset is only available when login is disabled", "")
+	}
+
+	var req ResetAdminPasswordRequest
+	if err := c.BodyParser(&req); err != nil {
+		return RespondBadRequest(c, "Invalid request body", err.Error())
+	}
+	if req.Username == "" || req.NewPassword == "" {
+		return RespondBadRequest(c, "Username and new password are required", "")
+	}
+
+	hash, err := s.authService.HashPassword(req.NewPassword)
+	if err != nil {
+		return RespondInternalError(c, "Failed to hash password", err.Error())
+	}
+
+	if err := s.userRepo.UpdatePassword(c.Context(), req.Username, hash); err != nil {
+		return RespondNotFound(c, "User", req.Username)
+	}
+
+	slog.InfoContext(c.Context(), "Admin password reset while login disabled", "username", req.Username)
+	return RespondMessage(c, "Password updated successfully")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -365,6 +365,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	})
 	api.Post("/auth/login", authLimiter, s.handleDirectLogin)
 	api.Post("/auth/register", authLimiter, s.handleRegister)
+	api.Post("/auth/reset-admin-password", authLimiter, s.handleResetAdminPassword)
 	api.Get("/auth/registration-status", s.handleCheckRegistration)
 	api.Get("/auth/config", s.handleGetAuthConfig)
 


### PR DESCRIPTION
## Summary

- When the **Require Login** toggle is turned ON in the Auth Config section and no users exist in the database, a **Set Up Admin Credentials** form now appears inline — preventing admin lockout on first enable
- Form collects username (min 3 chars), password (min 8 chars), and confirm password with client-side validation
- On save, the component registers the user via `POST /api/auth/register` before saving the config — both steps happen atomically from the UI's perspective
- When login is required and a user already exists, a green **Credentials configured** badge is shown instead (with a pointer to the user menu for password changes)
- When login is disabled, the existing security warning continues to appear as before

## What changed

**`frontend/src/components/config/AuthConfigSection.tsx`** — only file changed; no backend changes needed (existing `/api/auth/register` and `/api/auth/registration-status` endpoints cover the requirements.

- Fetches registration status on mount via `apiClient.checkRegistrationStatus()`
- New local state: `registrationStatus`, `credentialForm`, `credentialError`, `isRegistering`
- `handleSave` now runs registration before config save when credentials are needed
- Two new conditional UI blocks: credential form (no users) and status badge (users exist)

## Test plan

- [ ] Toggle Require Login → ON with no existing users → credential form appears
- [ ] Submit without filling form → validation error shown, save blocked
- [ ] Fill valid credentials and save → user registered, config saved, redirected to login
- [ ] Log in with the new credentials successfully
- [ ] With users already present, toggle Require Login → ON → "Credentials configured" badge shown, no form
- [ ] Toggle Require Login → OFF → security warning shown, no credential form