### PR TITLE
perf(importer): reuse parser first-segment bytes for archive header reads

### DIFF
--- a/internal/importer/filesystem/usenet_fs.go
+++ b/internal/importer/filesystem/usenet_fs.go
@@ -312,8 +312,24 @@ func (uf *UsenetFile) ReadAt(p []byte, off int64) (n int, err error) {
 	return io.ReadFull(reader, p)
 }
 
-// createUsenetReader creates a Usenet reader for the specified range
+// createUsenetReader creates a reader for the specified range. Reads that begin
+// at offset 0 are served from the file's warm first-segment bytes (captured by
+// the parser during first-segment analysis) for as far as those bytes reach,
+// falling through to the network only for the remainder. This lets archive
+// header parsing — which reads from offset 0 — reuse a segment already pulled
+// over the wire this import instead of re-fetching it. Files without warm bytes
+// (playback, decrypting FS, skipped/missing first segments) take the network
+// path directly.
 func (uf *UsenetFile) createUsenetReader(ctx context.Context, start, end int64) (io.ReadCloser, error) {
+	if start == 0 && len(uf.file.FirstSegmentBytes) > 0 {
+		return uf.newWarmPrefixReader(ctx, end), nil
+	}
+	return uf.newNetworkReader(ctx, start, end)
+}
+
+// newNetworkReader creates a Usenet reader that fetches the byte range [start,end]
+// from the provider.
+func (uf *UsenetFile) newNetworkReader(ctx context.Context, start, end int64) (io.ReadCloser, error) {
 	// Filter segments for this specific file
 	loader := dbSegmentLoader{segs: uf.file.Segments}
 
@@ -325,6 +341,67 @@ func (uf *UsenetFile) createUsenetReader(ctx context.Context, start, end int64) 
 
 	rg := usenet.GetSegmentsInRange(ctx, start, end, loader)
 	return usenet.NewUsenetReader(ctx, uf.poolManager.GetPool, rg, uf.maxPrefetch, uf.poolManager, uf.name, nil)
+}
+
+// newWarmPrefixReader builds a reader that serves the file's warm first-segment
+// bytes for the requested range [0,end], lazily creating a network reader for any
+// portion beyond the cached prefix. The cached bytes are the decoded payload of
+// the file at offset 0, so they are byte-identical to what the network path would
+// return — no risk of stale or mismatched data.
+func (uf *UsenetFile) newWarmPrefixReader(ctx context.Context, end int64) io.ReadCloser {
+	prefix := uf.file.FirstSegmentBytes
+	// Never serve past the requested range.
+	if limit := end + 1; limit >= 0 && limit < int64(len(prefix)) {
+		prefix = prefix[:limit]
+	}
+	prefixLen := int64(len(prefix))
+
+	wr := &warmPrefixReader{prefix: prefix}
+	if end >= prefixLen {
+		// Reads past the cached prefix fall through to the network, resuming
+		// exactly where the prefix ends so the combined stream has no gap or overlap.
+		wr.makeRest = func() (io.ReadCloser, error) {
+			return uf.newNetworkReader(ctx, prefixLen, end)
+		}
+	}
+	return wr
+}
+
+// warmPrefixReader serves an in-memory prefix, then transparently switches to a
+// lazily-created underlying reader for any bytes past the prefix. The underlying
+// reader is only constructed if a read actually crosses the prefix boundary, so a
+// header-only read (the common archive-analysis case) issues no wire calls.
+type warmPrefixReader struct {
+	prefix   []byte
+	consumed int
+	makeRest func() (io.ReadCloser, error)
+	rest     io.ReadCloser
+}
+
+func (r *warmPrefixReader) Read(p []byte) (int, error) {
+	if r.consumed < len(r.prefix) {
+		n := copy(p, r.prefix[r.consumed:])
+		r.consumed += n
+		return n, nil
+	}
+	if r.makeRest == nil {
+		return 0, io.EOF
+	}
+	if r.rest == nil {
+		rc, err := r.makeRest()
+		if err != nil {
+			return 0, err
+		}
+		r.rest = rc
+	}
+	return r.rest.Read(p)
+}
+
+func (r *warmPrefixReader) Close() error {
+	if r.rest != nil {
+		return r.rest.Close()
+	}
+	return nil
 }
 
 // dbSegmentLoader implements the segment loader interface for database segments

