### PR TITLE
fix(health): route all file_path writers through normalizeHealthPath (Windows backslash dupes/ghosts)

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -33,9 +33,13 @@ func NewHealthRepository(db *sql.DB, d Dialect) *HealthRepository {
 // file across two rows and silently defeat the repair_retry_count budget that the
 // repair state machine relies on. Every method that writes or matches on file_path
 // funnels through here.
+//
+// TrimLeft (not TrimPrefix) so ALL leading slashes are stripped: an import can yield
+// a doubled prefix ("//tv/x"), and trimming only one would leave "/tv/x" — still
+// non-canonical, unmatchable by every other caller, and stuck re-checking forever.
 func normalizeHealthPath(p string) string {
 	p = strings.ReplaceAll(p, `\`, "/")
-	p = strings.TrimPrefix(p, "/")
+	p = strings.TrimLeft(p, "/")
 	return p
 }
 

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -34,8 +34,9 @@ func NewHealthRepository(db *sql.DB, d Dialect) *HealthRepository {
 // repair state machine relies on. Every method that writes or matches on file_path
 // funnels through here.
 func normalizeHealthPath(p string) string {
+	p = strings.ReplaceAll(p, `\`, "/")
 	p = strings.TrimPrefix(p, "/")
-	return strings.ReplaceAll(p, `\`, "/")
+	return p
 }
 
 // escapeLikePrefix escapes the LIKE metacharacters in a literal prefix so it can be
@@ -2099,7 +2100,7 @@ func (r *HealthRepository) LogIndexerImport(ctx context.Context, indexer string,
 // relinkOrMergeRecordTx merges details or updates a matched health record under a transaction,
 // resolving any UNIQUE constraint violations on file_path.
 func (r *HealthRepository) relinkOrMergeRecordTx(ctx context.Context, tx *dialectAwareTx, id int64, filePath, libraryPath string, metadataStr *string, revalidate bool) error {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 
 	// 1. Fetch source/matched record info
 	var sourceStatus string
@@ -2299,7 +2300,7 @@ func (r *HealthRepository) relinkOrMergeRecordTx(ctx context.Context, tx *dialec
 //   - false (Rename events — no new content): preserve repair/corrupted state so a library
 //     reorganization cannot wipe repair progress.
 func (r *HealthRepository) RelinkFileByMetadata(ctx context.Context, webMeta *model.WebhookMetadata, filePath, libraryPath string, metadataStr *string, revalidate bool) (bool, error) {
-	filePath = strings.TrimPrefix(filePath, "/")
+	filePath = normalizeHealthPath(filePath)
 
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -1743,8 +1743,8 @@ func (r *HealthRepository) UpdateLibraryPath(ctx context.Context, filePath strin
 
 // RenameHealthRecord updates the file_path of a health record or records under a directory after a MOVE operation
 func (r *HealthRepository) RenameHealthRecord(ctx context.Context, oldPath, newPath string) error {
-	oldPath = strings.TrimPrefix(oldPath, "/")
-	newPath = strings.TrimPrefix(newPath, "/")
+	oldPath = normalizeHealthPath(oldPath)
+	newPath = normalizeHealthPath(newPath)
 
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/internal/database/normalize_health_path_test.go
+++ b/internal/database/normalize_health_path_test.go
@@ -17,6 +17,7 @@ func TestNormalizeHealthPath(t *testing.T) {
 	}{
 		{"already canonical", "tv/Show/S01E01.mkv", "tv/Show/S01E01.mkv"},
 		{"leading slash", "/tv/Show/S01E01.mkv", "tv/Show/S01E01.mkv"},
+		{"doubled leading slash", "//tv/Show/S01E01.mkv", "tv/Show/S01E01.mkv"},
 		{"internal backslashes", `tv\Show\S01E01.mkv`, "tv/Show/S01E01.mkv"},
 		{"leading backslash", `\tv\Show\S01E01.mkv`, "tv/Show/S01E01.mkv"},
 		{"absolute windows path", `C:\rclone\tv\S01E01.mkv`, "C:/rclone/tv/S01E01.mkv"},

--- a/internal/database/normalize_health_path_test.go
+++ b/internal/database/normalize_health_path_test.go
@@ -1,0 +1,32 @@
+package database
+
+import "testing"
+
+// TestNormalizeHealthPath pins the canonical form every file_path writer must
+// produce: backslashes converted to forward slashes BEFORE the leading-slash
+// trim, so a Windows path that arrives with a leading backslash (e.g. after a
+// library-dir prefix is stripped from C:\rclone\tv\...) collapses to the same
+// key as the import-time forward-slash path instead of splitting into a second
+// row. Doing the trim first would leave a stray leading slash ("/tv/..."),
+// which is the bug this guards against.
+func TestNormalizeHealthPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"already canonical", "tv/Show/S01E01.mkv", "tv/Show/S01E01.mkv"},
+		{"leading slash", "/tv/Show/S01E01.mkv", "tv/Show/S01E01.mkv"},
+		{"internal backslashes", `tv\Show\S01E01.mkv`, "tv/Show/S01E01.mkv"},
+		{"leading backslash", `\tv\Show\S01E01.mkv`, "tv/Show/S01E01.mkv"},
+		{"absolute windows path", `C:\rclone\tv\S01E01.mkv`, "C:/rclone/tv/S01E01.mkv"},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := normalizeHealthPath(c.in); got != c.want {
+				t.Errorf("normalizeHealthPath(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, several `file_health` write paths bypass `normalizeHealthPath` (or use it incompletely), so the same virtual file can be stored under a **non-canonical key** — a backslash form (`tv\Show\ep.mkv`) or a leading-slash form (`/tv/Show/ep.mkv`) — distinct from the canonical `tv/Show/ep.mkv` that every other writer uses. `file_path` carries a UNIQUE constraint, so this **splits one file across two rows** and produces duplicate/ghost records that get stuck: the health worker writes back through `normalizeHealthPath`, whose `WHERE file_path = ?` no longer matches the non-canonical row, so the record can never be finalized and re-checks forever.

**Windows-only.** On Linux every path is already canonical forward-slash, so all of this is a no-op there — which is why it hasn't surfaced upstream.

### Offenders

1. **`normalizeHealthPath` itself.** Two problems: it ran `TrimPrefix("/")` *before* converting `\`→`/`, so a leading backslash (`\tv\...`, produced by stripping a `C:\rclone` prefix) survived as `/tv/...`; and `TrimPrefix` strips only *one* leading slash, so an import that yields a doubled prefix (`//tv/...`) was left as `/tv/...`. Both are non-canonical and unmatchable. Fix: convert backslashes first, then `TrimLeft("/")` to strip **all** leading slashes.

2. **`RelinkFileByMetadata` + `relinkOrMergeRecordTx`** (added in #708) only did `strings.TrimPrefix(filePath, "/")`, so a backslash path from the ARR `Download` webhook is written straight into `file_path` via the relink `UPDATE`. This produces the duplicate on a re-download/repair cycle (the metadata-relink branch only fires once a record has metadata + a non-healthy status, i.e. after a prior import went corrupt).

3. **`RenameHealthRecord`** (older) also did bare `TrimPrefix`. It receives paths from `nzbfilesystem.normalizePath`, which ends in `filepath.Clean` — and on Windows `Clean` re-introduces backslashes (`Separator='\'`). So its exact-match `UPDATE ... WHERE file_path = ?` and child-directory `LIKE` prefix never match the stored forward-slash rows, silently no-op'ing the rename — the *"Metadata moved but DB update failed. Ghost record created."* path its own caller warns about.

## Fix

Route all three writers through `normalizeHealthPath`, and harden the function itself: backslash-convert before trimming, and `TrimLeft` so every leading slash is stripped. ~8 lines + unit tests. With this, **all INSERT/UPSERT writers funnel through one canonical form**, so `file_path` storage is always canonical and every read/match aligns.

## Risk

- **Linux/Docker: provably a no-op.** For forward-slash input with 0 or 1 leading slash — the only forms that occur off-Windows — the reordered convert and `TrimLeft`/`TrimPrefix` produce byte-identical output. Behavior diverges only on backslashes or 2+ leading slashes, neither of which occurs on Linux.
- `normalizeHealthPath` is the documented canonical form for `file_path`; this just makes the last few writers consistent with every other one.

## Test

Adds `TestNormalizeHealthPath` pinning the canonical form, including leading-backslash and doubled-leading-slash regression cases.