### PR TITLE
[1/4] fix: backend correctness — arr register, health bulk-delete, NZB export, queue dedup, whisparr panic

### DIFF
--- a/internal/api/arrs_handlers.go
+++ b/internal/api/arrs_handlers.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"log/slog"
 	"net/url"
@@ -1097,18 +1096,31 @@ func (s *Server) handleRegisterArrsDownloadClients(c *fiber.Ctx) error {
 		}
 	}
 
-	// Launch in background to not block
-	go func() {
-		ctx := context.Background()
-		if err := s.arrsService.EnsureDownloadClientRegistration(ctx, host, port, urlBase, apiKey); err != nil {
-			slog.ErrorContext(ctx, "Failed to register download clients", "error", err)
-		}
-	}()
+	// Register, then verify reachability so the response reflects the real outcome.
+	ctx := c.Context()
+	if err := s.arrsService.EnsureDownloadClientRegistration(ctx, host, port, urlBase, apiKey); err != nil {
+		slog.ErrorContext(ctx, "Failed to register download clients", "error", err)
+		return RespondInternalError(c, "Failed to register download client", err.Error())
+	}
 
-	return c.Status(200).JSON(fiber.Map{
-		"success": true,
-		"message": "Download client registration triggered in background",
-	})
+	results, err := s.arrsService.TestDownloadClientRegistration(ctx, host, port, urlBase, apiKey)
+	if err != nil {
+		return RespondInternalError(c, "Failed to verify download client registration", err.Error())
+	}
+
+	var failures []string
+	for name, res := range results {
+		if res != "OK" {
+			failures = append(failures, name+": "+res)
+		}
+	}
+	if len(failures) > 0 {
+		return RespondError(c, fiber.StatusBadGateway, ErrCodeInternalServer,
+			"Download client registered, but ARR instances cannot reach AltMount",
+			strings.Join(failures, "; "))
+	}
+
+	return RespondMessage(c, "Download client registered and verified successfully")
 }
 
 // handleTestArrsDownloadClients tests the connection from ARR instances to AltMount

--- a/internal/api/file_handlers.go
+++ b/internal/api/file_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"archive/zip"
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/xml"
@@ -418,112 +419,110 @@ func (s *Server) handleBatchExportNZB(c *fiber.Ctx) error {
 	slog.InfoContext(ctx, "Collected metadata files",
 		"total_count", len(metadataFiles))
 
-	// Create ZIP archive in memory
-	var zipBuffer bytes.Buffer
-	zipWriter := zip.NewWriter(&zipBuffer)
-
-	exportedCount := 0
-	skippedCount := 0
-
-	for _, metaPath := range metadataFiles {
-		// Calculate virtual path
-		relPath, err := filepath.Rel(metadataRootPath, metaPath)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to calculate relative path",
-				"error", err,
-				"meta_path", metaPath)
-			continue
-		}
-
-		// Remove .meta extension to get virtual filename
-		virtualFilename := strings.TrimSuffix(relPath, ".meta")
-
-		// Check if should exclude based on archive pattern
-		// Archives and AES-encrypted files are always excluded
-		if shouldExcludeFile(virtualFilename, true) {
-			skippedCount++
-			slog.DebugContext(ctx, "Skipping archive file",
-				"filename", virtualFilename)
-			continue
-		}
-
-		// Calculate full virtual path
-		virtualPath := filepath.Join(virtualRootPath, virtualFilename)
-		virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
-
-		// Read metadata
-		metadata, err := s.metadataReader.GetFileMetadata(virtualPath)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to read metadata",
-				"error", err,
-				"virtual_path", virtualPath)
-			continue
-		}
-
-		if metadata == nil {
-			slog.WarnContext(ctx, "Metadata not found",
-				"virtual_path", virtualPath)
-			continue
-		}
-
-		// Skip AES-encrypted files (encrypted archives)
-		if metadata.Encryption == metapb.Encryption_AES {
-			skippedCount++
-			continue
-		}
-
-		// Generate NZB
-		nzbContent, err := s.generateNZBFromMetadata(metadata, virtualPath)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to generate NZB",
-				"error", err,
-				"virtual_path", virtualPath)
-			continue
-		}
-
-		// Create NZB filename
-		nzbFilename := strings.TrimSuffix(virtualFilename, filepath.Ext(virtualFilename)) + ".nzb"
-
-		// Add to ZIP
-		writer, err := zipWriter.Create(nzbFilename)
-		if err != nil {
-			slog.WarnContext(ctx, "Failed to create ZIP entry",
-				"error", err,
-				"filename", nzbFilename)
-			continue
-		}
-
-		if _, err := io.Copy(writer, bytes.NewReader(nzbContent)); err != nil {
-			slog.WarnContext(ctx, "Failed to write NZB to ZIP",
-				"error", err,
-				"filename", nzbFilename)
-			continue
-		}
-
-		exportedCount++
-	}
-
-	// Close ZIP writer
-	if err := zipWriter.Close(); err != nil {
-		slog.ErrorContext(ctx, "Failed to close ZIP writer",
-			"error", err)
-		return RespondInternalError(c, "Failed to finalize ZIP archive", err.Error())
-	}
-
-	if exportedCount == 0 {
-		return RespondError(c, fiber.StatusNotFound, ErrCodeNotFound, "No files were exported", fmt.Sprintf("Skipped %d files (archives or AES-encrypted)", skippedCount))
-	}
-
-	slog.InfoContext(ctx, "Batch export completed",
-		"exported_count", exportedCount,
-		"skipped_count", skippedCount)
-
-	// Set response headers for ZIP download
+	// Set ZIP headers before streaming begins.
 	timestamp := time.Now().Unix()
 	zipFilename := fmt.Sprintf("nzb-export-%d.zip", timestamp)
