### PR TITLE
fix(arrs): resolve re-added Radarr movies by stable TMDB id, delete-s…

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -553,6 +553,46 @@ func (m *Manager) TriggerDownloadScan(ctx context.Context, instanceType string) 
 	}
 }
 
+// radarrFileMatchesTarget reports whether the movie's current file is the corrupt
+// target identified by filePath/relativePath. It is the single source of truth for
+// the Radarr delete-safety decision: both the library path scan and the TMDB-id
+// fallback route through it so the check cannot drift apart. A movie with no file
+// never matches. Match forms: exact path, basename, .strm-stripped, relative-suffix.
+func radarrFileMatchesTarget(movie *radarr.Movie, filePath, relativePath string) bool {
+	if movie == nil || !movie.HasFile || movie.MovieFile == nil {
+		return false
+	}
+	moviePath := movie.MovieFile.Path
+
+	// Exact path match
+	if moviePath == filePath {
+		return true
+	}
+
+	// Basename match (robust when only the parent directory differs)
+	if filepath.Base(moviePath) == filepath.Base(filePath) {
+		return true
+	}
+
+	// .strm-stripped match: filePath is a .strm pointing at the real file
+	if before, ok := strings.CutSuffix(filePath, ".strm"); ok {
+		if strings.TrimSuffix(moviePath, filepath.Ext(moviePath)) == before {
+			return true
+		}
+	}
+
+	// Relative-suffix match
+	if relativePath != "" {
+		strippedRelative := strings.TrimSuffix(relativePath, ".strm")
+		if strings.HasSuffix(moviePath, relativePath) ||
+			strings.HasSuffix(strings.TrimSuffix(moviePath, filepath.Ext(moviePath)), strippedRelative) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // triggerRadarrRescanByPath triggers a rescan in Radarr for the given file path
 func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.Radarr, filePath, relativePath, instanceName string, metadata *model.WebhookMetadata) error {
 	slog.InfoContext(ctx, "Searching Radarr for matching movie",
@@ -614,54 +654,67 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 		}
 
 		for _, movie := range movies {
-			// Try match by filename (the most robust way if paths differ)
-			requestFileName := filepath.Base(filePath)
-
-			if movie.HasFile && movie.MovieFile != nil {
-				// Try exact match
-				if movie.MovieFile.Path == filePath {
-					targetMovie = movie
-					targetMovieFileID = movie.MovieFile.ID
-					break
-				}
-
-				movieFileName := filepath.Base(movie.MovieFile.Path)
-				if movieFileName == requestFileName {
-					slog.InfoContext(ctx, "Found Radarr movie match by filename",
-						"movie", movie.Title,
-						"path", movie.MovieFile.Path)
-					targetMovie = movie
-					targetMovieFileID = movie.MovieFile.ID
-					break
-				}
-
-				// Try match without .strm extension if filePath is a .strm file
-				if before, ok := strings.CutSuffix(filePath, ".strm"); ok {
-					strippedPath := before
-					// Check if movie file path (without its own extension) matches stripped filePath
-					if strings.TrimSuffix(movie.MovieFile.Path, filepath.Ext(movie.MovieFile.Path)) == strippedPath {
-						targetMovie = movie
-						targetMovieFileID = movie.MovieFile.ID
-						break
-					}
-				}
-				// Try suffix match with relative path if provided
-				if relativePath != "" {
-					strippedRelative := strings.TrimSuffix(relativePath, ".strm")
-					if strings.HasSuffix(movie.MovieFile.Path, relativePath) ||
-						strings.HasSuffix(strings.TrimSuffix(movie.MovieFile.Path, filepath.Ext(movie.MovieFile.Path)), strippedRelative) {
-						slog.InfoContext(ctx, "Found Radarr movie match by relative path suffix",
-							"radarr_path", movie.MovieFile.Path,
-							"relative_path", relativePath)
-						targetMovie = movie
-						targetMovieFileID = movie.MovieFile.ID
-						break
-					}
-				}
-			}
-			
-			if targetMovieFileID > 0 {
+			// Route through the shared matcher so the library scan and the TMDB-id
+			// fallback below apply identical path-matching (and thus identical
+			// delete-safety) rules.
+			if radarrFileMatchesTarget(movie, filePath, relativePath) {
+				slog.InfoContext(ctx, "Found Radarr movie match by path",
+					"movie", movie.Title,
+					"path", movie.MovieFile.Path,
+					"file_path", filePath)
+				targetMovie = movie
+				targetMovieFileID = movie.MovieFile.ID
 				sceneName = movie.MovieFile.SceneName
+				break
+			}
+		}
+	}
+
+	// TMDB-id fallback: a removed-and-re-added movie gets a NEW internal Radarr id, so
+	// both the metadata-id lookup and the library path scan miss it and the file would
+	// be wrongly condemned. Resolve by the stable TMDB id instead.
+	//
+	// CRITICAL DELETE SAFETY: the resolved movie's file is deleted only when it actually
+	// matches the corrupt target, checked through the SAME radarrFileMatchesTarget matcher
+	// used by the path scan above (so the two cannot drift apart):
+	//   - file present AND matches   -> blocklist + delete + search (targetMovieFileID set)
+	//   - file present but DIFFERENT -> ErrEpisodeAlreadySatisfied, no delete
+	//   - no file yet                -> search only, no delete (targetMovieFileID stays 0)
+	if targetMovie == nil && metadata != nil && metadata.Movie != nil && metadata.Movie.TmdbId > 0 {
+		matches, lookupErr := client.GetMovieContext(ctx, &radarr.GetMovie{TMDBID: metadata.Movie.TmdbId})
+		if lookupErr != nil {
+			slog.WarnContext(ctx, "Radarr TMDB-id fallback lookup failed, falling through to queue/path-match handling",
+				"instance", instanceName, "tmdb_id", metadata.Movie.TmdbId, "error", lookupErr)
+		} else {
+			for _, movie := range matches {
+				if movie == nil || movie.TmdbID != metadata.Movie.TmdbId {
+					continue
+				}
+
+				if movie.HasFile && movie.MovieFile != nil {
+					if radarrFileMatchesTarget(movie, filePath, relativePath) {
+						slog.InfoContext(ctx, "Radarr TMDB-id fallback matched the corrupt target file",
+							"instance", instanceName, "tmdb_id", metadata.Movie.TmdbId,
+							"movie", movie.Title, "movie_path", movie.MovieFile.Path)
+						targetMovie = movie
+						targetMovieFileID = movie.MovieFile.ID
+						sceneName = movie.MovieFile.SceneName
+					} else {
+						// Re-added movie holds a DIFFERENT healthy file. Deleting it would
+						// destroy a good file; report satisfied so the redundant AltMount copy
+						// is cleaned up without any delete against Radarr.
+						slog.InfoContext(ctx, "Radarr TMDB-id fallback found a different healthy file; not deleting",
+							"instance", instanceName, "tmdb_id", metadata.Movie.TmdbId,
+							"movie", movie.Title, "movie_path", movie.MovieFile.Path, "file_path", filePath)
+						return model.ErrEpisodeAlreadySatisfied
+					}
+				} else {
+					// Movie re-added but has no file yet — search only, never delete.
+					slog.InfoContext(ctx, "Radarr TMDB-id fallback resolved movie with no file; search only",
+						"instance", instanceName, "tmdb_id", metadata.Movie.TmdbId, "movie", movie.Title)
+					targetMovie = movie
+				}
+				break
 			}
 		}
 	}

--- a/internal/arrs/scanner/matcher_test.go
+++ b/internal/arrs/scanner/matcher_test.go
@@ -1,0 +1,119 @@
+package scanner
+
+import (
+	"testing"
+
+	"golift.io/starr/radarr"
+)
+
+// movieWithFile builds a Radarr movie that has a file at the given path.
+func movieWithFile(path string) *radarr.Movie {
+	return &radarr.Movie{
+		Title:   "Test Movie",
+		HasFile: true,
+		MovieFile: &radarr.MovieFile{
+			ID:   42,
+			Path: path,
+		},
+	}
+}
+
+func TestRadarrFileMatchesTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		movie        *radarr.Movie
+		filePath     string
+		relativePath string
+		want         bool
+	}{
+		{
+			name:     "nil movie never matches",
+			movie:    nil,
+			filePath: "/movies/Film (2020)/Film.mkv",
+			want:     false,
+		},
+		{
+			name:     "movie without file never matches",
+			movie:    &radarr.Movie{Title: "No File", HasFile: false},
+			filePath: "/movies/Film (2020)/Film.mkv",
+			want:     false,
+		},
+		{
+			name: "HasFile true but nil MovieFile never matches",
+			movie: &radarr.Movie{
+				Title:     "Inconsistent",
+				HasFile:   true,
+				MovieFile: nil,
+			},
+			filePath: "/movies/Film (2020)/Film.mkv",
+			want:     false,
+		},
+		{
+			name:     "exact path match",
+			movie:    movieWithFile("/movies/Film (2020)/Film.mkv"),
+			filePath: "/movies/Film (2020)/Film.mkv",
+			want:     true,
+		},
+		{
+			name:     "basename match when parent directory differs",
+			movie:    movieWithFile("/data/movies/Film (2020)/Film.mkv"),
+			filePath: "/mnt/altmount/Film (2020)/Film.mkv",
+			want:     true,
+		},
+		{
+			name:     "different basename and path does not match",
+			movie:    movieWithFile("/movies/Other (2019)/Other.mkv"),
+			filePath: "/movies/Film (2020)/Film.mkv",
+			want:     false,
+		},
+		{
+			name:     "strm-stripped match: .strm filePath shares the movie stem",
+			movie:    movieWithFile("/movies/Film (2020)/Film.mkv"),
+			filePath: "/movies/Film (2020)/Film.strm",
+			want:     true,
+		},
+		{
+			name:     "strm-stripped mismatch: .strm stem differs from movie stem",
+			movie:    movieWithFile("/movies/Film (2020)/Film.mkv"),
+			filePath: "/movies/Film (2020)/Different.strm",
+			want:     false,
+		},
+		{
+			name:         "relative-suffix match on full relative path",
+			movie:        movieWithFile("/data/movies/Film (2020)/Film.mkv"),
+			filePath:     "/some/unrelated/path-xyz.mkv",
+			relativePath: "Film (2020)/Film.mkv",
+			want:         true,
+		},
+		{
+			name:         "relative-suffix match with .strm-stripped relative path",
+			movie:        movieWithFile("/data/movies/Film (2020)/Film.mkv"),
+			filePath:     "/some/unrelated/path-xyz.mkv",
+			relativePath: "Film (2020)/Film.strm",
+			want:         true,
+		},
+		{
+			name:         "relative path that is not a suffix does not match",
+			movie:        movieWithFile("/data/movies/Film (2020)/Film.mkv"),
+			filePath:     "/some/unrelated/path-xyz.mkv",
+			relativePath: "Other (2019)/Other.mkv",
+			want:         false,
+		},
+		{
+			name:     "completely different healthy file is not condemned",
+			movie:    movieWithFile("/data/movies/Healthy (2021)/Healthy.mkv"),
+			filePath: "/data/movies/Corrupt (2020)/Corrupt.mkv",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := radarrFileMatchesTarget(tt.movie, tt.filePath, tt.relativePath)
+			if got != tt.want {
+				t.Errorf("radarrFileMatchesTarget(%v, %q, %q) = %v, want %v",
+					tt.movie, tt.filePath, tt.relativePath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…afely

A removed-and-re-added Radarr movie gets a new internal id, so both the metadata-id lookup and the library path scan miss it and the corrupt file is wrongly condemned. Add a fallback that resolves the movie by its stable TMDB id via a targeted GetMovieContext(TMDBID) lookup.

Delete-safety is enforced through a single shared matcher, radarrFileMatchesTarget (exact path / basename / .strm-stripped / relative-suffix), which BOTH the library path scan and the TMDB-id fallback now route through so the rule cannot drift apart:
- file present AND matches the corrupt target -> blocklist + delete + search;
- file present but a DIFFERENT healthy file   -> ErrEpisodeAlreadySatisfied, no delete;
- no file yet                                 -> search only, no delete.

DeleteMovieFilesContext stays gated behind targetMovieFileID > 0, which the TMDB fallback only sets when the matcher confirms the target.


Claude-Session: https://claude.ai/code/session_01LGVEv2GpftTW5DWo9zXa1p