### PR TITLE
feat(stremio): add AIOStreams integration; deprecate built-in Prowlarr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ example/
 rclone.conf
 db.sqlite
 config/config.yaml
+config/shared/
 *.log
 build-test-image.sh
 .claude/worktrees/

--- a/cmd/altmount/cmd/serve.go
+++ b/cmd/altmount/cmd/serve.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -66,6 +68,11 @@ func runServe(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	configManager := config.NewManager(cfg, configFile)
+
+	// Write AIOStreams shared init file so the sidecar can auto-configure.
+	if cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled {
+		writeAIOStreamsInitFile(ctx, cfg, filepath.Dir(configFile))
+	}
 
 	// 3. Initialize core services
 	db, err := initializeDatabase(ctx, cfg)
@@ -437,5 +444,27 @@ func waitForHTTPServer(ctx context.Context, port int) error {
 			}
 		}
 	}
+}
+
+func writeAIOStreamsInitFile(ctx context.Context, cfg *config.Config, configDir string) {
+	baseURL := cfg.Stremio.BaseURL
+	if baseURL == "" {
+		baseURL = "http://altmount:8080"
+	}
+	sharedDir := filepath.Join(configDir, "shared")
+	if err := os.MkdirAll(sharedDir, 0755); err != nil {
+		slog.WarnContext(ctx, "Failed to create shared config dir", "error", err)
+		return
+	}
+	data, _ := json.Marshal(map[string]string{
+		"url":     baseURL,
+		"api_key": cfg.Stremio.ServiceAPIKey,
+	})
+	path := filepath.Join(sharedDir, "aiostreams-init.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		slog.WarnContext(ctx, "Failed to write AIOStreams init file", "error", err, "path", path)
+		return
+	}
+	slog.InfoContext(ctx, "AIOStreams init config written", "path", path)
 }
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -177,6 +177,28 @@ health:
 mount_path: '' # WebDAV mount path, Example: '/mnt/remotes/altmount' or '/mnt/unionfs'. Must be an absolute path.
                # Windows examples: 'Z:' (drive letter via WinFsp) or 'C:\altmount' (directory mount)
 
+# Stremio NZB stream endpoint configuration
+stremio:
+  enabled: false           # Enable the Stremio NZB streaming endpoint
+  nzb_ttl_hours: 24        # How long to cache processed NZB results (0 = forever)
+  base_url: ''             # Public base URL of this AltMount instance (auto-detected if empty)
+  # Auto-generated API key used by the AIOStreams sidecar to authenticate with /api/nzb/streams.
+  # Leave empty — AltMount generates and saves it on first start.
+  service_api_key: ''
+
+  # ─────────────────────────────────────────────────────────────────────
+  # DEPRECATED: The built-in Prowlarr integration is deprecated.
+  # Migrate to AIOStreams (docker-compose.stremio.yml) for NZB indexing.
+  # Prowlarr settings below continue to work but will be removed in a future release.
+  # ─────────────────────────────────────────────────────────────────────
+  prowlarr:
+    enabled: false
+    host: 'http://localhost:9696'
+    api_key: ''
+    categories: [2000, 2010, 2030, 2040, 2045, 2060, 5000, 5010, 5030, 5040]
+    languages: []
+    qualities: []
+
 # SABnzbd-compatible API configuration
 sabnzbd:
   enabled: false # Enable SABnzbd-compatible API

--- a/docker-compose.stremio.yml
+++ b/docker-compose.stremio.yml
@@ -1,0 +1,32 @@
+# docker-compose.stremio.yml
+# Optional AIOStreams addon sidecar for AltMount.
+#
+# Usage (with AltMount):
+#   docker compose -f docker-compose.yml -f docker-compose.stremio.yml up -d
+#
+# AltMount writes /config/shared/aiostreams-init.json at startup.
+# AIOStreams reads it on boot — no manual URL/key configuration needed.
+# Users only need to add their NZB indexers in the AIOStreams UI (port 8081).
+
+services:
+  aiostreams:
+    image: ghcr.io/viren070/aiostreams:latest
+    container_name: aiostreams
+    # Custom entrypoint reads the init file written by AltMount and sets env vars.
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    environment:
+      - PORT=8081
+      # Secret used by AIOStreams to sign addon config URLs — change in production.
+      - SECRET=change-me-to-a-strong-random-secret
+    volumes:
+      # Shared dir: AltMount writes aiostreams-init.json here; AIOStreams reads it.
+      - ./config/shared:/config/shared:ro
+      # Init script created in docker/aiostreams-entrypoint.sh
+      - ./docker/aiostreams-entrypoint.sh:/entrypoint.sh:ro
+    ports:
+      - "8081:8081"
+    restart: unless-stopped
+    # Only used when running together with the main compose file.
+    # Remove this block if running standalone.
+    networks:
+      - default

