### PR TITLE
fix(importer): resolve cross-device rename errors with centralized MoveFile helper

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/javi11/altmount/internal/pool"
 	"github.com/javi11/altmount/internal/progress"
 	"github.com/javi11/altmount/internal/sabnzbd"
+	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/altmount/pkg/rclonecli"
 	"github.com/javi11/nzbparser"
 )
@@ -628,33 +629,8 @@ func (s *Service) MoveToFailedFolder(ctx context.Context, item *database.ImportQ
 	}
 
 	// Move file
-	if err := os.Rename(item.NzbPath, newPath); err != nil {
-		// Fallback to Copy+Delete
-		s.log.DebugContext(ctx, "Rename failed, trying copy to failed dir", "error", err)
-
-		srcFile, err := os.Open(item.NzbPath)
-		if err != nil {
-			return fmt.Errorf("failed to open source NZB: %w", err)
-		}
-		defer srcFile.Close()
-
-		dstFile, err := os.Create(newPath)
-		if err != nil {
-			return fmt.Errorf("failed to create destination NZB: %w", err)
-		}
-		defer dstFile.Close()
-
-		if _, err := io.Copy(dstFile, srcFile); err != nil {
-			return fmt.Errorf("failed to copy NZB content: %w", err)
-		}
-
-		// Close files explicitly to allow deletion
-		srcFile.Close()
-		dstFile.Close()
-
-		if err := os.Remove(item.NzbPath); err != nil {
-			s.log.WarnContext(ctx, "Failed to remove source NZB after copy", "path", item.NzbPath, "error", err)
-		}
+	if err := utils.MoveFile(item.NzbPath, newPath); err != nil {
+		return fmt.Errorf("failed to move NZB to failed folder: %w", err)
 	}
 
 	// Update DB
@@ -1052,9 +1028,8 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 
 	s.log.DebugContext(ctx, "Moving NZB to persistent storage", "old_path", item.NzbPath, "new_path", newPath)
 
-	// Move the NZB as-is. If the rename fails (e.g. cross-device), leave the
-	// source untouched and abort — the caller can retry rather than risk a partial copy.
-	if err := os.Rename(item.NzbPath, newPath); err != nil {
+	// Move the NZB to persistent storage.
+	if err := utils.MoveFile(item.NzbPath, newPath); err != nil {
 		s.log.ErrorContext(ctx, "Failed to move NZB to persistent storage", "error", err, "src", item.NzbPath, "dst", newPath)
 		return fmt.Errorf("failed to move NZB to persistent storage: %w", err)
 	}

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -823,65 +823,21 @@ func (ms *MetadataService) RenameFileMetadata(oldVirtualPath, newVirtualPath str
 		return fmt.Errorf("failed to create destination metadata directory: %w", err)
 	}
 
-	// Try atomic rename first
-	if err := os.Rename(oldMetaPath, newMetaPath); err != nil {
-		// Fall back to read-write-delete for cross-device moves
-		if !isCrossDeviceError(err) {
-			return fmt.Errorf("failed to rename metadata file: %w", err)
-		}
-
-		if err := copyAndRemoveFile(oldMetaPath, newMetaPath); err != nil {
-			return fmt.Errorf("failed to copy metadata file across devices: %w", err)
-		}
+	// Try to move metadata file
+	if err := utils.MoveFile(oldMetaPath, newMetaPath); err != nil {
+		return fmt.Errorf("failed to rename metadata file: %w", err)
 	}
 
 	// Also rename the .id sidecar file if it exists
 	oldIDPath := oldMetaPath + ".id"
 	newIDPath := newMetaPath + ".id"
 	if _, err := os.Stat(oldIDPath); err == nil {
-		if err := os.Rename(oldIDPath, newIDPath); err != nil {
-			// Cross-device fallback for .id file
-			if isCrossDeviceError(err) {
-				_ = copyAndRemoveFile(oldIDPath, newIDPath)
-			} else {
-				slog.WarnContext(context.Background(), "Failed to rename .id sidecar file", "old", oldIDPath, "new", newIDPath, "error", err)
-			}
+		if err := utils.MoveFile(oldIDPath, newIDPath); err != nil {
+			slog.WarnContext(context.Background(), "Failed to rename .id sidecar file", "old", oldIDPath, "new", newIDPath, "error", err)
 		}
 	}
 
 	return nil
-}
-
-// isCrossDeviceError checks if an error is a cross-device link error (EXDEV).
-func isCrossDeviceError(err error) bool {
-	return strings.Contains(err.Error(), "cross-device") || strings.Contains(err.Error(), "invalid cross-device link")
-}
-
-// copyAndRemoveFile copies src to dst then removes src.
-func copyAndRemoveFile(src, dst string) error {
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer srcFile.Close()
-
-	dstFile, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer dstFile.Close()
-
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		os.Remove(dst) // Clean up partial write
-		return err
-	}
-
-	if err := dstFile.Close(); err != nil {
-		return err
-	}
-	srcFile.Close()
-
-	return os.Remove(src)
 }
 
 // GetMetadataFilePath returns the filesystem path for a metadata file

--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+// MoveFile atomically renames a file from src to dst.
+// If the rename fails due to cross-device boundaries, it falls back to a robust copy-and-delete.
+func MoveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !isCrossDeviceError(err) {
+		return err
+	}
+
+	// Fallback: Copy-and-delete for cross-device moves
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	// Create/overwrite destination with the same permissions as source
+	dstFile, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer dstFile.Close()
+
+	// Copy content
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		dstFile.Close()
+		os.Remove(dst) // Clean up partial write
+		return fmt.Errorf("failed to copy content: %w", err)
+	}
+
+	// Sync to ensure data integrity
+	if err := dstFile.Sync(); err != nil {
+		dstFile.Close()
+		os.Remove(dst) // Clean up partial write
+		return fmt.Errorf("failed to sync destination file: %w", err)
+	}
+
+	// Close both files before attempting removal
+	srcFile.Close()
+	if err := dstFile.Close(); err != nil {
+		return fmt.Errorf("failed to close destination file: %w", err)
+	}
+
+	// Remove source file
+	if err := os.Remove(src); err != nil {
+		return fmt.Errorf("failed to remove source file after successful copy: %w", err)
+	}
+
+	return nil
+}
+
+// isCrossDeviceError checks if an error is a cross-device link error (EXDEV).
+func isCrossDeviceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var lerr *os.LinkError
+	if errors.As(err, &lerr) {
+		return errors.Is(lerr.Err, syscall.EXDEV)
+	}
+	var perr *os.PathError
+	if errors.As(err, &perr) {
+		return errors.Is(perr.Err, syscall.EXDEV)
+	}
+	// Fallback to string check
+	errStr := err.Error()
+	return strings.Contains(errStr, "cross-device") || strings.Contains(errStr, "invalid cross-device link") || strings.Contains(errStr, "EXDEV")
+}

