### PR TITLE
[2/4] fix(stremio): coalesce concurrent plays so a release imports once

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/javi11/altmount/internal/rclone"
 	"github.com/javi11/altmount/internal/updater"
 	"github.com/javi11/altmount/internal/version"
+	"golang.org/x/sync/singleflight"
 )
 
 // Config represents API server configuration
@@ -69,6 +70,9 @@ type Server struct {
 
 	speedtest     *speedtestCoordinator
 	speedtestOnce sync.Once
+
+	// stremioPlayGroup coalesces concurrent Stremio plays of the same title (download once).
+	stremioPlayGroup singleflight.Group
 }
 
 // NewServer creates a new API server that can optionally register routes on the provided mux (for backwards compatibility)

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -362,72 +362,93 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 		}
 	}
 
-	// Write NZB to temp directory
-	uploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
-	if err := os.MkdirAll(uploadDir, 0755); err != nil {
-		slog.ErrorContext(ctx, "Failed to create upload directory", "error", err)
-		return RespondInternalError(c, "Failed to create upload directory", err.Error())
-	}
-	tempPath := filepath.Join(uploadDir, safeFilename)
-
-	// Short-circuit: join existing active queue item
-	if inQueue, _ := s.queueRepo.IsFileInQueue(ctx, tempPath); inQueue {
-		if activeItems, err := s.queueRepo.ListQueueItems(ctx, nil, safeFilename, "", 1, 0, "updated_at", "desc"); err == nil && len(activeItems) > 0 {
-			return s.waitAndRedirectToStream(c, activeItems[0].ID, baseURL, key, nzbName, 300)
+	// Coalesce concurrent plays of the same title so the release is downloaded/queued once.
+	v, err, _ := s.stremioPlayGroup.Do(safeFilename, func() (interface{}, error) {
+		// Serialized per title: reuse an in-flight or TTL-fresh import instead of re-downloading.
+		if items, e := s.queueRepo.ListQueueItems(ctx, nil, safeFilename, "", 1, 0, "updated_at", "desc"); e == nil && len(items) > 0 {
+			it := items[0]
+			switch it.Status {
+			case database.QueueStatusPending, database.QueueStatusProcessing, database.QueueStatusPaused:
+				return it.ID, nil
+			case database.QueueStatusCompleted:
+				reusable := it.StoragePath != nil && *it.StoragePath != ""
+				if reusable && ttlHours > 0 && it.CompletedAt != nil {
+					reusable = time.Since(*it.CompletedAt) < time.Duration(ttlHours)*time.Hour
+				}
+				if reusable {
+					return it.ID, nil
+				}
+			}
 		}
-	}
 
-	// Download NZB from Prowlarr
-	prowlarrCfg := cfg.Stremio.Prowlarr
-	client := prowlarr.NewClient(
-		prowlarrCfg.Host,
-		prowlarrCfg.APIKey,
-		httpclient.NewForExternal(cfg.Network, httpclient.LongTimeout),
-	)
-	nzbData, err := client.DownloadNZB(ctx, downloadURL)
+		if s.importerService == nil {
+			return nil, fmt.Errorf("importer service not available")
+		}
+
+		// Detach from the caller's request so one client disconnecting won't abort shared work.
+		workCtx := context.WithoutCancel(ctx)
+
+		// Unique per-request staging dir so concurrent plays never share a temp file.
+		uploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
+		if err := os.MkdirAll(uploadDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create upload directory: %w", err)
+		}
+		stageDir, err := os.MkdirTemp(uploadDir, "play-*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create staging directory: %w", err)
+		}
+		// Importer moves the NZB out on success; this clears the staged file / empty dir.
+		defer os.RemoveAll(stageDir)
+		tempPath := filepath.Join(stageDir, safeFilename)
+
+		// Download NZB from Prowlarr
+		prowlarrCfg := cfg.Stremio.Prowlarr
+		client := prowlarr.NewClient(
+			prowlarrCfg.Host,
+			prowlarrCfg.APIKey,
+			httpclient.NewForExternal(cfg.Network, httpclient.LongTimeout),
+		)
+		nzbData, err := client.DownloadNZB(workCtx, downloadURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to download NZB from Prowlarr: %w", err)
+		}
+		if err := os.WriteFile(tempPath, nzbData, 0644); err != nil {
+			return nil, fmt.Errorf("failed to write NZB temp file: %w", err)
+		}
+
+		var basePath *string
+		if completeDir := cfg.SABnzbd.CompleteDir; completeDir != "" {
+			basePath = &completeDir
+		}
+
+		priority := database.QueuePriorityHigh
+		// Map Stremio stream type to Newznab category name so downloads land in the
+		// correct folder (matches default SABnzbd category config).
+		category := "Movies"
+		if c.Query("type") == "series" {
+			category = "TV"
+		}
+		stremioDownloadID := stremioDownloadIDPrefix + uuid.NewString()
+		item, err := s.importerService.AddToQueue(workCtx, tempPath, basePath, &category, &priority, nil, &stremioDownloadID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add NZB to queue: %w", err)
+		}
+
+		slog.InfoContext(ctx, "Prowlarr NZB queued for Stremio play",
+			"queue_id", item.ID, "title", safeTitle)
+		return item.ID, nil
+	})
 	if err != nil {
-		slog.WarnContext(ctx, "Failed to download NZB from Prowlarr",
-			"error", err, "title", safeTitle)
-		return RespondServiceUnavailable(c, "Failed to download NZB from Prowlarr", err.Error())
+		slog.WarnContext(ctx, "Failed to prepare Stremio NZB stream", "error", err, "title", safeTitle)
+		return RespondServiceUnavailable(c, "Failed to prepare NZB stream", err.Error())
 	}
 
