### PR TITLE
fix(arrs): use targeted Radarr movie lookup in repair path

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,6 +33,7 @@ import type {
 	ConfigResponse,
 	ConfigSection,
 	ConfigUpdateRequest,
+	PipelineTuneResponse,
 	ProviderConfig,
 	ProviderCreateRequest,
 	ProviderReorderRequest,
@@ -813,6 +814,12 @@ class APIClient {
 				method: "POST",
 			},
 		);
+	}
+
+	async tuneProviderPipeline(id: string) {
+		return this.request<PipelineTuneResponse>(`/providers/${id}/tune-pipeline`, {
+			method: "POST",
+		});
 	}
 
 	async createProvider(data: ProviderCreateRequest) {

--- a/frontend/src/components/config/ProvidersConfigSection.tsx
+++ b/frontend/src/components/config/ProvidersConfigSection.tsx
@@ -51,8 +51,15 @@ export function ProvidersConfigSection({
 		(config.providers ?? []).map((p) => p.user_agent).find(Boolean) ?? "",
 	);
 
-	const { deleteProvider, testProviderSpeed, resetProviderQuota } = useProviders();
+	const { deleteProvider, testProviderSpeed, tuneProviderPipeline, resetProviderQuota } =
+		useProviders();
 	const [resettingQuotaId, setResettingQuotaId] = useState<string | null>(null);
+	const [pipelineTuning, setPipelineTuning] = useState<{
+		current: number;
+		total: number;
+		host?: string;
+	} | null>(null);
+	const [disablingPipeline, setDisablingPipeline] = useState(false);
 	const { confirmDelete } = useConfirm();
 	const { showToast } = useToast();
 
@@ -221,6 +228,97 @@ export function ProvidersConfigSection({
 		const newFormData = formData.map((p) => ({ ...p, user_agent: value }));
 		setFormData(newFormData);
 		setHasChanges(JSON.stringify(newFormData) !== JSON.stringify(config.providers));
+	};
+
+	const handleAutoTunePipeline = async () => {
+		const targets = formData.filter((p) => p.enabled);
+		if (targets.length === 0) {
+			return;
+		}
+
+		setPipelineTuning({ current: 0, total: targets.length });
+		const recommendations = new Map<string, number>();
+		const skipped: string[] = [];
+
+		for (let i = 0; i < targets.length; i++) {
+			const provider = targets[i];
+			setPipelineTuning({ current: i + 1, total: targets.length, host: provider.host });
+			try {
+				const result = await tuneProviderPipeline.mutateAsync(provider.id);
+				if (result.warning) {
+					skipped.push(`${provider.host}: ${result.warning}`);
+				} else {
+					recommendations.set(provider.id, result.recommended_inflight);
+				}
+			} catch (error) {
+				console.error("Failed to tune pipeline:", error);
+				skipped.push(`${provider.host}: test failed`);
+			}
+		}
+		setPipelineTuning(null);
+
+		if (recommendations.size === 0) {
+			showToast({
+				type: "warning",
+				title: "Pipeline Unchanged",
+				message: skipped.length ? skipped.join("; ") : "No providers could be tuned.",
+			});
+			return;
+		}
+
+		const newFormData = formData.map((p) =>
+			recommendations.has(p.id)
+				? { ...p, inflight_requests: recommendations.get(p.id) as number }
+				: p,
+		);
+		setFormData(newFormData);
+
+		if (!onUpdate) {
+			setHasChanges(true);
+			return;
+		}
+		try {
+			await onUpdate("providers", newFormData);
+			setHasChanges(false);
+			showToast({
+				type: "success",
+				title: "Pipeline Tuned",
+				message: `Updated ${recommendations.size} provider${recommendations.size === 1 ? "" : "s"}.${
+					skipped.length ? ` Skipped: ${skipped.join("; ")}` : ""
+				}`,
+			});
+		} catch (error) {
+			console.error("Failed to save tuned pipeline:", error);
+			showToast({
+				type: "error",
+				title: "Save Failed",
+				message: "Tuned values could not be saved.",
+			});
+		}
+	};
+
+	const handleDisablePipelining = async () => {
+		const newFormData = formData.map((p) => ({ ...p, inflight_requests: 1 }));
+		setFormData(newFormData);
+		if (!onUpdate) {
+			setHasChanges(true);
+			return;
+		}
+		setDisablingPipeline(true);
+		try {
+			await onUpdate("providers", newFormData);
+			setHasChanges(false);
+			showToast({
+				type: "success",
+				title: "Pipelining Disabled",
+				message: "All providers set to pipeline depth 1.",
+			});
+		} catch (error) {
+			console.error("Failed to disable pipelining:", error);
+			showToast({ type: "error", title: "Save Failed", message: "Could not disable pipelining." });
+		} finally {
+			setDisablingPipeline(false);
+		}
 	};
 
 	const handleSave = async () => {
@@ -599,6 +697,48 @@ export function ProvidersConfigSection({
 					onChange={(e) => handleGlobalUserAgentChange(e.target.value)}
 					placeholder="e.g. SABnzbd/4.5.5"
 				/>
+			</div>
+
+			{/* NNTP Pipeline Optimization */}
+			<div className="space-y-3 border-base-200 border-t pt-6">
+				<div>
+					<h3 className="font-bold text-base-content text-lg tracking-tight">NNTP Pipeline</h3>
+					<p className="text-base-content/50 text-xs">
+						Auto-tune the pipeline depth (requests in flight per connection) by speed-testing each
+						enabled provider, or disable pipelining everywhere. Run when downloads are idle for the
+						most accurate result.
+					</p>
+				</div>
+				<div className="flex flex-wrap items-center gap-3">
+					<button
+						type="button"
+						className="btn btn-primary gap-2"
+						onClick={handleAutoTunePipeline}
+						disabled={!!pipelineTuning || disablingPipeline || formData.length === 0}
+					>
+						{pipelineTuning ? (
+							<span className="loading loading-spinner loading-sm" />
+						) : (
+							<Gauge className="h-4 w-4" />
+						)}
+						{pipelineTuning
+							? `Testing ${pipelineTuning.current}/${pipelineTuning.total}${pipelineTuning.host ? ` · ${pipelineTuning.host}` : ""}…`
+							: "Auto-Tune Pipeline"}
+					</button>
+					<button
+						type="button"
+						className="btn btn-outline gap-2"
+						onClick={handleDisablePipelining}
+						disabled={!!pipelineTuning || disablingPipeline || formData.length === 0}
+					>
+						{disablingPipeline ? (
+							<span className="loading loading-spinner loading-sm" />
+						) : (
+							<PowerOff className="h-4 w-4" />
+						)}
+						Disable Pipelining
+					</button>
+				</div>
 			</div>
 
 			{/* Save & Validation */}

--- a/frontend/src/hooks/useProviders.ts
+++ b/frontend/src/hooks/useProviders.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "../api/client";
 import type {
+	PipelineTuneResponse,
 	ProviderConfig,
 	ProviderCreateRequest,
 	ProviderReorderRequest,
@@ -31,6 +32,13 @@ function useTestProviderSpeed() {
 			// Invalidate config cache to refetch providers
 			queryClient.invalidateQueries({ queryKey: configKeys.current() });
 		},
+	});
+}
+
+// Auto-tune provider pipeline depth (caller applies + saves the batch).
+function useTuneProviderPipeline() {
+	return useMutation<PipelineTuneResponse, Error, string>({
+		mutationFn: (id) => apiClient.tuneProviderPipeline(id),
 	});
 }
 
@@ -115,6 +123,7 @@ function useReorderProviders() {
 export function useProviders() {
 	const testProvider = useTestProvider();
 	const testProviderSpeed = useTestProviderSpeed();
+	const tuneProviderPipeline = useTuneProviderPipeline();
 	const createProvider = useCreateProvider();
 	const updateProvider = useUpdateProvider();
 	const deleteProvider = useDeleteProvider();
@@ -124,6 +133,7 @@ export function useProviders() {
 	return {
 		testProvider,
 		testProviderSpeed,
+		tuneProviderPipeline,
 		createProvider,
 		updateProvider,
 		deleteProvider,

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -269,6 +269,23 @@ export interface ProviderConfig {
 	account_expiration_date?: string;
 }
 
+// Pipeline auto-tune result for a single provider
+export interface PipelineDepthSample {
+	depth: number;
+	mbps: number;
+}
+
+export interface PipelineTuneResponse {
+	recommended_inflight: number;
+	baseline_mbps: number;
+	best_mbps: number;
+	improvement_pct: number;
+	enabled: boolean;
+	test_connections: number;
+	tested: PipelineDepthSample[];
+	warning?: string;
+}
+
 // NZBLNK resolver configuration
 export interface NzblnkConfig {
 	user_agent?: string;

--- a/internal/api/provider_pipeline_tune_handler.go
+++ b/internal/api/provider_pipeline_tune_handler.go
@@ -1,0 +1,190 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/nntppool/v4"
+)
+
+const (
+	pipelineTuneConns    = 4
+	pipelineTuneSegments = 160
+	pipelineLevelTimeout = 20 * time.Second
+	pipelineWinFactor    = 1.10
+)
+
+// pipelineTuneDepths are the inflight depths compared against the depth-1 baseline.
+var pipelineTuneDepths = []int{4, 8, 16}
+
+type PipelineDepthSample struct {
+	Depth int     `json:"depth"`
+	Mbps  float64 `json:"mbps"`
+}
+
+type PipelineTuneResponse struct {
+	RecommendedInflight int                   `json:"recommended_inflight"`
+	BaselineMbps        float64               `json:"baseline_mbps"`
+	BestMbps            float64               `json:"best_mbps"`
+	Improvement         float64               `json:"improvement_pct"`
+	Enabled             bool                  `json:"enabled"`
+	TestConnections     int                   `json:"test_connections"`
+	Tested              []PipelineDepthSample `json:"tested"`
+	Warning             string                `json:"warning,omitempty"`
+}
+
+// handleTunePipeline sweeps pipeline depths and recommends the best inflight (1 = off).
+//
+//	@Summary		Auto-tune provider pipeline depth
+//	@Description	Sweeps inflight depths against the provider and returns the recommended inflight_requests value.
+//	@Tags			Providers
+//	@Produce		json
+//	@Param			id	path	string	true	"Provider ID"
+//	@Success		200	{object}	APIResponse{data=PipelineTuneResponse}
+//	@Failure		400	{object}	APIResponse
+//	@Failure		404	{object}	APIResponse
+//	@Failure		500	{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/config/providers/{id}/tune-pipeline [post]
+func (s *Server) handleTunePipeline(c *fiber.Ctx) error {
+	providerID := c.Params("id")
+	if providerID == "" {
+		return RespondBadRequest(c, "Provider ID is required", "")
+	}
+	if s.configManager == nil {
+		return RespondInternalError(c, "Configuration management not available", "")
+	}
+
+	var target *config.ProviderConfig
+	for _, p := range s.configManager.GetConfig().Providers {
+		if p.ID == providerID {
+			pc := p
+			target = &pc
+			break
+		}
+	}
+	if target == nil {
+		return RespondNotFound(c, "Provider", "")
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), 3*time.Minute)
+	defer cancel()
+
+	resp, err := s.runPipelineSweep(ctx, target)
+	if err != nil {
+		return RespondInternalError(c, "Pipeline tuning failed", err.Error())
+	}
+	return RespondSuccess(c, resp)
+}
+
+// runPipelineSweep picks the best depth, or leaves it unchanged with a warning if it can't measure.
+func (s *Server) runPipelineSweep(ctx context.Context, p *config.ProviderConfig) (*PipelineTuneResponse, error) {
+	conns := p.MaxConnections
+	if conns > pipelineTuneConns {
+		conns = pipelineTuneConns
+	}
+	if conns < 1 {
+		conns = 1
+	}
+
+	current := p.InflightRequests
+	if current < 1 {
+		current = 1
+	}
+
+	resp := &PipelineTuneResponse{
+		RecommendedInflight: current,
+		TestConnections:     conns,
+	}
+
+	nzbBytes, err := fetchSpeedTestNZB(ctx)
+	if err != nil {
+		resp.Warning = "Could not fetch the speed-test NZB: " + err.Error()
+		return resp, nil
+	}
+
+	baseline := s.measurePipelineDepth(ctx, p, conns, 1, nzbBytes)
+	resp.BaselineMbps = round2(baseline)
+	resp.Tested = append(resp.Tested, PipelineDepthSample{Depth: 1, Mbps: resp.BaselineMbps})
+	if baseline <= 0 {
+		resp.Warning = "Provider was busy or at its connection limit; pipeline left unchanged."
+		return resp, nil
+	}
+
+	for _, depth := range pipelineTuneDepths {
+		mbps := s.measurePipelineDepth(ctx, p, conns, depth, nzbBytes)
+		resp.Tested = append(resp.Tested, PipelineDepthSample{Depth: depth, Mbps: round2(mbps)})
+	}
+
+	resp.RecommendedInflight, resp.Enabled, resp.Improvement, resp.BestMbps =
+		pickPipelineDepth(baseline, resp.Tested[1:])
+	return resp, nil
+}
+
+// pickPipelineDepth returns the smallest depth beating the baseline by the win factor, else 1.
+func pickPipelineDepth(baseline float64, samples []PipelineDepthSample) (inflight int, enabled bool, improvement, best float64) {
+	bestDepth := 0
+	for _, s := range samples {
+		if s.Mbps > best {
+			best, bestDepth = s.Mbps, s.Depth
+		}
+	}
+	if baseline > 0 && best > baseline {
+		improvement = round2((best - baseline) / baseline * 100)
+	}
+	if bestDepth > 0 && baseline > 0 && best >= baseline*pipelineWinFactor {
+		return bestDepth, true, improvement, best
+	}
+	return 1, false, improvement, best
+}
+
+// measurePipelineDepth returns MB/s for one bounded speed test at the given depth (0 on failure).
+func (s *Server) measurePipelineDepth(ctx context.Context, p *config.ProviderConfig, conns, inflight int, nzbBytes []byte) float64 {
+	client, err := buildAdHocClient(ctx, p, conns, inflight)
+	if err != nil {
+		return 0
+	}
+	defer client.Close()
+
+	levelCtx, cancel := context.WithTimeout(ctx, pipelineLevelTimeout)
+	defer cancel()
+
+	res, err := client.SpeedTest(levelCtx, nntppool.SpeedTestOptions{
+		NZBReader:   bytes.NewReader(nzbBytes),
+		MaxSegments: pipelineTuneSegments,
+	})
+	if err != nil || res == nil || res.WireSpeedBps <= 0 {
+		return 0
+	}
+	return res.WireSpeedBps / 1024 / 1024
+}
+
+func fetchSpeedTestNZB(ctx context.Context) ([]byte, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, nntppool.DefaultSpeedTestNZBURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("NZB HTTP %d", res.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(res.Body, 32*1024*1024))
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}

--- a/internal/api/provider_pipeline_tune_handler_test.go
+++ b/internal/api/provider_pipeline_tune_handler_test.go
@@ -1,0 +1,50 @@
+package api
+
+import "testing"
+
+func TestPickPipelineDepth(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseline float64
+		samples  []PipelineDepthSample
+		wantInfl int
+		wantOn   bool
+	}{
+		{
+			name:     "clear win enables smallest winning depth",
+			baseline: 10,
+			samples:  []PipelineDepthSample{{Depth: 4, Mbps: 12}, {Depth: 8, Mbps: 18}, {Depth: 16, Mbps: 18}},
+			wantInfl: 8,
+			wantOn:   true,
+		},
+		{
+			name:     "sub-threshold gain stays off",
+			baseline: 10,
+			samples:  []PipelineDepthSample{{Depth: 4, Mbps: 10.5}, {Depth: 8, Mbps: 10.9}, {Depth: 16, Mbps: 10.2}},
+			wantInfl: 1,
+			wantOn:   false,
+		},
+		{
+			name:     "no gain stays off",
+			baseline: 10,
+			samples:  []PipelineDepthSample{{Depth: 4, Mbps: 9}, {Depth: 8, Mbps: 8}},
+			wantInfl: 1,
+			wantOn:   false,
+		},
+		{
+			name:     "zero baseline stays off",
+			baseline: 0,
+			samples:  []PipelineDepthSample{{Depth: 4, Mbps: 5}, {Depth: 8, Mbps: 9}},
+			wantInfl: 1,
+			wantOn:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infl, on, _, _ := pickPipelineDepth(tt.baseline, tt.samples)
+			if infl != tt.wantInfl || on != tt.wantOn {
+				t.Fatalf("got (%d, %v), want (%d, %v)", infl, on, tt.wantInfl, tt.wantOn)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -339,6 +339,7 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	// Provider management endpoints
 	api.Post("/providers/test", s.handleTestProvider)
 	api.Post("/providers/:id/speedtest", s.handleTestProviderSpeed)
+	api.Post("/providers/:id/tune-pipeline", s.handleTunePipeline)
 	api.Post("/providers", s.handleCreateProvider)
 	api.Put("/providers/reorder", s.handleReorderProviders)
 	api.Put("/providers/:id", s.handleUpdateProvider)

--- a/internal/api/speedtest_coordinator.go
+++ b/internal/api/speedtest_coordinator.go
@@ -141,14 +141,6 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 	}
 	sc.mu.Unlock()
 
-	var tlsCfg *tls.Config
-	if p.TLS {
-		tlsCfg = &tls.Config{
-			InsecureSkipVerify: p.InsecureTLS,
-			ServerName:         p.Host,
-		}
-	}
-
 	// Mirror the production pool (ToNNTPProvider): without Inflight the
 	// nntppool client defaults to depth 1, making the fallback path
 	// latency-bound (one BODY per RTT) instead of pipelined.
@@ -157,16 +149,7 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 		inflight = 10
 	}
 
-	client, err := nntppool.NewClient(ctx, []nntppool.Provider{
-		{
-			Host:        host,
-			TLSConfig:   tlsCfg,
-			Auth:        nntppool.Auth{Username: p.Username, Password: p.Password},
-			Connections: p.MaxConnections,
-			Inflight:    inflight,
-			IdleTimeout: 60 * time.Second,
-		},
-	})
+	client, err := buildAdHocClient(ctx, p, p.MaxConnections, inflight)
 	if err != nil {
 		return nil, "", err
 	}
@@ -187,6 +170,27 @@ func (sc *speedtestCoordinator) getOrBuildClient(ctx context.Context, p *config.
 	sc.mu.Unlock()
 
 	return client, providerName, nil
+}
+
+// buildAdHocClient dials a throwaway single-provider client; the caller owns Close.
+func buildAdHocClient(ctx context.Context, p *config.ProviderConfig, connections, inflight int) (*nntppool.Client, error) {
+	var tlsCfg *tls.Config
+	if p.TLS {
+		tlsCfg = &tls.Config{
+			InsecureSkipVerify: p.InsecureTLS,
+			ServerName:         p.Host,
+		}
+	}
+	return nntppool.NewClient(ctx, []nntppool.Provider{
+		{
+			Host:        fmt.Sprintf("%s:%d", p.Host, p.Port),
+			TLSConfig:   tlsCfg,
+			Auth:        nntppool.Auth{Username: p.Username, Password: p.Password},
+			Connections: connections,
+			Inflight:    inflight,
+			IdleTimeout: 60 * time.Second,
+		},
+	})
 }
 
 // run executes fn under the singleflight key for the given provider,

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -565,41 +565,45 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	var sceneName string
 	var err error
 
-	// ID-Based Precision: If we have the movie ID from metadata, use it
+	// ID-Based Precision: If we have the movie ID from metadata, use it.
+	// Use a targeted GetMovieByID lookup instead of fetching the ENTIRE movie
+	// library and scanning it: on large libraries the full fetch can exceed the
+	// HTTP client timeout, surface as a generic error, and wrongly condemn the file.
+	// A failed/empty lookup (e.g. the movie was removed and re-added with a new
+	// internal id) just falls through to the path-based fallback below.
 	if metadata != nil && metadata.Movie != nil && metadata.Movie.Id > 0 {
-		movies, err := m.data.GetMovies(ctx, client, instanceName)
-		if err != nil {
-			return fmt.Errorf("failed to get movies from Radarr for ID lookup: %w", err)
-		}
-		for _, movie := range movies {
-			if movie.ID == metadata.Movie.Id {
-				targetMovie = movie
+		movie, lookupErr := client.GetMovieByIDContext(ctx, metadata.Movie.Id)
+		if lookupErr != nil {
+			slog.WarnContext(ctx, "Targeted Radarr movie lookup by ID failed, falling back to path-based matching",
+				"instance", instanceName,
+				"movie_id", metadata.Movie.Id,
+				"error", lookupErr)
+		} else if movie != nil {
+			targetMovie = movie
 
-				if metadata.MovieFile != nil && metadata.MovieFile.Id > 0 {
-					slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Radarr repair",
-						"movie_id", metadata.Movie.Id,
-						"movie_file_id", metadata.MovieFile.Id)
-					sceneName = metadata.MovieFile.SceneName
+			if metadata.MovieFile != nil && metadata.MovieFile.Id > 0 {
+				slog.InfoContext(ctx, "ID-Based Precision: Using metadata IDs for Radarr repair",
+					"movie_id", metadata.Movie.Id,
+					"movie_file_id", metadata.MovieFile.Id)
+				sceneName = metadata.MovieFile.SceneName
 
-					// Smart Repair Guard: Check if the movie already has a newer/different healthy file
-					if movie.HasFile && movie.MovieFile != nil {
-						if movie.MovieFile.ID != metadata.MovieFile.Id {
-							slog.InfoContext(ctx, "Smart Repair Guard: Movie already has a different healthy file (likely upgraded). Skipping repair.",
-								"movie", movie.Title,
-								"old_file_id", metadata.MovieFile.Id,
-								"new_file_id", movie.MovieFile.ID)
-							return model.ErrEpisodeAlreadySatisfied
-						}
-						targetMovieFileID = movie.MovieFile.ID
+				// Smart Repair Guard: Check if the movie already has a newer/different healthy file
+				if movie.HasFile && movie.MovieFile != nil {
+					if movie.MovieFile.ID != metadata.MovieFile.Id {
+						slog.InfoContext(ctx, "Smart Repair Guard: Movie already has a different healthy file (likely upgraded). Skipping repair.",
+							"movie", movie.Title,
+							"old_file_id", metadata.MovieFile.Id,
+							"new_file_id", movie.MovieFile.ID)
+						return model.ErrEpisodeAlreadySatisfied
 					}
-				} else {
-					slog.InfoContext(ctx, "ID-Based Precision: Using metadata movie ID for Radarr repair",
-						"movie_id", metadata.Movie.Id)
-					if movie.HasFile && movie.MovieFile != nil {
-						targetMovieFileID = movie.MovieFile.ID
-					}
+					targetMovieFileID = movie.MovieFile.ID
 				}
-				break
+			} else {
+				slog.InfoContext(ctx, "ID-Based Precision: Using metadata movie ID for Radarr repair",
+					"movie_id", metadata.Movie.Id)
+				if movie.HasFile && movie.MovieFile != nil {
+					targetMovieFileID = movie.MovieFile.ID
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Summary
The ID-based repair path fetched the **entire** Radarr movie library and scanned it to find one movie by id. On large libraries that full fetch can exceed the HTTP client timeout, surface as a generic error, and wrongly condemn the file.

### Change
- Replace the full-library fetch with a targeted `GetMovieByIDContext` lookup.
- A failed/empty lookup (e.g. the movie was removed and re-added with a new internal id) falls through to the existing path-based matching instead of erroring.
- The Smart Repair Guard (skip when the movie already has a different healthy file) is preserved unchanged.

Touches `internal/arrs/scanner/manager.go` (+36/-32).