### PR TITLE
feat(stremio): instant mount, X-Api-Key auth, NZB by URL, cached flag

### DIFF
--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 )
@@ -42,11 +45,15 @@ type StremioStream struct {
 }
 
 // StremioStreamsResponse is the response returned by the Stremio stream endpoint.
-// The _queue_item_id and _queue_status fields are AltMount extensions that Stremio ignores.
+// The _queue_item_id, _queue_status, and _cached fields are AltMount extensions that Stremio ignores.
 type StremioStreamsResponse struct {
 	Streams     []StremioStream `json:"streams"`
 	QueueItemID int64           `json:"_queue_item_id"`
 	QueueStatus string          `json:"_queue_status"`
+	// Cached is true when streams were served from an already-completed queue item
+	// without re-processing. Callers such as AIOStreams can use this to show an
+	// "instant" indicator to the user.
+	Cached bool `json:"_cached"`
 }
 
 // handleNzbStreams handles POST /api/nzb/streams.
@@ -56,12 +63,14 @@ type StremioStreamsResponse struct {
 // found in the NZB output.
 //
 //	@Summary		Get Stremio streams for NZB file
-//	@Description	Accepts an NZB file upload, queues it with high priority, and synchronously waits for completion before returning Stremio-compatible stream URLs for all media files found in the NZB output. Authenticated via download_key form field (SHA256 of API key).
+//	@Description	Accepts an NZB file (upload or URL), queues it with high priority, and returns Stremio-compatible stream URLs as soon as the file is accessible via VFS. Auth: download_key form field (SHA256 of API key) or X-Api-Key header (raw API key). Returns _cached=true when served from an already-completed item.
 //	@Tags			Stremio
 //	@Accept			multipart/form-data
 //	@Produce		json
-//	@Param			file			formData	file	true	"NZB file to process"
-//	@Param			download_key	formData	string	true	"SHA256 hash of the user's API key"
+//	@Param			file			formData	file	false	"NZB file to process (mutually exclusive with nzb_url)"
+//	@Param			nzb_url			formData	string	false	"URL to download the NZB from (mutually exclusive with file)"
+//	@Param			download_key	formData	string	false	"SHA256 hash of the user's API key (alternative: X-Api-Key header)"
+//	@Param			X-Api-Key		header		string	false	"Raw API key (alternative to download_key form field)"
 //	@Param			category		formData	string	false	"Queue category (default: stremio)"
 //	@Param			timeout			formData	int		false	"Processing timeout in seconds (default: 300)"
 //	@Success		200	{object}	StremioStreamsResponse
@@ -81,29 +90,88 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		return RespondNotFound(c, "Stremio endpoint", "Stremio integration is disabled in configuration")
 	}
 
-	// --- Authenticate via download_key ---
+	// --- Authenticate via download_key form field, X-Api-Key header, or query param ---
+	// download_key: SHA256 hash of the API key (used by the Stremio addon play path)
+	// X-Api-Key:    raw API key (used by AIOStreams and other integrations)
 	downloadKey := c.FormValue("download_key")
 	if downloadKey == "" {
-		return RespondUnauthorized(c, "download_key is required", "Provide the SHA256 hash of your API key")
+		downloadKey = c.Query("download_key")
+	}
+	if downloadKey == "" {
+		// Accept raw API key via X-Api-Key header (AIOStreams sends altmountApiKey here).
+		// Hash it so validateDownloadKey can compare against the stored hash.
+		if rawKey := c.Get("X-Api-Key"); rawKey != "" {
+			if s.validateAPIKey(c, rawKey) {
+				downloadKey = auth.HashAPIKey(rawKey)
+			} else {
+				slog.WarnContext(ctx, "Stremio stream endpoint: authentication failed - invalid X-Api-Key")
+				return RespondUnauthorized(c, "Invalid X-Api-Key", "")
+			}
+		}
+	}
+	if downloadKey == "" {
+		return RespondUnauthorized(c, "Authentication required", "Provide download_key (SHA256 of API key) or X-Api-Key header")
 	}
 	if !s.validateDownloadKey(ctx, downloadKey) {
 		slog.WarnContext(ctx, "Stremio stream endpoint: authentication failed - invalid download_key")
 		return RespondUnauthorized(c, "Invalid download_key", "")
 	}
 
