### PR TITLE
fix(arrs): redact API key in webhook registration log line

### DIFF
--- a/internal/arrs/registrar/manager.go
+++ b/internal/arrs/registrar/manager.go
@@ -48,8 +48,10 @@ func (m *Manager) EnsureWebhookRegistration(ctx context.Context, altmountURL str
 	allInstances := m.instances.GetAllInstances()
 	webhookName := "AltMount Webhook"
 	webhookURL := fmt.Sprintf("%s/api/arrs/webhook?apikey=%s", altmountURL, apiKey)
+	// Redact the API key when logging; the real webhookURL is still used for registration.
+	redactedWebhookURL := fmt.Sprintf("%s/api/arrs/webhook?apikey=***", altmountURL)
 
-	slog.InfoContext(ctx, "Ensuring webhook registration in ARR instances", "webhook_url", webhookURL)
+	slog.InfoContext(ctx, "Ensuring webhook registration in ARR instances", "webhook_url", redactedWebhookURL)
 
 	for _, instance := range allInstances {
 		if !instance.Enabled {


### PR DESCRIPTION
The webhook registration log emitted the full webhook URL including the plaintext apikey query parameter. Log a redacted URL (apikey=***) instead while still using the real URL for the actual *arr registration calls.


Claude-Session: https://claude.ai/code/session_01LGVEv2GpftTW5DWo9zXa1p