--- a/internal/importer/filesystem/warm_cache_test.go
+++ b/internal/importer/filesystem/warm_cache_test.go
@@ -1,0 +1,184 @@
+package filesystem
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/importer/parser"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+)
+
+// fsFakePoolManager satisfies the full pool.Manager surface so UsenetFile can
+// call GetPool / HasPool / metric helpers without nil-deref. GetPool returns the
+// embedded fakepool client so wire calls are counted.
+type fsFakePoolManager struct {
+	client pool.NntpClient
+}
+
+var _ pool.Manager = (*fsFakePoolManager)(nil)
+
+func (m *fsFakePoolManager) GetPool() (pool.NntpClient, error)        { return m.client, nil }
+func (m *fsFakePoolManager) SetProviders(_ []nntppool.Provider) error { return nil }
+func (m *fsFakePoolManager) ClearPool() error                         { return nil }
+func (m *fsFakePoolManager) HasPool() bool                            { return true }
+func (m *fsFakePoolManager) GetMetrics() (pool.MetricsSnapshot, error) {
+	return pool.MetricsSnapshot{}, nil
+}
+func (m *fsFakePoolManager) ResetMetrics(_ context.Context, _, _ bool) error { return nil }
+func (m *fsFakePoolManager) ResetProviderErrors(_ context.Context) error     { return nil }
+func (m *fsFakePoolManager) IncArticlesDownloaded()                          {}
+func (m *fsFakePoolManager) UpdateDownloadProgress(_ string, _ int64)        {}
+func (m *fsFakePoolManager) IncArticlesPosted()                              {}
+func (m *fsFakePoolManager) AddProvider(_ nntppool.Provider) error           { return nil }
+func (m *fsFakePoolManager) RemoveProvider(_ string) error                   { return nil }
+func (m *fsFakePoolManager) ResetProviderQuota(_ context.Context, _ string) error {
+	return nil
+}
+func (m *fsFakePoolManager) SetProviderIDs(_ map[string]string) {}
+func (m *fsFakePoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *fsFakePoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *fsFakePoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
+func (m *fsFakePoolManager) NotifyStreamChange()                         {}
+
+// TestWarmCacheServesPrefixWithoutNetwork verifies that a read confined to a
+// file's warm first-segment bytes is served from memory, issuing zero wire calls.
+func TestWarmCacheServesPrefixWithoutNetwork(t *testing.T) {
+	const size = 50
+	want := make([]byte, size)
+	for i := range want {
+		want[i] = byte('A' + (i % 26))
+	}
+
+	fpc := fakepool.New()
+	mgr := &fsFakePoolManager{client: fpc}
+
+	file := parser.ParsedFile{
+		Filename: "movie.part01.rar",
+		Size:     size,
+		Segments: []*metapb.SegmentData{
+			{Id: "seg0", StartOffset: 0, EndOffset: size - 1, SegmentSize: size},
+		},
+		FirstSegmentBytes: want,
+	}
+
+	ufs := NewUsenetFileSystem(context.Background(), mgr, []parser.ParsedFile{file}, 1, nil, time.Minute)
+	f, err := ufs.Open("movie.part01.rar")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+
+	ra, ok := f.(io.ReaderAt)
+	if !ok {
+		t.Fatalf("file does not implement io.ReaderAt")
+	}
+
+	buf := make([]byte, 20)
+	n, err := ra.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		t.Fatalf("ReadAt: %v", err)
+	}
+	if n != len(buf) {
+		t.Fatalf("ReadAt returned n=%d, want %d", n, len(buf))
+	}
+	if string(buf) != string(want[:20]) {
+		t.Fatalf("ReadAt bytes mismatch:\n got %q\nwant %q", buf, want[:20])
+	}
+
+	if got := fpc.BodyPriorityCalls(); got != 0 {
+		t.Errorf("warm-cache read issued %d BodyPriority calls, want 0", got)
+	}
+	if got := fpc.BodyCalls(); got != 0 {
+		t.Errorf("warm-cache read issued %d Body calls, want 0", got)
+	}
+}
+
+// stubReadCloser is an in-memory ReadCloser for warmPrefixReader unit tests.
+type stubReadCloser struct {
+	data   []byte
+	pos    int
+	closed bool
+}
+
+func (s *stubReadCloser) Read(p []byte) (int, error) {
+	if s.pos >= len(s.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data[s.pos:])
+	s.pos += n
+	return n, nil
+}
+
+func (s *stubReadCloser) Close() error {
+	s.closed = true
+	return nil
+}
+
+// TestWarmPrefixReaderFallsThrough verifies the reader serves the prefix
+// from memory and only invokes the network factory when a read crosses past it.
+func TestWarmPrefixReaderFallsThrough(t *testing.T) {
+	prefix := []byte("HEADERBYTES") // 11 bytes
+	rest := []byte("TAILDATA")      // 8 bytes
+
+	madeRest := 0
+	stub := &stubReadCloser{data: rest}
+	wr := &warmPrefixReader{
+		prefix: prefix,
+		makeRest: func() (io.ReadCloser, error) {
+			madeRest++
+			return stub, nil
+		},
+	}
+
+	// Read the full concatenation in small chunks.
+	got, err := io.ReadAll(wr)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != string(prefix)+string(rest) {
+		t.Fatalf("concat mismatch:\n got %q\nwant %q", got, string(prefix)+string(rest))
+	}
+	if madeRest != 1 {
+		t.Errorf("makeRest called %d times, want 1", madeRest)
+	}
+	if err := wr.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !stub.closed {
+		t.Errorf("underlying rest reader was not closed")
+	}
+}
+
+// TestWarmPrefixReaderPrefixOnly verifies that a read fully contained in the
+// prefix never constructs the network reader.
+func TestWarmPrefixReaderPrefixOnly(t *testing.T) {
+	prefix := []byte("HEADER")
+	madeRest := 0
+	wr := &warmPrefixReader{
+		prefix: prefix,
+		// makeRest must never be called for a prefix-only read.
+		makeRest: func() (io.ReadCloser, error) {
+			madeRest++
+			return nil, nil
+		},
+	}
+
+	buf := make([]byte, len(prefix))
+	n, err := io.ReadFull(wr, buf)
+	if err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+	if n != len(prefix) || string(buf) != string(prefix) {
+		t.Fatalf("prefix read mismatch: n=%d buf=%q", n, buf)
+	}
+	if madeRest != 0 {
+		t.Errorf("makeRest called %d times for prefix-only read, want 0", madeRest)
+	}
+}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -151,6 +151,12 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// size from "=ybegin size=") lets normalization derive the LAST part's size arithmetically,
 	// eliminating the per-file last-segment fetch that would otherwise drain a full body.
 	firstSegmentSizeCache := make(map[string]firstSegmentYencInfo)