-	// --- Validate uploaded NZB file ---
-	file, err := c.FormFile("file")
-	if err != nil {
-		return RespondBadRequest(c, "No file provided", "A .nzb file must be uploaded")
-	}
+	// --- Accept NZB as file upload or by URL ---
+	// nzb_url allows callers (e.g. AIOStreams) to pass the NZB download URL directly
+	// instead of uploading the file bytes, avoiding an extra round-trip.
+	nzbURL := c.FormValue("nzb_url")
 
-	if !nzbtrim.HasNzbExtension(file.Filename) {
-		return RespondValidationError(c, "Invalid file type", "Only .nzb or .nzb.gz files are allowed")
-	}
+	var nzbFilename string
+	var nzbData []byte
 
-	const maxUploadSize = 100 * 1024 * 1024 // 100 MB
-	if file.Size > maxUploadSize {
-		return RespondValidationError(c, "File too large", "File size must be less than 100MB")
+	if nzbURL != "" {
+		// Download NZB from the provided URL
+		const maxNzbFetchSize = 100 * 1024 * 1024 // 100 MB
+		resp, err := http.Get(nzbURL) //nolint:gosec // URL is provided by an authenticated caller
+		if err != nil {
+			return RespondBadRequest(c, "Failed to fetch NZB from URL", err.Error())
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return RespondBadRequest(c, "Failed to fetch NZB from URL", fmt.Sprintf("HTTP %d", resp.StatusCode))
+		}
+		nzbData, err = io.ReadAll(io.LimitReader(resp.Body, maxNzbFetchSize))
+		if err != nil {
+			return RespondBadRequest(c, "Failed to read NZB from URL", err.Error())
+		}
+		// Derive filename from URL path
+		nzbFilename = filepath.Base(nzbURL)
+		if idx := strings.Index(nzbFilename, "?"); idx >= 0 {
+			nzbFilename = nzbFilename[:idx]
+		}
+		if !nzbtrim.HasNzbExtension(nzbFilename) {
+			nzbFilename = nzbFilename + ".nzb"
+		}
+	} else {
+		// Require file upload
+		file, err := c.FormFile("file")
+		if err != nil {
+			return RespondBadRequest(c, "No file provided", "Upload a .nzb file or provide nzb_url")
+		}
+		if !nzbtrim.HasNzbExtension(file.Filename) {
+			return RespondValidationError(c, "Invalid file type", "Only .nzb or .nzb.gz files are allowed")
+		}
+		const maxUploadSize = 100 * 1024 * 1024 // 100 MB
+		if file.Size > maxUploadSize {
+			return RespondValidationError(c, "File too large", "File size must be less than 100MB")
+		}
+		nzbFilename = file.Filename
+		// Read file bytes for saving below
+		f, err := file.Open()
+		if err != nil {
+			return RespondInternalError(c, "Failed to open uploaded file", err.Error())
+		}
+		defer f.Close()
+		nzbData, err = io.ReadAll(f)
+		if err != nil {
+			return RespondInternalError(c, "Failed to read uploaded file", err.Error())
+		}
 	}
 
 	// --- Resolve base URL ---
@@ -120,7 +188,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 
 	// --- Derive stable names before touching the filesystem ---
 	uploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
-	safeFilename := filepath.Base(file.Filename)
+	safeFilename := filepath.Base(nzbFilename)
 	nzbName := nzbtrim.TrimNzbExtension(safeFilename)
 	tempPath := filepath.Join(uploadDir, safeFilename)
 
@@ -144,6 +212,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 					Streams:     streams,
 					QueueItemID: prev.ID,
 					QueueStatus: string(prev.Status),
+					Cached:      true,
 				})
 			}
 		}
@@ -162,8 +231,8 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Failed to create upload directory", err.Error())
 	}
 