-
 	c.Set("Content-Type", "application/zip")
 	c.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, zipFilename))
 
-	return c.Send(zipBuffer.Bytes())
+	// Stream the ZIP instead of buffering the whole archive in memory.
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		zipWriter := zip.NewWriter(w)
+		exportedCount := 0
+		skippedCount := 0
+
+		for _, metaPath := range metadataFiles {
+			// Calculate virtual path
+			relPath, err := filepath.Rel(metadataRootPath, metaPath)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to calculate relative path",
+					"error", err,
+					"meta_path", metaPath)
+				continue
+			}
+
+			// Remove .meta extension to get virtual filename
+			virtualFilename := strings.TrimSuffix(relPath, ".meta")
+
+			// Check if should exclude based on archive pattern
+			// Archives and AES-encrypted files are always excluded
+			if shouldExcludeFile(virtualFilename, true) {
+				skippedCount++
+				slog.DebugContext(ctx, "Skipping archive file",
+					"filename", virtualFilename)
+				continue
+			}
+
+			// Calculate full virtual path
+			virtualPath := filepath.Join(virtualRootPath, virtualFilename)
+			virtualPath = strings.ReplaceAll(virtualPath, string(filepath.Separator), "/")
+
+			// Read metadata
+			metadata, err := s.metadataReader.GetFileMetadata(virtualPath)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to read metadata",
+					"error", err,
+					"virtual_path", virtualPath)
+				continue
+			}
+
+			if metadata == nil {
+				slog.WarnContext(ctx, "Metadata not found",
+					"virtual_path", virtualPath)
+				continue
+			}
+
+			// Skip AES-encrypted files (encrypted archives)
+			if metadata.Encryption == metapb.Encryption_AES {
+				skippedCount++
+				continue
+			}
+
+			// Generate NZB
+			nzbContent, err := s.generateNZBFromMetadata(metadata, virtualPath)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to generate NZB",
+					"error", err,
+					"virtual_path", virtualPath)
+				continue
+			}
+
+			// Create NZB filename
+			nzbFilename := strings.TrimSuffix(virtualFilename, filepath.Ext(virtualFilename)) + ".nzb"
+
+			// Add to ZIP
+			writer, err := zipWriter.Create(nzbFilename)
+			if err != nil {
+				slog.WarnContext(ctx, "Failed to create ZIP entry",
+					"error", err,
+					"filename", nzbFilename)
+				continue
+			}
+
+			if _, err := io.Copy(writer, bytes.NewReader(nzbContent)); err != nil {
+				slog.WarnContext(ctx, "Failed to write NZB to ZIP",
+					"error", err,
+					"filename", nzbFilename)
+				continue
+			}
+
+			exportedCount++
+		}
+
+		// Headers are already sent, so finalize errors can only be logged.
+		if err := zipWriter.Close(); err != nil {
+			slog.ErrorContext(ctx, "Failed to close ZIP writer", "error", err)
+			return
+		}
+		if err := w.Flush(); err != nil {
+			slog.WarnContext(ctx, "Failed to flush export stream", "error", err)
+			return
+		}
+
+		slog.InfoContext(ctx, "Batch export completed",
+			"exported_count", exportedCount,
+			"skipped_count", skippedCount)
+	})
+
+	return nil
 }