+	// warmFirstSegmentBytes carries each fetched file's decoded first-segment bytes
+	// (keyed by first-segment ID) into the archive analysis phase, so a volume's
+	// header read — which starts at offset 0 — is served from memory instead of
+	// re-fetching a segment already pulled over the wire here. Skipped/missing first
+	// segments contribute nothing; those volumes are read lazily by the analyzer.
+	warmFirstSegmentBytes := make(map[string][]byte)
 	for _, data := range firstSegmentCache {
 		if data != nil && data.File != nil && !data.MissingFirstSegment && len(data.File.Segments) > 0 {
 			if data.Headers.PartSize > 0 {
@@ -158,6 +164,9 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 					PartSize: data.Headers.PartSize,
 					FileSize: data.Headers.FileSize,
 				}
+			}
+			if !data.SkippedFirstSegment && len(data.RawBytes) > 0 {
+				warmFirstSegmentBytes[data.File.Segments[0].ID] = data.RawBytes
 			}
 		}
 	}
@@ -282,7 +291,7 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 	// Process files in parallel using conc pool
 	for _, info := range fileInfos {
 		concPool.Go(func(ctx context.Context) (fileResult, error) {
-			parsedFile, err := p.parseFile(ctx, n.Meta, parsed.Filename, info, firstSegmentSizeCache, nzbStandardPartSize, notFoundIDs, parsed.SegmentIndex)
+			parsedFile, err := p.parseFile(ctx, n.Meta, parsed.Filename, info, firstSegmentSizeCache, warmFirstSegmentBytes, nzbStandardPartSize, notFoundIDs, parsed.SegmentIndex)
 
 			return fileResult{
 				parsedFile: parsedFile,
@@ -353,7 +362,7 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 // firstSegmentSizeCache contains pre-fetched yEnc info (PartSize + total FileSize) for first segments to avoid redundant fetching.
 // nzbStandardPartSize, when >0, is the yEnc PartSize of a representative middle segment in the NZB;
 // it lets normalization skip the per-file second-segment fetch.
-func (p *Parser) parseFile(ctx context.Context, meta map[string]string, nzbFilename string, info *fileinfo.FileInfo, firstSegmentSizeCache map[string]firstSegmentYencInfo, nzbStandardPartSize int64, notFoundIDs map[string]struct{}, segmentIndex map[string]int64) (*ParsedFile, error) {
+func (p *Parser) parseFile(ctx context.Context, meta map[string]string, nzbFilename string, info *fileinfo.FileInfo, firstSegmentSizeCache map[string]firstSegmentYencInfo, warmFirstSegmentBytes map[string][]byte, nzbStandardPartSize int64, notFoundIDs map[string]struct{}, segmentIndex map[string]int64) (*ParsedFile, error) {
 	if len(info.NzbFile.Segments) == 0 {
 		return nil, fmt.Errorf("file has no segments")
 	}
@@ -544,6 +553,15 @@ func (p *Parser) parseFile(ctx context.Context, meta map[string]string, nzbFilen
 		IsPar2Archive: info.IsPar2Archive,
 		OriginalIndex: info.OriginalIndex,
 		NzbdavID:      nzbdavID,
+	}
+
+	// Attach the warm first-segment bytes (decoded leading payload at offset 0)
+	// so the archive analysis phase can serve this file's header read from memory.
+	// Keyed by the same first-segment ID domain as firstSegmentSizeCache.
+	if len(info.NzbFile.Segments) > 0 {
+		if b, ok := warmFirstSegmentBytes[info.NzbFile.Segments[0].ID]; ok {
+			parsedFile.FirstSegmentBytes = b
+		}
 	}
 
 	return parsedFile, nil

--- a/internal/importer/parser/parser_warmcache_test.go
+++ b/internal/importer/parser/parser_warmcache_test.go
@@ -1,0 +1,105 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// TestParseNzbPopulatesWarmFirstSegmentBytes verifies that a fetched file's
+// decoded first-segment payload is carried onto ParsedFile.FirstSegmentBytes,
+// so the archive analysis phase can serve that file's offset-0 read from memory
+// instead of re-fetching the segment.
+func TestParseNzbPopulatesWarmFirstSegmentBytes(t *testing.T) {
+	payload := []byte("RAR!\x1a\x07\x00decoded-header-bytes-from-first-segment")
+
+	fp := fakepool.New()
+	fp.SetBehavior("seg-0", fakepool.SegmentBehavior{
+		Bytes: payload,
+		YEnc:  nntppool.YEncMeta{PartSize: int64(len(payload)), FileSize: int64(len(payload))},
+	})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(2))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{
+				Filename: "movie.part01.rar",
+				Segments: nzbparser.NzbSegments{
+					{Bytes: len(payload), Number: 1, ID: "seg-0"},
+				},
+			},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1", len(parsed.Files))
+	}
+	if !bytes.Equal(parsed.Files[0].FirstSegmentBytes, payload) {
+		t.Errorf("FirstSegmentBytes = %q, want %q", parsed.Files[0].FirstSegmentBytes, payload)
+	}
+}
+
+// TestParseNzbLeavesWarmBytesEmptyWhenFirstSegmentSkipped pins that a file whose
+// first segment fetch was intentionally skipped (clean-named multipart video)
+// carries no warm bytes — there is nothing fetched to cache, and the analyzer
+// reads such files lazily.
+func TestParseNzbLeavesWarmBytesEmptyWhenFirstSegmentSkipped(t *testing.T) {
+	const (
+		fullEncoded = 720000
+		lastEncoded = 51000
+		partDecoded = 700000
+		lastDecoded = 50000
+		name        = "Inception.2010.1080p.BluRay.mkv"
+	)
+
+	fp := fakepool.New()
+	// First segment must NOT be fetched (skip path); only the representative
+	// middle segment and the last segment are consulted for sizing.
+	fp.SetBehavior("seg-1", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: name, PartSize: partDecoded},
+	})
+	fp.SetBehavior("seg-2", fakepool.SegmentBehavior{
+		YEnc: nntppool.YEncMeta{FileName: name, PartSize: lastDecoded},
+	})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(4))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{
+				Filename: name,
+				Segments: nzbparser.NzbSegments{
+					{Bytes: fullEncoded, Number: 1, ID: "seg-0"},
+					{Bytes: fullEncoded, Number: 2, ID: "seg-1"},
+					{Bytes: lastEncoded, Number: 3, ID: "seg-2"},
+				},
+			},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1", len(parsed.Files))
+	}
+	if len(parsed.Files[0].FirstSegmentBytes) != 0 {
+		t.Errorf("FirstSegmentBytes len = %d, want 0 (first segment was skipped)", len(parsed.Files[0].FirstSegmentBytes))
+	}
+	// Sanity: confirm the first segment was never fetched over the wire.
+	if got := fp.PerMessageCalls("seg-0"); got != 0 {
+		t.Errorf("seg-0 was fetched %d times, want 0 (skip path)", got)
+	}
+}

