### PR TITLE
fix(rclonecli): stop health check from killing healthy rcd on startup

### DIFF
--- a/pkg/rclonecli/health.go
+++ b/pkg/rclonecli/health.go
@@ -6,6 +6,23 @@ import (
 	"time"
 )
 
+const (
+	// healthCheckInterval is how often MonitorMounts probes mount/rcd health.
+	healthCheckInterval = 30 * time.Second
+
+	// startupGracePeriod is the window after the RC server first becomes ready
+	// during which the health check will NOT kill+restart the rcd subprocess.
+	// The rcd is busiest while it initializes FUSE mounts right after startup,
+	// which is exactly when a liveness probe is most likely to be slow; killing
+	// it then is the regression we are guarding against.
+	startupGracePeriod = 90 * time.Second
+
+	// maxConsecutiveProbeFailures is how many back-to-back failed liveness
+	// probes are required before the rcd subprocess is considered wedged and
+	// restarted. Prevents a single transient miss from nuking a healthy rcd.
+	maxConsecutiveProbeFailures = 3
+)
+
 // checkMountHealth checks if a specific mount is healthy
 func (m *Manager) checkMountHealth(provider string) bool {
 	// Try to list the root directory of the mount
@@ -37,9 +54,9 @@ func (m *Manager) RecoverMount(ctx context.Context, provider string) error {
 	// every subsequent RPC (mount/unmount, config/create, mount/mount) will
 	// hang on context deadline exceeded. Kill+respawn rcd before issuing
 	// recovery RPCs to break out of that wedge.
-	if !m.pingServerWithTimeout(ctx, 5*time.Second) {
+	if !m.probe(ctx, 5*time.Second) {
 		m.logger.WarnContext(ctx, "rcd unresponsive during recovery, restarting subprocess", "provider", provider)
-		if err := m.restartServer(ctx); err != nil {
+		if err := m.restart(ctx); err != nil {
 			return fmt.Errorf("failed to restart wedged rcd: %w", err)
 		}
 		// After restart there is nothing to RC-unmount; skip straight to Mount,
@@ -74,7 +91,7 @@ func (m *Manager) MonitorMounts(ctx context.Context) {
 		return
 	}
 
-	ticker := time.NewTicker(30 * time.Second) // Check every 30 seconds
+	ticker := time.NewTicker(healthCheckInterval)
 	defer ticker.Stop()
 
 	for {
@@ -97,9 +114,36 @@ func (m *Manager) performMountHealthCheck() {
 	// IsReady() only reflects startup state. Probe the rcd subprocess with a
 	// bounded timeout so a wedged rcd is detected even when no individual
 	// mount has failed yet.
-	if !m.pingServerWithTimeout(m.ctx, 5*time.Second) {
-		m.logger.WarnContext(m.ctx, "rcd unresponsive during health check, restarting subprocess")
-		if err := m.restartServer(m.ctx); err != nil {
+	if m.probe(m.ctx, 5*time.Second) {
+		// Healthy probe: clear the failure streak and continue to per-mount checks.
+		m.consecutiveProbeFailures = 0
+	} else {
+		m.consecutiveProbeFailures++
+
+		// Never kill the rcd during the startup grace period: right after
+		// startup it is busy initializing FUSE mounts, so a slow probe is
+		// expected rather than a wedge. Killing it then is the regression we
+		// guard against. Also require sustained failure before restarting so a
+		// single transient miss can't nuke a healthy rcd.
+		m.mu.RLock()
+		readyAt := m.readyAt
+		m.mu.RUnlock()
+		withinGrace := !readyAt.IsZero() && time.Since(readyAt) < startupGracePeriod
+
+		if withinGrace || m.consecutiveProbeFailures < maxConsecutiveProbeFailures {
+			m.logger.WarnContext(m.ctx, "rcd liveness probe failed; not restarting yet",
+				"consecutive_failures", m.consecutiveProbeFailures,
+				"threshold", maxConsecutiveProbeFailures,
+				"within_startup_grace", withinGrace)
+			// Skip per-mount recovery this tick: if rcd is slow, operations/list
+			// would fail too and could trigger a restart that bypasses this guard.
+			return
+		}
+
+		m.logger.WarnContext(m.ctx, "rcd unresponsive during health check, restarting subprocess",
+			"consecutive_failures", m.consecutiveProbeFailures)
+		m.consecutiveProbeFailures = 0
+		if err := m.restart(m.ctx); err != nil {
 			m.logger.ErrorContext(m.ctx, "Failed to restart wedged rcd", "err", err)
 			return
 		}

--- a/pkg/rclonecli/health_test.go
+++ b/pkg/rclonecli/health_test.go
@@ -1,0 +1,115 @@
+package rclonecli
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newHealthTestManager builds a minimal Manager wired only with the fields
+// performMountHealthCheck touches, plus injectable probe/restart seams so the
+// restart decision can be asserted without a live rcd subprocess.
+func newHealthTestManager(t *testing.T, probeOK bool, readyAt time.Time) (*Manager, *int32) {
+	t.Helper()
+
+	ready := make(chan struct{})
+	close(ready) // IsReady() == true
+
+	var restartCalls int32
+	m := &Manager{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctx:         context.Background(),
+		mounts:      make(map[string]*MountInfo),
+		serverReady: ready,
+		readyAt:     readyAt,
+		probe: func(context.Context, time.Duration) bool {
+			return probeOK
+		},
+	}
+	m.restart = func(context.Context) error {
+		atomic.AddInt32(&restartCalls, 1)
+		return nil
+	}
+	return m, &restartCalls
+}
+
+// afterGrace returns a readyAt timestamp old enough that the startup grace
+// period has elapsed.
+func afterGrace() time.Time {
+	return time.Now().Add(-2 * startupGracePeriod)
+}
+
+func TestPerformMountHealthCheck_SuccessResetsFailureStreak(t *testing.T) {
+	m, restarts := newHealthTestManager(t, true, afterGrace())
+	m.consecutiveProbeFailures = 2
+
+	m.performMountHealthCheck()
+
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("healthy probe must not restart rcd, got %d restarts", got)
+	}
+	if m.consecutiveProbeFailures != 0 {
+		t.Fatalf("healthy probe must reset failure streak, got %d", m.consecutiveProbeFailures)
+	}
+}
+
+func TestPerformMountHealthCheck_WithinGraceNeverRestarts(t *testing.T) {
+	// readyAt = now -> firmly inside the startup grace period.
+	m, restarts := newHealthTestManager(t, false, time.Now())
+
+	// Even well past the failure threshold, no restart may happen during grace.
+	for range maxConsecutiveProbeFailures + 2 {
+		m.performMountHealthCheck()
+	}
+
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("must not restart rcd during startup grace period, got %d restarts", got)
+	}
+}
+
+func TestPerformMountHealthCheck_BelowThresholdDoesNotRestart(t *testing.T) {
+	m, restarts := newHealthTestManager(t, false, afterGrace())
+
+	for range maxConsecutiveProbeFailures - 1 {
+		m.performMountHealthCheck()
+	}
+
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("must not restart below threshold, got %d restarts", got)
+	}
+	if m.consecutiveProbeFailures != maxConsecutiveProbeFailures-1 {
+		t.Fatalf("failure streak = %d, want %d", m.consecutiveProbeFailures, maxConsecutiveProbeFailures-1)
+	}
+}
+
+func TestPerformMountHealthCheck_AtThresholdRestartsOnceAndResets(t *testing.T) {
+	m, restarts := newHealthTestManager(t, false, afterGrace())
+
+	for range maxConsecutiveProbeFailures {
+		m.performMountHealthCheck()
+	}
+
+	if got := atomic.LoadInt32(restarts); got != 1 {
+		t.Fatalf("expected exactly 1 restart at threshold, got %d", got)
+	}
+	if m.consecutiveProbeFailures != 0 {
+		t.Fatalf("failure streak must reset after restart, got %d", m.consecutiveProbeFailures)
+	}
+}
+
+func TestPerformMountHealthCheck_NotReadyIsNoOp(t *testing.T) {
+	m, restarts := newHealthTestManager(t, false, afterGrace())
+	m.serverReady = make(chan struct{}) // open -> IsReady() == false
+
+	m.performMountHealthCheck()
+
+	if got := atomic.LoadInt32(restarts); got != 0 {
+		t.Fatalf("must not restart before server is ready, got %d restarts", got)
+	}
+	if m.consecutiveProbeFailures != 0 {
+		t.Fatalf("must not touch failure streak before ready, got %d", m.consecutiveProbeFailures)
+	}
+}

--- a/pkg/rclonecli/manager.go
+++ b/pkg/rclonecli/manager.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -35,6 +36,30 @@ type Manager struct {
 	serverStarted  bool
 	mu             sync.RWMutex
 	cfg            *config.Manager
+
+	// readyAt is stamped when the RC server first becomes ready (serverReady
+	// closed). Guarded by mu. Used to enforce a startup grace period before
+	// the health check is allowed to kill+restart the rcd subprocess.
+	readyAt time.Time
+
+	// consecutiveProbeFailures counts back-to-back failed rcd liveness probes.
+	// Mutated only by the single MonitorMounts goroutine (see monitorOnce), so
+	// it needs no additional locking.
+	consecutiveProbeFailures int
+
+	// monitorOnce ensures MonitorMounts is launched at most once for the
+	// lifetime of the Manager, so a restart (which calls Start again) does not
+	// leak a second monitor goroutine.
+	monitorOnce sync.Once
+
+	// probe checks rcd liveness; defaults to pingServerWithTimeout. Injectable
+	// for testing the health-check decision logic without a live subprocess.
+	probe func(ctx context.Context, timeout time.Duration) bool
+
+	// restart kills+respawns the rcd subprocess; defaults to restartServer.
+	// Injectable so health-check tests can assert the restart decision without
+	// touching a real process.
+	restart func(ctx context.Context) error
 }
 
 type MountInfo struct {
@@ -72,7 +97,7 @@ func NewManager(cfm *config.Manager) *Manager {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &Manager{
+	m := &Manager{
 		cfg:         cfm,
 		rcPort:      rcPort,
 		rcloneDir:   rcloneDir,
@@ -84,6 +109,9 @@ func NewManager(cfm *config.Manager) *Manager {
 		serverReady:   make(chan struct{}),
 		processExited: make(chan struct{}),
 	}
+	m.probe = m.pingServerWithTimeout
+	m.restart = m.restartServer
+	return m
 }
 
 // Start starts the rclone RC server
@@ -183,17 +211,28 @@ func (m *Manager) Start(ctx context.Context) error {
 		}()
 
 		m.waitForServer()
+
+		// Stamp readiness so the health check can enforce a startup grace
+		// period before it is allowed to kill+restart the rcd subprocess.
+		m.mu.Lock()
+		m.readyAt = time.Now()
+		m.mu.Unlock()
+
 		close(serverReady)
 
-		// Start mount monitoring once server is ready
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					m.logger.ErrorContext(m.ctx, "Panic in mount monitor", "panic", r)
-				}
+		// Start mount monitoring once server is ready. monitorOnce guarantees a
+		// single monitor for the Manager's lifetime, so a restart (which calls
+		// Start again) cannot spawn a duplicate monitor goroutine.
+		m.monitorOnce.Do(func() {
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						m.logger.ErrorContext(m.ctx, "Panic in mount monitor", "panic", r)
+					}
+				}()
+				m.MonitorMounts(ctx)
 			}()
-			m.MonitorMounts(ctx)
-		}()
+		})
 
 		// Wait for command to finish and log output
 		err := cmd.Wait()
@@ -215,10 +254,14 @@ func (m *Manager) Start(ctx context.Context) error {
 			m.logger.InfoContext(m.ctx, "Rclone RC server hard-terminated")
 
 		default:
+			// Abnormal exit (e.g. failed to bind the RC port, immediate crash).
+			// Log at WARN with captured output so a failed (re)start is visible
+			// at the default INFO log level instead of being hidden behind a
+			// generic "did not become ready" timeout.
 			if code, ok := ExitCode(err); ok {
-				m.logger.DebugContext(m.ctx, "Rclone RC server error", "exit_code", code, "err", err, "stderr", stderr.String(), "stdout", stdout.String())
+				m.logger.WarnContext(m.ctx, "Rclone RC server exited with error", "exit_code", code, "err", err, "stderr", stderr.String(), "stdout", stdout.String())
 			} else {
-				m.logger.DebugContext(m.ctx, "Rclone RC server error (no exit code)", "err", err, "stderr", stderr.String(), "stdout", stdout.String())
+				m.logger.WarnContext(m.ctx, "Rclone RC server exited with error (no exit code)", "err", err, "stderr", stderr.String(), "stdout", stdout.String())
 			}
 		}
 	}()
@@ -482,6 +525,28 @@ func (m *Manager) pingServerWithTimeout(ctx context.Context, timeout time.Durati
 	return resp.StatusCode == http.StatusOK
 }
 
+// waitForPortFree polls the RC port until a TCP connection can no longer be
+// established (i.e. the old listener is gone) or the timeout elapses. It is a
+// best-effort guard against a kill→respawn bind race; it never fails the
+// restart, only logs if the port is still held when the window expires.
+func (m *Manager) waitForPortFree(ctx context.Context, timeout time.Duration) {
+	addr := net.JoinHostPort("localhost", m.rcPort)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ctx.Err() != nil {
+			return
+		}
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			// Connection refused -> nothing listening -> port is free.
+			return
+		}
+		_ = conn.Close()
+		time.Sleep(100 * time.Millisecond)
+	}
+	m.logger.WarnContext(ctx, "RC port still in use after waiting; restarting rcd anyway", "rc_port", m.rcPort)
+}
+
 // restartServer force-kills the rcd subprocess and starts a fresh one.
 // Used by recovery paths when the rcd has wedged and is not responding to RPCs.
 // The mount map is preserved; callers are expected to re-establish mounts
@@ -514,6 +579,12 @@ func (m *Manager) restartServer(ctx context.Context) error {
 		return ctx.Err()
 	}
 
+	// The killed process may not have released the RC listening socket the
+	// instant Wait returned. Give it a bounded window to free the port so the
+	// fresh rcd doesn't immediately fail to bind (the failure would otherwise
+	// only surface as a 30s "did not become ready" timeout).
+	m.waitForPortFree(ctx, 5*time.Second)
+
 	// Reset lifecycle state so Start() will spawn a new subprocess.
 	m.mu.Lock()
 	m.serverStarted = false
@@ -527,6 +598,8 @@ func (m *Manager) restartServer(ctx context.Context) error {
 	}
 
 	if err := m.WaitForReady(30 * time.Second); err != nil {
+		m.logger.ErrorContext(ctx, "Respawned rcd never answered core/version; see preceding rclone RC server exit logs for the cause (e.g. port still in use or stale mountpoint)",
+			"rc_port", m.rcPort)
 		return fmt.Errorf("rcd did not become ready after restart: %w", err)
 	}
 


### PR DESCRIPTION
## Context

A user reported that ~20s after starting an rclone **internal mount**, the mount breaks with:

```
WARN  rcd unresponsive during health check, restarting subprocess
WARN  Killing wedged rcd subprocess {"pid": 3418401}
INFO  Rclone RC server hard-terminated
INFO  Starting rclone RC server {...}
ERROR Failed to restart wedged rcd {"err":"rcd did not become ready after restart: timeout waiting for rclone RC server to be ready"}
```

The kill→"Failed to restart" gap is **exactly 30s** (the `WaitForReady(30s)` timeout). This does **not** happen on stable tag `v0.2.0`.

## Root cause

The rcd kill/respawn machinery was added after `v0.2.0` (`#566` `7a588e8c`, `#705` `ee1178ea`); `v0.2.0` never kills rcd. The current behavior turns a transient blip into a permanent outage:

1. The first `MonitorMounts` tick (~30s after startup) fires a single 5s `core/version` probe.
2. **One** failed probe immediately kills rcd — no startup grace, no failure threshold. The rcd is busiest initializing the FUSE mount at that moment, so the probe is most likely to be slow precisely then.
3. The respawn times out after exactly 30s.
4. The respawned rcd's startup failure was logged at **DEBUG** (invisible at the user's INFO level), so only the generic timeout showed.

Two amplifying bugs: every `Start()` leaked a second `MonitorMounts` goroutine on restart, and the kill→immediate-respawn could race on the RC port bind.

## Fix (harden, keep auto-recovery)

- **Startup grace period (90s)** + **3 consecutive failures** required before restarting; reset on a healthy probe; skip per-mount recovery on a failed tick so it can't bypass the guard.
- Stamp `readyAt`; guard `MonitorMounts` with `sync.Once` (fixes the double-monitor leak).
- Promote the swallowed abnormal-exit log DEBUG→**WARN** with stderr/stdout so a failed respawn is visible at INFO.
- Wait for the RC port to free before respawning; log a clear ERROR when the respawned rcd never answers.
- Added injectable `probe`/`restart` seams and table-driven regression tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/rclonecli/...`
- [x] `go test -race ./pkg/rclonecli/...` (new tests: grace skip, below-threshold no-restart, at-threshold single restart + reset, success reset, not-ready no-op)
- [ ] Manual: start an internal mount, watch logs ≥2 min — no spurious "Killing wedged rcd subprocess"
- [ ] Manual: `kill -STOP <rcd_pid>` — confirm restart after 3 ticks, respawn becomes ready, mounts re-establish