### PR TITLE
fix(importer): keep PAR2-recovered filenames so obfuscated RAR sets don't fragment

### DIFF
--- a/internal/importer/parser/fileinfo/fileinfo.go
+++ b/internal/importer/parser/fileinfo/fileinfo.go
@@ -71,13 +71,17 @@ func getFileInfo(
 
 	// Select best filename using priority system (PAR2 > subject > yEnc header > subject header)
 	filename := selectBestFilename(par2Filename, subjectFilename, headerFilename, file.SubjectHeader)
+	fromPar2 := par2Filename != "" && filename == par2Filename
 
 	// Gap 4: Correct extension based on magic bytes when filename appears obfuscated.
 	// This handles files that were uploaded with a wrong or missing extension.
 	filename = correctExtensionFromMagicBytes(filename, file.First16KB)
 
 	// Gap 5: Last resort — use NZB filename stem when all other sources are obfuscated/empty.
-	if nzbFilenameStem != "" && (filename == "" || isProbablyObfuscated(filename)) {
+	// A PAR2-sourced name is authoritative, so trust it even when the obfuscation heuristic
+	// flags it (e.g. a short base like "yay.rar"); overriding it would split a multi-volume
+	// RAR set whose first volume PAR2 named differently from its .rNN continuations.
+	if !fromPar2 && nzbFilenameStem != "" && (filename == "" || isProbablyObfuscated(filename)) {
 		ext := filepath.Ext(filename)
 		if ext != "" {
 			filename = nzbFilenameStem + ext

--- a/internal/importer/parser/fileinfo/fileinfo_test.go
+++ b/internal/importer/parser/fileinfo/fileinfo_test.go
@@ -1,8 +1,10 @@
 package fileinfo
 
 import (
+	"crypto/md5"
 	"testing"
 
+	"github.com/javi11/altmount/internal/importer/parser/par2"
 	"github.com/javi11/nntppool/v4"
 	"github.com/javi11/nzbparser"
 )
@@ -281,5 +283,46 @@ func TestGetFileInfo_Par2DetectionViaSubject(t *testing.T) {
 					info.IsPar2Archive, tt.wantIsPar2, tt.subjectFilename, tt.headerFilename, info.Filename)
 			}
 		})
+	}
+}
+
+// par2DescFor builds a descriptor map keyed the same way getFileInfo computes it:
+// md5 of the first 16KB zero-padded to 16384 bytes.
+func par2DescFor(first16KB []byte, name string) map[[16]byte]*par2.FileDescriptor {
+	padded := make([]byte, 16384)
+	copy(padded, first16KB)
+	key := md5.Sum(padded)
+	return map[[16]byte]*par2.FileDescriptor{key: {Name: name, Hash16k: key, Length: 100}}
+}
+
+// TestGetFileInfo_Par2NameSurvivesGap5 guards the RAR-set fragmentation bug: PAR2
+// recovers a real first-volume name "yay.rar", but its short lowercase base trips
+// isProbablyObfuscated, so Gap 5 used to overwrite it with the NZB stem. That split
+// the volume from its yay.rNN siblings and broke the whole set. PAR2 is
+// authoritative, so its name must survive.
+func TestGetFileInfo_Par2NameSurvivesGap5(t *testing.T) {
+	content := []byte("rar volume payload")
+	file := &NzbFileWithFirstSegment{
+		NzbFile:   &nzbparser.NzbFile{Filename: "3fefe1fb9d2632bed19c026e37af5f92"},
+		First16KB: content,
+	}
+
+	info := getFileInfo(file, par2DescFor(content, "yay.rar"), "Example.Show.S01E01.1080p.WEB-DL-GRP")
+	if info.Filename != "yay.rar" {
+		t.Errorf("Filename = %q, want %q (PAR2 name was clobbered by Gap 5)", info.Filename, "yay.rar")
+	}
+}
+
+// TestGetFileInfo_Gap5StillFiresWithoutPar2 ensures the fix does not disable Gap 5:
+// with no PAR2 match and an obfuscated subject, the NZB stem is still used.
+func TestGetFileInfo_Gap5StillFiresWithoutPar2(t *testing.T) {
+	file := &NzbFileWithFirstSegment{
+		NzbFile:   &nzbparser.NzbFile{Filename: "b082fa0beaa644d3aa01045d5b8d0b36"},
+		First16KB: make([]byte, 16),
+	}
+
+	info := getFileInfo(file, nil, "My.Show.S01E01")
+	if info.Filename != "My.Show.S01E01" {
+		t.Errorf("Filename = %q, want %q (Gap 5 should still substitute the NZB stem)", info.Filename, "My.Show.S01E01")
 	}
 }