--- a/internal/importer/parser/types.go
+++ b/internal/importer/parser/types.go
@@ -78,4 +78,13 @@ type ParsedFile struct {
 	NzbdavID      string            // Original ID from nzbdav (for backward compatibility)
 	AesKey        []byte            // AES encryption key (for nzbdav compatibility)
 	AesIv         []byte            // AES initialization vector (for nzbdav compatibility)
+
+	// FirstSegmentBytes holds the decoded leading bytes (≤16KB) of this file's first
+	// segment, captured when the parser fetched it during first-segment analysis. It
+	// lets the archive analysis phase (UsenetFileSystem) serve a volume's header read,
+	// which starts at offset 0, from memory instead of re-fetching a segment already
+	// pulled over the wire this import. Empty when the first segment was skipped/missing
+	// or for files built outside the parser — those paths fall through to the network.
+	// Transient (not persisted); valid only for the lifetime of the import.
+	FirstSegmentBytes []byte
 }


### PR DESCRIPTION
## Context

While comparing AltMount's NZB import to AIOStreams' native usenet module, we confirmed both projects hit the same NNTP physics (`BODY` has no range mechanism, so the wire carries the full article regardless), and that AltMount already implements nearly every fast-import technique. The one genuine gap was a **cross-phase refetch** on multi-volume archives:

- The parser fetches every file's first segment (magic-byte / yEnc / PAR2 analysis).
- RAR/7z analysis (`UsenetFileSystem` → `rardecode.ListArchiveInfo` / sevenzip) then independently re-reads each volume's header from the network.

For a 50-volume RAR that's ~100 reads where ~50 suffice — `rardecode` must read every volume header anyway, but they had already been pulled by the parser and discarded.

## Change

Carry the bytes the parser already decoded forward to the analysis phase, on the `ParsedFile` struct that is already threaded down to `NewUsenetFileSystem` (no signature churn through the archive interfaces):

- **`parser/types.go`** — new transient `FirstSegmentBytes []byte` on `ParsedFile` (≤16KB, not persisted).
- **`parser/parser.go`** — builds `warmFirstSegmentBytes` from existing first-segment fetch results (skipped/missing segments contribute nothing) and attaches it per file in `parseFile`.
- **`filesystem/usenet_fs.go`** — `createUsenetReader` serves offset-0 reads via a new `warmPrefixReader` that **lazily** creates the network reader only when a read crosses past the cached prefix. Header-only reads (the archive-analysis case) issue zero wire calls. The cached bytes are byte-identical to the network payload; callers without warm bytes (playback, decrypting FS) take the network path unchanged.

A second planned optimization (skipping continuation-volume fetches) was dropped after implementation analysis showed it is redundant once this cache exists — `rardecode` needs every volume header regardless, and skipping the parser fetch merely moves the read to the analysis phase.

## Test plan

- [x] New tests (TDD, written first): `TestWarmCacheServesPrefixWithoutNetwork` (asserts 0 wire calls), `TestWarmPrefixReaderFallsThrough`, `TestWarmPrefixReaderPrefixOnly`, plus producer tests `TestParseNzbPopulatesWarmFirstSegmentBytes` / `...LeavesWarmBytesEmptyWhenFirstSegmentSkipped`.
- [x] `go test -race ./internal/importer/...` — all pass (battery, rardecode multipart, service, processor included).
- [x] `go build ./...`, `go vet ./internal/importer/...`, and `golangci-lint` on the changed packages — clean.