--- a/internal/api/health_handlers.go
+++ b/internal/api/health_handlers.go
@@ -332,14 +332,14 @@ func (s *Server) handleDeleteHealthBulk(c *fiber.Ctx) error {
 	}
 
 	// Delete health records in bulk
-	err := s.healthRepo.DeleteHealthRecordsBulk(c.Context(), req.FilePaths)
+	deletedCount, err := s.healthRepo.DeleteHealthRecordsBulk(c.Context(), req.FilePaths)
 	if err != nil {
 		return RespondInternalError(c, "Failed to delete health records", err.Error())
 	}
 
 	return RespondSuccess(c, fiber.Map{
 		"message":               "Health records deleted successfully",
-		"deleted_count":         len(req.FilePaths),
+		"deleted_count":         deletedCount,
 		"file_paths":            req.FilePaths,
 		"deleted_at":            time.Now().Format(time.RFC3339),
 		"meta_deleted_count":    metaDeletedCount,
@@ -825,12 +825,12 @@ func (s *Server) cleanupHealthRecords(ctx context.Context, olderThan time.Time, 
 	}
 
 	// Delete database records (proceed even if some file deletions failed)
-	deleteErr := s.healthRepo.DeleteHealthRecordsBulk(ctx, allFilePaths)
+	deletedRecords, deleteErr := s.healthRepo.DeleteHealthRecordsBulk(ctx, allFilePaths)
 	if deleteErr != nil {
 		return 0, deletedFileCount, fileErrors, fmt.Errorf("failed to delete health records from database: %w", deleteErr)
 	}
 
-	return len(allFilePaths), deletedFileCount, fileErrors, nil
+	return int(deletedRecords), deletedFileCount, fileErrors, nil
 }
 
 // handleAddHealthCheck handles POST /api/health/check

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -611,6 +611,23 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 		priority = database.QueuePriorityNormal
 	}
 
+	// Add to queue using importer service
+	if s.importerService == nil {
+		return RespondServiceUnavailable(c, "Importer service not available", "The import service is not configured or running")
+	}
+
+	var categoryPtr *string
+	if category != "" {
+		categoryPtr = &category
+	}
+
+	// De-dupe re-uploads: update the existing pending item instead of creating a duplicate.
+	if existing, err := s.importerService.FindAndUpdatePendingUpload(c.Context(), file.Filename, categoryPtr, &priority); err != nil {
+		return RespondInternalError(c, "Failed to update existing queue item", err.Error())
+	} else if existing != nil {
+		return RespondCreated(c, ToQueueItemResponse(existing))
+	}
+
 	// Create temporary directory for upload
 	tempDir := os.TempDir()
 	uploadDir := filepath.Join(tempDir, "altmount-uploads")
@@ -624,19 +641,6 @@ func (s *Server) handleUploadToQueue(c *fiber.Ctx) error {
 	tempFile := filepath.Join(uploadDir, safeFilename)
 	if err := c.SaveFile(file, tempFile); err != nil {
 		return RespondInternalError(c, "Failed to save file", err.Error())
-	}
-
-	// Add to queue using importer service
-	if s.importerService == nil {
-		// Clean up temp file
-		os.Remove(tempFile)
-		return RespondServiceUnavailable(c, "Importer service not available", "The import service is not configured or running")
-	}
-
-	// Add the file to the processing queue
-	var categoryPtr *string
-	if category != "" {
-		categoryPtr = &category
 	}
 
 	// Build base path from CompleteDir for manually uploaded files
@@ -743,6 +747,28 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 			continue
 		}
 
+		// Sanitize filename from title
+		safeTitle := sanitizeFilename(resolved.Title)
+
+		var categoryPtr *string
+		if req.Category != "" {
+			categoryPtr = &req.Category
+		}
+		priority := database.QueuePriority(req.Priority)
+
+		// De-dupe re-submissions: update the existing pending item instead of creating a duplicate.
+		if existing, err := s.importerService.FindAndUpdatePendingUpload(c.Context(), safeTitle+".nzb", categoryPtr, &priority); err != nil {
+			result.ErrorMessage = "Failed to update existing queue item: " + err.Error()
+			results = append(results, result)
+			continue
+		} else if existing != nil {
+			result.Success = true
+			result.QueueID = &existing.ID
+			successCount++
+			results = append(results, result)
+			continue
+		}
+
 		// Create temp file for the NZB
 		tempDir := os.TempDir()
 		uploadDir := filepath.Join(tempDir, "altmount-uploads")