-	if err := os.WriteFile(tempPath, nzbData, 0644); err != nil {
-		slog.ErrorContext(ctx, "Failed to write NZB temp file", "error", err)
-		return RespondInternalError(c, "Failed to write NZB temp file", err.Error())
+	itemID, ok := v.(int64)
+	if !ok {
+		return RespondInternalError(c, "Unexpected play result", "")
 	}
 
-	// Add NZB to queue with high priority
-	if s.importerService == nil {
-		os.Remove(tempPath)
-		slog.ErrorContext(ctx, "Importer service not available for Stremio addon play")
-		return RespondServiceUnavailable(c, "Importer service not available", "")
-	}
-
-	var basePath *string
-	if completeDir := cfg.SABnzbd.CompleteDir; completeDir != "" {
-		basePath = &completeDir
-	}
-
-	priority := database.QueuePriorityHigh
-	// Map Stremio stream type to Newznab category name so downloads land in the
-	// correct folder (matches default SABnzbd category config).
-	category := "Movies"
-	switch c.Query("type") {
-	case "series":
-		category = "TV"
-	}
-	stremioDownloadID := stremioDownloadIDPrefix + uuid.NewString()
-	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &category, &priority, nil, &stremioDownloadID)
-	if err != nil {
-		os.Remove(tempPath)
-		slog.ErrorContext(ctx, "Failed to add Prowlarr NZB to queue", "error", err, "title", safeTitle)
-		return RespondInternalError(c, "Failed to add NZB to queue", err.Error())
-	}
-
-	slog.InfoContext(ctx, "Prowlarr NZB queued for Stremio play",
-		"queue_id", item.ID, "title", safeTitle)
-
-	return s.waitAndRedirectToStream(c, item.ID, baseURL, key, nzbName, 300)
+	return s.waitAndRedirectToStream(c, itemID, baseURL, key, nzbName, 300)
 }
 
 // waitAndRedirectToStream waits for a queue item to complete and 302-redirects to the first stream URL.


### PR DESCRIPTION
## Summary

Fixes a race where a single Stremio "play" click triggers several import attempts of the same release, producing empty-file import failures and duplicate queue entries. Single commit, backend only.

This is **PR 2 of 4** in a series (see merge-series note below). All four PRs are based on current `main` and are mutually conflict-free in any order.

## The bug

Stremio fires several play requests per click. `handleStremioAddonPlay` staged every request's NZB at a **shared** temp path (`altmount-uploads/<title>.nzb`) and queued it. Concurrent plays of the same title therefore raced on that one file — `os.WriteFile` truncate vs. the import-time read / `os.Rename` — yielding:

- empty-file `EOF` and `no such file` import failures (items dumped to `.nzbs/failed/`), and
- N duplicate queue entries for a single release.

## The fix

Concurrent plays of the same release are **coalesced** so it is staged and imported exactly once: requests for an already in-flight title join the existing operation instead of each writing the shared temp file and enqueuing their own copy.

## Notes for review
- This was originally developed against an earlier `handleStremioAddonPlay`. It has been **rebased onto current `main`** and reconciled with the recent Stremio work (instant mount / X-Api-Key auth / NZB-by-URL, #693); the reconciled result is what's in this branch.
- Files: `internal/api/server.go`, `internal/api/stremio_addon_handlers.go` (2 files, +80 / −55).

## Merge series
- [1/4] `fix`: backend correctness fixes
- **[2/4] this PR** — stremio coalesce concurrent plays
- [3/4] `feat`: config + provider/health UI overhaul
- [4/4] `chore`: dead-code cleanup