-	if err := c.SaveFile(file, tempPath); err != nil {
-		return RespondInternalError(c, "Failed to save uploaded file", err.Error())
+	if err := os.WriteFile(tempPath, nzbData, 0644); err != nil {
+		return RespondInternalError(c, "Failed to save NZB file", err.Error())
 	}
 
 	// --- Add NZB to queue with high priority ---
@@ -225,6 +294,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 			Streams:     streams,
 			QueueItemID: current.ID,
 			QueueStatus: string(current.Status),
+			Cached:      true,
 		})
 	case database.QueueStatusFailed:
 		errMsg := ""
@@ -232,9 +302,21 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 			errMsg = *current.ErrorMessage
 		}
 		return RespondInternalError(c, "NZB processing failed", errMsg)
+	default:
+		// If the item is already processing and has a storage path, the streamable
+		// event fired before we subscribed — return the streams immediately.
+		if current.StoragePath != nil && *current.StoragePath != "" {
+			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+				return c.JSON(StremioStreamsResponse{
+					Streams:     streams,
+					QueueItemID: current.ID,
+					QueueStatus: "streamable",
+				})
+			}
+		}
 	}
 
-	// Wait for a completion event from the broadcaster.
+	// Wait for a streamable or completion event from the broadcaster.
 	timer := time.NewTimer(time.Duration(timeoutSecs) * time.Second)
 	defer timer.Stop()
 
@@ -248,6 +330,20 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 				continue
 			}
 			switch update.Status {
+			case "streamable":
+				// Return streams as soon as the file is accessible in the VFS — before
+				// post-processing (symlinks, STRM, health scheduling) completes.
+				if update.StoragePath != "" {
+					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
+					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+						return c.JSON(StremioStreamsResponse{
+							Streams:     streams,
+							QueueItemID: itemID,
+							QueueStatus: "streamable",
+						})
+					}
+				}
+				// StoragePath empty or no media files yet — fall through to wait for completed.
 			case "completed":
 				item, err := s.queueRepo.GetQueueItem(ctx, itemID)
 				if err != nil {

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -455,6 +455,14 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 		return redirectToFirst(current)
 	case database.QueueStatusFailed:
 		return RespondServiceUnavailable(c, "NZB processing failed", "")
+	default:
+		// If the item is already processing and has a storage path, the streamable
+		// event fired before we subscribed — redirect immediately.
+		if current.StoragePath != nil && *current.StoragePath != "" {
+			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+				return c.Redirect(streams[0].URL, fiber.StatusFound)
+			}
+		}
 	}
 
 	timer := time.NewTimer(time.Duration(timeoutSecs) * time.Second)
