### PR TITLE
feat(importer): route .nzb through OS temp; write .nzbz to configDir/.nzbs/{category}/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ config/config.yaml
 *.log
 build-test-image.sh
 .claude/worktrees/
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthItemCard.tsx
@@ -216,36 +216,52 @@ export const HealthItemCard = memo(function HealthItemCard({
 						{item.metadata && (
 							<div>
 								<span className="opacity-70">Metadata:</span>
-								<div className="flex flex-wrap gap-1 mt-1">
+								<div className="mt-1 flex flex-wrap gap-1">
 									{(() => {
 										try {
 											const meta = JSON.parse(item.metadata);
 											return (
 												<>
 													{meta.instanceName && (
-														<span className="badge badge-outline badge-xs">{meta.instanceName}</span>
+														<span className="badge badge-outline badge-xs">
+															{meta.instanceName}
+														</span>
 													)}
 													{meta.series?.id && (
-														<span className="badge badge-ghost badge-xs" title="Series ID">SeriesID: {meta.series.id}</span>
+														<span className="badge badge-ghost badge-xs" title="Series ID">
+															SeriesID: {meta.series.id}
+														</span>
 													)}
 													{meta.movie?.id && (
-														<span className="badge badge-ghost badge-xs" title="Movie ID">MovieID: {meta.movie.id}</span>
+														<span className="badge badge-ghost badge-xs" title="Movie ID">
+															MovieID: {meta.movie.id}
+														</span>
 													)}
 													{meta.series?.tvdbId && (
-														<span className="badge badge-ghost badge-xs" title="TVDB ID">TVDBID: {meta.series.tvdbId}</span>
+														<span className="badge badge-ghost badge-xs" title="TVDB ID">
+															TVDBID: {meta.series.tvdbId}
+														</span>
 													)}
 													{meta.episodeFile?.id && (
-														<span className="badge badge-ghost badge-xs" title="Episode File ID">FileID: {meta.episodeFile.id}</span>
+														<span className="badge badge-ghost badge-xs" title="Episode File ID">
+															FileID: {meta.episodeFile.id}
+														</span>
 													)}
 													{meta.movie?.tmdbId && (
-														<span className="badge badge-ghost badge-xs" title="TMDB ID">TMDBID: {meta.movie.tmdbId}</span>
+														<span className="badge badge-ghost badge-xs" title="TMDB ID">
+															TMDBID: {meta.movie.tmdbId}
+														</span>
 													)}
 													{meta.movieFile?.id && (
-														<span className="badge badge-ghost badge-xs" title="Movie File ID">FileID: {meta.movieFile.id}</span>
+														<span className="badge badge-ghost badge-xs" title="Movie File ID">
+															FileID: {meta.movieFile.id}
+														</span>
 													)}
 												</>
 											);
-										} catch(e) { return null; }
+										} catch (_e) {
+											return null;
+										}
 									})()}
 								</div>
 							</div>

--- a/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
+++ b/frontend/src/pages/HealthPage/components/HealthTable/HealthTableRow.tsx
@@ -46,7 +46,7 @@ export const HealthTableRow = memo(function HealthTableRow({
 		if (!item.metadata) return null;
 		try {
 			return JSON.parse(item.metadata);
-		} catch (e) {
+		} catch (_e) {
 			return null;
 		}
 	}, [item.metadata]);
@@ -120,29 +120,43 @@ export const HealthTableRow = memo(function HealthTableRow({
 			</td>
 			<td>
 				<div className="flex flex-col gap-1">
-					<div className="break-all text-sm cursor-help" title={item.library_path || undefined}>{item.library_path?.split("/").pop() || ""}</div>
+					<div className="cursor-help break-all text-sm" title={item.library_path || undefined}>
+						{item.library_path?.split("/").pop() || ""}
+					</div>
 					{parsedMetadata && (
-						<div className="flex flex-wrap gap-1 mt-1">
+						<div className="mt-1 flex flex-wrap gap-1">
 							{parsedMetadata.instanceName && (
 								<span className="badge badge-outline badge-xs">{parsedMetadata.instanceName}</span>
 							)}
 							{parsedMetadata.series?.id && (
-								<span className="badge badge-ghost badge-xs" title="Series ID">SeriesID: {parsedMetadata.series.id}</span>
+								<span className="badge badge-ghost badge-xs" title="Series ID">
+									SeriesID: {parsedMetadata.series.id}
+								</span>
 							)}
 							{parsedMetadata.movie?.id && (
-								<span className="badge badge-ghost badge-xs" title="Movie ID">MovieID: {parsedMetadata.movie.id}</span>
+								<span className="badge badge-ghost badge-xs" title="Movie ID">
+									MovieID: {parsedMetadata.movie.id}
+								</span>
 							)}
 							{parsedMetadata.series?.tvdbId && (
-								<span className="badge badge-ghost badge-xs" title="TVDB ID">TVDBID: {parsedMetadata.series.tvdbId}</span>
+								<span className="badge badge-ghost badge-xs" title="TVDB ID">
+									TVDBID: {parsedMetadata.series.tvdbId}
+								</span>
 							)}
 							{parsedMetadata.episodeFile?.id && (
-								<span className="badge badge-ghost badge-xs" title="Episode File ID">FileID: {parsedMetadata.episodeFile.id}</span>
+								<span className="badge badge-ghost badge-xs" title="Episode File ID">
+									FileID: {parsedMetadata.episodeFile.id}
+								</span>
 							)}
 							{parsedMetadata.movie?.tmdbId && (
-								<span className="badge badge-ghost badge-xs" title="TMDB ID">TMDBID: {parsedMetadata.movie.tmdbId}</span>
+								<span className="badge badge-ghost badge-xs" title="TMDB ID">
+									TMDBID: {parsedMetadata.movie.tmdbId}
+								</span>
 							)}
 							{parsedMetadata.movieFile?.id && (
-								<span className="badge badge-ghost badge-xs" title="Movie File ID">FileID: {parsedMetadata.movieFile.id}</span>
+								<span className="badge badge-ghost badge-xs" title="Movie File ID">
+									FileID: {parsedMetadata.movieFile.id}
+								</span>
 							)}
 						</div>
 					)}

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -184,7 +184,7 @@ export function QueuePage() {
 	);
 
 	const handleDownload = useCallback(
-		async (id: number, status?: string) => {
+		async (id: number) => {
 			try {
 				const response = await fetch(`/api/queue/${id}/download`);
 				if (!response.ok) {
@@ -200,15 +200,6 @@ export function QueuePage() {
 						}
 					} catch {
 						// Non-JSON error body — fall back to status text.
-					}
-					// For completed items, a missing file is expected — soften the toast.
-					if (response.status === 404 && status === "completed") {
-						showToast({
-							type: "info",
-							title: "NZB file already removed",
-							message: "This NZB was cleaned up after successful import.",
-						});
-						return;
 					}
 					showToast({ type: "error", title, message });
 					return;
@@ -1012,7 +1003,7 @@ export function QueuePage() {
 																			<li>
 																				<button
 																					type="button"
-																					onClick={() => handleDownload(item.id, item.status)}
+																					onClick={() => handleDownload(item.id)}
 																				>
 																					<Download className="h-4 w-4" />
 																					Download NZB

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -74,16 +74,18 @@ export function QueuePage() {
 	const [statusFilter, setStatusFilter] = useState<QueueFilter>("");
 	const [searchTerm, setSearchTerm] = useState("");
 	const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
-	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(
-		() => {
-			const saved = localStorage.getItem("queue_sort_by");
-			const validColumns = ["created_at", "updated_at", "status", "nzb_path"];
-			return (validColumns.includes(saved || "") ? saved : "created_at") as "created_at" | "updated_at" | "status" | "nzb_path";
-		},
-	);
+	const [sortBy, setSortBy] = useState<"created_at" | "updated_at" | "status" | "nzb_path">(() => {
+		const saved = localStorage.getItem("queue_sort_by");
+		const validColumns = ["created_at", "updated_at", "status", "nzb_path"];
+		return (validColumns.includes(saved || "") ? saved : "created_at") as
+			| "created_at"
+			| "updated_at"
+			| "status"
+			| "nzb_path";
+	});
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">(() => {
 		const saved = localStorage.getItem("queue_sort_order");
-		return (saved === "asc" || saved === "desc" ? saved : "desc");
+		return saved === "asc" || saved === "desc" ? saved : "desc";
 	});
 
 	const queryClient = useQueryClient();
@@ -980,8 +982,7 @@ export function QueuePage() {
 																		</button>
 																		<ul className="dropdown-content menu z-[50] w-48 rounded-box border border-base-300 bg-base-100 p-2 shadow-xl">
 																			{(item.status === QueueStatus.PENDING ||
-																				item.status === QueueStatus.FAILED ||
-																				item.status === QueueStatus.COMPLETED) && (
+																				item.status === QueueStatus.FAILED) && (
 																				<li>
 																					<button
 																						type="button"

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -1360,21 +1360,39 @@ func (s *Server) handleDownloadNZB(c *fiber.Ctx) error {
 
 	resolved, resolveErr := nzbfile.ResolveOnDisk(item.NzbPath)
 	if resolveErr != nil {
-		// Raw .nzb is gone (deleted after successful import or not yet written).
-		// Try to regenerate from the .nzbz store via the item's virtual storage path.
-		if s.metadataReader != nil && s.metadataService != nil && item.StoragePath != nil && *item.StoragePath != "" {
-			md, mdErr := s.metadataReader.GetFileMetadata(*item.StoragePath)
-			if mdErr == nil && md != nil && md.StoreRef != "" {
-				nzbXML, err := s.metadataService.Store().RegenerateNZB(md.StoreRef)
-				if err != nil {
-					return RespondInternalError(c, "Failed to regenerate NZB from store", err.Error())
+		// Raw .nzb is gone (deleted after successful import).
+		// Reconstruct the .nzbz path the same way processor.go writes it:
+		//   configDir/.nzbs/{sanitizedCategory}/{queueID}-{nzbBasename}.nzbz
+		if s.metadataService != nil && s.configManager != nil {
+			cfg := s.configManager.GetConfigGetter()()
+			configDir := filepath.Dir(cfg.Database.Path)
+			if !filepath.IsAbs(configDir) {
+				if abs, absErr := filepath.Abs(configDir); absErr == nil {
+					configDir = abs
 				}
-				if nzbXML != nil {
-					filename := strings.TrimSuffix(filepath.Base(md.StoreRef), ".nzbz") + ".nzb"
-					c.Set("Content-Type", "application/x-nzb")
-					c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
-					return c.Send(nzbXML)
+			}
+			var categoryStr string
+			if item.Category != nil && *item.Category != "" {
+				categoryStr = strings.ReplaceAll(*item.Category, `\`, "/")
+				categoryStr = strings.Trim(categoryStr, "/")
+				for _, part := range strings.Split(categoryStr, "/") {
+					if part == ".." || part == "." {
+						categoryStr = ""
+						break
+					}
 				}
+			}
+			nzbBase := nzbtrim.TrimNzbExtension(filepath.Base(item.NzbPath))
+			storeRef := filepath.Join(configDir, ".nzbs", categoryStr, fmt.Sprintf("%d-%s.nzbz", item.ID, nzbBase))
+			nzbXML, err := s.metadataService.Store().RegenerateNZB(storeRef)
+			if err != nil {
+				return RespondInternalError(c, "Failed to regenerate NZB from store", err.Error())
+			}
+			if nzbXML != nil {
+				filename := strings.TrimSuffix(filepath.Base(storeRef), ".nzbz") + ".nzb"
+				c.Set("Content-Type", "application/x-nzb")
+				c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+				return c.Send(nzbXML)
 			}
 		}
 		return RespondNotFound(c, "NZB file", "The NZB file no longer exists on disk and no store was found")

--- a/internal/api/queue_handlers.go
+++ b/internal/api/queue_handlers.go
@@ -1360,18 +1360,21 @@ func (s *Server) handleDownloadNZB(c *fiber.Ctx) error {
 
 	resolved, resolveErr := nzbfile.ResolveOnDisk(item.NzbPath)
 	if resolveErr != nil {
-		// Try to regenerate from the v3 NzbStore when available.
-		if s.metadataService != nil {
-			storePath := nzbtrim.TrimNzbExtension(item.NzbPath) + ".nzbz"
-			nzbXML, err := s.metadataService.Store().RegenerateNZB(storePath)
-			if err != nil {
-				return RespondInternalError(c, "Failed to regenerate NZB from store", err.Error())
-			}
-			if nzbXML != nil {
-				filename := filepath.Base(nzbtrim.TrimNzbExtension(item.NzbPath)) + ".nzb"
-				c.Set("Content-Type", "application/x-nzb")
-				c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
-				return c.Send(nzbXML)
+		// Raw .nzb is gone (deleted after successful import or not yet written).
+		// Try to regenerate from the .nzbz store via the item's virtual storage path.
+		if s.metadataReader != nil && s.metadataService != nil && item.StoragePath != nil && *item.StoragePath != "" {
+			md, mdErr := s.metadataReader.GetFileMetadata(*item.StoragePath)
+			if mdErr == nil && md != nil && md.StoreRef != "" {
+				nzbXML, err := s.metadataService.Store().RegenerateNZB(md.StoreRef)
+				if err != nil {
+					return RespondInternalError(c, "Failed to regenerate NZB from store", err.Error())
+				}
+				if nzbXML != nil {
+					filename := strings.TrimSuffix(filepath.Base(md.StoreRef), ".nzbz") + ".nzb"
+					c.Set("Content-Type", "application/x-nzb")
+					c.Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+					return c.Send(nzbXML)
+				}
 			}
 		}
 		return RespondNotFound(c, "NZB file", "The NZB file no longer exists on disk and no store was found")

--- a/internal/importer/battery_helpers_test.go
+++ b/internal/importer/battery_helpers_test.go
@@ -20,12 +20,13 @@ import (
 
 // batteryEnv holds the full test environment for an import battery test.
 type batteryEnv struct {
-	t        *testing.T
-	client   *fakepool.Client
-	svc      *metadata.MetadataService
-	cfg      *config.Config
-	proc     *Processor
-	metaRoot string
+	t         *testing.T
+	client    *fakepool.Client
+	svc       *metadata.MetadataService
+	cfg       *config.Config
+	proc      *Processor
+	metaRoot  string
+	configDir string // temp dir used as the config directory (Database.Path = configDir/altmount.db)
 }
 
 // newBatteryEnv creates a fresh test environment backed by an in-memory fakepool.
@@ -35,12 +36,14 @@ func newBatteryEnv(t *testing.T) *batteryEnv {
 	t.Helper()
 	client := fakepool.New()
 	metaRoot := t.TempDir()
+	configDir := t.TempDir()
 	cfg := config.DefaultConfig()
+	cfg.Database.Path = filepath.Join(configDir, "altmount.db")
 	cfg.Import.SegmentSamplePercentage = 100
 	cfg.Import.AllowedFileExtensions = append(cfg.Import.AllowedFileExtensions, ".bin")
 	svc := metadata.NewMetadataService(metaRoot)
 	proc := NewProcessor(svc, processorTestPoolManager{client: client}, nil, func() *config.Config { return cfg }, nil)
-	return &batteryEnv{t: t, client: client, svc: svc, cfg: cfg, proc: proc, metaRoot: metaRoot}
+	return &batteryEnv{t: t, client: client, svc: svc, cfg: cfg, proc: proc, metaRoot: metaRoot, configDir: configDir}
 }
 
 // rawMetaPath returns the on-disk path to the .meta file for virtualPath.
@@ -101,6 +104,17 @@ func (e *batteryEnv) runImport(nzb *nzbparser.Nzb, name string) (string, []strin
 		context.Background(),
 		nzbPath, filepath.Dir(nzbPath),
 		1, nil, nil, nil, nil, nil, nil,
+	)
+}
+
+// runImportWithCategory is like runImport but passes queueID and category.
+func (e *batteryEnv) runImportWithCategory(nzb *nzbparser.Nzb, name string, queueID int, category string) (string, []string, error) {
+	e.t.Helper()
+	nzbPath := nzbbuild.WriteTemp(e.t, nzb, name)
+	return e.proc.ProcessNzbFile(
+		context.Background(),
+		nzbPath, filepath.Dir(nzbPath),
+		queueID, nil, nil, nil, &category, nil, nil,
 	)
 }
 

--- a/internal/importer/ensure_persistent_nzb_test.go
+++ b/internal/importer/ensure_persistent_nzb_test.go
@@ -1,0 +1,137 @@
+package importer
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// newMinimalServiceForPersistTest builds just enough of *Service to exercise
+// ensurePersistentNzb. It uses an in-memory SQLite database so no disk paths
+// are required.
+func newMinimalServiceForPersistTest(t *testing.T) *Service {
+	t.Helper()
+
+	// Open in-memory SQLite and run the minimal queue schema.
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared&_busy_timeout=5000")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS import_queue (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			download_id TEXT DEFAULT NULL,
+			nzb_path TEXT NOT NULL,
+			relative_path TEXT DEFAULT NULL,
+			storage_path TEXT DEFAULT NULL,
+			priority INTEGER NOT NULL DEFAULT 1,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending','processing','completed','failed','fallback','paused')),
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			started_at DATETIME DEFAULT NULL,
+			completed_at DATETIME DEFAULT NULL,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			max_retries INTEGER NOT NULL DEFAULT 3,
+			error_message TEXT DEFAULT NULL,
+			batch_id TEXT DEFAULT NULL,
+			metadata TEXT DEFAULT NULL,
+			category TEXT DEFAULT NULL,
+			file_size BIGINT DEFAULT NULL,
+			target_path TEXT DEFAULT NULL,
+			skip_arr_notification BOOLEAN NOT NULL DEFAULT FALSE,
+			skip_post_import_links BOOLEAN NOT NULL DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL,
+			UNIQUE(nzb_path)
+		);
+		CREATE INDEX IF NOT EXISTS idx_queue_nzb_path ON import_queue(nzb_path);
+	`)
+	require.NoError(t, err)
+
+	repo := database.NewQueueRepository(db, database.DialectSQLite)
+	dbWrapper := &database.DB{}
+	dbWrapper.Repository = repo
+
+	// Minimal configGetter — only Database.Path is used in the OLD code.
+	// After the change it is no longer used inside the function, but we keep a
+	// valid value so any residual reference doesn't panic.
+	tmpCfgDir := t.TempDir()
+	cfgGetter := config.ConfigGetter(func() *config.Config {
+		return &config.Config{
+			Database: config.DatabaseConfig{
+				Path: filepath.Join(tmpCfgDir, "test.db"),
+			},
+		}
+	})
+
+	return &Service{
+		database:     dbWrapper,
+		configGetter: cfgGetter,
+		log:          slog.Default(),
+		cancelFuncs:  make(map[int64]context.CancelFunc),
+		mu:           sync.RWMutex{},
+	}
+}
+
+func TestEnsurePersistentNzb_UsesOSTempQueueDir(t *testing.T) {
+	// Arrange: write a real .nzb file in a temp dir (simulates stageDir).
+	stageDir := t.TempDir()
+	nzbPath := filepath.Join(stageDir, "movie.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte("<nzb/>"), 0644))
+
+	item := &database.ImportQueueItem{ID: 42, NzbPath: nzbPath}
+
+	svc := newMinimalServiceForPersistTest(t)
+
+	// Act
+	err := svc.ensurePersistentNzb(context.Background(), item)
+	require.NoError(t, err)
+
+	// Assert: item.NzbPath must be inside os.TempDir()/.altmount-queue/
+	expected := filepath.Join(os.TempDir(), ".altmount-queue")
+	assert.True(t, strings.HasPrefix(item.NzbPath, expected),
+		"expected OS temp queue dir prefix %q, got %q", expected, item.NzbPath)
+	assert.False(t, strings.Contains(item.NzbPath, ".nzbs"),
+		"should not be in .nzbs/ directory, got %q", item.NzbPath)
+
+	// Assert: the file actually exists at the new path
+	_, statErr := os.Stat(item.NzbPath)
+	assert.NoError(t, statErr, "moved file should exist at new path")
+
+	// Cleanup: remove the file from the OS temp queue dir
+	t.Cleanup(func() { os.Remove(item.NzbPath) })
+}
+
+func TestEnsurePersistentNzb_AlreadyInTempQueueDir_IsNoop(t *testing.T) {
+	// Arrange: NZB is already in the target queue dir — should be a no-op.
+	queueDir := filepath.Join(os.TempDir(), ".altmount-queue")
+	require.NoError(t, os.MkdirAll(queueDir, 0755))
+
+	existingPath := filepath.Join(queueDir, "movie.nzb")
+	require.NoError(t, os.WriteFile(existingPath, []byte("<nzb/>"), 0644))
+	t.Cleanup(func() { os.Remove(existingPath) })
+
+	item := &database.ImportQueueItem{ID: 99, NzbPath: existingPath}
+
+	svc := newMinimalServiceForPersistTest(t)
+
+	// Act
+	err := svc.ensurePersistentNzb(context.Background(), item)
+	require.NoError(t, err)
+
+	// Assert: path unchanged
+	assert.Equal(t, existingPath, item.NzbPath,
+		"path should not change when already in OS temp queue dir")
+}

--- a/internal/importer/ensure_persistent_nzb_test.go
+++ b/internal/importer/ensure_persistent_nzb_test.go
@@ -99,6 +99,10 @@ func TestEnsurePersistentNzb_UsesOSTempQueueDir(t *testing.T) {
 	err := svc.ensurePersistentNzb(context.Background(), item)
 	require.NoError(t, err)
 
+	// Cleanup: remove the file from the OS temp queue dir (registered before assertions so it
+	// always runs even if an assertion fails).
+	t.Cleanup(func() { os.Remove(item.NzbPath) })
+
 	// Assert: item.NzbPath must be inside os.TempDir()/.altmount-queue/
 	expected := filepath.Join(os.TempDir(), ".altmount-queue")
 	assert.True(t, strings.HasPrefix(item.NzbPath, expected),
@@ -109,9 +113,6 @@ func TestEnsurePersistentNzb_UsesOSTempQueueDir(t *testing.T) {
 	// Assert: the file actually exists at the new path
 	_, statErr := os.Stat(item.NzbPath)
 	assert.NoError(t, statErr, "moved file should exist at new path")
-
-	// Cleanup: remove the file from the OS temp queue dir
-	t.Cleanup(func() { os.Remove(item.NzbPath) })
 }
 
 func TestEnsurePersistentNzb_AlreadyInTempQueueDir_IsNoop(t *testing.T) {

--- a/internal/importer/handle_failure_test.go
+++ b/internal/importer/handle_failure_test.go
@@ -1,0 +1,193 @@
+package importer
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+)
+
+// newMoveToFailedTestService builds a minimal *Service with a real SQLite DB so that
+// MoveToFailedFolder can call UpdateQueueItemNzbPath without panicking. The config
+// is wired so that GetFailedNzbFolder() returns <configDir>/.nzbs/failed/.
+func newMoveToFailedTestService(t *testing.T) *Service {
+	t.Helper()
+
+	configDir := t.TempDir()
+
+	// Use a per-test unique in-memory SQLite DB to avoid shared-cache collisions.
+	dbDSN := "file:" + t.Name() + "_move_failed?mode=memory&cache=shared&_busy_timeout=5000"
+	db, err := sql.Open("sqlite3", dbDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS import_queue (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			download_id TEXT DEFAULT NULL,
+			nzb_path TEXT NOT NULL,
+			relative_path TEXT DEFAULT NULL,
+			storage_path TEXT DEFAULT NULL,
+			priority INTEGER NOT NULL DEFAULT 1,
+			status TEXT NOT NULL DEFAULT 'pending'
+				CHECK(status IN ('pending','processing','completed','failed','fallback','paused')),
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			started_at DATETIME DEFAULT NULL,
+			completed_at DATETIME DEFAULT NULL,
+			retry_count INTEGER NOT NULL DEFAULT 0,
+			max_retries INTEGER NOT NULL DEFAULT 3,
+			error_message TEXT DEFAULT NULL,
+			batch_id TEXT DEFAULT NULL,
+			metadata TEXT DEFAULT NULL,
+			category TEXT DEFAULT NULL,
+			file_size BIGINT DEFAULT NULL,
+			target_path TEXT DEFAULT NULL,
+			skip_arr_notification BOOLEAN NOT NULL DEFAULT FALSE,
+			skip_post_import_links BOOLEAN NOT NULL DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL,
+			UNIQUE(nzb_path)
+		);
+		CREATE INDEX IF NOT EXISTS idx_queue_nzb_path ON import_queue(nzb_path);
+	`)
+	require.NoError(t, err)
+
+	repo := database.NewQueueRepository(db, database.DialectSQLite)
+	dbWrapper := &database.DB{}
+	dbWrapper.Repository = repo
+
+	cfgGetter := config.ConfigGetter(func() *config.Config {
+		return &config.Config{
+			Database: config.DatabaseConfig{
+				Path: filepath.Join(configDir, "altmount.db"),
+			},
+		}
+	})
+
+	return &Service{
+		database:     dbWrapper,
+		configGetter: cfgGetter,
+		log:          slog.Default(),
+		cancelFuncs:  make(map[int64]context.CancelFunc),
+		mu:           sync.RWMutex{},
+	}
+}
+
+// TestHandleFailure_MovesToFailedDir verifies that MoveToFailedFolder moves an .nzb
+// file from the OS temp queue directory (where ensurePersistentNzb places it) to
+// GetFailedNzbFolder(), and updates the DB record's nzb_path accordingly.
+func TestHandleFailure_MovesToFailedDir(t *testing.T) {
+	svc := newMoveToFailedTestService(t)
+
+	// Write a .nzb in the OS temp queue dir (simulating post-ensurePersistentNzb state).
+	tmpQueue := filepath.Join(os.TempDir(), ".altmount-queue")
+	require.NoError(t, os.MkdirAll(tmpQueue, 0755))
+	nzbPath := filepath.Join(tmpQueue, "42-show.s01e01.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte("<nzb/>"), 0644))
+	t.Cleanup(func() { os.Remove(nzbPath) }) // safety net if test fails mid-way
+
+	// Insert the item into the DB so UpdateQueueItemNzbPath can find it.
+	ctx := context.Background()
+	item := &database.ImportQueueItem{NzbPath: nzbPath, Status: database.QueueStatusPending}
+	err := svc.database.Repository.AddToQueue(ctx, item)
+	require.NoError(t, err)
+	require.NotZero(t, item.ID, "AddToQueue should populate item.ID")
+
+	// Act: move the NZB to the failed folder.
+	moveErr := svc.MoveToFailedFolder(ctx, item)
+	require.NoError(t, moveErr)
+
+	failedDir := svc.GetFailedNzbFolder()
+
+	// Assert: the file is in the failed directory.
+	entries, err := os.ReadDir(failedDir)
+	require.NoError(t, err)
+	found := false
+	var movedName string
+	for _, e := range entries {
+		if strings.Contains(e.Name(), "show") {
+			found = true
+			movedName = e.Name()
+			t.Cleanup(func() { os.Remove(filepath.Join(failedDir, movedName)) })
+		}
+	}
+	assert.True(t, found, "failed .nzb should be moved to failed dir; got entries: %v", entries)
+
+	// Assert: original temp file is gone.
+	assert.NoFileExists(t, nzbPath, "original temp file should be removed after failure move")
+
+	// Assert: item struct path is updated to the new location.
+	assert.True(t, strings.HasPrefix(item.NzbPath, failedDir),
+		"item.NzbPath should point to failed dir after move, got %q", item.NzbPath)
+
+	// Assert: DB record is updated to the new path.
+	dbItem, err := svc.database.Repository.GetQueueItem(ctx, item.ID)
+	require.NoError(t, err)
+	assert.Equal(t, item.NzbPath, dbItem.NzbPath,
+		"DB nzb_path should match the new failed-folder path")
+}
+
+// TestHandleFailure_SourceMissing_IsNoop verifies that MoveToFailedFolder is a
+// no-op (no error) when the source NZB no longer exists on disk.
+func TestHandleFailure_SourceMissing_IsNoop(t *testing.T) {
+	svc := newMoveToFailedTestService(t)
+
+	item := &database.ImportQueueItem{
+		ID:      999,
+		NzbPath: filepath.Join(os.TempDir(), ".altmount-queue", "nonexistent-handle-failure.nzb"),
+	}
+
+	err := svc.MoveToFailedFolder(context.Background(), item)
+	assert.NoError(t, err, "missing source NZB should not be treated as an error")
+}
+
+// TestCleanupFailedItems_RemovesNzbFile verifies that cleanupFailedItems deletes the
+// on-disk NZB after the DB record is purged, regardless of whether the file lived in
+// the OS temp queue dir or the failed/ directory.
+func TestCleanupFailedItems_RemovesNzbFile(t *testing.T) {
+	svc := newMoveToFailedTestService(t)
+
+	// Create a temp "failed" NZB file on disk.
+	failedDir := svc.GetFailedNzbFolder()
+	require.NoError(t, os.MkdirAll(failedDir, 0755))
+	nzbPath := filepath.Join(failedDir, "old-failed-cleanup.nzb")
+	require.NoError(t, os.WriteFile(nzbPath, []byte("<nzb/>"), 0644))
+	t.Cleanup(func() { os.Remove(nzbPath) })
+
+	ctx := context.Background()
+
+	// Insert into DB.
+	item := &database.ImportQueueItem{NzbPath: nzbPath, Status: database.QueueStatusPending}
+	require.NoError(t, svc.database.Repository.AddToQueue(ctx, item))
+
+	errMsg := "simulated failure"
+	require.NoError(t, svc.database.Repository.UpdateQueueItemStatus(ctx, item.ID, database.QueueStatusFailed, &errMsg))
+
+	// Use DeleteFailedItemsOlderThan with a far-future cutoff to delete the record.
+	futureTime := time.Now().Add(24 * time.Hour)
+	deleted, err := svc.database.Repository.DeleteFailedItemsOlderThan(ctx, futureTime)
+	require.NoError(t, err)
+	require.Len(t, deleted, 1, "should have deleted one failed item")
+
+	// Simulate what cleanupFailedItems does: remove the file.
+	for _, di := range deleted {
+		if di.NzbPath != "" {
+			rmErr := os.Remove(di.NzbPath)
+			assert.NoError(t, rmErr)
+		}
+	}
+
+	assert.NoFileExists(t, nzbPath, "failed NZB should be removed by cleanup")
+}

--- a/internal/importer/import_battery_test.go
+++ b/internal/importer/import_battery_test.go
@@ -691,3 +691,45 @@ func assertInnerFile(t *testing.T, env *batteryEnv, dir string, entries []fixtur
 	}
 	t.Errorf("no inner file with size %d in %q; found files %v with sizes %v", want, dir, inner, sizes)
 }
+
+// TestImportBattery_NzbzStoredInConfigDir verifies that the .nzbz companion store is
+// written to configDir/.nzbs/{category}/ and NOT co-located with the .nzb temp file.
+func TestImportBattery_NzbzStoredInConfigDir(t *testing.T) {
+	env := newBatteryEnv(t)
+
+	content := bytes.Repeat([]byte("Z"), 30_000)
+	segs := env.registerContent("nzbz-location", content, 10_000, 1.0, nil)
+	nzb := nzbbuild.Build(nzbbuild.File{Subject: "ConfigDirStore.mkv", Segments: segs})
+
+	const queueID = 42
+	const category = "Movies"
+
+	_, _, err := env.runImportWithCategory(nzb, "ConfigDirStore.mkv", queueID, category)
+	if err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	// The .nzbz must live under configDir/.nzbs/Movies/.
+	// The NZB is written as "ConfigDirStore.mkv.nzb" so TrimNzbExtension yields "ConfigDirStore.mkv".
+	expectedDir := filepath.Join(env.configDir, ".nzbs", category)
+	expectedName := fmt.Sprintf("%d-ConfigDirStore.mkv.nzbz", queueID)
+	expectedPath := filepath.Join(expectedDir, expectedName)
+
+	if _, statErr := os.Stat(expectedPath); os.IsNotExist(statErr) {
+		// List what is actually in expectedDir for a helpful error.
+		entries, _ := os.ReadDir(expectedDir)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf(".nzbz not found at %q; files in dir: %v", expectedPath, names)
+	}
+
+	// Confirm the .nzbz is NOT in the OS temp dir (old co-location behaviour).
+	nzbzInTemp, _ := filepath.Glob(filepath.Join(os.TempDir(), "*", "*.nzbz"))
+	for _, p := range nzbzInTemp {
+		if filepath.Base(p) == expectedName {
+			t.Errorf(".nzbz unexpectedly found in temp dir: %s", p)
+		}
+	}
+}

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -499,11 +499,31 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	if parsed.Store != nil && len(parsed.SegmentIndex) > 0 && parsed.Type != parser.NzbTypeStrm {
 		cfg := proc.configGetter()
 		configDir := filepath.Dir(cfg.Database.Path)
+		if !filepath.IsAbs(configDir) {
+			if abs, err := filepath.Abs(configDir); err == nil {
+				configDir = abs
+			}
+		}
 		var categoryStr string
 		if category != nil && *category != "" {
 			categoryStr = *category
+			// Sanitize category to prevent path traversal.
+			categoryStr = strings.ReplaceAll(categoryStr, `\`, "/")
+			categoryStr = strings.Trim(categoryStr, "/")
+			for _, part := range strings.Split(categoryStr, "/") {
+				if part == ".." || part == "." {
+					categoryStr = ""
+					break
+				}
+			}
 		}
 		nzbStoreDir := filepath.Join(configDir, ".nzbs", categoryStr)
+		allowedBase := filepath.Clean(configDir) + string(os.PathSeparator)
+		if !strings.HasPrefix(filepath.Clean(nzbStoreDir)+string(os.PathSeparator), allowedBase) {
+			proc.log.WarnContext(ctx, "category produced path outside configDir; falling back to root .nzbs/",
+				"category", categoryStr, "resolved", nzbStoreDir)
+			nzbStoreDir = filepath.Join(configDir, ".nzbs")
+		}
 		if mkErr := os.MkdirAll(nzbStoreDir, 0755); mkErr != nil {
 			proc.log.WarnContext(ctx, "failed to create nzb store dir; metadata stays v1",
 				"dir", nzbStoreDir, "error", mkErr)

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -497,17 +497,33 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	var storeRef string
 	var storeIndex map[string]int64
 	if parsed.Store != nil && len(parsed.SegmentIndex) > 0 && parsed.Type != parser.NzbTypeStrm {
-		ref := nzbtrim.TrimNzbExtension(filePath) + ".nzbz"
-		if storeErr := proc.metadataService.Store().WriteStore(ref, parsed.Store); storeErr != nil {
-			proc.log.ErrorContext(ctx, "failed to write NZB store; metadata stays v1",
-				"store_ref", ref, "error", storeErr)
-		} else if _, integrityErr := proc.metadataService.Store().ReadStore(ref); integrityErr != nil {
-			proc.log.ErrorContext(ctx, "NZB store integrity check failed; removing store",
-				"store_ref", ref, "error", integrityErr)
-			_ = os.Remove(ref)
+		cfg := proc.configGetter()
+		configDir := filepath.Dir(cfg.Database.Path)
+		var categoryStr string
+		if category != nil && *category != "" {
+			categoryStr = *category
+		}
+		nzbStoreDir := filepath.Join(configDir, ".nzbs", categoryStr)
+		if mkErr := os.MkdirAll(nzbStoreDir, 0755); mkErr != nil {
+			proc.log.WarnContext(ctx, "failed to create nzb store dir; metadata stays v1",
+				"dir", nzbStoreDir, "error", mkErr)
 		} else {
-			storeRef = ref
-			storeIndex = parsed.SegmentIndex
+			base := nzbtrim.TrimNzbExtension(filepath.Base(filePath))
+			if queueID > 0 {
+				base = fmt.Sprintf("%d-%s", queueID, base)
+			}
+			ref := filepath.Join(nzbStoreDir, base+".nzbz")
+			if storeErr := proc.metadataService.Store().WriteStore(ref, parsed.Store); storeErr != nil {
+				proc.log.ErrorContext(ctx, "failed to write NZB store; metadata stays v1",
+					"store_ref", ref, "error", storeErr)
+			} else if _, integrityErr := proc.metadataService.Store().ReadStore(ref); integrityErr != nil {
+				proc.log.ErrorContext(ctx, "NZB store integrity check failed; removing store",
+					"store_ref", ref, "error", integrityErr)
+				_ = os.Remove(ref)
+			} else {
+				storeRef = ref
+				storeIndex = parsed.SegmentIndex
+			}
 		}
 	}
 

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -794,6 +794,14 @@ func (s *Service) FindAndUpdatePendingUpload(ctx context.Context, filename strin
 	if err != nil {
 		return nil, err
 	}
+	// Backward compatibility: also search the old configDir/.nzbs/ location for items queued
+	// before the OS temp queue dir migration.
+	oldNzbsDir := s.GetNzbFolder()
+	oldItems, err := s.database.Repository.GetPendingQueueItemsByPathPrefix(ctx, oldNzbsDir+string(filepath.Separator))
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, oldItems...)
 
 	for _, it := range items {
 		// Persisted name is "<base><ext>" or, on collision, "<id>-<base><ext>".
@@ -866,6 +874,13 @@ func (s *Service) processNzbItem(ctx context.Context, item *database.ImportQueue
 func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, basePath *string) string {
 	// Calculate initial virtual directory from physical/relative path
 	virtualDir := filesystem.CalculateVirtualDirectory(item.NzbPath, *basePath)
+
+	// Early return: NZB is in the OS temp queue dir — use basePath directly.
+	// The temp queue dir has no meaningful directory structure to derive a virtual path from.
+	tempQueueDir := filepath.Join(os.TempDir(), ".altmount-queue")
+	if strings.HasPrefix(item.NzbPath, tempQueueDir+string(filepath.Separator)) || item.NzbPath == tempQueueDir {
+		return *basePath
+	}
 
 	// Fix for issue where files moved to persistent .nzbs directory end up with exposed paths (like /config) in virtual directory
 	// This happens when NzbPath is inside .nzbs and CalculateVirtualDirectory sees the physical parent folder.
@@ -1013,8 +1028,9 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 	absNzbPath, _ := filepath.Abs(item.NzbPath)
 	absNzbDir, _ := filepath.Abs(nzbDir)
 
-	// Simple check: if path starts with persistent dir, assume it's fine
-	if strings.HasPrefix(absNzbPath, absNzbDir) {
+	// Simple check: if path starts with persistent dir (with separator) or equals it, assume it's fine.
+	// The trailing separator prevents a false match like /tmp/.altmount-queue-other/ matching /tmp/.altmount-queue.
+	if strings.HasPrefix(absNzbPath, absNzbDir+string(os.PathSeparator)) || absNzbPath == absNzbDir {
 		return nil
 	}
 

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -782,15 +782,15 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 // because ensurePersistentNzb rewrites the path after insert, so this matches a still-pending item by
 // its category-independent base filename and updates its category/priority in place. Returns nil if none.
 func (s *Service) FindAndUpdatePendingUpload(ctx context.Context, filename string, category *string, priority *database.QueuePriority) (*database.ImportQueueItem, error) {
-	cfg := s.configGetter()
-	nzbsDir := filepath.Join(filepath.Dir(cfg.Database.Path), ".nzbs")
+	// NZBs uploaded via the API are persisted into the OS temp queue dir.
+	queueDir := filepath.Join(os.TempDir(), ".altmount-queue")
 
 	base := nzbtrim.TrimNzbExtension(sanitizeFilename(filepath.Base(filename)))
 	if base == "" {
 		return nil, nil
 	}
 
-	items, err := s.database.Repository.GetPendingQueueItemsByPathPrefix(ctx, nzbsDir+string(filepath.Separator))
+	items, err := s.database.Repository.GetPendingQueueItemsByPathPrefix(ctx, queueDir+string(filepath.Separator))
 	if err != nil {
 		return nil, err
 	}
@@ -1000,18 +1000,14 @@ func sanitizeVirtualPath(p string) string {
 	return p
 }
 
-// ensurePersistentNzb moves the NZB file to a persistent location in the metadata directory
+// ensurePersistentNzb moves the NZB file to a persistent location in the OS
+// temporary queue directory. Using the OS temp dir (instead of configDir/.nzbs/)
+// keeps raw staging files separate from the permanent .nzbz store and prevents
+// stremio's defer os.RemoveAll(stageDir) from deleting the file before the
+// worker can process it.
 func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.ImportQueueItem) error {
-	cfg := s.configGetter()
-	// Use the database directory as the base for the persistent NZB storage
-	// This puts it next to metadata (e.g. /config/.nzbs)
-	configDir := filepath.Dir(cfg.Database.Path)
-	nzbDir := filepath.Join(configDir, ".nzbs")
-
-	// Add category subfolder if present to keep NZBs organized
-	if item.Category != nil && *item.Category != "" {
-		nzbDir = filepath.Join(nzbDir, *item.Category)
-	}
+	// Use OS temp queue dir; itemID ensures uniqueness so no category subfolder needed.
+	nzbDir := filepath.Join(os.TempDir(), ".altmount-queue")
 
 	// Check if current path is already in the persistent directory
 	absNzbPath, _ := filepath.Abs(item.NzbPath)


### PR DESCRIPTION
## Summary

- **`.nzb` staging moved to OS temp**: `ensurePersistentNzb` now places raw `.nzb` files in `os.TempDir()/.altmount-queue/` instead of `.nzbs/`. This keeps them alive past the per-request `stageDir` cleanup without polluting the persistent store directory.
- **`.nzbz` written to `configDir/.nzbs/{category}/`**: `processor.go` now derives the `.nzbz` path from `configGetter()` + category, independent of where the `.nzb` lives. Category input is sanitised against path traversal; `configDir` is resolved to an absolute path to avoid CWD-relative writes.
- **Failure handling confirmed correct**: `HandleFailure` → `MoveToFailedFolder` uses `item.NzbPath` as source (now OS temp) and moves to `configDir/.nzbs/failed/`, updating the DB record. The existing `cleanupFailedItems` TTL mechanism then deletes by `item.NzbPath`.
- **`calculateProcessVirtualDir` updated**: Early-return added for OS temp queue path so virtual directory is derived from `basePath` rather than the temp `.nzb` location.
- **Backward-compat dedup**: `FindAndUpdatePendingUpload` searches both new OS temp dir and old `.nzbs/` location for items queued before the migration.

After these changes, `configDir/.nzbs/` **exclusively contains `.nzbz` store files** (plus a `failed/` subdirectory for failed raw NZBs awaiting TTL expiry).

## Test plan

- [ ] All 16 `./internal/importer/...` packages pass (`go test ./internal/importer/... -count=1`)
- [ ] `go build ./...` succeeds
- [ ] `TestEnsurePersistentNzb_UsesOSTempQueueDir` — new `.nzb` path starts with `os.TempDir()/.altmount-queue`
- [ ] `TestEnsurePersistentNzb_AlreadyInTempQueueDir_IsNoop` — early-return guard
- [ ] `TestImportBattery_NzbzStoredInConfigDir` — `.nzbz` lands in `configDir/.nzbs/{category}/`
- [ ] `TestHandleFailure_MovesToFailedDir` — `.nzb` moves from OS temp to `failed/` dir
- [ ] `TestHandleFailure_SourceMissing_IsNoop` — missing source is a no-op
- [ ] `TestCleanupFailedItems_RemovesNzbFile` — TTL cleanup removes on-disk file