--- a/docker/aiostreams-entrypoint.sh
+++ b/docker/aiostreams-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+INIT_FILE="/config/shared/aiostreams-init.json"
+
+if [ -f "$INIT_FILE" ]; then
+  # Pure-sh JSON parse (no external dependencies needed)
+  ALTMOUNT_URL=$(grep -o '"url":"[^"]*"' "$INIT_FILE" | head -1 | cut -d'"' -f4)
+  ALTMOUNT_API_KEY=$(grep -o '"api_key":"[^"]*"' "$INIT_FILE" | head -1 | cut -d'"' -f4)
+
+  if [ -n "$ALTMOUNT_URL" ]; then
+    export ALTMOUNT_URL
+    export ALTMOUNT_API_KEY
+    printf '[aiostreams-entrypoint] Loaded AltMount config from %s\n' "$INIT_FILE"
+  else
+    printf '[aiostreams-entrypoint] WARN: init file found but .url is empty\n'
+  fi
+else
+  printf '[aiostreams-entrypoint] WARN: %s not found, starting without AltMount config\n' "$INIT_FILE"
+fi
+
+# Hand off to AIOStreams' default start command.
+# Adjust if AIOStreams image uses a different CMD (check: docker inspect ghcr.io/viren070/aiostreams:latest)
+exec node /app/dist/index.js "$@"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -39,6 +39,7 @@ import type {
 	ProviderTestRequest,
 	ProviderTestResponse,
 	ProviderUpdateRequest,
+	StremioSetupResponse,
 } from "../types/config";
 import type { UpdateChannel, UpdateStatusResponse } from "../types/update";
 
@@ -1027,6 +1028,10 @@ class APIClient {
 		if (params?.limit) searchParams.set("limit", params.limit.toString());
 		const query = searchParams.toString();
 		return this.request<LogEntry[]>(`/logs${query ? `?${query}` : ""}`);
+	}
+
+	async getStremioSetup(): Promise<StremioSetupResponse> {
+		return this.request<StremioSetupResponse>("/stremio/setup");
 	}
 }
 

--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -1,6 +1,18 @@
-import { Check, Copy, ExternalLink, Save, Tv, X } from "lucide-react";
+import {
+	AlertTriangle,
+	Check,
+	CheckCircle2,
+	ChevronDown,
+	Copy,
+	ExternalLink,
+	Save,
+	Tv,
+	X,
+} from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { copyToClipboard } from "../../lib/utils";
+import { apiClient } from "../../api/client";
 import type { ConfigResponse, ProwlarrConfig, StremioConfig } from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
 
