### PR TITLE
fix(stremio): include nested season pack streams

### DIFF
--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -411,24 +411,50 @@ func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, do
 		return nil, fmt.Errorf("metadata service not available")
 	}
 
-	files, err := s.metadataService.ListDirectory(storagePath)
+	files, err := s.listStremioMediaFiles(storagePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list directory %q: %w", storagePath, err)
 	}
 
-	var streams []StremioStream
+	streams := make([]StremioStream, 0, len(files))
 	for _, name := range files {
-		if !isMediaExtension(filepath.Ext(name)) {
-			continue
-		}
 		if selector != nil && !selector.matches(name) {
 			continue
 		}
-		virtualPath := filepath.ToSlash(filepath.Join(storagePath, name))
+		virtualPath := filepath.ToSlash(filepath.Join(storagePath, filepath.FromSlash(name)))
 		streams = append(streams, stremioStreamFromPath(virtualPath, baseURL, downloadKey))
 	}
 
 	return streams, nil
+}
+
+func (s *Server) listStremioMediaFiles(storagePath string) ([]string, error) {
+	dirs, files, err := s.metadataService.ListDirectoryAll(storagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	mediaFiles := make([]string, 0, len(files))
+	for _, name := range files {
+		if isMediaExtension(filepath.Ext(name)) {
+			mediaFiles = append(mediaFiles, name)
+		}
+	}
+
+	for _, dir := range dirs {
+		if dir == nil {
+			continue
+		}
+		children, err := s.listStremioMediaFiles(filepath.ToSlash(filepath.Join(storagePath, dir.Name())))
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			mediaFiles = append(mediaFiles, filepath.ToSlash(filepath.Join(dir.Name(), filepath.FromSlash(child))))
+		}
+	}
+
+	return mediaFiles, nil
 }
 
 // stremioStreamFromPath creates a StremioStream for a given virtual file path.

--- a/internal/api/nzb_stremio_handlers_test.go
+++ b/internal/api/nzb_stremio_handlers_test.go
@@ -51,6 +51,35 @@ func TestBuildStremioStreamsFiltersSeasonPackByEpisodeSelector(t *testing.T) {
 	require.Equal(t, "Show.S01E02.mkv", streams[0].Title)
 }
 
+func TestBuildStremioStreamsFindsMediaFilesInNestedSeasonPackDirectories(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"Season 01/Show.S01E01.mkv",
+		"Season 01/Show.S01E02.mkv",
+	})
+
+	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
+	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+	require.Equal(t, "Show.S01E02.mkv", streams[0].Name)
+
+	parsedURL, err := url.Parse(streams[0].URL)
+	require.NoError(t, err)
+	require.Equal(t, "/complete/TV/Release.Name/Season 01/Show.S01E02.mkv", parsedURL.Query().Get("path"))
+}
+
+func TestBuildStremioStreamsReturnsEmptySliceWhenSelectorDoesNotMatch(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"Show.S01E01.mkv",
+	})
+
+	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
+	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	require.NoError(t, err)
+	require.NotNil(t, streams)
+	require.Empty(t, streams)
+}
+
 func TestStremioEpisodeSelectorMatchesCommonEpisodeFilenameForms(t *testing.T) {
 	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
 
@@ -70,7 +99,9 @@ func newStremioStreamsTestServer(t *testing.T, names []string) (*Server, *databa
 	metadataDir := filepath.Join(root, strings.TrimPrefix(storagePath, "/"))
 	require.NoError(t, os.MkdirAll(metadataDir, 0755))
 	for _, name := range names {
-		require.NoError(t, os.WriteFile(filepath.Join(metadataDir, name+".meta"), []byte("test"), 0644))
+		metaPath := filepath.Join(metadataDir, name+".meta")
+		require.NoError(t, os.MkdirAll(filepath.Dir(metaPath), 0755))
+		require.NoError(t, os.WriteFile(metaPath, []byte("test"), 0644))
 	}
 
 	server := &Server{metadataService: metadata.NewMetadataService(root)}


### PR DESCRIPTION
## Summary
- recursively discover media files produced in nested season-pack directories
- return an initialized empty stream list when selector filtering finds no match
- add tests for nested episode files and no-match responses

## Validation
- go test ./internal/api
- go test ./...