### PR TITLE
Fix: deduplicate SABnzbd history by nzo_id in addition to name

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -831,6 +831,20 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	// Combine and deduplicate by NZB Name
 	// Priority goes to items still in the queue (as they have more metadata)
 	seenNames := make(map[string]bool)
+	// Also dedupe by the nzo_id we will actually emit. The same logical release
+	// can carry two different name strings across the live-completed-queue and
+	// persistent-history sources (e.g. "<id>-Name.nzb.gz" vs the clean NzbName),
+	// so name-only dedup leaks it through as two slots sharing one nzo_id. *arr
+	// then ingests the same download_id twice, building duplicate queue rows and
+	// tripping a .Single() collision on queue delete. nzoKey mirrors the id logic
+	// in ToSABnzbd{Queue,History}Slot so the guard matches the emitted value.
+	seenNzoIDs := make(map[string]bool)
+	nzoKey := func(downloadID *string, id int64) string {
+		if downloadID != nil && *downloadID != "" {
+			return *downloadID
+		}
+		return fmt.Sprintf("%d", id)
+	}
 	finalItems := make([]*database.ImportQueueItem, 0)
 	// Track items sourced from the live queue with status=Completed. Only these
 	// are eligible to be rewritten as Failed when their reported path is
@@ -854,10 +868,12 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 				continue
 			}
 		}
-		if !seenNames[name] {
+		key := nzoKey(item.DownloadID, item.ID)
+		if !seenNames[name] && !seenNzoIDs[key] {
 			finalItems = append(finalItems, item)
 			liveCompleted[item] = true
 			seenNames[name] = true
+			seenNzoIDs[key] = true
 		}
 	}
 
@@ -878,7 +894,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			}
 		}
 
-		if !seenNames[item.NzbName] {
+		if !seenNames[item.NzbName] && !seenNzoIDs[nzoKey(item.DownloadID, id)] {
 			qItem := &database.ImportQueueItem{
 				ID:          id,
 				DownloadID:  item.DownloadID,
@@ -891,6 +907,7 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 			}
 			finalItems = append(finalItems, qItem)
 			seenNames[item.NzbName] = true
+			seenNzoIDs[nzoKey(item.DownloadID, id)] = true
 		}
 	}
 
@@ -917,9 +934,11 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 				continue
 			}
 		}
-		if !seenNames[name] {
+		key := nzoKey(item.DownloadID, item.ID)
+		if !seenNames[name] && !seenNzoIDs[key] {
 			finalItems = append(finalItems, item)
 			seenNames[name] = true
+			seenNzoIDs[key] = true
 		}
 	}
 


### PR DESCRIPTION
**Summary**

- The SABnzbd history endpoint deduplicates items by NZB name, but the same logical release can carry different name strings across the live-queue and persistent-history sources (e.g. <id>-Name.nzb.gz vs the clean NzbName)
- Name-only dedup let these through as two separate slots that share the same nzo_id, causing *arr apps to ingest the same download twice
- This built duplicate queue rows in *arr and triggered a .Single() collision on queue delete
- Adds a secondary seenNzoIDs guard that mirrors the nzo_id key logic already used in ToSABnzbdQueueSlot/ToSABnzbdHistorySlot, ensuring a release can't appear twice regardless of how its name is represented in each source

**Test plan**

1. Import a release via SABnzbd API and confirm it appears only once in the *arr queue
2. Confirm no duplicate nzo_id entries appear in the SABnzbd history response when the same item exists in both the live queue (as Completed) and persistent history
3. Verify *arr queue delete no longer throws a .Single() collision error for previously affected items

Co-authored with Claude Sonnet 4.6