### PR TITLE
fix(importer): deobfuscate multi-volume RAR sets with divergent per-volume base names

### DIFF
--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -23,6 +23,7 @@ import (
 	"github.com/javi11/altmount/internal/errors"
 	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	"github.com/javi11/altmount/internal/importer/parser/par2"
+	"github.com/javi11/altmount/internal/importer/rarname"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/pool"
@@ -138,10 +139,13 @@ func (p *Parser) ParseNzb(ctx context.Context, n *nzbparser.Nzb, nzbPath string,
 
 	// PAR2 descriptor matching is only worth network I/O when (a) the NZB actually
 	// contains a PAR2 index AND (b) at least one fetched file has an untrustworthy
-	// name that the descriptors could recover. When every name is already clean,
-	// downloading the PAR2 index and completing files to 16KB would only confirm
-	// what we already trust — skip both entirely.
-	par2MatchingUseful := p.hasPar2IndexCandidate(firstSegmentCache) && anyFileNeedsPar2Matching(firstSegmentCache)
+	// name that the descriptors could recover — either an individually obfuscated name
+	// or a member of a .partNN.rar set whose volumes all have distinct (obfuscated) bases
+	// (hasObfuscatedVolumeSet). When every name is already clean, downloading the PAR2
+	// index and completing files to 16KB would only confirm what we already trust — skip
+	// both entirely.
+	par2MatchingUseful := p.hasPar2IndexCandidate(firstSegmentCache) &&
+		(anyFileNeedsPar2Matching(firstSegmentCache) || hasObfuscatedVolumeSet(firstSegmentCache))
 	if par2MatchingUseful {
 		p.complete16KBReads(ctx, firstSegmentCache, notFoundIDs)
 	}
@@ -932,6 +936,44 @@ func needsPar2Matching(d *FirstSegmentData) bool {
 // names we already trust.
 func anyFileNeedsPar2Matching(cache []*FirstSegmentData) bool {
 	return slices.ContainsFunc(cache, needsPar2Matching)
+}
+
+// hasObfuscatedVolumeSet reports whether the NZB contains a multi-volume .partNN.rar set
+// whose volumes each carry a distinct base name — the fingerprint of per-volume filename
+// obfuscation (US8yidqp….part01.rar, BtEPCuoF….part02.rar, …). These random bases defeat
+// the per-file obfuscation heuristic (mixed case with '-'/'_' separators reads as a clean,
+// readable name), so needsPar2Matching never flags them; yet a numbered set in which every
+// volume's base differs is unambiguous, because a real multi-volume set shares one base.
+//
+// When such a set exists, PAR2 descriptors can recover the real, shared volume names
+// (Hash16k → name), letting grouping reassemble the set — so PAR2 matching is worth the
+// network I/O even though no individual filename looks obfuscated. The "all bases distinct"
+// rule keeps the trigger tight: one clean set has a single base, and two clean sets share a
+// few bases across many volumes — neither trips it.
+func hasObfuscatedVolumeSet(cache []*FirstSegmentData) bool {
+	bases := make(map[string]struct{})
+	count := 0
+	for _, d := range cache {
+		if d == nil || d.File == nil || d.MissingFirstSegment {
+			continue
+		}
+		name := d.File.Filename
+		if fileinfo.IsPar2File(name) {
+			continue
+		}
+		// Only the part scheme (.partNN.rar); divergent-base obfuscation in the roll/numeric
+		// schemes is rarer and left out to keep the trigger tight.
+		if scheme, _, ok := rarname.VolumeNumber(name); !ok || scheme != rarname.SchemePart {
+			continue
+		}
+		key, ok := rarname.SetKey(name)
+		if !ok {
+			continue
+		}
+		bases[key] = struct{}{}
+		count++
+	}
+	return count >= 2 && len(bases) == count
 }
 
 // needs16KBCompletion decides whether a file is worth completing up to 16KB

--- a/internal/importer/parser/parser_obfuscatedvolumes_test.go
+++ b/internal/importer/parser/parser_obfuscatedvolumes_test.go
@@ -1,0 +1,94 @@
+package parser
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/par2gen"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// TestParseNzbDeobfuscatesDivergentVolumeSet is the end-to-end regression for the
+// Supergirl-style failure: a multi-volume .partNN.rar set whose volumes each carry a
+// distinct random base name. The per-file obfuscation heuristic treats those names as
+// clean, so without the divergent-base gate (hasObfuscatedVolumeSet) the PAR2 index is
+// never downloaded and the real names are never recovered — leaving every volume under a
+// different base, which splits the set during grouping.
+//
+// With the gate, PAR2 matching runs, each volume's first-16KB hash resolves to the real
+// FileDesc name, and all volumes converge on one shared base so grouping can reassemble
+// the set.
+func TestParseNzbDeobfuscatesDivergentVolumeSet(t *testing.T) {
+	const (
+		numVols  = 4
+		realBase = "Real.Show.S01E01.1080p.WEB-DL"
+		volSize  = 20_000 // > 16 KB so Hash16k is taken from real bytes, not zero-padding
+	)
+	obfBases := []string{
+		"US8yidqpbbD0tHBa-Y5l_Phs8V5qb",
+		"BtEPCuoFuvkpQLMHo1rs_Qp4fOtj6",
+		"bY2YttkbyosUtsy",
+		"DasjtQyqvxamxMrKTsW-Nw6t9",
+	}
+
+	fp := fakepool.New()
+	var nzbFiles nzbparser.NzbFiles
+	par2Entries := make([]par2gen.FileEntry, numVols)
+
+	for i := range numVols {
+		// Unique payload per volume → unique Hash16k → unique FileDesc match.
+		content := bytes.Repeat([]byte{byte('A' + i)}, volSize)
+		segID := fmt.Sprintf("vol-%d-seg0", i)
+		fp.SetBehavior(segID, fakepool.SegmentBehavior{
+			Bytes: content,
+			YEnc:  nntppool.YEncMeta{PartSize: volSize, FileSize: volSize},
+		})
+
+		nzbFiles = append(nzbFiles, nzbparser.NzbFile{
+			Filename: fmt.Sprintf("%s.part%02d.rar", obfBases[i], i+1),
+			Segments: nzbparser.NzbSegments{{Bytes: volSize, Number: 1, ID: segID}},
+		})
+
+		par2Entries[i] = par2gen.FileEntry{
+			Name:    fmt.Sprintf("%s.part%02d.rar", realBase, i+1),
+			Content: content,
+		}
+	}
+
+	// PAR2 index naming every volume with the real, shared base.
+	par2Bytes := par2gen.Build(par2Entries...)
+	fp.SetBehavior("par2-seg0", fakepool.SegmentBehavior{Bytes: par2Bytes})
+	nzbFiles = append(nzbFiles, nzbparser.NzbFile{
+		Filename: "deadbeefcafe.par2",
+		Segments: nzbparser.NzbSegments{{Bytes: len(par2Bytes), Number: 1, ID: "par2-seg0"}},
+	})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(4))
+
+	parsed, err := p.ParseNzb(context.Background(), &nzbparser.Nzb{Files: nzbFiles}, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+
+	// Every RAR volume must have been renamed to the real, shared base recovered from PAR2.
+	recovered := 0
+	for _, f := range parsed.Files {
+		if strings.HasSuffix(strings.ToLower(f.Filename), ".par2") {
+			continue
+		}
+		if !strings.HasPrefix(f.Filename, realBase+".part") {
+			t.Errorf("volume %q was not deobfuscated to the real base %q", f.Filename, realBase)
+			continue
+		}
+		recovered++
+	}
+	if recovered != numVols {
+		t.Fatalf("recovered %d/%d volume names from PAR2; want all volumes renamed to the shared base", recovered, numVols)
+	}
+}

--- a/internal/importer/parser/parser_par2gate_test.go
+++ b/internal/importer/parser/parser_par2gate_test.go
@@ -96,6 +96,71 @@ func TestNeedsPar2Matching(t *testing.T) {
 	}
 }
 
+func TestHasObfuscatedVolumeSet(t *testing.T) {
+	cache := func(names ...string) []*FirstSegmentData {
+		c := make([]*FirstSegmentData, len(names))
+		for i, n := range names {
+			c[i] = fsd(n, []byte("data"))
+		}
+		return c
+	}
+
+	tests := []struct {
+		name  string
+		cache []*FirstSegmentData
+		want  bool
+	}{
+		{
+			// The real-world failure: every volume of one .partNN.rar set has a distinct
+			// random base. needsPar2Matching can't see this (the names read as clean), but
+			// the all-distinct-bases divergence is unambiguous.
+			name: "obfuscated divergent-base part set",
+			cache: cache(
+				"US8yidqpbbD0tHBa-Y5l_Phs8V5qb.part01.rar",
+				"BtEPCuoFuvkpQLMHo1rs_Qp4fOtj6.part02.rar",
+				"bY2YttkbyosUtsy.part03.rar",
+				"DasjtQyqvxamxMrKTsW-Nw6t9.part04.rar",
+			),
+			want: true,
+		},
+		{
+			name: "clean single multi-volume set shares one base",
+			cache: cache(
+				"Movie.Name.2023.1080p.part01.rar",
+				"Movie.Name.2023.1080p.part02.rar",
+				"Movie.Name.2023.1080p.part03.rar",
+			),
+			want: false,
+		},
+		{
+			name: "two clean part sets: few bases across many volumes",
+			cache: cache(
+				"MovieA.part01.rar", "MovieA.part02.rar", "MovieA.part03.rar",
+				"MovieB.part01.rar", "MovieB.part02.rar", "MovieB.part03.rar",
+			),
+			want: false,
+		},
+		{
+			name:  "single part volume is not a set",
+			cache: cache("US8yidqpbbD0tHBa.part01.rar"),
+			want:  false,
+		},
+		{
+			name:  "non-volume files ignored",
+			cache: cache("b082fa0beaa644d3aa01045d5b8d0b36.mkv", "release.nfo"),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasObfuscatedVolumeSet(tt.cache); got != tt.want {
+				t.Errorf("hasObfuscatedVolumeSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAnyFileNeedsPar2Matching(t *testing.T) {
 	clean := fsd("Great.Movie.2020.mkv", []byte("data"))
 	obfuscated := fsd("b082fa0beaa644d3aa01045d5b8d0b36.mkv", []byte("data"))


### PR DESCRIPTION
## What

Fixes import of NZBs where a multi-volume `.partNN.rar` set is fully obfuscated — every volume has a **distinct random base name** (`US8yidqp….part01.rar`, `BtEPCuoF….part02.rar`, …) and only the `.partNN.rar` suffix encodes order.

## Why it failed

Grouping is by base name (`GroupArchivesByBaseName` → `SetKey`), so such a set splits into one singleton group per volume and every volume fails analysis → the whole import fails.

AltMount already has a working PAR2 filename-deobfuscation pipeline (`par2.GetFileDescriptors` → Hash16k → real `FileDesc` name). If it ran, all volumes would converge on the real shared base and grouping would reassemble the set with zero special-casing. But it never ran: the PAR2 download is gated by `needsPar2Matching` → `IsProbablyObfuscated`, which:
1. treats any `.partNN.rar` name as clean (the `archiveVolumePattern` guard), and
2. even on the stripped base, reads separator-heavy random names like `US8yidqp-Y5l_Phs8V5qb` as "clean readable names" (rule: upper≥2 && lower≥2 && separators≥1).

So the per-file heuristic can't detect this obfuscation style and the PAR2 index is never downloaded.

## The fix

Detect obfuscation at the **set level** instead. New `hasObfuscatedVolumeSet(cache)` flags a `.partNN.rar` set whose volumes all have **distinct bases** (≥2 volumes, every base unique) and OR's it into `par2MatchingUseful`, triggering the existing PAR2 deobfuscation. Recovered real names give all volumes a shared base, and grouping reassembles the set.

The "all bases distinct" rule keeps the trigger tight:
- one clean set → a single base → not flagged
- two clean sets → a few bases shared across many volumes → not flagged
- obfuscated set → every base unique → flagged

## Reviewer notes

- **No change to `isProbablyObfuscated`** — preserves the last-resort rename guard (Gap 5) that would otherwise mangle volume names to `<stem>.rar` when PAR2 yields no match.
- **No 16 KB-completion change** needed: the first-segment fetch already caps `RawBytes` at 16 KB and RAR first parts exceed that, so `Hash16k` is exact.
- **Scope/limitation:** recovery requires the NZB to contain a PAR2 index that covers the RAR volumes (the common case). NZBs lacking PAR2 are out of scope (no offline fallback). Only the part scheme is covered; divergent-base obfuscation in roll/numeric schemes is left out as rare.

## Tests

- Unit: `TestHasObfuscatedVolumeSet` (divergent set, clean single set, two clean sets, single volume, non-volume files).
- Integration: `TestParseNzbDeobfuscatesDivergentVolumeSet` — 4 distinct-base obfuscated volumes + a generated PAR2 index → `ParseNzb` recovers all real shared-base names.
- `go build ./...`, `go vet`, `gofmt` clean; `go test -race ./internal/importer/...` all pass.

Not verified: live import of the original NZB against a Usenet provider (no provider access in the dev environment).