### PR TITLE
fix(stremio): prevent duplicate NZB queue entries after path persistence

### DIFF
--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -231,12 +232,17 @@ func (r *QueueRepository) AddStoragePath(ctx context.Context, itemID int64, stor
 	return nil
 }
 
-// IsFileInQueue checks if a file is already in the queue (pending or processing)
+// IsFileInQueue checks if a file is already in the queue (pending, processing, or paused).
+// It matches by exact nzb_path first, and also by filename suffix to handle the case where
+// ensurePersistentNzb has already moved the file and updated nzb_path from the temp path to
+// the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42/x.nzb).
 func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (bool, error) {
-	query := `SELECT 1 FROM import_queue WHERE nzb_path = ? AND status IN ('pending', 'processing', 'paused') LIMIT 1`
+	filename := filepath.Base(filePath)
+	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status IN ('pending', 'processing', 'paused') LIMIT 1`
+	likePattern := "%/" + filename
 
 	var exists int
-	err := r.db.QueryRowContext(ctx, query, filePath).Scan(&exists)
+	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(&exists)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil


### PR DESCRIPTION
## Summary

- `IsFileInQueue` used an exact `nzb_path =` match, but `importer/service.go`'s `AddToQueue` first inserts the row with the temp path (`/tmp/altmount-uploads/x.nzb`) then immediately updates it to the persistent path (`/.nzbs/stremio/42/x.nzb`) via `ensurePersistentNzb`.
- After that update, any second request for the same NZB (aiostreams retry, user re-clicking play) would pass `IsFileInQueue` (exact match fails), skip the active-item dedup check, and create a **duplicate queue entry** — causing the NZB to be downloaded twice.
- Fix: add a `nzb_path LIKE '%/filename'` suffix match alongside the existing exact match so dedup works regardless of which path variant is stored in the DB.

## Changes

**`internal/database/queue_repository.go`** — `IsFileInQueue`:
- Added `path/filepath` import
- Changed query from single exact match to `(nzb_path = ? OR nzb_path LIKE ?)` where the LIKE pattern is `%/<basename>`

## Test plan

- [ ] `make` passes (Go build + frontend)
- [ ] Submit same NZB URL twice to `POST /api/nzb/streams` with a ~1s gap (after `ensurePersistentNzb` runs) — second request should join the existing queue item, not create a new row
- [ ] Confirm only one `import_queue` row exists for the NZB after both requests