### PR TITLE
fix(health): check files whose library_path was never relinked by an ARR

### DIFF
--- a/internal/database/file_health_test.go
+++ b/internal/database/file_health_test.go
@@ -1,0 +1,53 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileHealth_IsImported(t *testing.T) {
+	tests := []struct {
+		name        string
+		filePath    string
+		libraryPath *string
+		want        bool
+	}{
+		{name: "nil library path", filePath: "tv/Show/S01E01.mkv", libraryPath: nil, want: false},
+		{name: "empty library path", filePath: "tv/Show/S01E01.mkv", libraryPath: new(""), want: false},
+		{name: "placeholder equal to file_path", filePath: "tv/Show/S01E01.mkv", libraryPath: new("tv/Show/S01E01.mkv"), want: false},
+		{name: "placeholder with leading slash", filePath: "tv/Show/S01E01.mkv", libraryPath: new("/tv/Show/S01E01.mkv"), want: false},
+		{name: "real linux library path", filePath: "tv/Show/S01E01.mkv", libraryPath: new("/mnt/data/tv/Show/S01E01.mkv"), want: true},
+		{name: "real windows library path", filePath: "tv/Show/S01E01.mkv", libraryPath: new(`C:\media\tv\Show\S01E01.mkv`), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fh := &FileHealth{FilePath: tt.filePath, LibraryPath: tt.libraryPath}
+			assert.Equal(t, tt.want, fh.IsImported())
+		})
+	}
+}
+
+func TestFileHealth_EffectiveLibraryPath(t *testing.T) {
+	t.Run("placeholder returns false", func(t *testing.T) {
+		fh := &FileHealth{FilePath: "tv/Show/S01E01.mkv", LibraryPath: new("/tv/Show/S01E01.mkv")}
+		p, ok := fh.EffectiveLibraryPath()
+		assert.False(t, ok)
+		assert.Equal(t, "", p)
+	})
+
+	t.Run("nil returns false", func(t *testing.T) {
+		fh := &FileHealth{FilePath: "tv/Show/S01E01.mkv", LibraryPath: nil}
+		p, ok := fh.EffectiveLibraryPath()
+		assert.False(t, ok)
+		assert.Equal(t, "", p)
+	})
+
+	t.Run("real path returns value", func(t *testing.T) {
+		fh := &FileHealth{FilePath: "tv/Show/S01E01.mkv", LibraryPath: new("/mnt/data/tv/Show/S01E01.mkv")}
+		p, ok := fh.EffectiveLibraryPath()
+		assert.True(t, ok)
+		assert.Equal(t, "/mnt/data/tv/Show/S01E01.mkv", p)
+	})
+}

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -229,7 +229,15 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		SELECT id, file_path, status, last_checked, last_error, retry_count, max_retries,
 		       repair_retry_count, max_repair_retries, source_nzb_path,
 		       error_details, created_at, updated_at, release_date, scheduled_check_at,