@@ -751,9 +777,6 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 			results = append(results, result)
 			continue
 		}
-
-		// Sanitize filename from title
-		safeTitle := sanitizeFilename(resolved.Title)
 		tempFile := filepath.Join(uploadDir, safeTitle+".nzb")
 
 		// Embed password in NZB if provided
@@ -771,12 +794,6 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 			continue
 		}
 
-		// Add to queue
-		var categoryPtr *string
-		if req.Category != "" {
-			categoryPtr = &req.Category
-		}
-
 		var basePath *string
 		if s.configManager != nil {
 			completeDir := s.configManager.GetConfig().SABnzbd.CompleteDir
@@ -789,7 +806,6 @@ func (s *Server) handleUploadNZBLnk(c *fiber.Ctx) error {
 			}
 		}
 
-		priority := database.QueuePriority(req.Priority)
 		item, err := s.importerService.AddToQueue(c.Context(), tempFile, basePath, categoryPtr, &priority, nil, nil)
 		if err != nil {
 			os.Remove(tempFile)
@@ -898,11 +914,29 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 		return RespondNotFound(c, "NZB", "Could not find NZB for name '"+req.Name+"': "+err.Error())
 	}
 
+	safeTitle := sanitizeFilename(resolved.Title)
+
+	var categoryPtr *string
+	if req.Category != "" {
+		categoryPtr = &req.Category
+	}
+	priority := database.QueuePriority(req.Priority)
+
+	// De-dupe re-submissions: update the existing pending item instead of creating a duplicate.
+	if existing, err := s.importerService.FindAndUpdatePendingUpload(c.Context(), safeTitle+".nzb", categoryPtr, &priority); err != nil {
+		return RespondInternalError(c, "Failed to update existing queue item", err.Error())
+	} else if existing != nil {
+		return RespondCreated(c, fiber.Map{
+			"queue_id": existing.ID,
+			"title":    resolved.Title,
+			"indexer":  resolved.Indexer,
+		})
+	}
+
 	uploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
 	if err := os.MkdirAll(uploadDir, 0755); err != nil {
 		return RespondInternalError(c, "Failed to create upload directory", err.Error())
 	}
-	safeTitle := sanitizeFilename(resolved.Title)
 	tempFile := filepath.Join(uploadDir, safeTitle+".nzb")
 
 	nzbContent := resolved.NZBContent
@@ -912,11 +946,6 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 	}
 	if err := os.WriteFile(tempFile, nzbContent, 0644); err != nil {
 		return RespondInternalError(c, "Failed to save NZB file", err.Error())
-	}
-
-	var categoryPtr *string
-	if req.Category != "" {
-		categoryPtr = &req.Category
 	}
 
 	var basePath *string
@@ -930,7 +959,6 @@ func (s *Server) handleSearchNZBByName(c *fiber.Ctx) error {
 		}
 	}
 
