### PR TITLE
fix(config): always serialize acceptable_missing_segments_percentage

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -355,7 +355,7 @@ type HealthConfig struct {
 	VerifyData                          *bool        `yaml:"verify_data" mapstructure:"verify_data" json:"verify_data,omitempty"`
 	CheckAllSegments                    *bool        `yaml:"check_all_segments" mapstructure:"check_all_segments" json:"check_all_segments,omitempty"`
 	ReadTimeoutSeconds                  int          `yaml:"read_timeout_seconds" mapstructure:"read_timeout_seconds" json:"read_timeout_seconds,omitempty"`
-	AcceptableMissingSegmentsPercentage float64      `yaml:"acceptable_missing_segments_percentage" mapstructure:"acceptable_missing_segments_percentage" json:"acceptable_missing_segments_percentage,omitempty"`
+	AcceptableMissingSegmentsPercentage float64      `yaml:"acceptable_missing_segments_percentage" mapstructure:"acceptable_missing_segments_percentage" json:"acceptable_missing_segments_percentage"`
 	Repair                              RepairConfig `yaml:"repair" mapstructure:"repair" json:"repair"`
 }
 


### PR DESCRIPTION
The field carried json:",omitempty", so a value of 0 (the default and a meaningful "strict" setting) was dropped from the JSON config response and hidden in the UI. Remove omitempty so 0 serializes, matching how max_retries and other zero-meaningful fields are handled.


Claude-Session: https://claude.ai/code/session_01LGVEv2GpftTW5DWo9zXa1p