--- a/internal/utils/file_test.go
+++ b/internal/utils/file_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestMoveFile_Normal(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "altmount-move-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	src := filepath.Join(tmpDir, "src.txt")
+	dst := filepath.Join(tmpDir, "dst.txt")
+
+	content := []byte("hello altmount")
+	if err := os.WriteFile(src, content, 0644); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	if err := MoveFile(src, dst); err != nil {
+		t.Fatalf("MoveFile failed: %v", err)
+	}
+
+	// Verify dst exists and src is gone
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Errorf("expected source file to be gone, but stat got: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("failed to read destination file: %v", err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("got content %q, want %q", got, content)
+	}
+}
+
+func TestIsCrossDeviceError(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("some standard error"), false},
+		{errors.New("invalid cross-device link"), true},
+		{errors.New("cross-device link error"), true},
+		{errors.New("EXDEV: invalid cross-device link"), true},
+		{&os.LinkError{Op: "rename", Old: "a", New: "b", Err: syscall.EXDEV}, true},
+		{&os.PathError{Op: "rename", Path: "a", Err: syscall.EXDEV}, true},
+	}
+
+	for _, tt := range tests {
+		if got := isCrossDeviceError(tt.err); got != tt.want {
+			t.Errorf("isCrossDeviceError(%v) = %v; want %v", tt.err, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This PR replaces the raw os.Rename calls in importer/service.go and metadata/service.go with a centralized utils.MoveFile utility that transparently falls back to copy+delete on cross-device boundary failures (EXDEV).