### PR TITLE
Add episode selection to Stremio season pack streams

### DIFF
--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +36,17 @@ var mediaExtensions = map[string]bool{
 	".webm": true,
 	".ogv":  true,
 	".iso":  true,
+}
+
+var (
+	stremioSeasonEpisodePattern = regexp.MustCompile(`(?i)s0*(\d{1,2})((?:[ ._-]*e0*\d{1,3})+)`)
+	stremioEpisodeOnlyPattern   = regexp.MustCompile(`(?i)e0*(\d{1,3})`)
+	stremioXEpisodePattern      = regexp.MustCompile(`(?i)(?:^|[^0-9])0*(\d{1,2})x0*(\d{1,3})(?:[^0-9]|$)`)
+)
+
+type stremioEpisodeSelector struct {
+	Season  int
+	Episode int
 }
 
 // StremioStream represents a single stream entry in the Stremio addon format.
@@ -73,6 +85,8 @@ type StremioStreamsResponse struct {
 //	@Param			X-Api-Key		header		string	false	"Raw API key (alternative to download_key form field)"
 //	@Param			category		formData	string	false	"Queue category (default: stremio)"
 //	@Param			timeout			formData	int		false	"Processing timeout in seconds (default: 300)"
+//	@Param			season			formData	int		false	"Season number for selecting one episode from a season pack"
+//	@Param			episode			formData	int		false	"Episode number for selecting one episode from a season pack"
 //	@Success		200	{object}	StremioStreamsResponse
 //	@Failure		400	{object}	APIResponse
 //	@Failure		401	{object}	APIResponse
@@ -128,7 +142,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 	if nzbURL != "" {
 		// Download NZB from the provided URL
 		const maxNzbFetchSize = 100 * 1024 * 1024 // 100 MB
-		resp, err := http.Get(nzbURL) //nolint:gosec // URL is provided by an authenticated caller
+		resp, err := http.Get(nzbURL)             //nolint:gosec // URL is provided by an authenticated caller
 		if err != nil {
 			return RespondBadRequest(c, "Failed to fetch NZB from URL", err.Error())
 		}
@@ -176,6 +190,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 
 	// --- Resolve base URL ---
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
+	selector := stremioEpisodeSelectorFromRequest(c)
 
 	category := c.FormValue("category")
 
@@ -205,7 +220,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
 		}
 		if cacheValid {
-			if streams, err := s.buildStremioStreams(prev, baseURL, downloadKey, nzbName); err == nil {
+			if streams, err := s.buildStremioStreams(prev, baseURL, downloadKey, nzbName, selector); err == nil {
 				slog.InfoContext(ctx, "Returning cached Stremio streams for already-processed NZB",
 					"nzb_name", nzbName, "queue_id", prev.ID)
 				return c.JSON(StremioStreamsResponse{
@@ -222,7 +237,7 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 	if inQueue, _ := s.queueRepo.IsFileInQueue(ctx, tempPath); inQueue {
 		activeItems, err := s.queueRepo.ListQueueItems(ctx, nil, safeFilename, "", 1, 0, "updated_at", "desc")
 		if err == nil && len(activeItems) > 0 {
-			return s.waitAndRespond(c, activeItems[0].ID, baseURL, downloadKey, nzbName, timeoutSecs)
+			return s.waitAndRespond(c, activeItems[0].ID, baseURL, downloadKey, nzbName, selector, timeoutSecs)
 		}
 	}
 
@@ -262,13 +277,13 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		"nzb_path", tempPath,
 		"timeout_secs", timeoutSecs)
 
-	return s.waitAndRespond(c, item.ID, baseURL, downloadKey, nzbName, timeoutSecs)
+	return s.waitAndRespond(c, item.ID, baseURL, downloadKey, nzbName, selector, timeoutSecs)
 }
 
 // waitAndRespond subscribes to the progress broadcaster and waits for the queue item to
 // reach a terminal state (completed or failed), then returns the appropriate Stremio response.
 // This avoids polling by using an event-driven approach via the ProgressBroadcaster.
-func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey, nzbName string, timeoutSecs int) error {
+func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector, timeoutSecs int) error {
 	ctx := c.Context()
 
 	// Subscribe before the status check to eliminate the race between AddToQueue and the event.
@@ -286,7 +301,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 
 	switch current.Status {
 	case database.QueueStatusCompleted:
-		streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName)
+		streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector)
 		if err != nil {
 			return RespondInternalError(c, "Failed to list output media files", err.Error())
 		}
@@ -306,7 +321,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 		// If the item is already processing and has a storage path, the streamable
 		// event fired before we subscribed — return the streams immediately.
 		if current.StoragePath != nil && *current.StoragePath != "" {
-			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 				return c.JSON(StremioStreamsResponse{
 					Streams:     streams,
 					QueueItemID: current.ID,
@@ -335,7 +350,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 				// post-processing (symlinks, STRM, health scheduling) completes.
 				if update.StoragePath != "" {
 					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
-					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 						return c.JSON(StremioStreamsResponse{
 							Streams:     streams,
 							QueueItemID: itemID,
@@ -349,7 +364,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 				if err != nil {
 					return RespondInternalError(c, "Failed to fetch completed item", err.Error())
 				}
-				streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName)
+				streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName, selector)
 				if err != nil {
 					return RespondInternalError(c, "Failed to list output media files", err.Error())
 				}
@@ -376,7 +391,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 
 // buildStremioStreams resolves the virtual paths from a completed queue item and
 // returns Stremio stream objects for all media files in the NZB output.
-func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, downloadKey, nzbName string) ([]StremioStream, error) {
+func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector) ([]StremioStream, error) {
 	if item.StoragePath == nil || *item.StoragePath == "" {
 		return nil, fmt.Errorf("completed queue item %d has no storage path", item.ID)
 	}
@@ -385,7 +400,10 @@ func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, do
 
 	// If the storage path already points to a media file, return it directly.
 	if isMediaExtension(filepath.Ext(storagePath)) {
-		return []StremioStream{stremioStreamFromPath(storagePath, baseURL, downloadKey, nzbName)}, nil
+		if selector != nil && !selector.matches(filepath.Base(storagePath)) {
+			return []StremioStream{}, nil
+		}
+		return []StremioStream{stremioStreamFromPath(storagePath, baseURL, downloadKey)}, nil
 	}
 
 	// Otherwise treat it as a virtual directory and list its media files.
@@ -403,25 +421,82 @@ func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, do
 		if !isMediaExtension(filepath.Ext(name)) {
 			continue
 		}
+		if selector != nil && !selector.matches(name) {
+			continue
+		}
 		virtualPath := filepath.ToSlash(filepath.Join(storagePath, name))
-		streams = append(streams, stremioStreamFromPath(virtualPath, baseURL, downloadKey, nzbName))
+		streams = append(streams, stremioStreamFromPath(virtualPath, baseURL, downloadKey))
 	}
 
 	return streams, nil
 }
 
 // stremioStreamFromPath creates a StremioStream for a given virtual file path.
-func stremioStreamFromPath(virtualPath, baseURL, downloadKey, nzbName string) StremioStream {
+func stremioStreamFromPath(virtualPath, baseURL, downloadKey string) StremioStream {
 	streamURL := baseURL + "/api/files/stream?path=" +
 		url.QueryEscape(virtualPath) + "&download_key=" + url.QueryEscape(downloadKey)
+	filename := filepath.Base(virtualPath)
 	return StremioStream{
 		URL:   streamURL,
-		Title: filepath.Base(virtualPath),
-		Name:  nzbName,
+		Title: filename,
+		Name:  filename,
 	}
 }
 
 // isMediaExtension reports whether ext is a common video/media file extension.
 func isMediaExtension(ext string) bool {
 	return mediaExtensions[strings.ToLower(ext)]
+}
+
+func stremioEpisodeSelectorFromRequest(c *fiber.Ctx) *stremioEpisodeSelector {
+	season, okSeason := positiveIntFormOrQuery(c, "season")
+	episode, okEpisode := positiveIntFormOrQuery(c, "episode")
+	if !okSeason || !okEpisode {
+		return nil
+	}
+	return &stremioEpisodeSelector{Season: season, Episode: episode}
+}
+
+func positiveIntFormOrQuery(c *fiber.Ctx, key string) (int, bool) {
+	value := c.FormValue(key)
+	if value == "" {
+		value = c.Query(key)
+	}
+	if value == "" {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func (s *stremioEpisodeSelector) matches(filename string) bool {
+	if s == nil || s.Season <= 0 || s.Episode <= 0 {
+		return true
+	}
+
+	for _, match := range stremioSeasonEpisodePattern.FindAllStringSubmatch(filename, -1) {
+		season, err := strconv.Atoi(match[1])
+		if err != nil || season != s.Season {
+			continue
+		}
+		for _, episodeMatch := range stremioEpisodeOnlyPattern.FindAllStringSubmatch(match[2], -1) {
+			episode, err := strconv.Atoi(episodeMatch[1])
+			if err == nil && episode == s.Episode {
+				return true
+			}
+		}
+	}
+
+	for _, match := range stremioXEpisodePattern.FindAllStringSubmatch(filename, -1) {
+		season, seasonErr := strconv.Atoi(match[1])
+		episode, episodeErr := strconv.Atoi(match[2])
+		if seasonErr == nil && episodeErr == nil && season == s.Season && episode == s.Episode {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/api/nzb_stremio_handlers_test.go
+++ b/internal/api/nzb_stremio_handlers_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildStremioStreamsReturnsEverySeasonPackFileWithFilenameIdentity(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"Show.S01E01.mkv",
+		"Show.S01E02.mkv",
+		"Show.S01E03.mkv",
+	})
+
+	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", nil)
+	require.NoError(t, err)
+	require.Len(t, streams, 3)
+
+	for i, stream := range streams {
+		expectedName := []string{"Show.S01E01.mkv", "Show.S01E02.mkv", "Show.S01E03.mkv"}[i]
+		require.Equal(t, expectedName, stream.Title)
+		require.Equal(t, expectedName, stream.Name)
+		require.Contains(t, stream.URL, "download_key=download-key")
+
+		parsedURL, err := url.Parse(stream.URL)
+		require.NoError(t, err)
+		require.Equal(t, "/api/files/stream", parsedURL.Path)
+		require.Equal(t, "/complete/TV/Release.Name/"+expectedName, parsedURL.Query().Get("path"))
+	}
+}
+
+func TestBuildStremioStreamsFiltersSeasonPackByEpisodeSelector(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"Show.S01E01.mkv",
+		"Show.S01E02.mkv",
+		"Show.S01E03.mkv",
+	})
+
+	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
+	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+	require.Equal(t, "Show.S01E02.mkv", streams[0].Name)
+	require.Equal(t, "Show.S01E02.mkv", streams[0].Title)
+}
+
+func TestStremioEpisodeSelectorMatchesCommonEpisodeFilenameForms(t *testing.T) {
+	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
+
+	require.True(t, selector.matches("Show.S01E02.mkv"))
+	require.True(t, selector.matches("Show.s1e2.mkv"))
+	require.True(t, selector.matches("Show.1x02.mkv"))
+	require.True(t, selector.matches("Show.S01E01E02.mkv"))
+	require.False(t, selector.matches("Show.S01E01.mkv"))
+	require.False(t, selector.matches("Show.S02E02.mkv"))
+}
+
+func newStremioStreamsTestServer(t *testing.T, names []string) (*Server, *database.ImportQueueItem) {
+	t.Helper()
+
+	root := t.TempDir()
+	storagePath := "/complete/TV/Release.Name"
+	metadataDir := filepath.Join(root, strings.TrimPrefix(storagePath, "/"))
+	require.NoError(t, os.MkdirAll(metadataDir, 0755))
+	for _, name := range names {
+		require.NoError(t, os.WriteFile(filepath.Join(metadataDir, name+".meta"), []byte("test"), 0644))
+	}
+
+	server := &Server{metadataService: metadata.NewMetadataService(root)}
+	return server, &database.ImportQueueItem{
+		ID:          42,
+		StoragePath: &storagePath,
+	}
+}

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -246,6 +246,10 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 			"?url=" + url.QueryEscape(r.DownloadURL) +
 			"&title=" + url.QueryEscape(safeTitle) +
 			"&type=" + url.QueryEscape(streamType)
+		if streamType == "series" && season > 0 && episode > 0 {
+			playURL += "&season=" + url.QueryEscape(strconv.Itoa(season)) +
+				"&episode=" + url.QueryEscape(strconv.Itoa(episode))
+		}
 
 		sizeGB := float64(r.Size) / 1e9
 		indexerLabel := r.Indexer
@@ -306,6 +310,8 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 //	@Param			key		path	string	true	"Download key (SHA256 of API key)"
 //	@Param			url		query	string	true	"Prowlarr NZB download URL"
 //	@Param			title	query	string	false	"Safe filename title for the NZB"
+//	@Param			season	query	int		false	"Season number for selecting one episode from a season pack"
+//	@Param			episode	query	int		false	"Episode number for selecting one episode from a season pack"
 //	@Success		302	{string}	string	"Redirects to media stream URL"
 //	@Failure		400	{object}	APIResponse
 //	@Failure		401	{object}	APIResponse
@@ -340,6 +346,7 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 	}
 
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
+	selector := stremioEpisodeSelectorFromRequest(c)
 
 	safeFilename := safeTitle + ".nzb"
 	nzbName := safeTitle
@@ -354,7 +361,7 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
 		}
 		if cacheValid {
-			if streams, err := s.buildStremioStreams(prev, baseURL, key, nzbName); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(prev, baseURL, key, nzbName, selector); err == nil && len(streams) > 0 {
 				slog.InfoContext(ctx, "Returning cached Stremio stream for Prowlarr NZB",
 					"nzb_name", nzbName)
 				return c.Redirect(streams[0].URL, fiber.StatusFound)
@@ -448,11 +455,11 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 		return RespondInternalError(c, "Unexpected play result", "")
 	}
 
-	return s.waitAndRedirectToStream(c, itemID, baseURL, key, nzbName, 300)
+	return s.waitAndRedirectToStream(c, itemID, baseURL, key, nzbName, selector, 300)
 }
 
 // waitAndRedirectToStream waits for a queue item to complete and 302-redirects to the first stream URL.
-func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, downloadKey, nzbName string, timeoutSecs int) error {
+func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector, timeoutSecs int) error {
 	ctx := c.Context()
 
 	subID, ch := s.progressBroadcaster.Subscribe()
@@ -464,7 +471,7 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 	}
 
 	redirectToFirst := func(item *database.ImportQueueItem) error {
-		streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName)
+		streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName, selector)
 		if err != nil || len(streams) == 0 {
 			return RespondServiceUnavailable(c, "No streams available", "")
 		}
@@ -480,7 +487,7 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 		// If the item is already processing and has a storage path, the streamable
 		// event fired before we subscribed — redirect immediately.
 		if current.StoragePath != nil && *current.StoragePath != "" {
-			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 				return c.Redirect(streams[0].URL, fiber.StatusFound)
 			}
 		}
@@ -503,7 +510,7 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 				// Redirect as soon as the file is accessible in the VFS — before post-processing.
 				if update.StoragePath != "" {
 					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
-					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName); err == nil && len(streams) > 0 {
+					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 						return c.Redirect(streams[0].URL, fiber.StatusFound)
 					}
 				}


### PR DESCRIPTION
## Summary
- Propagate `season` and `episode` through Stremio add-on play and NZB stream flows
- Filter completed season-pack outputs to the requested episode when present
- Update stream metadata to use the resolved filename for both title and name
- Add unit coverage for episode matching and filtered stream selection

## Testing
- Unit tests added for common episode filename formats and selector filtering
- Not run (not requested)