### PR TITLE
Fix: correctly import obfuscated multi-volume RAR sets

### DIFF
--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -448,7 +448,12 @@ func GroupArchivesByBaseName(files []parser.ParsedFile) [][]parser.ParsedFile {
 	// A single physical RAR set whose first volume was reposted under a different
 	// base name (e.g. movie.repost.part01.rar alongside movie.r00..) splits into
 	// multiple groups above; fold it back into one set so the whole archive maps.
-	return reconcileRepostedFirstVolume(groups)
+	groups = reconcileRepostedFirstVolume(groups)
+
+	// An obfuscated set whose every volume has a different random base name splits
+	// into one single-file group per volume; fold those back into one followable
+	// set. No-op unless the whole NZB is exactly that shape (see the function doc).
+	return reconcileObfuscatedPartSet(groups)
 }
 
 // normalizeArchiveReleaseFilename aligns the filename to the NZB basename while keeping the original extension.

--- a/internal/importer/archive/rar/reconcile_obfuscated.go
+++ b/internal/importer/archive/rar/reconcile_obfuscated.go
@@ -1,0 +1,129 @@
+package rar
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/javi11/altmount/internal/importer/parser"
+)
+
+// obfuscatedSetMinVolumes is the floor below which reconcileObfuscatedPartSet
+// will not act. Genuine obfuscated multi-volume releases have many parts;
+// requiring at least this many keeps the heuristic clear of small, ambiguous
+// groupings.
+const obfuscatedSetMinVolumes = 3
+
+// obfuscatedSetSyntheticBase is the base name every volume is renamed to when an
+// obfuscated part-set is detected. It MUST contain no digits: rardecode derives
+// each next volume name by incrementing the digit run it finds in the current
+// name (see nextNewVolName in the rardecode library), so any digit in the base
+// would be incremented instead of the part number and break volume following.
+// A constant is safe because detection only fires when the entire NZB is a
+// single obfuscated set, so there is exactly one set to name.
+const obfuscatedSetSyntheticBase = "obfuscatedrarset"
+
+// reconcileObfuscatedPartSet detects an NZB that is a single multi-volume RAR
+// set whose every volume carries a different random base name (e.g.
+// aB3x.part01.rar, Q4I6.part02.rar, …) with only the ".partNN.rar" tail shared.
+//
+// Grouping by base name turns such a set into N single-file groups, which
+// defeats analysis: rardecode follows a multi-volume set by computing sibling
+// names from the first volume's name, so randomized bases make the chain
+// unfollowable. Each volume analyzed alone yields nothing for continuation
+// volumes (their header has no first-block to anchor a file) and only the true
+// first volume produces a Content — one declaring the full file size while
+// carrying only its own ~1/N of the segments. The import then looks healthy but
+// is truncated, and any read past the first volume fails.
+//
+// When the grouping matches that exact shape, this folds the volumes back into
+// one group and renames them onto a single shared, digit-free base in part
+// order, so rardecode's native volume following works and the standard
+// multi-volume path assembles the complete file. Renaming only changes each
+// file's Filename; segments, NzbdavID and all other fields travel unchanged, and
+// the final output name comes from the archive's internal file name, not these
+// volume names.
+//
+// The predicate is deliberately strict: it acts only when EVERY group is a
+// single-file, part-scheme, distinctly-based volume and their ordinals form a
+// contiguous 1..N run with no gaps or duplicates. Anything ambiguous — a clean
+// shared-base set present alongside (which never groups into singletons), a
+// duplicate ordinal from two overlapping sets, a missing interior volume, a
+// non-part scheme — leaves the grouping untouched. An import that works today
+// can never be altered, and an ambiguous one is left exactly as-is rather than
+// guessed at. (A missing *trailing* volume past N is undetectable from numbering
+// and is left to downstream segment-coverage validation, as it is today.)
+func reconcileObfuscatedPartSet(groups [][]parser.ParsedFile) [][]parser.ParsedFile {
+	if len(groups) < obfuscatedSetMinVolumes {
+		return groups
+	}
+
+	type vol struct {
+		ordinal int
+		file    parser.ParsedFile
+	}
+	vols := make([]vol, 0, len(groups))
+	seenOrdinal := make(map[int]struct{}, len(groups))
+	seenBase := make(map[string]struct{}, len(groups))
+
+	for _, g := range groups {
+		// Every group must be a single volume. A multi-file group means a normal
+		// shared-base set is present (clean, or a clean set mixed in), which must
+		// not be disturbed.
+		if len(g) != 1 {
+			return groups
+		}
+		f := g[0]
+
+		// Must be a part-scheme volume (.partNN.rar).
+		scheme, ordinal, ok := rarVolumeNumber(f.Filename)
+		if !ok || scheme != schemePart {
+			return groups
+		}
+
+		// A distinct base per volume is the signature of per-volume obfuscation.
+		// A shared base would not have produced single-file groups; guard anyway.
+		base, ok := SetKey(f.Filename)
+		if !ok {
+			return groups
+		}
+		if _, dup := seenBase[base]; dup {
+			return groups
+		}
+		seenBase[base] = struct{}{}
+
+		// A duplicate ordinal means two overlapping sets (e.g. both start at
+		// part01). Unresolvable from names alone; bail rather than splice volumes
+		// from different files together.
+		if _, dup := seenOrdinal[ordinal]; dup {
+			return groups
+		}
+		seenOrdinal[ordinal] = struct{}{}
+
+		vols = append(vols, vol{ordinal: ordinal, file: f})
+	}
+
+	// Ordinals must be exactly the contiguous run 1..N (N == number of groups).
+	// With N distinct ordinals already guaranteed, requiring each of 1..N to be
+	// present forces the set to be exactly {1..N} (no leading/interior gap, no
+	// out-of-range value).
+	n := len(vols)
+	for i := 1; i <= n; i++ {
+		if _, ok := seenOrdinal[i]; !ok {
+			return groups
+		}
+	}
+
+	// Matched. Order by true part number and rename onto one digit-free base so
+	// rardecode follows the chain natively. Padding width tracks N so part
+	// numbers are zero-padded consistently (part01..part63 for N=63).
+	sort.Slice(vols, func(a, b int) bool { return vols[a].ordinal < vols[b].ordinal })
+	width := len(fmt.Sprint(n))
+
+	merged := make([]parser.ParsedFile, 0, n)
+	for _, v := range vols {
+		f := v.file // struct copy; preserves Segments, NzbdavID, OriginalIndex, etc.
+		f.Filename = fmt.Sprintf("%s.part%0*d.rar", obfuscatedSetSyntheticBase, width, v.ordinal)
+		merged = append(merged, f)
+	}
+	return [][]parser.ParsedFile{merged}
+}

