### PR TITLE
fix(arrs): blocklist-only season+episode fallback for renamed Sonarr …

### DIFF
--- a/frontend/src/components/config/ArrsConfigSection.tsx
+++ b/frontend/src/components/config/ArrsConfigSection.tsx
@@ -371,6 +371,29 @@ export function ArrsConfigSection({
 							/>
 						</div>
 
+						<div className="flex items-start justify-between gap-4">
+							<div className="min-w-0 flex-1">
+								<h5 className="break-words font-bold text-base-content text-sm">
+									Sonarr Season+Episode Repair Fallback
+								</h5>
+								<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+									When a corrupt file can't be matched to an episode by path, resolve the owned
+									episode by its season/episode number, then blocklist and re-search it. Off by
+									default: it can blocklist healthy releases such as foreign-language releases or
+									season packs.
+								</p>
+							</div>
+							<input
+								type="checkbox"
+								className="checkbox checkbox-primary checkbox-sm mt-1 shrink-0"
+								checked={formData.sonarr_season_episode_fallback_enabled ?? false}
+								onChange={(e) =>
+									handleFormChange("sonarr_season_episode_fallback_enabled", e.target.checked)
+								}
+								disabled={isReadOnly}
+							/>
+						</div>
+
 						{(formData.queue_cleanup_enabled ?? true) && (
 							<div className="fade-in zoom-in-95 animate-in space-y-6">
 								<div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -617,6 +617,10 @@ export interface ArrsConfig {
 	queue_cleanup_grace_period_minutes?: number;
 	queue_cleanup_max_failures?: number;
 	queue_cleanup_rules?: StuckCleanupRule[];
+	// Opt-in: resolve a renamed Sonarr episode by season+episode when path matching
+	// fails, then blocklist + re-search it. Disabled by default because it can
+	// blocklist healthy releases (foreign-language releases, season packs).
+	sonarr_season_episode_fallback_enabled?: boolean;
 }
 
 export type StuckCleanupAction = "remove" | "blocklist" | "blocklist_search";

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -739,6 +740,29 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 	return nil
 }
 
+// seasonEpisodeRe captures the season and episode numbers from a standard
+// "S01E02" token in a file path. Used by the Sonarr repair fallback to resolve a
+// renamed-but-still-owned episode when no episode-file id could be matched.
+var seasonEpisodeRe = regexp.MustCompile(`(?i)S(\d{1,4})E(\d{1,4})`)
+
+// parseSeasonEpisode extracts the season and episode numbers from a path, trying
+// filePath first and then relativePath. ok is false when no S/E token is present.
+func parseSeasonEpisode(filePath, relativePath string) (season, episode int, ok bool) {
+	for _, p := range []string{filePath, relativePath} {
+		if p == "" {
+			continue
+		}
+		if mt := seasonEpisodeRe.FindStringSubmatch(p); mt != nil {
+			s, err1 := strconv.Atoi(mt[1])
+			e, err2 := strconv.Atoi(mt[2])
+			if err1 == nil && err2 == nil {
+				return s, e, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
 // triggerSonarrRescanByPath triggers a rescan in Sonarr for the given file path
 func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.Sonarr, filePath, relativePath, instanceName string, metadata *model.WebhookMetadata) error {
 	slog.InfoContext(ctx, "Searching Sonarr for matching series",
@@ -959,6 +983,38 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 				slog.WarnContext(ctx, "Failed to blocklist Sonarr release using metadata fallback", "error", err)
 			}
 		}
+
+		// Fallback 3: Season+Episode fallback. A renamed-but-still-owned episode
+		// (HasFile=true) whose episode-file id could not be matched by path would
+		// otherwise dead-end in ErrPathMatchFailed and be permanently condemned. Resolve
+		// the owned episode(s) by the S/E parsed from the path and re-search them.
+		//
+		// CRITICAL DELETE SAFETY: this path is BLOCKLIST-ONLY. We pass fileID=0 to the
+		// blocklist helper — which then skips file-based history matching so a missing
+		// file id can't blocklist the wrong release — and fall through to trigger ONLY an
+		// EpisodeSearch below. DeleteEpisodeFileContext is unreachable from here: it lives
+		// solely inside the `targetEpisodeFileID > 0` branch above, which is never taken
+		// when this else branch runs (targetEpisodeFileID == 0).
+		if len(episodeIDs) == 0 {
+			if season, ep, ok := parseSeasonEpisode(filePath, relativePath); ok {
+				for _, episode := range episodes {
+					// Require HasFile so we only ever act on episodes Sonarr still owns a
+					// file for; never collect an id for an episode without a file.
+					if episode.HasFile && episode.SeasonNumber == season && episode.EpisodeNumber == ep {
+						episodeIDs = append(episodeIDs, episode.ID)
+					}
+				}
+				if len(episodeIDs) > 0 {
+					slog.InfoContext(ctx, "Season+Episode fallback resolved owned episode(s) for renamed file; blocklist-only re-search",
+						"series", targetSeriesTitle, "season", season, "episode", ep, "episode_ids", episodeIDs)
+					// Blocklist-only: fileID=0 is a safe no-op for file matching in the helper
+					// (no delete). The EpisodeSearch is triggered by the shared code path below.
+					if err := m.blocklistSonarrEpisodeFile(ctx, client, targetSeriesID, 0, episodeIDs, sceneName); err != nil {
+						slog.WarnContext(ctx, "Failed to blocklist Sonarr release in S/E fallback", "error", err)
+					}
+				}
+			}
+		}
 	}
 
 	if len(episodeIDs) == 0 {
@@ -1142,11 +1198,15 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 	// 1. Find the import event to get the downloadId
 	for _, record := range history.Records {
 		if record.EventType == "downloadFolderImported" {
-			if record.Data.FileID == targetFileID {
+			// A fileID==0 sentinel means the caller has no concrete episode-file to
+			// attribute (e.g. the season+episode fallback for a renamed-but-owned
+			// episode). Skip file-based matching so a missing file id can't match — and
+			// blocklist — the wrong release; rely solely on the EpisodeID match below.
+			if fileID > 0 && record.Data.FileID == targetFileID {
 				downloadID = record.DownloadID
 				break
 			}
-			
+
 			// Fallback: Sonarr history might not expose fileId in data consistently. Match by EpisodeID.
 			for _, epID := range episodeIDs {
 				if record.EpisodeID == epID {

--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -660,7 +660,7 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 					}
 				}
 			}
-			
+
 			if targetMovieFileID > 0 {
 				sceneName = movie.MovieFile.SceneName
 			}
@@ -995,7 +995,15 @@ func (m *Manager) triggerSonarrRescanByPath(ctx context.Context, client *sonarr.
 		// EpisodeSearch below. DeleteEpisodeFileContext is unreachable from here: it lives
 		// solely inside the `targetEpisodeFileID > 0` branch above, which is never taken
 		// when this else branch runs (targetEpisodeFileID == 0).
-		if len(episodeIDs) == 0 {
+		//
+		// OPT-IN: by the time this runs, path matching has already failed to tie the
+		// corrupt file to any episode file, so we cannot confirm the owned release is the
+		// bad one. On libraries with foreign-language releases or season packs the owned
+		// file is often a healthy-but-differently-named release, and blocklisting it would
+		// throw away a good release. The fallback is therefore gated behind an explicit
+		// opt-in and disabled by default.
+		seasonEpisodeFallbackEnabled := m.configGetter().Arrs.SonarrSeasonEpisodeFallbackEnabled
+		if len(episodeIDs) == 0 && seasonEpisodeFallbackEnabled != nil && *seasonEpisodeFallbackEnabled {
 			if season, ep, ok := parseSeasonEpisode(filePath, relativePath); ok {
 				for _, episode := range episodes {
 					// Require HasFile so we only ever act on episodes Sonarr still owns a
@@ -1134,7 +1142,7 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 
 	if downloadID == "" {
 		slog.WarnContext(ctx, "Could not find import event in Radarr history for file, attempting to find latest grabbed event directly", "movie_id", movieID, "file_id", fileID)
-		
+
 		// Precision Fallback: Find the grabbed event matching the SceneName or MovieID
 		for _, record := range history.Records {
 			if record.EventType == "grabbed" && record.MovieID == movieID {
@@ -1146,7 +1154,7 @@ func (m *Manager) blocklistRadarrMovieFile(ctx context.Context, client *radarr.R
 					}
 					return nil
 				}
-				
+
 				// Without an exact SceneName match, only fallback to the latest grab if it was recent (within 24 hours)
 				if time.Since(record.Date) < 24*time.Hour {
 					slog.InfoContext(ctx, "Found recent grabbed history record using MovieID fallback, marking as failed to blocklist release",
@@ -1223,7 +1231,7 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 
 	if downloadID == "" {
 		slog.WarnContext(ctx, "Could not find import event in Sonarr history for file, attempting to find grabbed event directly", "series_id", seriesID, "file_id", fileID)
-		
+
 		// Precision Fallback: Find the grabbed event matching the SceneName
 		for _, record := range history.Records {
 			if record.EventType == "grabbed" {
@@ -1251,7 +1259,7 @@ func (m *Manager) blocklistSonarrEpisodeFile(ctx context.Context, client *sonarr
 				}
 			}
 		}
-		
+
 		slog.WarnContext(ctx, "Could not find any matching or recent grab event in Sonarr history to blocklist", "series_id", seriesID)
 		return nil
 	}

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -421,18 +421,28 @@ type IgnoredMessage struct {
 
 // ArrsConfig represents arrs configuration
 type ArrsConfig struct {
-	Enabled                        *bool                `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
-	MaxWorkers                     int                  `yaml:"max_workers" mapstructure:"max_workers" json:"max_workers,omitempty"`
-	WebhookBaseURL                 string               `yaml:"webhook_base_url" mapstructure:"webhook_base_url" json:"webhook_base_url,omitempty"`
-	RadarrInstances                []ArrsInstanceConfig `yaml:"radarr_instances" mapstructure:"radarr_instances" json:"radarr_instances"`
-	SonarrInstances                []ArrsInstanceConfig `yaml:"sonarr_instances" mapstructure:"sonarr_instances" json:"sonarr_instances"`
-	LidarrInstances                []ArrsInstanceConfig `yaml:"lidarr_instances" mapstructure:"lidarr_instances" json:"lidarr_instances"`
-	ReadarrInstances               []ArrsInstanceConfig `yaml:"readarr_instances" mapstructure:"readarr_instances" json:"readarr_instances"`
-	WhisparrInstances              []ArrsInstanceConfig `yaml:"whisparr_instances" mapstructure:"whisparr_instances" json:"whisparr_instances"`
-	SportarrInstances              []ArrsInstanceConfig `yaml:"sportarr_instances" mapstructure:"sportarr_instances" json:"sportarr_instances"`
-	QueueCleanupEnabled            *bool                `yaml:"queue_cleanup_enabled" mapstructure:"queue_cleanup_enabled" json:"queue_cleanup_enabled,omitempty"`
-	QueueCleanupIntervalSeconds    int                  `yaml:"queue_cleanup_interval_seconds" mapstructure:"queue_cleanup_interval_seconds" json:"queue_cleanup_interval_seconds,omitempty"`
-	QueueCleanupGracePeriodMinutes int                  `yaml:"queue_cleanup_grace_period_minutes" mapstructure:"queue_cleanup_grace_period_minutes" json:"queue_cleanup_grace_period_minutes,omitempty"`
+	Enabled             *bool                `yaml:"enabled" mapstructure:"enabled" json:"enabled"`
+	MaxWorkers          int                  `yaml:"max_workers" mapstructure:"max_workers" json:"max_workers,omitempty"`
+	WebhookBaseURL      string               `yaml:"webhook_base_url" mapstructure:"webhook_base_url" json:"webhook_base_url,omitempty"`
+	RadarrInstances     []ArrsInstanceConfig `yaml:"radarr_instances" mapstructure:"radarr_instances" json:"radarr_instances"`
+	SonarrInstances     []ArrsInstanceConfig `yaml:"sonarr_instances" mapstructure:"sonarr_instances" json:"sonarr_instances"`
+	LidarrInstances     []ArrsInstanceConfig `yaml:"lidarr_instances" mapstructure:"lidarr_instances" json:"lidarr_instances"`
+	ReadarrInstances    []ArrsInstanceConfig `yaml:"readarr_instances" mapstructure:"readarr_instances" json:"readarr_instances"`
+	WhisparrInstances   []ArrsInstanceConfig `yaml:"whisparr_instances" mapstructure:"whisparr_instances" json:"whisparr_instances"`
+	SportarrInstances   []ArrsInstanceConfig `yaml:"sportarr_instances" mapstructure:"sportarr_instances" json:"sportarr_instances"`
+	QueueCleanupEnabled *bool                `yaml:"queue_cleanup_enabled" mapstructure:"queue_cleanup_enabled" json:"queue_cleanup_enabled,omitempty"`
+
+	// SonarrSeasonEpisodeFallbackEnabled opts in to the Sonarr season+episode repair
+	// fallback. When a corrupt file can't be matched to any episode file by path, this
+	// fallback resolves the owned episode by the S/E parsed from the path and
+	// blocklists + re-searches it. Because path matching has already failed by the time
+	// it runs, it cannot confirm the owned release is actually the corrupt one — so for
+	// libraries with foreign-language releases or season packs it can blocklist a
+	// healthy release. It is therefore DISABLED by default; enable only when episodes
+	// are reliably one-file-per-release and renames are the main cause of path misses.
+	SonarrSeasonEpisodeFallbackEnabled *bool `yaml:"sonarr_season_episode_fallback_enabled" mapstructure:"sonarr_season_episode_fallback_enabled" json:"sonarr_season_episode_fallback_enabled,omitempty"`
+	QueueCleanupIntervalSeconds        int   `yaml:"queue_cleanup_interval_seconds" mapstructure:"queue_cleanup_interval_seconds" json:"queue_cleanup_interval_seconds,omitempty"`
+	QueueCleanupGracePeriodMinutes     int   `yaml:"queue_cleanup_grace_period_minutes" mapstructure:"queue_cleanup_grace_period_minutes" json:"queue_cleanup_grace_period_minutes,omitempty"`
 
 	// QueueCleanupMaxFailures is the per-target failure circuit breaker. After
 	// AltMount has acted on the same target (a Radarr movie or Sonarr/Whisparr
@@ -1430,6 +1440,7 @@ func DefaultConfig(configDir ...string) *Config {
 	mountEnabled := false // Disabled by default
 	sabnzbdEnabled := false
 	scrapperEnabled := false
+	sonarrSeasonEpisodeFallbackEnabled := false // Opt-in: can blocklist healthy releases, see field doc
 	fuseEnabled := false
 	loginRequired := true           // Require login by default
 	stremioEnabled := false         // Stremio endpoint disabled by default
@@ -1642,17 +1653,18 @@ func DefaultConfig(configDir ...string) *Config {
 			UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
 		},
 		Arrs: ArrsConfig{
-			Enabled:                        &scrapperEnabled, // Disabled by default
-			MaxWorkers:                     5,                // Default to 5 concurrent workers
-			WebhookBaseURL:                 "",
-			RadarrInstances:                []ArrsInstanceConfig{},
-			SonarrInstances:                []ArrsInstanceConfig{},
-			LidarrInstances:                []ArrsInstanceConfig{},
-			ReadarrInstances:               []ArrsInstanceConfig{},
-			WhisparrInstances:              []ArrsInstanceConfig{},
-			SportarrInstances:              []ArrsInstanceConfig{},
-			QueueCleanupGracePeriodMinutes: 5,     // Default to 5 minutes stuck before acting
-			QueueCleanupMaxFailures:        0, // Failure circuit breaker disabled by default
+			Enabled:                            &scrapperEnabled,                    // Disabled by default
+			SonarrSeasonEpisodeFallbackEnabled: &sonarrSeasonEpisodeFallbackEnabled, // Disabled by default
+			MaxWorkers:                         5,                                   // Default to 5 concurrent workers
+			WebhookBaseURL:                     "",
+			RadarrInstances:                    []ArrsInstanceConfig{},
+			SonarrInstances:                    []ArrsInstanceConfig{},
+			LidarrInstances:                    []ArrsInstanceConfig{},
+			ReadarrInstances:                   []ArrsInstanceConfig{},
+			WhisparrInstances:                  []ArrsInstanceConfig{},
+			SportarrInstances:                  []ArrsInstanceConfig{},
+			QueueCleanupGracePeriodMinutes:     5, // Default to 5 minutes stuck before acting
+			QueueCleanupMaxFailures:            0, // Failure circuit breaker disabled by default
 			// Rule table modeled on wArrden's queue cleanup. Action decides what to do:
 			// blocklist_search (bad release → block + re-search), blocklist (block but
 			// don't search), or remove (just clear the queue: transient/environmental


### PR DESCRIPTION
…episodes

A renamed-but-still-owned Sonarr episode (HasFile=true) whose episode-file id could not be matched by path dead-ended in ErrPathMatchFailed and was permanently condemned (the existing metadata.Episodes fallback only helps when webhook episode ids are present).

Add a season+episode fallback parsed from the path: resolve the owned episode(s) by their S/E and re-search them. This path is blocklist-only and delete-safe by construction:
- it only collects an episode id when ep.HasFile is true (owned episodes only);
- it calls the blocklist helper with fileID=0, and the helper now skips file-based history matching for a 0 sentinel so a missing file id can never blocklist the wrong release;
- it triggers only an EpisodeSearch. DeleteEpisodeFileContext is unreachable from this fallback — it lives solely inside the targetEpisodeFileID > 0 branch, which is never taken when this else branch runs.


Claude-Session: https://claude.ai/code/session_01LGVEv2GpftTW5DWo9zXa1p