### PR TITLE
fix(importer): strip dash separator from collision-namespaced NZB filename

### DIFF
--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -78,7 +78,7 @@ func NewProcessor(metadataService *metadata.MetadataService, poolManager pool.Ma
 // getCleanNzbName removes the queue ID prefix from the NZB filename if present
 func (proc *Processor) getCleanNzbName(nzbPath string, queueID int) string {
 	baseName := filepath.Base(nzbPath)
-	prefix := fmt.Sprintf("%d_", queueID)
+	prefix := fmt.Sprintf("%d-", queueID)
 	if after, ok := strings.CutPrefix(baseName, prefix); ok {
 		return after
 	}


### PR DESCRIPTION
## Problem

`uniqueFailedNzbPath` (PR #667) prefixes colliding NZB filenames with `{id}-` (dash):
```go
newPath = filepath.Join(failedDir, fmt.Sprintf(%d-%s, itemID, fileName))
```

`persistentNzbPath` (PR #679) uses the same dash convention:
```go
return filepath.Join(nzbDir, fmt.Sprintf(%d-%s%s, itemID, baseName, ext))
```

But `getCleanNzbName` in `processor.go` was stripping `{id}_` (underscore):
```go
prefix := fmt.Sprintf(%d_, queueID)  // never matches the dash-prefixed path
```

Because `CutPrefix` never matched, the numeric prefix was never removed and leaked into the virtual folder name created by `filesystem.CreateNzbFolder` — visible in WebDAV/FUSE and to media servers like Plex, breaking automatic title matching.

## Fix

Change the separator in `getCleanNzbName` from underscore to dash so it correctly strips the prefix added by both `uniqueFailedNzbPath` and `persistentNzbPath`:

```go
prefix := fmt.Sprintf(%d-, queueID)  // matches dash prefix
```

## Impact

- Affects any item whose NZB filename collided (either in the failed folder or in persistent storage)
- Virtual folder names are now clean (e.g. `Frasier.S05E02.Something.mkv` instead of `14275-Frasier.S05E02.Something.mkv`)
- One-character change, no new logic
- Applies equally to Windows and Linux