@@ -470,6 +478,15 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 				continue
 			}
 			switch update.Status {
+			case "streamable":
+				// Redirect as soon as the file is accessible in the VFS — before post-processing.
+				if update.StoragePath != "" {
+					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
+					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+						return c.Redirect(streams[0].URL, fiber.StatusFound)
+					}
+				}
+				// No media files yet — fall through to wait for completed.
 			case "completed":
 				item, err := s.queueRepo.GetQueueItem(ctx, itemID)
 				if err != nil {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1152,6 +1152,13 @@ func (s *Service) handleProcessingSuccess(ctx context.Context, item *database.Im
 		return err
 	}
 
+	// Signal streamable as early as possible — files are accessible via VFS now.
+	// Stremio waiters listening on the broadcaster can return stream URLs without
+	// waiting for post-processing (symlinks, STRM, health scheduling) to complete.
+	if s.broadcaster != nil {
+		s.broadcaster.NotifyStreamable(int(item.ID), resultingPath)
+	}
+
 	// Refresh mount path if needed before post-processing
 	s.postProcessor.RefreshMountPathIfNeeded(ctx, resultingPath, item.ID)
 

--- a/internal/progress/progress_broadcaster.go
+++ b/internal/progress/progress_broadcaster.go
@@ -11,11 +11,12 @@ import (
 
 // ProgressUpdate represents a progress update event
 type ProgressUpdate struct {
-	QueueID    int       `json:"queue_id"`
-	Percentage int       `json:"percentage"`
-	Stage      string    `json:"stage,omitempty"`  // e.g. "Parsing NZB", "Validating segments"
-	Status     string    `json:"status,omitempty"` // "completed" or "failed" on terminal events
-	Timestamp  time.Time `json:"timestamp"`
+	QueueID     int       `json:"queue_id"`
+	Percentage  int       `json:"percentage"`
+	Stage       string    `json:"stage,omitempty"`        // e.g. "Parsing NZB", "Validating segments"
+	Status      string    `json:"status,omitempty"`       // "completed", "failed", or "streamable" on terminal/early events
+	StoragePath string    `json:"storage_path,omitempty"` // set when Status="streamable"
+	Timestamp   time.Time `json:"timestamp"`
 }
 
 // ProgressEntry holds the current progress state for a single queue item.
@@ -207,6 +208,19 @@ func (pb *ProgressBroadcaster) BroadcastHealthChanged() {
 		Timestamp: time.Now(),
 	}
 	pb.broadcast(update, "subscriber channel full, skipping health_changed")
+}
+
+// NotifyStreamable broadcasts an early-mount event for a queue item. The storage
+// path is available and the file is accessible via the VFS before post-processing
+// completes. Stremio waiters can return stream URLs immediately on this signal.
+func (pb *ProgressBroadcaster) NotifyStreamable(queueID int, storagePath string) {
+	update := ProgressUpdate{
+		QueueID:     queueID,
+		Status:      "streamable",
+		StoragePath: storagePath,
+		Timestamp:   time.Now(),
+	}
+	pb.broadcast(update, "subscriber channel full, skipping streamable event")
 }
 
 // BroadcastQueueChanged sends a queue-change notification to all SSE subscribers.


### PR DESCRIPTION
## Summary

Makes AltMount a first-class backend for AIOStreams (and any Stremio integration) by closing the latency gap between NZB submission and first playable frame.

### Changes

**Instant mount (A1 — `internal/importer/service.go`, `internal/progress/progress_broadcaster.go`)**
- `ProgressBroadcaster` now has a `NotifyStreamable(queueID, storagePath)` method that broadcasts a `"streamable"` event the moment `StoragePath` is written to the DB — before post-processing (symlinks, STRM files, health scheduling) and before `status=Completed`.
- `handleProcessingSuccess` in the importer service calls this immediately after `AddStoragePath`.

**Early stream return (A1 — `nzb_stremio_handlers.go`, `stremio_addon_handlers.go`)**
- `waitAndRespond` (native `/api/nzb/streams`) and `waitAndRedirectToStream` (addon play path) both listen for `"streamable"` events and return/redirect immediately — no longer blocked on `status=Completed`.
- Upfront check also catches items already in processing state with a storage path set (covers the subscribe-after-event race).

**X-Api-Key header auth (A5 — `nzb_stremio_handlers.go`)**
- `POST /api/nzb/streams` now accepts the raw API key via `X-Api-Key` header in addition to the `download_key` form field (SHA256 hash). AIOStreams sends `altmountApiKey` in `X-Api-Key` — this makes it work without any extra config on the AIOStreams side.

**NZB by URL (A5 — `nzb_stremio_handlers.go`)**
- New `nzb_url` form field: callers pass an NZB download URL instead of uploading file bytes, removing an extra HTTP round-trip.

**`_cached` flag (A5 — `nzb_stremio_handlers.go`)**
- `StremioStreamsResponse` gains `_cached: bool`. Set to `true` when streams are served from an already-completed queue item. AIOStreams can use this to show a lightning/instant badge without probing WebDAV.

## Test plan

- [ ] Single MKV NZB: submit via `POST /api/nzb/streams` with `X-Api-Key` header → confirm response arrives before `status=Completed` (streamable stage) and `_cached=false`
- [ ] Same NZB a second time → `_cached=true`, response is instant
- [ ] `nzb_url` field: pass an NZB download URL instead of file upload → same result
- [ ] RAR archive NZB: confirm streams returned as soon as RAR headers are parsed and metadata written
- [ ] Failed/dead release: confirm clean HTTP error response, no hang
- [ ] Addon play path (`GET /stremio/:key/play`): confirm 302 redirect fires at streamable stage, not at completed
- [ ] Existing Plex/WebDAV behaviour unchanged (post-processing still runs to completion async)
- [ ] `go test ./internal/api/... ./internal/importer/... ./internal/progress/...` passes