### PR DESCRIPTION
## Summary

Obfuscated, RAR-packed releases (hashed Usenet subjects, no file extensions) failed to import when the set used the old-style `.rar` + `.rNN` volume scheme. The NZB-stem fallback was overwriting the authoritative PAR2-recovered name of the first volume, which split the multi-volume set and broke reconstruction. This change makes a PAR2-sourced filename win over the obfuscation heuristic, so the set stays intact.

## Symptom

Importing a NZB failed with:

```
RAR archive contains no files with allowed extensions (found: [], allowed: [.mkv .mp4 ...])
```

The logs showed the set split in two and the inner file only partially covered:

```
Skipping RAR archive group with missing volume(s) first_file=yay.r19 parts=45
Starting RAR analysis main_file=<NZB-stem>.rar total_parts=1
Omitting partially-covered inner file ... declared_size=2401132141 mapped_bytes=52223830
```

## Root cause

1. PAR2 descriptors correctly recover each volume's real name (`yay.rar`, `yay.r00` … `yay.r44`) by matching the first 16 KB MD5.
2. `getFileInfo`'s Gap 5 fallback replaces the selected filename with the NZB filename stem whenever `isProbablyObfuscated()` is true.
3. `archiveVolumePattern` exempts `.partNN.rar`, `.rNN`, and `.NNN`, but **not** the plain `.rar` first volume. Its short base (`yay`) trips the heuristic, so the recovered name `yay.rar` is overwritten with the NZB stem (e.g. `Example.Show.S01E01.1080p.WEB-DL-GRP.rar`).
4. The renamed first volume now has a different `SetKey` than its `yay.rNN` siblings, so `GroupArchivesByBaseName` splits the set into two groups. `reconcileRepostedFirstVolume` cannot merge them because the NZB stem shares no base name with `yay`.
5. The continuation group is skipped as "missing leading volume," and the lone first volume cannot cover the inner `.mkv` (only ~52 MB of 2.4 GB mapped), so the import fails.

Part-scheme sets (`yay.partNN.rar`) were unaffected because those names already match `archiveVolumePattern`, so Gap 5 never fired on them.

## Fix

`internal/importer/parser/fileinfo/fileinfo.go`: trust a PAR2-sourced name. Skip the Gap 5 fallback when the selected filename came from a PAR2 descriptor, since that is the authoritative real name even if it looks obfuscated.

```go
fromPar2 := par2Filename != "" && filename == par2Filename
...
// A PAR2-sourced name is authoritative, so trust it even when the obfuscation
// heuristic flags it (e.g. a short base like "yay.rar").
if !fromPar2 && nzbFilenameStem != "" && (filename == "" || isProbablyObfuscated(filename)) {
```

Minimal change: +6 / -1 in `fileinfo.go`.

## Tests

- `TestGetFileInfo_Par2NameSurvivesGap5` — a PAR2 name (`yay.rar`) that looks obfuscated is preserved (RED before the fix: returned the NZB stem).
- `TestGetFileInfo_Gap5StillFiresWithoutPar2` — with no PAR2 match, the NZB-stem fallback still applies (guards against disabling Gap 5).
- Regression: `internal/importer/parser/...` and `internal/importer/archive/rar/...` pass.

## Verification

Reproduced and confirmed fixed end-to-end against three obfuscated releases (`S07E13`, `S07E14`, `S08E08`). All now process and mount successfully; before the fix all three failed with "no files with allowed extensions."

## Scope / notes

- Does not touch the `reconcileRepostedFirstVolume` `baseExtends` guard. Fixing the naming at the source keeps the set together, so reconcile is not needed for this case. (A reconcile-layer relaxation remains a possible defense-in-depth follow-up if a release ever ships a first volume whose PAR2 name genuinely differs from its continuations.)
- No behavior change for non-obfuscated releases or part-scheme RAR sets.