@@ -80,6 +92,7 @@ interface StremioConfigSectionProps {
 }
 
 const DEFAULT_PROWLARR: ProwlarrConfig = {
+	deprecated: true,
 	enabled: false,
 	host: "http://localhost:9696",
 	api_key: "",
@@ -92,6 +105,7 @@ function resolveProwlarr(p: ProwlarrConfig | undefined): ProwlarrConfig {
 	const base = p ?? DEFAULT_PROWLARR;
 	return {
 		...base,
+		deprecated: true,
 		categories: base.categories?.length ? base.categories : DEFAULT_PROWLARR.categories,
 	};
 }
@@ -110,6 +124,7 @@ export function StremioConfigSection({
 	});
 	const [hasChanges, setHasChanges] = useState(false);
 	const [urlCopied, setUrlCopied] = useState(false);
+	const [addonCopied, setAddonCopied] = useState(false);
 
 	useEffect(() => {
 		setFormData({
@@ -120,6 +135,13 @@ export function StremioConfigSection({
 		});
 		setHasChanges(false);
 	}, [config.stremio]);
+
+	const { data: setup } = useQuery({
+		queryKey: ["stremio-setup"],
+		queryFn: () => apiClient.getStremioSetup(),
+		enabled: config.stremio?.enabled === true,
+		retry: false,
+	});
 
 	const markChanged = (updated: StremioConfig) => {
 		const orig = config.stremio;
@@ -150,6 +172,7 @@ export function StremioConfigSection({
 		}
 	};
 
+	// Legacy per-user Prowlarr addon URL
 	const addonURL =
 		formData.enabled && config.download_key
 			? `${(formData.base_url || "").replace(/\/$/, "") || window.location.origin}/stremio/${config.download_key}/manifest.json`
@@ -169,10 +192,27 @@ export function StremioConfigSection({
 		window.open(`stremio://${addonURL.replace(/^https?:\/\//, "")}`, "_blank");
 	};
 
+	const handleCopyAddonURL = async () => {
+		if (!setup?.aiostreams_addon_url) return;
+		const ok = await copyToClipboard(setup.aiostreams_addon_url);
+		if (ok) {
+			setAddonCopied(true);
+			setTimeout(() => setAddonCopied(false), 2000);
+		}
+	};
+
+	const aioStreamsInstallURL = setup?.aiostreams_addon_url
+		? `stremio://${setup.aiostreams_addon_url.replace(/^https?:\/\//, "")}`
+		: null;
+
+	const aioStreamsUIURL =
+		setup?.aiostreams_ui_url ??
+		`${window.location.protocol}//${window.location.hostname}:8081`;
+
 	return (
 		<div className="min-w-0 space-y-10">
 			<div className="min-w-0 space-y-8">
-				{/* Enable / Disable */}
+				{/* ── Enable / Base Config ─────────────────────────────────── */}
 				<div className="min-w-0 space-y-6 overflow-hidden rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
 					<div className="flex items-center gap-2">
 						<Tv className="h-4 w-4 text-base-content/60" />
@@ -235,151 +275,280 @@ export function StremioConfigSection({
 					</div>
 				</div>
 
-				{/* Addon URL */}
-				{addonURL && (
-					<div className="min-w-0 space-y-4 overflow-hidden rounded-2xl border-2 border-primary/30 bg-primary/5 p-6">
+				{/* ── AIOStreams — recommended (shown when Stremio is enabled) ── */}
+				{formData.enabled && (
+					<div className="min-w-0 overflow-hidden rounded-2xl border-2 border-success/40 bg-success/5 p-6 space-y-5">
 						<div className="flex items-center gap-2">
-							<Tv className="h-4 w-4 text-primary" />
-							<h4 className="font-bold text-primary text-xs uppercase tracking-widest">
-								Addon Install URL
+							<CheckCircle2 className="h-4 w-4 text-success" />
+							<h4 className="font-bold text-success text-xs uppercase tracking-widest">
+								AIOStreams
 							</h4>
-							<div className="h-px flex-1 bg-primary/20" />
+							<span className="badge badge-success badge-sm">Recommended</span>
+							<div className="h-px flex-1 bg-success/20" />
 						</div>
-						<p className="min-w-0 break-words text-base-content/60 text-xs">
-							Install this URL in Stremio to enable automatic Usenet streaming via Prowlarr.
+
+						<p className="text-sm text-base-content/70">
+							AIOStreams handles NZB indexer search. AltMount handles NZB download and
+							streaming. Your NNTP providers stay in AltMount — nothing moves.
 						</p>
-						<div className="flex min-w-0 flex-wrap items-center gap-2">
-							<code className="min-w-0 flex-1 basis-0 truncate rounded-lg bg-base-300 px-3 py-2 font-mono text-[11px]">
-								{addonURL}
-							</code>
-							<button
-								type="button"
-								className="btn btn-sm btn-ghost shrink-0"
-								onClick={handleCopyURL}
-								title="Copy URL"
+
+						{/* AIOStreams UI link */}
+						<div className="flex items-center justify-between rounded-xl bg-base-200 px-4 py-3">
+							<div className="min-w-0 flex-1">
+								<div className="text-sm font-medium">AIOStreams UI</div>
+								<div className="text-xs text-base-content/60 font-mono truncate">
+									{aioStreamsUIURL}
+								</div>
+							</div>
+							<a
+								href={aioStreamsUIURL}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="btn btn-sm btn-outline gap-1 shrink-0 ml-3"
 							>
-								{urlCopied ? (
-									<Check className="h-4 w-4 text-success" />
-								) : (
-									<Copy className="h-4 w-4" />
-								)}
-							</button>
-							<button
-								type="button"
-								className="btn btn-sm btn-primary shrink-0"
-								onClick={handleInstallInStremio}
-								title="Install in Stremio"
-							>
-								<ExternalLink className="h-4 w-4" />
-								Install
-							</button>
+								Open <ExternalLink className="h-3.5 w-3.5" />
+							</a>
 						</div>
+
+						{/* Step-by-step guide */}
+						<details className="group">
+							<summary className="flex cursor-pointer items-center gap-2 text-sm font-medium select-none list-none">
+								<ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180" />
+								Setup guide — 3 steps
+							</summary>
+
+							<ol className="mt-4 space-y-5">
+								<li className="flex gap-3">
+									<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-primary-content text-xs font-bold">
+										1
+									</span>
+									<div className="min-w-0">
+										<div className="text-sm font-medium">
+											Start AIOStreams alongside AltMount
+										</div>
+										<div className="text-xs text-base-content/60 mt-1">
+											Run the following from your AltMount directory. AIOStreams will boot
+											already wired to this instance — no URL or key configuration needed.
+										</div>
+										<code className="block mt-2 rounded-lg bg-base-200 px-3 py-2 text-xs font-mono break-all">
+											docker compose -f docker-compose.yml -f docker-compose.stremio.yml up -d
+										</code>
+									</div>
+								</li>
+
+								<li className="flex gap-3">
+									<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-primary-content text-xs font-bold">
+										2
+									</span>
+									<div className="min-w-0">
+										<div className="text-sm font-medium">
+											Open AIOStreams and add your NZB indexers
+										</div>
+										<div className="text-xs text-base-content/60 mt-1">
+											Configure Prowlarr, NZBgeek, or any other indexer in the AIOStreams UI
+											(port 8081). AltMount is already set as the NZB download backend.
+										</div>
+									</div>
+								</li>
+
+								<li className="flex gap-3">
+									<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary text-primary-content text-xs font-bold">
+										3
+									</span>
+									<div className="min-w-0 flex-1 space-y-2">
+										<div className="text-sm font-medium">
+											Install the AIOStreams addon in Stremio
+										</div>
+										{setup?.aiostreams_addon_url ? (
+											<>
+												<div className="flex items-center gap-2">
+													<code className="flex-1 truncate rounded-lg bg-base-200 px-2 py-1 text-xs font-mono">
+														{setup.aiostreams_addon_url}
+													</code>
+													<button
+														type="button"
+														className="btn btn-xs btn-ghost shrink-0"
+														onClick={handleCopyAddonURL}
+														title="Copy addon URL"
+													>
+														{addonCopied ? (
+															<CheckCircle2 className="h-3.5 w-3.5 text-success" />
+														) : (
+															<Copy className="h-3.5 w-3.5" />
+														)}
+													</button>
+												</div>
+												{aioStreamsInstallURL && (
+													<a
+														href={aioStreamsInstallURL}
+														className="btn btn-sm btn-primary gap-1"
+													>
+														Install in Stremio{" "}
+														<ExternalLink className="h-3.5 w-3.5" />
+													</a>
+												)}
+											</>
+										) : (
+											<div className="text-xs text-base-content/40">
+												Start AIOStreams first to generate your addon URL.
+											</div>
+										)}
+									</div>
+								</li>
+							</ol>
+						</details>
 					</div>
 				)}
 
-				{/* Prowlarr */}
-				<div className="min-w-0 space-y-6 overflow-hidden rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
-					<div className="flex items-center gap-2">
-						<Tv className="h-4 w-4 text-base-content/60" />
-						<h4 className="font-bold text-base-content/40 text-xs uppercase tracking-widest">
-							Prowlarr Indexer
-						</h4>
-						<div className="h-px flex-1 bg-base-300/50" />
-					</div>
+				{/* ── Prowlarr — deprecated (collapsible) ─────────────────── */}
+				<details className="group">
+					<summary className="flex cursor-pointer items-center gap-2 select-none list-none rounded-xl border-2 border-warning/30 bg-warning/5 px-4 py-3">
+						<ChevronDown className="h-4 w-4 transition-transform group-open:rotate-180 shrink-0" />
+						<AlertTriangle className="h-4 w-4 text-warning shrink-0" />
+						<span className="font-medium text-sm flex-1">Prowlarr integration</span>
+						<span className="badge badge-warning badge-sm">Deprecated</span>
+					</summary>
 
-					<div className="flex items-center justify-between gap-4">
-						<div className="min-w-0 flex-1">
-							<h5 className="break-words font-bold text-sm">Enable Prowlarr Search</h5>
-							<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
-								When enabled, the Stremio addon automatically searches Prowlarr for NZBs by IMDB ID
-								and queues the best result.
-							</p>
+					<div className="mt-3 min-w-0 space-y-6 overflow-hidden rounded-2xl border-2 border-warning/30 bg-base-200/60 p-6">
+						<div className="alert alert-warning py-2 text-sm">
+							<AlertTriangle className="h-4 w-4 shrink-0" />
+							<div>
+								The built-in Prowlarr integration is deprecated. Migrate to AIOStreams above
+								— it supports Prowlarr and other indexers with better filtering.
+							</div>
 						</div>
-						<input
-							type="checkbox"
-							className="toggle toggle-primary mt-1 shrink-0"
-							checked={formData.prowlarr?.enabled ?? false}
-							disabled={isReadOnly}
-							onChange={(e) => updateProwlarr({ enabled: e.target.checked })}
-						/>
-					</div>
 
-					{formData.prowlarr?.enabled && (
-						<div className="fade-in slide-in-from-top-2 animate-in space-y-6 border-base-300/50 border-t pt-6">
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend">Prowlarr Host</legend>
-								<input
-									type="url"
-									className="input w-full min-w-0 max-w-full"
-									placeholder="http://localhost:9696"
-									value={formData.prowlarr?.host ?? ""}
-									disabled={isReadOnly}
-									onChange={(e) => updateProwlarr({ host: e.target.value })}
-								/>
-							</fieldset>
-
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend">API Key</legend>
-								<input
-									type="password"
-									className="input w-full min-w-0 max-w-full"
-									placeholder="Prowlarr API key"
-									value={formData.prowlarr?.api_key ?? ""}
-									disabled={isReadOnly}
-									onChange={(e) => updateProwlarr({ api_key: e.target.value })}
-								/>
-							</fieldset>
-
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend">Categories</legend>
-								<TagInput
-									tags={(formData.prowlarr?.categories ?? []).map(String)}
-									onChange={(tags) =>
-										updateProwlarr({ categories: tags.map((t) => Number.parseInt(t, 10)) })
-									}
-									disabled={isReadOnly}
-									placeholder="Add ID..."
-									parseValue={(raw) => {
-										const n = Number.parseInt(raw.trim(), 10);
-										return Number.isNaN(n) ? null : String(n);
-									}}
-								/>
-								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
-									Newznab category IDs. Press Enter or comma to add. Defaults: 2000 (Movies), 2040
-									(Movies/HD), 2060 (Movies/4K), 5000 (TV), 5040 (TV/HD).
+						<div className="flex items-center justify-between gap-4">
+							<div className="min-w-0 flex-1">
+								<h5 className="break-words font-bold text-sm">Enable Prowlarr Search</h5>
+								<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+									When enabled, the Stremio addon automatically searches Prowlarr for NZBs
+									by IMDB ID and queues the best result.
 								</p>
-							</fieldset>
-
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend">Language Filter</legend>
-								<TagInput
-									tags={formData.prowlarr?.languages ?? []}
-									onChange={(languages) => updateProwlarr({ languages })}
-									disabled={isReadOnly}
-									placeholder="Add keyword..."
-								/>
-								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
-									Only show releases whose title contains at least one of these keywords. Leave
-									empty to show all languages.
-								</p>
-							</fieldset>
-
-							<fieldset className="fieldset min-w-0">
-								<legend className="fieldset-legend">Quality Filter</legend>
-								<TagInput
-									tags={formData.prowlarr?.qualities ?? []}
-									onChange={(qualities) => updateProwlarr({ qualities })}
-									disabled={isReadOnly}
-									placeholder="Add keyword..."
-								/>
-								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
-									Only show releases whose title contains at least one of these keywords. Leave
-									empty to show all quality tiers.
-								</p>
-							</fieldset>
+							</div>
+							<input
+								type="checkbox"
+								className="toggle toggle-warning mt-1 shrink-0"
+								checked={formData.prowlarr?.enabled ?? false}
+								disabled={isReadOnly}
+								onChange={(e) => updateProwlarr({ enabled: e.target.checked })}
+							/>
 						</div>
-					)}
-				</div>
+
+						{formData.prowlarr?.enabled && (
+							<div className="fade-in slide-in-from-top-2 animate-in space-y-6 border-base-300/50 border-t pt-6">
+								<fieldset className="fieldset min-w-0">
+									<legend className="fieldset-legend">Prowlarr Host</legend>
+									<input
+										type="url"
+										className="input w-full min-w-0 max-w-full"
+										placeholder="http://localhost:9696"
+										value={formData.prowlarr?.host ?? ""}
+										disabled={isReadOnly}
+										onChange={(e) => updateProwlarr({ host: e.target.value })}
+									/>
+								</fieldset>
+
+								<fieldset className="fieldset min-w-0">
+									<legend className="fieldset-legend">API Key</legend>
+									<input
+										type="password"
+										className="input w-full min-w-0 max-w-full"
+										placeholder="Prowlarr API key"
+										value={formData.prowlarr?.api_key ?? ""}
+										disabled={isReadOnly}
+										onChange={(e) => updateProwlarr({ api_key: e.target.value })}
+									/>
+								</fieldset>
+
+								<fieldset className="fieldset min-w-0">
+									<legend className="fieldset-legend">Categories</legend>
+									<TagInput
+										tags={(formData.prowlarr?.categories ?? []).map(String)}
+										onChange={(tags) =>
+											updateProwlarr({
+												categories: tags.map((t) => Number.parseInt(t, 10)),
+											})
+										}
+										disabled={isReadOnly}
+										placeholder="Add ID..."
+										parseValue={(raw) => {
+											const n = Number.parseInt(raw.trim(), 10);
+											return Number.isNaN(n) ? null : String(n);
+										}}
+									/>
+									<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+										Newznab category IDs. Press Enter or comma to add. Defaults: 2000
+										(Movies), 2040 (Movies/HD), 2060 (Movies/4K), 5000 (TV), 5040 (TV/HD).
+									</p>
+								</fieldset>
+
+								<fieldset className="fieldset min-w-0">
+									<legend className="fieldset-legend">Language Filter</legend>
+									<TagInput
+										tags={formData.prowlarr?.languages ?? []}
+										onChange={(languages) => updateProwlarr({ languages })}
+										disabled={isReadOnly}
+										placeholder="Add keyword..."
+									/>
+									<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+										Only show releases whose title contains at least one of these keywords.
+										Leave empty to show all languages.
+									</p>
+								</fieldset>
+
+								<fieldset className="fieldset min-w-0">
+									<legend className="fieldset-legend">Quality Filter</legend>
+									<TagInput
+										tags={formData.prowlarr?.qualities ?? []}
+										onChange={(qualities) => updateProwlarr({ qualities })}
+										disabled={isReadOnly}
+										placeholder="Add keyword..."
+									/>
+									<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+										Only show releases whose title contains at least one of these keywords.
+										Leave empty to show all quality tiers.
+									</p>
+								</fieldset>
+							</div>
+						)}
+
+						{/* Legacy Prowlarr addon URL */}
+						{addonURL && (
+							<div className="min-w-0 space-y-3 rounded-xl border border-base-300 bg-base-100 p-4">
+								<p className="text-xs text-base-content/50">
+									Legacy Prowlarr addon URL — use the AIOStreams addon URL above instead.
+								</p>
+								<div className="flex min-w-0 flex-wrap items-center gap-2">
+									<code className="min-w-0 flex-1 basis-0 truncate rounded-lg bg-base-300 px-3 py-2 font-mono text-[11px]">
+										{addonURL}
+									</code>
+									<button
+										type="button"
+										className="btn btn-sm btn-ghost shrink-0"
+										onClick={handleCopyURL}
+										title="Copy URL"
+									>
+										{urlCopied ? (
+											<Check className="h-4 w-4 text-success" />
+										) : (
+											<Copy className="h-4 w-4" />
+										)}
+									</button>
+									<button
+										type="button"
+										className="btn btn-sm btn-outline shrink-0"
+										onClick={handleInstallInStremio}
+										title="Install in Stremio"
+									>
+										<ExternalLink className="h-4 w-4" />
+										Install
+									</button>
+								</div>
+							</div>
+						)}
+					</div>
+				</details>
 			</div>
 
 			{/* Save Button */}

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -629,6 +629,7 @@ export interface StuckCleanupRule {
 
 // Prowlarr indexer configuration (nested inside StremioConfig)
 export interface ProwlarrConfig {
+	deprecated: boolean; // always true from server — migrate to AIOStreams
 	enabled: boolean;
 	host: string;
 	api_key: string;
@@ -642,7 +643,16 @@ export interface StremioConfig {
 	enabled: boolean;
 	nzb_ttl_hours: number;
 	base_url?: string;
+	service_api_key?: string;
 	prowlarr: ProwlarrConfig;
+}
+
+// AIOStreams onboarding info returned by /api/stremio/setup
+export interface StremioSetupResponse {
+	aiostreams_ui_url: string;
+	aiostreams_addon_url: string;
+	nzb_streams_url: string;
+	service_api_key: string;
 }
 
 // Helper type for configuration sections

--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"log/slog"
@@ -101,7 +102,11 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		// Accept raw API key via X-Api-Key header (AIOStreams sends altmountApiKey here).
 		// Hash it so validateDownloadKey can compare against the stored hash.
 		if rawKey := c.Get("X-Api-Key"); rawKey != "" {
-			if s.validateAPIKey(c, rawKey) {
+			// Check service API key first (used by AIOStreams sidecar).
+			svcKey := s.configManager.GetConfig().Stremio.ServiceAPIKey
+			if svcKey != "" && subtle.ConstantTimeCompare([]byte(rawKey), []byte(svcKey)) == 1 {
+				downloadKey = auth.HashAPIKey(svcKey)
+			} else if s.validateAPIKey(c, rawKey) {
 				downloadKey = auth.HashAPIKey(rawKey)
 			} else {
 				slog.WarnContext(ctx, "Stremio stream endpoint: authentication failed - invalid X-Api-Key")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -379,6 +379,9 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/user/logout", s.handleAuthLogout)
 	api.Post("/user/api-key/regenerate", s.handleRegenerateAPIKey)
 	api.Put("/user/password", s.handleChangeOwnPassword)
+
+	// Stremio onboarding info (authenticated; used by the frontend setup wizard)
+	api.Get("/stremio/setup", s.handleStremioSetup)
 }
 
 // Shutdown shuts down the API server and its managed resources

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -524,9 +524,19 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 	}
 }
 
-// validateDownloadKey returns true if key matches any user's hashed API key.
+// validateDownloadKey returns true if key matches any user's hashed API key or the service API key hash.
 func (s *Server) validateDownloadKey(ctx context.Context, key string) bool {
-	if s.userRepo == nil || key == "" {
+	if key == "" {
+		return false
+	}
+	// Check service API key hash (used by AIOStreams sidecar).
+	if s.configManager != nil {
+		svcKey := s.configManager.GetConfig().Stremio.ServiceAPIKey
+		if svcKey != "" && subtle.ConstantTimeCompare([]byte(auth.HashAPIKey(svcKey)), []byte(key)) == 1 {
+			return true
+		}
+	}
+	if s.userRepo == nil {
 		return false
 	}
 	users, err := s.userRepo.GetAllUsers(ctx)

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -553,3 +553,35 @@ func (s *Server) validateDownloadKey(ctx context.Context, key string) bool {
 	}
 	return false
 }
+
+// StremioSetupResponse contains the URLs and key needed for AIOStreams onboarding.
+type StremioSetupResponse struct {
+	AIOStreamsUIURL    string `json:"aiostreams_ui_url"`
+	AIOStreamsAddonURL string `json:"aiostreams_addon_url"`
+	NzbStreamsURL      string `json:"nzb_streams_url"`
+	ServiceAPIKey     string `json:"service_api_key"`
+}
+
+// handleStremioSetup returns the AIOStreams onboarding information for the frontend wizard.
+func (s *Server) handleStremioSetup(c *fiber.Ctx) error {
+	cfg := s.configManager.GetConfig()
+	if !isStremioEnabled(cfg) {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "Stremio addon is disabled"})
+	}
+
+	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
+
+	// Derive the AIOStreams base URL: same host as AltMount, port 8081.
+	aioStreamsBase := strings.TrimRight(baseURL, "/")
+	if idx := strings.LastIndex(aioStreamsBase, ":"); idx > strings.Index(aioStreamsBase, "//") {
+		aioStreamsBase = aioStreamsBase[:idx]
+	}
+	aioStreamsBase += ":8081"
+
+	return c.JSON(StremioSetupResponse{
+		AIOStreamsUIURL:    aioStreamsBase,
+		AIOStreamsAddonURL: aioStreamsBase + "/manifest.json",
+		NzbStreamsURL:      baseURL + "/api/nzb/streams",
+		ServiceAPIKey:     cfg.Stremio.ServiceAPIKey,
+	})
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -202,14 +202,16 @@ type ArrsInstanceAPIResponse struct {
 
 // StremioAPIResponse sanitizes Stremio config for API responses
 type StremioAPIResponse struct {
-	Enabled     bool                `json:"enabled"`
-	NzbTTLHours int                 `json:"nzb_ttl_hours,omitempty"`
-	BaseURL     string              `json:"base_url,omitempty"`
-	Prowlarr    ProwlarrAPIResponse `json:"prowlarr"`
+	Enabled       bool                `json:"enabled"`
+	NzbTTLHours   int                 `json:"nzb_ttl_hours,omitempty"`
+	BaseURL       string              `json:"base_url,omitempty"`
+	ServiceAPIKey string              `json:"service_api_key,omitempty"`
+	Prowlarr      ProwlarrAPIResponse `json:"prowlarr"`
 }
 
 // ProwlarrAPIResponse sanitizes Prowlarr config for API responses
 type ProwlarrAPIResponse struct {
+	Deprecated bool     `json:"deprecated"` // always true — users should migrate to AIOStreams
 	Enabled    bool     `json:"enabled"`
 	Host       string   `json:"host,omitempty"`
 	APIKey     string   `json:"api_key"`
@@ -376,10 +378,12 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 	}
 
 	stremioResp := StremioAPIResponse{
-		Enabled:     cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled,
-		NzbTTLHours: cfg.Stremio.NzbTTLHours,
-		BaseURL:     cfg.Stremio.BaseURL,
+		Enabled:       cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled,
+		NzbTTLHours:   cfg.Stremio.NzbTTLHours,
+		BaseURL:       cfg.Stremio.BaseURL,
+		ServiceAPIKey: cfg.Stremio.ServiceAPIKey,
 		Prowlarr: ProwlarrAPIResponse{
+			Deprecated: true,
 			Enabled:    cfg.Stremio.Prowlarr.Enabled != nil && *cfg.Stremio.Prowlarr.Enabled,
 			Host:       cfg.Stremio.Prowlarr.Host,
 			APIKey:     cfg.Stremio.Prowlarr.APIKey,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os"
@@ -173,6 +175,9 @@ type StremioConfig struct {
 	BaseURL string `yaml:"base_url" mapstructure:"base_url" json:"base_url,omitempty"`
 	// Prowlarr configures the Prowlarr indexer used by the Stremio addon to search for NZBs.
 	Prowlarr ProwlarrConfig `yaml:"prowlarr" mapstructure:"prowlarr" json:"prowlarr"`
+	// ServiceAPIKey is used by AIOStreams to authenticate /api/nzb/streams requests.
+	// Auto-generated on first start if empty.
+	ServiceAPIKey string `yaml:"service_api_key" mapstructure:"service_api_key" json:"service_api_key,omitempty"`
 }
 
 // AuthConfig represents authentication configuration
@@ -1221,10 +1226,19 @@ type Manager struct {
 
 // NewManager creates a new configuration manager
 func NewManager(config *Config, configFile string) *Manager {
-	return &Manager{
+	m := &Manager{
 		current:    config,
 		configFile: configFile,
 	}
+	// Auto-generate a stable service key for AIOStreams if not yet set.
+	if m.current.Stremio.ServiceAPIKey == "" {
+		b := make([]byte, 32)
+		if _, err := rand.Read(b); err == nil {
+			m.current.Stremio.ServiceAPIKey = hex.EncodeToString(b)
+			_ = m.SaveConfig()
+		}
+	}
+	return m
 }
 
 // GetConfig returns the current configuration (thread-safe)


### PR DESCRIPTION
## Summary

- **AIOStreams sidecar**: adds `docker-compose.stremio.yml` for optional `ghcr.io/viren070/aiostreams` container; a pure-sh entrypoint reads AltMount's shared config file and auto-wires `ALTMOUNT_URL`/`ALTMOUNT_API_KEY` at container startup — no manual URL/key configuration needed
- **ServiceAPIKey**: auto-generated 32-byte hex key added to `StremioConfig`; written to `config/shared/aiostreams-init.json` on startup; accepted by `POST /api/nzb/streams` (X-Api-Key header) and by `validateDownloadKey` for stream URL auth
- **`/api/stremio/setup` endpoint**: returns AIOStreams UI URL, addon URL, NZB streams URL, and service API key for the frontend onboarding wizard
- **Prowlarr deprecated**: `deprecated: true` field added to Prowlarr config and API response; built-in functionality kept working but clearly marked deprecated
- **Frontend wizard**: `StremioConfigSection` rewrites with an AIOStreams "Recommended" card (3-step guide, live addon URL, one-click Stremio install), Prowlarr moved to a collapsible `<details>` with a Deprecated badge

## Test plan

- [ ] Start with `docker compose -f docker-compose.yml -f docker-compose.stremio.yml up -d`; confirm AIOStreams container starts with correct env vars
- [ ] Enable Stremio in config; confirm `config/shared/aiostreams-init.json` is written with correct URL and service key
- [ ] `GET /api/stremio/setup` (authenticated) returns AIOStreams URLs and service key
- [ ] `POST /api/nzb/streams` with `X-Api-Key: <service_key>` returns 200; with bad key returns 401
- [ ] Stremio stream URL generated using service key hash resolves correctly
- [ ] Frontend: Stremio enabled → AIOStreams card visible with setup guide; addon URL appears after AIOStreams is running
- [ ] Frontend: Prowlarr collapsible is collapsed by default, shows Deprecated badge, still configurable
- [ ] Existing per-user Prowlarr addon URL still works (backward compat)