### PR TITLE
fix(health): defer repair when *arr is temporarily unreachable

### DIFF
--- a/internal/arrs/service.go
+++ b/internal/arrs/service.go
@@ -2,7 +2,9 @@ package arrs
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"net"
 	"strings"
 	"time"
 
@@ -29,6 +31,41 @@ var (
 	ErrEpisodeAlreadySatisfied = model.ErrEpisodeAlreadySatisfied
 	ErrInstanceNotFound        = model.ErrInstanceNotFound
 )
+
+// IsTemporarilyUnreachable reports whether err indicates the *arr was only
+// temporarily unreachable — a network/transport failure (timeout, connection
+// refused, DNS, TLS, etc.) or a 5xx server response — rather than a definitive
+// answer about the release. Such errors must DEFER a repair (keep the file
+// repair-pending so it self-heals when the *arr returns) instead of condemning
+// the file as corrupted. starr surfaces non-2xx responses as a *starr.ReqError
+// whose Code carries the HTTP status; transport failures surface as net.Error
+// (often wrapped in *url.Error) or a context deadline.
+func IsTemporarilyUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Typed 5xx response from the starr app (server-side, almost always transient).
+	var reqErr *starr.ReqError
+	if errors.As(err, &reqErr) && reqErr.Code >= 500 && reqErr.Code <= 599 {
+		return true
+	}
+
+	// Network/transport failure: timeouts, connection refused, DNS, TLS handshake,
+	// etc. *url.Error (returned by the HTTP client) also satisfies net.Error.
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// A context deadline tripping mid-request is an unreachable/too-slow *arr, not
+	// a corrupt file.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	return false
+}
 
 // Service manages Radarr, Sonarr, Lidarr, Readarr, and Whisparr instances for health monitoring and file repair
 type Service struct {

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -915,6 +915,7 @@ const (
 	repairOutcomeCorrupted                        // ARR failed with a generic error; mark file corrupted
 	repairOutcomeDeleted                          // Health record and/or metadata were deleted (zombie)
 	repairOutcomeRegenerated                      // Metadata was successfully regenerated from NZB
+	repairOutcomeDeferred                         // ARR temporarily unreachable; keep repair-pending, do not condemn
 )
 
 // applyRepairOutcome maps a repairOutcome to the corresponding fields on the HealthStatusUpdate.
@@ -935,6 +936,14 @@ func applyRepairOutcome(update *database.HealthStatusUpdate, outcome repairOutco
 			errMsg := err.Error()
 			update.ErrorMessage = &errMsg
 		}
+	case repairOutcomeDeferred:
+		// The ARR was only temporarily unreachable. Keep the file in repair_triggered
+		// WITHOUT incrementing repair_retry_count (UpdateTypeRepairTrigger does not bump
+		// the budget) and without condemning it, so the next repair cycle retries and the
+		// file self-heals once the ARR returns. The caller's pre-set ScheduledCheckAt
+		// (repair back-off) is preserved.
+		update.Type = database.UpdateTypeRepairTrigger
+		update.Status = database.HealthStatusRepairTriggered
 	}
 }
 
@@ -1051,6 +1060,15 @@ func (hw *HealthWorker) triggerFileRepair(ctx context.Context, item *database.Fi
 			return repairOutcomeCorrupted, err
 		}
 
+		// A temporarily unreachable ARR (network/transport error or 5xx) must NOT condemn
+		// the file. Defer: keep it repair-pending (no retry-count bump, no metadata move)
+		// so it self-heals on the next cycle once the ARR returns.
+		if arrs.IsTemporarilyUnreachable(err) {
+			slog.WarnContext(ctx, "ARR temporarily unreachable during repair trigger; deferring (file kept repair-pending, not condemned)",
+				"file_path", filePath, "path_for_rescan", pathForRescan, "arr_error", err)
+			return repairOutcomeDeferred, err
+		}
+
 		slog.ErrorContext(ctx, "Failed to trigger ARR rescan",
 			"file_path", filePath,
 			"path_for_rescan", pathForRescan,
@@ -1087,9 +1105,6 @@ func (hw *HealthWorker) retriggerFileRepair(ctx context.Context, item *database.
 
 	slog.InfoContext(ctx, "Re-triggering ARR rescan for file in repair", "file_path", filePath, "path_for_rescan", pathForRescan)
 
-	// Ensure metadata is moved to safety folder if the file has now been imported
-	hw.moveMetadataToSafetyFolder(ctx, item)
-
 	err := hw.arrsService.TriggerFileRescan(ctx, pathForRescan, filePath, metadataStr)
 	if err != nil {
 		// See triggerFileRepair: only an ID-confirmed replacement (ErrEpisodeAlreadySatisfied)
@@ -1108,9 +1123,23 @@ func (hw *HealthWorker) retriggerFileRepair(ctx context.Context, item *database.
 			return repairOutcomeCorrupted, err
 		}
 
+		// Temporarily unreachable ARR: defer instead of condemning. Note the metadata move
+		// happens only on the success path below, so a deferred outcome leaves the file
+		// visible and untouched until the ARR comes back.
+		if arrs.IsTemporarilyUnreachable(err) {
+			slog.WarnContext(ctx, "ARR temporarily unreachable during repair re-trigger; deferring (file kept repair-pending, not condemned)",
+				"file_path", filePath, "path_for_rescan", pathForRescan, "arr_error", err)
+			return repairOutcomeDeferred, err
+		}
+
 		slog.ErrorContext(ctx, "Failed to re-trigger ARR rescan", "file_path", filePath, "error", err)
 		return repairOutcomeCorrupted, err
 	}
+
+	// ARR rescan re-triggered successfully — only now move the metadata to the safety
+	// folder (if the file has been imported) so a deferred/failed outcome above never
+	// hides a file that was not actually condemned.
+	hw.moveMetadataToSafetyFolder(ctx, item)
 
 	slog.InfoContext(ctx, "Successfully re-triggered ARR rescan", "file_path", filePath)
 	return repairOutcomeTriggered, nil


### PR DESCRIPTION
When an *arr is only temporarily unreachable during a repair trigger — a network/transport error or a typed 5xx response — the file was condemned as corrupted on the spot. Classify those transient failures (new arrs.IsTemporarilyUnreachable, which inspects *starr.ReqError codes and net.Error/context-deadline transport failures) and DEFER instead: keep the file in repair_triggered without bumping repair_retry_count and without condemning it, so it self-heals on the next cycle once the *arr returns.

Also move the metadata-to-safety-folder step in retriggerFileRepair to the success path so a deferred (or failed) outcome never hides a file that was not actually condemned.


Claude-Session: https://claude.ai/code/session_01LGVEv2GpftTW5DWo9zXa1p