### PR TITLE
fix(importer): restore category folder for temp-queue staged NZBs

### DIFF
--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -851,17 +851,20 @@ func (s *Service) calculateProcessVirtualDir(item *database.ImportQueueItem, bas
 	// Calculate initial virtual directory from physical/relative path
 	virtualDir := filesystem.CalculateVirtualDirectory(item.NzbPath, *basePath)
 
-	// Early return: NZB is in the OS temp queue dir — use basePath directly.
-	// The temp queue dir has no meaningful directory structure to derive a virtual path from.
+	// NZB is in the OS temp queue dir — the temp dir has no meaningful directory
+	// structure to derive a virtual path from, so start from basePath. We must NOT
+	// return early here: the category resolution and CompleteDir prepend below still
+	// need to run, otherwise category-tagged uploads (SABnzbd/manual/Stremio) would
+	// land at the mount root instead of inside their category folder.
 	tempQueueDir := filepath.Join(os.TempDir(), ".altmount-queue")
-	if strings.HasPrefix(item.NzbPath, tempQueueDir+string(filepath.Separator)) || item.NzbPath == tempQueueDir {
-		return *basePath
-	}
+	inTempQueue := strings.HasPrefix(item.NzbPath, tempQueueDir+string(filepath.Separator)) || item.NzbPath == tempQueueDir
 
 	// Fix for issue where files moved to persistent .nzbs directory end up with exposed paths (like /config) in virtual directory
 	// This happens when NzbPath is inside .nzbs and CalculateVirtualDirectory sees the physical parent folder.
 	nzbFolder := s.GetNzbFolder()
-	if strings.HasPrefix(item.NzbPath, nzbFolder) {
+	if inTempQueue {
+		virtualDir = *basePath
+	} else if strings.HasPrefix(item.NzbPath, nzbFolder) {
 		// Calculate path relative to the persistent NZB folder
 		if relPath, err := filepath.Rel(nzbFolder, item.NzbPath); err == nil {
 			// If file is directly in root of .nzbs (e.g. "file.nzb"), relDir is "."

--- a/internal/importer/service_path_test.go
+++ b/internal/importer/service_path_test.go
@@ -1,6 +1,7 @@
 package importer
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -94,6 +95,31 @@ func TestCalculateProcessVirtualDir_FailedPath(t *testing.T) {
 			basePath:     "",
 			itemID:       22,
 			expectedPath: "/mnt/remotes/altmount",
+		},
+		{
+			// Production path after PR #717: ensurePersistentNzb stages the NZB in the
+			// OS temp queue dir. The category must still be appended to the destination.
+			name:         "temp queue nzb with category and basePath",
+			nzbPath:      filepath.Join(os.TempDir(), ".altmount-queue", "22-Show.S01E01.nzb"),
+			basePath:     "media",
+			category:     "tv",
+			itemID:       22,
+			expectedPath: "/mnt/remotes/altmount/media/tv",
+		},
+		{
+			name:         "temp queue nzb with category, basePath is CompleteDir",
+			nzbPath:      filepath.Join(os.TempDir(), ".altmount-queue", "7-Movie.nzb"),
+			basePath:     "/mnt/remotes/altmount",
+			category:     "tv",
+			itemID:       7,
+			expectedPath: "/mnt/remotes/altmount/tv",
+		},
+		{
+			name:         "temp queue nzb no category",
+			nzbPath:      filepath.Join(os.TempDir(), ".altmount-queue", "9-Show.nzb"),
+			basePath:     "media",
+			itemID:       9,
+			expectedPath: "/mnt/remotes/altmount/media",
 		},
 	}
 


### PR DESCRIPTION
## What

Fixes a regression introduced by #717 where imported files' metadata landed at the **root of the mount** (`<CompleteDir>/<release>`) instead of inside their **category folder** (`<CompleteDir>/<categoryDir>/<release>`) for every NZB added via the API — SABnzbd/Sonarr/Radarr, manual upload, and Stremio.

> Note: the `.nzbz` *store* files were never affected — those still go to `configDir/.nzbs/{category}/`. The regression was purely the **virtual destination** of imported content in the mount.

## Why

#717 made two coupled changes:

1. `ensurePersistentNzb` now stages NZBs in the OS temp queue dir (`os.TempDir()/.altmount-queue/{id}-file.nzb`) during `AddToQueue`, so by processing time `item.NzbPath` already points there.
2. It added an early `return *basePath` in `calculateProcessVirtualDir` for temp-queue paths.

The category is appended to the destination **only** inside the `buildCategoryPath` block (followed by the CompleteDir prepend + path sanitization). The early return fired *before* that block, so the category was dropped. `basePath` for all API uploads is `SABnzbd.CompleteDir` and never contains the category by design — the upload handlers explicitly rely on `calculateProcessVirtualDir` to append it (see the comments in `queue_handlers.go`).

The existing tests passed because they only used the old `/config/.nzbs/...` paths and never exercised the new temp-queue path.

## How

- Replace the early return with an `else if` branch: when the NZB is in the temp queue dir, set `virtualDir = *basePath` and **fall through** to category resolution + CompleteDir prepend. The `nzbFolder` block is still skipped for temp paths, preserving the "don't derive a path from the temp dir's physical structure" intent.
- Add temp-queue test cases covering the real production path (with category + basePath, with category + CompleteDir basePath, and no category). These would return the bare `basePath` before the fix.

## Testing

- `go test ./internal/importer/ -run CalculateProcessVirtualDir -v` — all pass, including new cases
- `go test -race ./internal/importer/` — pass
- `go build ./...` + `go vet ./internal/importer/` — clean

Reviewer note: manual end-to-end check still worth doing — upload an NZB with a category via the SABnzbd endpoint and confirm it appears under `<CompleteDir>/<categoryDir>/...` in the mount.