-	priority := database.QueuePriority(req.Priority)
 	item, err := s.importerService.AddToQueue(c.Context(), tempFile, basePath, categoryPtr, &priority, nil, nil)
 	if err != nil {
 		os.Remove(tempFile)

--- a/internal/arrs/scanner/discovery.go
+++ b/internal/arrs/scanner/discovery.go
@@ -66,20 +66,20 @@ func (m *Manager) DiscoverFileMetadata(ctx context.Context, filePath, relativePa
 func (m *Manager) runStrictDiscovery(ctx context.Context, inst *model.ConfigInstance, filePath, cleanNzbName, libraryPath string) (*model.WebhookMetadata, error) {
 	switch inst.Type {
 	case "radarr":
-		return m.discoverRadarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+		return m.discoverRadarrStrict(ctx, inst, filePath, cleanNzbName, libraryPath)
 	case "sonarr", "whisparr":
-		return m.discoverSonarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+		return m.discoverSonarrStrict(ctx, inst, filePath, cleanNzbName, libraryPath)
 	case "lidarr":
-		return m.discoverLidarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+		return m.discoverLidarrStrict(ctx, inst, filePath, cleanNzbName, libraryPath)
 	case "readarr":
-		return m.discoverReadarrStrict(ctx, filePath, cleanNzbName, libraryPath, inst.Name)
+		return m.discoverReadarrStrict(ctx, inst, filePath, cleanNzbName, libraryPath)
 	}
 	return nil, fmt.Errorf("unsupported type")
 }
 
-func (m *Manager) discoverRadarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
-	instanceConfig, _ := m.instances.FindConfigInstance("radarr", instanceName)
-	client, _ := m.clients.GetOrCreateRadarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
+func (m *Manager) discoverRadarrStrict(ctx context.Context, inst *model.ConfigInstance, filePath, cleanNzbName, libraryPath string) (*model.WebhookMetadata, error) {
+	instanceName := inst.Name
+	client, _ := m.clients.GetOrCreateRadarrClient(instanceName, inst.URL, inst.APIKey)
 
 	// 1. Check Library (Active Files)
 	movies, err := m.data.GetMovies(ctx, client, instanceName)
@@ -130,9 +130,13 @@ func (m *Manager) discoverRadarrStrict(ctx context.Context, filePath, cleanNzbNa
 	return nil, fmt.Errorf("not found")
 }
 
-func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
-	instanceConfig, _ := m.instances.FindConfigInstance("sonarr", instanceName)
-	client, _ := m.clients.GetOrCreateSonarrClient(instanceName, instanceConfig.URL, instanceConfig.APIKey)
+func (m *Manager) discoverSonarrStrict(ctx context.Context, inst *model.ConfigInstance, filePath, cleanNzbName, libraryPath string) (*model.WebhookMetadata, error) {
+	// Use the already-resolved instance config (inst) directly. Both "sonarr" and
+	// "whisparr" instances route here, so re-looking up by a hardcoded "sonarr"
+	// type would miss whisparr instances and return a nil config, causing a
+	// nil-pointer dereference. inst is guaranteed non-nil by runStrictDiscovery.
+	instanceName := inst.Name
+	client, _ := m.clients.GetOrCreateSonarrClient(instanceName, inst.URL, inst.APIKey)
 
 	// 1. Check Library (Active Files)
 	series, err := m.data.GetSeries(ctx, client, instanceName)
@@ -192,10 +196,10 @@ func (m *Manager) discoverSonarrStrict(ctx context.Context, filePath, cleanNzbNa
 	return nil, fmt.Errorf("not found")
 }
 
-func (m *Manager) discoverLidarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
+func (m *Manager) discoverLidarrStrict(_ context.Context, _ *model.ConfigInstance, _, _, _ string) (*model.WebhookMetadata, error) {
 	return nil, fmt.Errorf("lidarr strict discovery not implemented")
 }
 
-func (m *Manager) discoverReadarrStrict(ctx context.Context, filePath, cleanNzbName, libraryPath, instanceName string) (*model.WebhookMetadata, error) {
+func (m *Manager) discoverReadarrStrict(_ context.Context, _ *model.ConfigInstance, _, _, _ string) (*model.WebhookMetadata, error) {
 	return nil, fmt.Errorf("readarr strict discovery not implemented")
 }

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1008,9 +1008,9 @@ func (r *HealthRepository) ResetStalePendingFiles(ctx context.Context) error {
 }
 
 // DeleteHealthRecordsBulk removes multiple health records from the database
-func (r *HealthRepository) DeleteHealthRecordsBulk(ctx context.Context, filePaths []string) error {
+func (r *HealthRepository) DeleteHealthRecordsBulk(ctx context.Context, filePaths []string) (int64, error) {
 	if len(filePaths) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// SQLite parameter limit typically is 999. Batch delete in chunks of 500.
@@ -1032,21 +1032,18 @@ func (r *HealthRepository) DeleteHealthRecordsBulk(ctx context.Context, filePath
 
 		result, err := r.db.ExecContext(ctx, query, args...)
 		if err != nil {
-			return fmt.Errorf("failed to delete health records batch starting at %d: %w", i, err)
+			return totalRowsAffected, fmt.Errorf("failed to delete health records batch starting at %d: %w", i, err)
 		}
 
 		rowsAffected, err := result.RowsAffected()
 		if err != nil {
-			return fmt.Errorf("failed to get rows affected for batch starting at %d: %w", i, err)
+			return totalRowsAffected, fmt.Errorf("failed to get rows affected for batch starting at %d: %w", i, err)
 		}
 		totalRowsAffected += rowsAffected
 	}
 
-	if totalRowsAffected == 0 {
-		return fmt.Errorf("no health records found to delete")
-	}
-
-	return nil
+	// Zero deletions is not an error; callers report the actual count.
+	return totalRowsAffected, nil
 }
 
 // ResetHealthChecksBulk resets multiple health records to pending status

--- a/internal/database/health_repository_test.go
+++ b/internal/database/health_repository_test.go
@@ -180,6 +180,38 @@ func TestHealthRepository_DeleteHealthRecordsByPrefix(t *testing.T) {
 	assert.Nil(t, h)
 }
 
+func TestHealthRepository_DeleteHealthRecordsBulk(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Insert two health records.
+	for _, f := range []string{"movies/Keep/file.mkv", "movies/Gone/file.mkv"} {
+		require.NoError(t, repo.UpdateFileHealth(ctx, f, HealthStatusHealthy, nil, nil, nil, false))
+	}
+
+	// Mixed existing/non-existent paths: returns the actual deleted count.
+	count, err := repo.DeleteHealthRecordsBulk(ctx, []string{"movies/Gone/file.mkv", "movies/DoesNotExist/file.mkv"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+
+	h, err := repo.GetFileHealth(ctx, "movies/Gone/file.mkv")
+	require.NoError(t, err)
+	assert.Nil(t, h)
+	h, err = repo.GetFileHealth(ctx, "movies/Keep/file.mkv")
+	require.NoError(t, err)
+	assert.NotNil(t, h)
+
+	// All non-existent: no-op success, not the old 500.
+	count, err = repo.DeleteHealthRecordsBulk(ctx, []string{"nope/a.mkv", "nope/b.mkv"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	// Empty input is a no-op success.
+	count, err = repo.DeleteHealthRecordsBulk(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
 // queryScheduledCheckAt reads scheduled_check_at directly from the DB for a given file path.
 // This is needed because GetFileHealth does not select that column.
 // go-sqlite3 may return datetimes in either space-separated or RFC3339 format.

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -14,6 +14,11 @@ import (
 // PostgreSQL's 65535 parameter limit.
 const bulkChunkSize = 500
 
+// escapeLikePattern escapes LIKE wildcards so a literal string can be matched as a prefix.
+func escapeLikePattern(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
+}
+
 // inPlaceholders builds an IN-clause body of n "?" placeholders.
 func inPlaceholders(n int) string {
 	if n == 0 {
@@ -547,6 +552,35 @@ func (r *QueueRepository) UpdateQueueItemNzbPath(ctx context.Context, id int64, 
 		return fmt.Errorf("failed to update queue item nzb path: %w", err)
 	}
 	return nil
+}
+
+// UpdateQueueItemCategory updates the category and priority of a queue item.
+func (r *QueueRepository) UpdateQueueItemCategory(ctx context.Context, id int64, category *string, priority QueuePriority) error {
+	query := `UPDATE import_queue SET category = ?, priority = ?, updated_at = datetime('now') WHERE id = ?`
+	if _, err := r.db.ExecContext(ctx, query, category, priority, id); err != nil {
+		return fmt.Errorf("failed to update queue item category: %w", err)
+	}
+	return nil
+}
+
+// GetPendingQueueItemsByPathPrefix returns pending queue items whose nzb_path starts with prefix.
+func (r *QueueRepository) GetPendingQueueItemsByPathPrefix(ctx context.Context, prefix string) ([]*ImportQueueItem, error) {
+	query := `SELECT id, nzb_path FROM import_queue WHERE status = 'pending' AND nzb_path LIKE ? ESCAPE '\'`
+	rows, err := r.db.QueryContext(ctx, query, escapeLikePattern(prefix)+"%")
+	if err != nil {
+		return nil, fmt.Errorf("failed to query pending queue items by prefix: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*ImportQueueItem
+	for rows.Next() {
+		var it ImportQueueItem
+		if err := rows.Scan(&it.ID, &it.NzbPath); err != nil {
+			return nil, fmt.Errorf("failed to scan pending queue item: %w", err)
+		}
+		items = append(items, &it)
+	}
+	return items, rows.Err()
 }
 
 // GetQueueItemByNzbPath returns the queue item with the given NZB path, or nil if not found.

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -404,7 +404,7 @@ func (lsw *LibrarySyncWorker) syncDatabaseRecords(
 	// Batch delete orphaned files
 	if len(filesToDelete) > 0 {
 		if !dryRun {
-			if err := lsw.healthRepo.DeleteHealthRecordsBulk(ctx, filesToDelete); err != nil {
+			if _, err := lsw.healthRepo.DeleteHealthRecordsBulk(ctx, filesToDelete); err != nil {
 				slog.ErrorContext(ctx, "Failed to delete orphaned health records",
 					"count", len(filesToDelete),
 					"error", err)

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -776,6 +776,53 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 	return item, nil
 }
 
+// FindAndUpdatePendingUpload de-duplicates manual NZB re-uploads. UNIQUE(nzb_path) can't catch them
+// because ensurePersistentNzb rewrites the path after insert, so this matches a still-pending item by
+// its category-independent base filename and updates its category/priority in place. Returns nil if none.
+func (s *Service) FindAndUpdatePendingUpload(ctx context.Context, filename string, category *string, priority *database.QueuePriority) (*database.ImportQueueItem, error) {
+	cfg := s.configGetter()
+	nzbsDir := filepath.Join(filepath.Dir(cfg.Database.Path), ".nzbs")
+
+	base := nzbtrim.TrimNzbExtension(sanitizeFilename(filepath.Base(filename)))
+	if base == "" {
+		return nil, nil
+	}
+
+	items, err := s.database.Repository.GetPendingQueueItemsByPathPrefix(ctx, nzbsDir+string(filepath.Separator))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, it := range items {
+		// Persisted name is "<base><ext>" or, on collision, "<id>-<base><ext>".
+		cand := nzbtrim.TrimNzbExtension(filepath.Base(it.NzbPath))
+		if cand != base && cand != fmt.Sprintf("%d-%s", it.ID, base) {
+			continue
+		}
+
+		prio := it.Priority
+		if priority != nil {
+			prio = *priority
+		}
+		if err := s.database.Repository.UpdateQueueItemCategory(ctx, it.ID, category, prio); err != nil {
+			return nil, err
+		}
+
+		updated, err := s.database.Repository.GetQueueItem(ctx, it.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if s.broadcaster != nil {
+			s.broadcaster.BroadcastQueueChanged()
+		}
+		s.log.InfoContext(ctx, "Updated existing pending upload instead of creating a duplicate", "queue_id", it.ID)
+		return updated, nil
+	}
+
+	return nil, nil
+}
+
 // processNzbItem processes the NZB file for a queue item
 func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueueItem) (string, []string, error) {
 	// Determine the base path

--- a/internal/importer/upload_dedup_test.go
+++ b/internal/importer/upload_dedup_test.go
@@ -1,0 +1,128 @@
+package importer
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/stretchr/testify/require"
+)
+
+const dedupNzbContent = `<?xml version="1.0" encoding="UTF-8"?>
+<nzb xmlns="http://www.newzbin.com/DTD/2003/nzb">
+  <file poster="x@x" date="1700000000" subject="Movie.bin (1/1)">
+    <groups><group>alt.binaries.test</group></groups>
+    <segments><segment bytes="100" number="1">abc123@example</segment></segments>
+  </file>
+</nzb>
+`
+
+func newDedupTestService(t *testing.T) (*Service, string) {
+	t.Helper()
+	configDir := t.TempDir()
+	dbPath := filepath.Join(configDir, "altmount.db")
+
+	db, err := database.NewDB(database.Config{Type: "sqlite", DatabasePath: dbPath})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	compressOff := false
+	s := &Service{
+		log:      slog.Default(),
+		database: db,
+		configGetter: func() *config.Config {
+			return &config.Config{
+				Database: config.DatabaseConfig{Path: dbPath},
+				Import:   config.ImportConfig{CompressNzb: &compressOff},
+			}
+		},
+	}
+	return s, configDir
+}
+
+// uploadViaHandlerFlow mirrors handleUploadToQueue: de-dupe first, add only when there's no match.
+func uploadViaHandlerFlow(t *testing.T, s *Service, uploadDir, filename string, category *string) *database.ImportQueueItem {
+	t.Helper()
+	prio := database.QueuePriorityNormal
+
+	existing, err := s.FindAndUpdatePendingUpload(context.Background(), filename, category, &prio)
+	require.NoError(t, err)
+	if existing != nil {
+		return existing
+	}
+
+	require.NoError(t, os.MkdirAll(uploadDir, 0o755))
+	tempFile := filepath.Join(uploadDir, filename)
+	require.NoError(t, os.WriteFile(tempFile, []byte(dedupNzbContent), 0o644))
+
+	item, err := s.AddToQueue(context.Background(), tempFile, nil, category, &prio, nil, nil)
+	require.NoError(t, err)
+	return item
+}
+
+func countQueueRows(t *testing.T, dbPath string) []struct {
+	id       int64
+	category sql.NullString
+} {
+	t.Helper()
+	read, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer read.Close()
+
+	rows, err := read.Query(`SELECT id, category FROM import_queue ORDER BY id`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var out []struct {
+		id       int64
+		category sql.NullString
+	}
+	for rows.Next() {
+		var r struct {
+			id       int64
+			category sql.NullString
+		}
+		require.NoError(t, rows.Scan(&r.id, &r.category))
+		out = append(out, r)
+	}
+	return out
+}
+
+// TestReuploadSetsCategoryInPlace: re-uploading the same file to set a category must update the
+// existing pending item, not create a duplicate.
+func TestReuploadSetsCategoryInPlace(t *testing.T) {
+	s, configDir := newDedupTestService(t)
+	uploadDir := filepath.Join(configDir, "altmount-uploads")
+	dbPath := filepath.Join(configDir, "altmount.db")
+
+	first := uploadViaHandlerFlow(t, s, uploadDir, "Movie.nzb", nil)
+	cat := "movies"
+	second := uploadViaHandlerFlow(t, s, uploadDir, "Movie.nzb", &cat)
+
+	require.Equal(t, first.ID, second.ID, "re-upload must reuse the existing queue item")
+	require.NotNil(t, second.Category)
+	require.Equal(t, "movies", *second.Category)
+
+	rows := countQueueRows(t, dbPath)
+	require.Len(t, rows, 1, "re-upload must not create a duplicate queue entry")
+	require.Equal(t, "movies", rows[0].category.String)
+}
+
+// TestReuploadDifferentFileIsNotDeduped: distinct files must each get their own queue entry.
+func TestReuploadDifferentFileIsNotDeduped(t *testing.T) {
+	s, configDir := newDedupTestService(t)
+	uploadDir := filepath.Join(configDir, "altmount-uploads")
+	dbPath := filepath.Join(configDir, "altmount.db")
+
+	cat := "movies"
+	uploadViaHandlerFlow(t, s, uploadDir, "Movie.nzb", nil)
+	uploadViaHandlerFlow(t, s, uploadDir, "Other.nzb", &cat)
+
+	rows := countQueueRows(t, dbPath)
+	require.Len(t, rows, 2, "distinct files must each get their own queue entry")
+}


### PR DESCRIPTION
## Summary

Three independent backend bug fixes, each addressing a case where AltMount reported success while the underlying operation silently failed, crashed, or duplicated work. Backend only (Go), with unit tests.

This is **PR 1 of 4** in a series that splits a batch of fork work into small, reviewable pieces. The four PRs are based on current `main` and have been verified **mutually conflict-free in any merge order**; the suggested sequence is 1 → 2 → 3 → 4.

## What's included

### 1. `fix(api)`: report true outcomes for arr register / health bulk-delete / NZB export
- **arrs:** download-client registration now runs synchronously and verifies reachability from each *arr instance, so the endpoint returns the real result (`502` + per-instance detail) instead of always reporting success from a fire-and-forget goroutine.
- **health:** `DeleteHealthRecordsBulk` now returns the actual deleted count and treats zero matches as a no-op success — bulk delete returns `200 deleted_count: 0` instead of a `500` when the selected records are already gone.
- **files:** the batch NZB export ZIP is streamed directly to the response instead of being buffered entirely in memory, avoiding timeouts / OOM on large libraries.

### 2. `fix(queue)`: de-duplicate manual NZB re-uploads when setting a category
Re-uploading a manually-added NZB to set or change its category created a **duplicate** queue entry instead of updating the existing pending item. The `UNIQUE(nzb_path)` guard can't catch this because `ensurePersistentNzb` rewrites `nzb_path` to a category-dependent persistent path right after insert, so the re-upload's temp path never collides. The re-upload now detects and updates the existing pending item instead of inserting a second one.

### 3. `fix(arrs)`: prevent nil-pointer panic in strict discovery for whisparr instances
`runStrictDiscovery` routes both `sonarr` and `whisparr` instance types to `discoverSonarrStrict`, but that helper (and `discoverRadarrStrict`) re-looked up the instance config via a hardcoded `FindConfigInstance("sonarr"/"radarr", name)` and discarded the error with `_`. For a whisparr instance the `sonarr`-typed lookup misses, `FindConfigInstance` returns `(nil, err)`, and the subsequent dereference panics. The lookup now uses the instance's real type and handles the error.

> Credit: the whisparr fix was authored by @EsmailELBoBDev2 (authorship preserved in the commit).

## Testing
- `internal/database/health_repository_test.go` — bulk-delete count / zero-match behavior
- `internal/importer/upload_dedup_test.go` — manual re-upload dedup

## Scope
11 files changed (+440 / −159). Backend only — no frontend changes.

## Merge series
- **[1/4] this PR** — backend correctness fixes
- [2/4] `fix(stremio)`: coalesce concurrent plays
- [3/4] `feat`: config + provider/health UI overhaul
- [4/4] `chore`: dead-code cleanup