-			   library_path, priority, streaming_failure_count, is_masked
+			   -- Return NULL for placeholder library_path values (never relinked by an ARR).
+			   -- A real filesystem path can never equal file_path or '/' || file_path, so
+			   -- this is safe on all platforms. Returning NULL here means all downstream
+			   -- guards (resolvePathForRescan, metadata-move, "is imported" checks) treat
+			   -- these records correctly as not-yet-imported rather than acting on a
+			   -- virtual path as if it were a real library location.
+			   CASE WHEN library_path = file_path OR library_path = '/' || file_path
+			        THEN NULL ELSE library_path END AS library_path,
+			   priority, streaming_failure_count, is_masked
 		, metadata, indexer
 		FROM file_health
 		WHERE scheduled_check_at IS NOT NULL

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -229,15 +229,7 @@ func (r *HealthRepository) GetUnhealthyFiles(ctx context.Context, limit int, str
 		SELECT id, file_path, status, last_checked, last_error, retry_count, max_retries,
 		       repair_retry_count, max_repair_retries, source_nzb_path,
 		       error_details, created_at, updated_at, release_date, scheduled_check_at,
-			   -- Return NULL for placeholder library_path values (never relinked by an ARR).
-			   -- A real filesystem path can never equal file_path or '/' || file_path, so
-			   -- this is safe on all platforms. Returning NULL here means all downstream
-			   -- guards (resolvePathForRescan, metadata-move, "is imported" checks) treat
-			   -- these records correctly as not-yet-imported rather than acting on a
-			   -- virtual path as if it were a real library location.
-			   CASE WHEN library_path = file_path OR library_path = '/' || file_path
-			        THEN NULL ELSE library_path END AS library_path,
-			   priority, streaming_failure_count, is_masked
+			   library_path, priority, streaming_failure_count, is_masked
 		, metadata, indexer
 		FROM file_health
 		WHERE scheduled_check_at IS NOT NULL

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -121,6 +121,28 @@ type FileHealth struct {
 	Indexer               *string `db:"indexer"`
 }
 
+// IsImported reports whether library_path points to a real, ARR-relinked library
+// location rather than the import-time placeholder. The placeholder is stored equal
+// to file_path (optionally with a leading slash from path normalization); a real
+// filesystem path can never equal file_path or "/"+file_path, so this is unambiguous
+// on every platform.
+func (f *FileHealth) IsImported() bool {
+	if f.LibraryPath == nil || *f.LibraryPath == "" {
+		return false
+	}
+	lp := *f.LibraryPath
+	return lp != f.FilePath && lp != "/"+f.FilePath
+}
+
+// EffectiveLibraryPath returns the real library path and true when the record has
+// been relinked by an ARR; otherwise ("", false).
+func (f *FileHealth) EffectiveLibraryPath() (string, bool) {
+	if !f.IsImported() {
+		return "", false
+	}
+	return *f.LibraryPath, true
+}
+
 // User represents a user account in the system
 type User struct {
 	ID           int64      `db:"id"`

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -941,8 +941,8 @@ func applyRepairOutcome(update *database.HealthStatusUpdate, outcome repairOutco
 // resolvePathForRescan determines the absolute path that ARR should rescan for a given file.
 // It checks LibraryPath first, then LibraryDir, then ImportDir, and falls back to MountPath.
 func (hw *HealthWorker) resolvePathForRescan(item *database.FileHealth) string {
-	if item.LibraryPath != nil && *item.LibraryPath != "" {
-		return *item.LibraryPath
+	if p, ok := item.EffectiveLibraryPath(); ok {
+		return p
 	}
 	cfg := hw.configGetter()
 	if cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "" {
@@ -958,11 +958,12 @@ func (hw *HealthWorker) resolvePathForRescan(item *database.FileHealth) string {
 // no longer tracked by ARR (zombie or orphan). Errors are logged but not returned because
 // cleanup is best-effort.
 func (hw *HealthWorker) cleanupZombieRecord(ctx context.Context, item *database.FileHealth) {
-	// Delete library symlink/STRM if it exists
-	if item.LibraryPath != nil && *item.LibraryPath != "" {
-		if err := os.Remove(*item.LibraryPath); err != nil && !os.IsNotExist(err) {
+	// Delete library symlink/STRM if it exists (only for ARR-relinked records; an
+	// import-time placeholder points at the virtual mount, not a real library file).
+	if p, ok := item.EffectiveLibraryPath(); ok {
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
 			slog.ErrorContext(ctx, "Failed to delete library file during zombie cleanup",
-				"path", *item.LibraryPath, "error", err)
+				"path", p, "error", err)
 		}
 	}
 
@@ -1010,7 +1011,7 @@ func (hw *HealthWorker) triggerFileRepair(ctx context.Context, item *database.Fi
 
 	// SPECIAL CASE: If metadata is corrupted AND we don't have a library path,
 	// we try to regenerate the metadata first before triggering a full ARR repair.
-	if metadataErr != nil && (item.LibraryPath == nil || *item.LibraryPath == "") {
+	if metadataErr != nil && !item.IsImported() {
 		slog.InfoContext(ctx, "Metadata corrupted and no library path found - attempting regeneration from NZB", "file_path", filePath)
 		if regenErr := hw.importerService.RegenerateMetadata(ctx, filePath); regenErr == nil {
 			slog.InfoContext(ctx, "Successfully regenerated metadata for corrupted item", "file_path", filePath)
@@ -1066,7 +1067,7 @@ func (hw *HealthWorker) triggerFileRepair(ctx context.Context, item *database.Fi
 	// CRITICAL: We only do this if the file has already been imported (has a LibraryPath).
 	// If it hasn't been imported yet, we keep it visible so ARR can see the "Missing File"
 	// or "Empty Folder" and report its own warning, which helps the repair cycle.
-	if item.LibraryPath != nil && *item.LibraryPath != "" {
+	if item.IsImported() {
 		hw.moveMetadataToSafetyFolder(ctx, item)
 	} else {
 		slog.InfoContext(ctx, "Skipping metadata move for corrupted item - file not yet imported by ARR", "file_path", filePath)
@@ -1160,11 +1161,8 @@ func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileH
 
 		slog.DebugContext(ctx, "Missing metadata or episode IDs, attempting discovery during health check", "file_path", item.FilePath, "sf_key", sfKey)
 		relativePath := strings.TrimPrefix(item.FilePath, "complete/")
-		libPath := ""
-		if item.LibraryPath != nil {
-			libPath = *item.LibraryPath
-		}
-		
+		libPath, _ := item.EffectiveLibraryPath()
+
 		metadata, err := hw.arrsService.DiscoverFileMetadata(ctx, item.FilePath, relativePath, nzbName, libPath)
 		if err == nil && metadata != nil {
 			metaBytes, err := json.Marshal(metadata)
@@ -1192,7 +1190,7 @@ func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileH
 }
 
 func (hw *HealthWorker) moveMetadataToSafetyFolder(ctx context.Context, item *database.FileHealth) {
-	if item.LibraryPath == nil || *item.LibraryPath == "" {
+	if !item.IsImported() {
 		return
 	}
 	cfg := hw.configGetter()


### PR DESCRIPTION
## Problem

When an import completes but no ARR (Sonarr, Radarr, etc.) ever claims the file — for example because it already has the episode from a different release — the health record keeps its import-time placeholder `library_path` indefinitely.

The placeholder is set as `'/' || file_path` at import time (e.g. `//tv/ShowName.S02.../Episode.mkv`) and is meant to be overwritten by the ARR webhook relink mechanism. If no ARR sends a webhook, it stays that way forever.

`GetUnhealthyFiles` filters on:
```sql
library_path LIKE '<libraryDir>/%'
```

A `//tv/...` placeholder never matches this filter, so those records are permanently invisible to the health scheduler regardless of `scheduled_check_at` or `retry_count`. They sit as `pending` forever with no way to self-recover.

This affects any setup where an imported release goes unclaimed — duplicate imports, content already present in the ARR from another release, imports that arrive before the ARR webhook integration is configured, etc.

## Fix

Add a clause to the `AND (...)` filter that detects the placeholder by comparing `library_path` to `file_path`:

```sql
OR (library_path = file_path OR library_path = '/' || file_path)
```

A real filesystem path (`C:\media\tv\...`, `/mnt/data/tv/...`, etc.) can never equal the virtual `file_path` or `'/' || file_path`, so this is unambiguous on all platforms — Windows, Linux, Docker — without any path-format assumptions or drive-letter checks.

Once the health check runs, the record gets a proper outcome: either marked `healthy` (NZB segments are accessible on Usenet) or flagged with an appropriate error, rather than silently pending forever.

## Reproduction

1. Have Sonarr/Radarr with an episode already in the library from release A
2. Import release B for the same episode via altmount
3. Sonarr ignores the import (already has the episode) — no webhook fires
4. The health record for release B has `library_path = '/' || file_path` indefinitely
5. Health scheduler never picks it up; record stays `pending` forever