--- a/internal/importer/archive/rar/reconcile_obfuscated_test.go
+++ b/internal/importer/archive/rar/reconcile_obfuscated_test.go
@@ -1,0 +1,186 @@
+package rar
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/javi11/altmount/internal/importer/parser"
+)
+
+// The real 63 obfuscated volume filenames from the Supergirl import that
+// motivated this fix: one multi-volume RAR set, every volume a distinct random
+// base sharing only the .partNN.rar tail.
+var supergirlObfuscatedNames = []string{
+	"L3A5Gk5sWzcpO6dRRh9c9XOfVDO.part01.rar",
+	"dEVjNplTaH_Uyli0lv7iwzqp.part02.rar",
+	"dwqjwYy9uDXcBB6Yq77U.part03.rar",
+	"v9eQrQMSTksT_KW.part04.rar",
+	"UzdC_P-XSgn0zxjNWgCBxMu.part05.rar",
+	"5UiylPHkjhquLl-X.part06.rar",
+	"hwuiEqkiNcDvsBagMJTKZXZNCxy.part07.rar",
+	"cij_8OH4GRxF9wFcAMaVRXPhT.part08.rar",
+	"HzR78H-BTCWNAQos8.part09.rar",
+	"UlbjH6LXDAjKHSPdUd-v.part10.rar",
+	"8wtnCv_2rf5YLIDPDv.part11.rar",
+	"513qIlRC5AB1KC9d.part12.rar",
+	"Q4I6bwgWUWL1PNctnCPlfoou.part13.rar",
+	"NMWAnBYCelmpfTuXgKhTuThVBNXOI.part14.rar",
+	"3VyRPUgW0hpPMPMrgUpNvj72NMD.part15.rar",
+	"QlMTceOhfxwxOXo8WS3wueozmBBp_.part16.rar",
+	"oSTJyDFyxRsLp97J4v7TUMF4bVbV.part17.rar",
+	"XgxuiGSvg2PbQjEi9N.part18.rar",
+	"qjLYWZY046oYHrMZyurueBKyi9.part19.rar",
+	"NHdIG0aOmToeHPiLM3X71IQdYjjBu.part20.rar",
+	"yYdnWiTk-3vM1aP_ZfNe-LvjA.part21.rar",
+	"yHvbhmhU5l8PBGF_0f-ha2Q.part22.rar",
+	"4E570NfUj92vJRMa.part23.rar",
+	"qZt8l451hOC6q1mVmaIu-Tk76f.part24.rar",
+	"QUSXp9oEDPB-jfmDkXLj05.part25.rar",
+	"hY6hAN6WfwV4lXzf1M.part26.rar",
+	"pWbQNRgW_cJutY0sB.part27.rar",
+	"WkIwxU5v9BJc890.part28.rar",
+	"giOOfS-2-LXG7zGL378AlS20GaT-.part29.rar",
+	"bntdLuVRscqtaQVpnz9X456o.part30.rar",
+	"qJeCl4aVTqKQrAk0zu7MIK5YF2.part31.rar",
+	"lJaBCejA5Wnx72JDPtnkWoQ5.part32.rar",
+	"8HTLOmEtET6x1iYfs2hfxef0h_I.part33.rar",
+	"69y0B9W9O9IvnHidspGQz8.part34.rar",
+	"kaIouYfU-5V1bqpakxkCL_BSVhw.part35.rar",
+	"7jZx9koqiE1sAlE0.part36.rar",
+	"1RbJ9Sbpu3N4VjuKP7viA.part37.rar",
+	"uQHYRfN6IyWGMyxnUMw.part38.rar",
+	"hc9Iiqze1OCh-w5MXm6hVdNKlch.part39.rar",
+	"1cWdeqO_34yy04nuVPimGhQVzttu1.part40.rar",
+	"Q7oIYisCBLHReCoKxU2QJAF3uOV.part41.rar",
+	"8PcBe3NkRmhzH8JR8SuIAYg.part42.rar",
+	"rbDtxFr53aNtolA6.part43.rar",
+	"LuXEbAQAqTn7oc4N10.part44.rar",
+	"567dEAE4nEhzszXZBz-mK4u54L37.part45.rar",
+	"OmZV7RflINJ_wmD_RM6.part46.rar",
+	"WPJieG5E2bCI_Yix9BJbLl.part47.rar",
+	"VOiBNRNksZa6PQa4nJ.part48.rar",
+	"hnWsPCGkpBhwW7ZKAaVO.part49.rar",
+	"5VZazJMVS4D80JeMe19QwVrR.part50.rar",
+	"V9DuskcVYLXjHWWPkJkryo6nJB.part51.rar",
+	"s_Iu4rp6150lW0-KKL0BWuZjLZf.part52.rar",
+	"FnCfK_SVUZdLvessJISJw6V.part53.rar",
+	"MqBTEfs9-iwr7ra.part54.rar",
+	"9KjFsbvoE9THLyuonPbZIfYO8j.part55.rar",
+	"ey77la3f8ivtmVt_3TN.part56.rar",
+	"tNDfyngMRCBeYzoiHb31Mm.part57.rar",
+	"8T1-58mVkESwn6iesDsSofzN-VNp.part58.rar",
+	"W7q64eEkiwCVm_6OhZWcLGF.part59.rar",
+	"7td-8bmggETPPMRuj4.part60.rar",
+	"ba2cnYicTsi9OETwJHvpQlDyr3.part61.rar",
+	"6mZCXfIFhD0oWjgMJhJXcUUmDpL.part62.rar",
+	"dTg6VhL2GwBJZ2jeEAm5SEA3qLY.part63.rar",
+}
+
+// flatFiles builds a parser.ParsedFile list (NzbdavID = filename, so identity
+// can be tracked through the rename) for feeding GroupArchivesByBaseName.
+func flatFiles(names []string) []parser.ParsedFile {
+	out := make([]parser.ParsedFile, 0, len(names))
+	for _, n := range names {
+		out = append(out, parser.ParsedFile{Filename: n, NzbdavID: n})
+	}
+	return out
+}
+
+// singletonGroups builds one-file-per-group input, the shape
+// GroupArchivesByBaseName produces for an obfuscated set, for direct unit tests
+// of reconcileObfuscatedPartSet.
+func singletonGroups(names []string) [][]parser.ParsedFile {
+	groups := make([][]parser.ParsedFile, 0, len(names))
+	for _, n := range names {
+		groups = append(groups, []parser.ParsedFile{{Filename: n, NzbdavID: n}})
+	}
+	return groups
+}
+
+// TestGroupArchivesByBaseName_ObfuscatedSet exercises the full grouping pipeline
+// end to end: 63 distinctly-named volumes must collapse into one followable set.
+func TestGroupArchivesByBaseName_ObfuscatedSet(t *testing.T) {
+	groups := GroupArchivesByBaseName(flatFiles(supergirlObfuscatedNames))
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group after reconcile, got %d", len(groups))
+	}
+	merged := groups[0]
+	if len(merged) != 63 {
+		t.Fatalf("expected 63 volumes, got %d", len(merged))
+	}
+
+	for i, f := range merged {
+		ord := i + 1
+		wantName := fmt.Sprintf("%s.part%02d.rar", obfuscatedSetSyntheticBase, ord)
+		if f.Filename != wantName {
+			t.Errorf("vol %d: filename = %q, want %q", i, f.Filename, wantName)
+		}
+		// Identity preserved: the volume now named partNN is the original file
+		// whose ordinal was NN (NzbdavID still holds the original name).
+		wantSuffix := fmt.Sprintf(".part%02d.rar", ord)
+		if got := f.NzbdavID; len(got) < len(wantSuffix) || got[len(got)-len(wantSuffix):] != wantSuffix {
+			t.Errorf("vol %d (%s): original identity %q lacks ordinal %d", i, f.Filename, f.NzbdavID, ord)
+		}
+	}
+}
+
+// TestReconcileObfuscatedPartSet_Bails verifies every non-trigger shape is left
+// exactly as-is, so an import that works today can never be altered.
+func TestReconcileObfuscatedPartSet_Bails(t *testing.T) {
+	cases := []struct {
+		name string
+		in   [][]parser.ParsedFile
+	}{
+		{
+			name: "clean shared-base set (single multi-file group)",
+			in: [][]parser.ParsedFile{{
+				{Filename: "Movie.part01.rar"},
+				{Filename: "Movie.part02.rar"},
+				{Filename: "Movie.part03.rar"},
+			}},
+		},
+		{
+			name: "mixed clean set + obfuscated singletons",
+			in: append(
+				[][]parser.ParsedFile{{
+					{Filename: "Movie.part01.rar"},
+					{Filename: "Movie.part02.rar"},
+				}},
+				singletonGroups(supergirlObfuscatedNames[:5])...,
+			),
+		},
+		{
+			name: "duplicate ordinal (two overlapping sets)",
+			in: singletonGroups([]string{
+				"aaa.part01.rar", "bbb.part02.rar", "ccc.part03.rar",
+				"ddd.part01.rar", "eee.part02.rar", "fff.part03.rar",
+			}),
+		},
+		{
+			name: "interior gap",
+			in:   singletonGroups([]string{"aaa.part01.rar", "bbb.part02.rar", "ddd.part04.rar"}),
+		},
+		{
+			name: "leading gap (does not start at 1)",
+			in:   singletonGroups([]string{"aaa.part02.rar", "bbb.part03.rar", "ccc.part04.rar"}),
+		},
+		{
+			name: "below N>=3 floor",
+			in:   singletonGroups([]string{"aaa.part01.rar", "bbb.part02.rar"}),
+		},
+		{
+			name: "non-part scheme singletons",
+			in:   singletonGroups([]string{"aaa.rar", "aaa.r00", "aaa.r01"}),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := reconcileObfuscatedPartSet(tc.in)
+			if len(out) != len(tc.in) {
+				t.Fatalf("%s: expected unchanged (%d groups), got %d", tc.name, len(tc.in), len(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
NZBs where every RAR volume has a distinct random base name (e.g. aB3x.part01.rar, Q4I6.part02.rar) were split into N singleton groups by GroupArchivesByBaseName. Each volume was then analysed independently: continuation volumes produced no content, only the first volume wrote metadata — declaring the full file size but carrying only ~1/N segments — causing every read past the first volume to fail with a segment mismatch.

reconcileObfuscatedPartSet detects this exact shape (all-singleton groups, part-scheme volumes, contiguous 1..N ordinals, all distinct base names) and folds them into one group with a shared digit-free synthetic base name so rardecode can follow the volume chain natively.