### PR TITLE
feat(importer): deduplicate completed NZB queue items

### DIFF
--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -238,8 +238,8 @@ func (r *QueueRepository) AddStoragePath(ctx context.Context, itemID int64, stor
 // the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42/x.nzb).
 func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (bool, error) {
 	filename := filepath.Base(filePath)
-	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status IN ('pending', 'processing', 'paused', 'completed') LIMIT 1`
-	likePattern := "%/" + filename
+	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\') AND status IN ('pending', 'processing', 'paused', 'completed') LIMIT 1`
+	likePattern := "%/" + escapeLikePattern(filename)
 
 	var exists int
 	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(&exists)
@@ -258,12 +258,12 @@ func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (b
 // completed item matches (not an error).
 func (r *QueueRepository) FindCompletedItemByNzbPath(ctx context.Context, filePath string) (*ImportQueueItem, error) {
 	filename := filepath.Base(filePath)
-	likePattern := "%/" + filename
+	likePattern := "%/" + escapeLikePattern(filename)
 	query := `
 		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
 		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path, skip_arr_notification, skip_post_import_links, indexer
 		FROM import_queue
-		WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status = 'completed'
+		WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\') AND status = 'completed'
 		ORDER BY completed_at DESC
 		LIMIT 1
 	`

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -190,7 +190,7 @@ func (r *QueueRepository) AddToQueue(ctx context.Context, item *ImportQueueItem)
 		started_at = NULL,
 		updated_at = datetime('now'),
 		relative_path = excluded.relative_path
-		WHERE status NOT IN ('processing', 'pending')
+		WHERE status NOT IN ('processing', 'pending', 'completed')
 	`
 
 	args := []any{item.DownloadID, item.NzbPath, item.RelativePath, item.Category, item.Priority, item.Status,
@@ -238,7 +238,7 @@ func (r *QueueRepository) AddStoragePath(ctx context.Context, itemID int64, stor
 // the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42/x.nzb).
 func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (bool, error) {
 	filename := filepath.Base(filePath)
-	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status IN ('pending', 'processing', 'paused') LIMIT 1`
+	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status IN ('pending', 'processing', 'paused', 'completed') LIMIT 1`
 	likePattern := "%/" + filename
 
 	var exists int
@@ -251,6 +251,35 @@ func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (b
 	}
 
 	return true, nil
+}
+
+// FindCompletedItemByNzbPath returns the most-recently completed queue item whose
+// nzb_path matches either exactly or by filename suffix. Returns nil, nil when no
+// completed item matches (not an error).
+func (r *QueueRepository) FindCompletedItemByNzbPath(ctx context.Context, filePath string) (*ImportQueueItem, error) {
+	filename := filepath.Base(filePath)
+	likePattern := "%/" + filename
+	query := `
+		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path, skip_arr_notification, skip_post_import_links, indexer
+		FROM import_queue
+		WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status = 'completed'
+		ORDER BY completed_at DESC
+		LIMIT 1
+	`
+	var item ImportQueueItem
+	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(
+		&item.ID, &item.DownloadID, &item.NzbPath, &item.RelativePath, &item.Category, &item.Priority, &item.Status,
+		&item.CreatedAt, &item.UpdatedAt, &item.StartedAt, &item.CompletedAt,
+		&item.RetryCount, &item.MaxRetries, &item.ErrorMessage, &item.BatchID, &item.Metadata, &item.FileSize, &item.StoragePath, &item.TargetPath, &item.SkipArrNotification, &item.SkipPostImportLinks, &item.Indexer,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find completed queue item by nzb path: %w", err)
+	}
+	return &item, nil
 }
 
 // ClaimNextQueueItem atomically claims and returns the next available queue item

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -233,16 +233,17 @@ func (r *QueueRepository) AddStoragePath(ctx context.Context, itemID int64, stor
 }
 
 // IsFileInQueue checks if a file is already in the queue (pending, processing, or paused).
-// It matches by exact nzb_path first, and also by filename suffix to handle the case where
-// ensurePersistentNzb has already moved the file and updated nzb_path from the temp path to
-// the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42/x.nzb).
+// It matches by exact nzb_path first, by filename suffix, and also by the ID-prefixed variant
+// that ensurePersistentNzb produces (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/42/123-x.nzb).
 func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (bool, error) {
 	filename := filepath.Base(filePath)
-	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\') AND status IN ('pending', 'processing', 'paused', 'completed') LIMIT 1`
-	likePattern := "%/" + escapeLikePattern(filename)
+	escaped := escapeLikePattern(filename)
+	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\' OR nzb_path LIKE ? ESCAPE '\') AND status IN ('pending', 'processing', 'paused', 'completed') LIMIT 1`
+	likePattern := "%/" + escaped
+	likePatternIDPrefixed := "%/%-" + escaped
 
 	var exists int
-	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(&exists)
+	err := r.db.QueryRowContext(ctx, query, filePath, likePattern, likePatternIDPrefixed).Scan(&exists)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
@@ -254,21 +255,24 @@ func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (b
 }
 
 // FindCompletedItemByNzbPath returns the most-recently completed queue item whose
-// nzb_path matches either exactly or by filename suffix. Returns nil, nil when no
-// completed item matches (not an error).
+// nzb_path matches exactly, by filename suffix, or by the ID-prefixed variant that
+// ensurePersistentNzb produces (e.g. /tmp/show.nzb → /persistent/123-show.nzb).
+// Returns nil, nil when no completed item matches (not an error).
 func (r *QueueRepository) FindCompletedItemByNzbPath(ctx context.Context, filePath string) (*ImportQueueItem, error) {
 	filename := filepath.Base(filePath)
-	likePattern := "%/" + escapeLikePattern(filename)
+	escaped := escapeLikePattern(filename)
+	likePattern := "%/" + escaped
+	likePatternIDPrefixed := "%/%-" + escaped
 	query := `
 		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
 		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path, skip_arr_notification, skip_post_import_links, indexer
 		FROM import_queue
-		WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\') AND status = 'completed'
+		WHERE (nzb_path = ? OR nzb_path LIKE ? ESCAPE '\' OR nzb_path LIKE ? ESCAPE '\') AND status = 'completed'
 		ORDER BY completed_at DESC
 		LIMIT 1
 	`
 	var item ImportQueueItem
-	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(
+	err := r.db.QueryRowContext(ctx, query, filePath, likePattern, likePatternIDPrefixed).Scan(
 		&item.ID, &item.DownloadID, &item.NzbPath, &item.RelativePath, &item.Category, &item.Priority, &item.Status,
 		&item.CreatedAt, &item.UpdatedAt, &item.StartedAt, &item.CompletedAt,
 		&item.RetryCount, &item.MaxRetries, &item.ErrorMessage, &item.BatchID, &item.Metadata, &item.FileSize, &item.StoragePath, &item.TargetPath, &item.SkipArrNotification, &item.SkipPostImportLinks, &item.Indexer,

--- a/internal/database/queue_repository_test.go
+++ b/internal/database/queue_repository_test.go
@@ -164,6 +164,84 @@ func TestGetQueueItemByNzbPath(t *testing.T) {
 	assert.Nil(t, notFound)
 }
 
+func TestAddToQueue_CompletedItem_NotRequeued(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	setupQueueSchema(t, db)
+
+	repo := NewQueueRepository(db, DialectSQLite)
+	ctx := context.Background()
+
+	// Add and complete an item.
+	item := &ImportQueueItem{NzbPath: "/nzbs/show.nzb", Priority: QueuePriorityNormal, Status: QueueStatusPending, MaxRetries: 3}
+	require.NoError(t, repo.AddToQueue(ctx, item))
+	_, err = db.Exec(`UPDATE import_queue SET status = 'completed' WHERE nzb_path = '/nzbs/show.nzb'`)
+	require.NoError(t, err)
+
+	// Try to re-add the same path.
+	item2 := &ImportQueueItem{NzbPath: "/nzbs/show.nzb", Priority: QueuePriorityNormal, Status: QueueStatusPending, MaxRetries: 3}
+	require.NoError(t, repo.AddToQueue(ctx, item2))
+
+	// The status must still be 'completed', not reset to 'pending'.
+	assert.Equal(t, "completed", getQueueItemStatusByPath(t, db, "/nzbs/show.nzb"))
+	assert.Equal(t, 1, countQueueItemsByStatus(t, db, "completed"))
+	assert.Equal(t, 0, countQueueItemsByStatus(t, db, "pending"))
+}
+
+func TestIsFileInQueue_CompletedItem_ReturnsTrue(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	setupQueueSchema(t, db)
+
+	insertQueueItem(t, db, 1, "/nzbs/show.nzb", "completed")
+	repo := NewQueueRepository(db, DialectSQLite)
+
+	inQueue, err := repo.IsFileInQueue(context.Background(), "/nzbs/show.nzb")
+	require.NoError(t, err)
+	assert.True(t, inQueue, "completed item should be reported as in-queue to prevent re-add")
+}
+
+func TestFindCompletedItemByNzbPath(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	setupQueueSchema(t, db)
+
+	insertQueueItem(t, db, 1, "/persistent/123-show.nzb", "completed")
+	insertQueueItem(t, db, 2, "/other/unrelated.nzb", "pending")
+	repo := NewQueueRepository(db, DialectSQLite)
+	ctx := context.Background()
+
+	t.Run("exact match", func(t *testing.T) {
+		got, err := repo.FindCompletedItemByNzbPath(ctx, "/persistent/123-show.nzb")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(1), got.ID)
+	})
+
+	t.Run("filename suffix match (path changed after ensurePersistentNzb)", func(t *testing.T) {
+		// Upload temp path differs from persisted path but shares filename.
+		got, err := repo.FindCompletedItemByNzbPath(ctx, "/tmp/uploads/123-show.nzb")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(1), got.ID)
+	})
+
+	t.Run("no match for pending item", func(t *testing.T) {
+		got, err := repo.FindCompletedItemByNzbPath(ctx, "/other/unrelated.nzb")
+		require.NoError(t, err)
+		assert.Nil(t, got, "pending items must not be returned")
+	})
+
+	t.Run("no match for unknown path", func(t *testing.T) {
+		got, err := repo.FindCompletedItemByNzbPath(ctx, "/does/not/exist.nzb")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
 func TestResetStaleItems_UpdatedAtFieldUpdated(t *testing.T) {
 	// Setup
 	db, err := sql.Open("sqlite3", ":memory:")

--- a/internal/database/queue_repository_test.go
+++ b/internal/database/queue_repository_test.go
@@ -203,6 +203,21 @@ func TestIsFileInQueue_CompletedItem_ReturnsTrue(t *testing.T) {
 	assert.True(t, inQueue, "completed item should be reported as in-queue to prevent re-add")
 }
 
+func TestIsFileInQueue_IDPrefixedCompletedItem_ReturnsTrue(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	defer db.Close()
+	setupQueueSchema(t, db)
+
+	// Stored with ensurePersistentNzb ID prefix, submitted under original name.
+	insertQueueItem(t, db, 1, "/nzbs/Movies/123-show.nzb", "completed")
+	repo := NewQueueRepository(db, DialectSQLite)
+
+	inQueue, err := repo.IsFileInQueue(context.Background(), "/tmp/uploads/show.nzb")
+	require.NoError(t, err)
+	assert.True(t, inQueue, "ID-prefixed completed item should be detected as in-queue")
+}
+
 func TestFindCompletedItemByNzbPath(t *testing.T) {
 	db, err := sql.Open("sqlite3", ":memory:")
 	require.NoError(t, err)
@@ -224,6 +239,14 @@ func TestFindCompletedItemByNzbPath(t *testing.T) {
 	t.Run("filename suffix match (path changed after ensurePersistentNzb)", func(t *testing.T) {
 		// Upload temp path differs from persisted path but shares filename.
 		got, err := repo.FindCompletedItemByNzbPath(ctx, "/tmp/uploads/123-show.nzb")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, int64(1), got.ID)
+	})
+
+	t.Run("ID-prefixed match (stremio: submitted as show.nzb, stored as 123-show.nzb)", func(t *testing.T) {
+		// ensurePersistentNzb renames to {id}-{original}; original upload name must still match.
+		got, err := repo.FindCompletedItemByNzbPath(ctx, "/tmp/uploads/show.nzb")
 		require.NoError(t, err)
 		require.NotNil(t, got)
 		assert.Equal(t, int64(1), got.ID)

--- a/internal/database/testing_test.go
+++ b/internal/database/testing_test.go
@@ -110,3 +110,13 @@ func countQueueItemsByStatus(t *testing.T, db *sql.DB, status string) int {
 	}
 	return count
 }
+
+func getQueueItemStatusByPath(t *testing.T, db *sql.DB, nzbPath string) string {
+	t.Helper()
+	var status string
+	err := db.QueryRow("SELECT status FROM import_queue WHERE nzb_path = ?", nzbPath).Scan(&status)
+	if err != nil {
+		t.Fatalf("Failed to get queue item status by path: %v", err)
+	}
+	return status
+}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -685,6 +685,16 @@ func (s *Service) AddToQueue(ctx context.Context, filePath string, relativePath 
 	default:
 	}
 
+	// Dedup: if an NZB with the same path (or filename) already completed
+	// successfully, return it as-is instead of re-queuing.
+	if existing, err := s.database.Repository.FindCompletedItemByNzbPath(ctx, filePath); err != nil {
+		return nil, fmt.Errorf("failed to check for completed duplicate: %w", err)
+	} else if existing != nil {
+		s.log.InfoContext(ctx, "NZB already completed, skipping duplicate",
+			"file", filePath, "existing_queue_id", existing.ID)
+		return existing, nil
+	}
+
 	// Calculate file size before adding to queue
 	var fileSize *int64
 	if size, err := s.CalculateFileSizeOnly(filePath); err == nil {


### PR DESCRIPTION
## Summary

- Adds deduplication so NZBs that have already been successfully imported (status `completed`) are never re-queued when the same file is uploaded again or picked up by the directory scanner
- Fixes an inconsistency where `AddToQueue`'s ON CONFLICT SQL would reset completed items back to `pending` (this was already guarded in `AddBatchToQueue` but not the single-item path)
- Escapes LIKE wildcards (`%`, `_`, `\`) in filename suffix match patterns, preventing false dedup matches on NZB filenames that contain those characters (e.g. `Show_S01E01_720p.nzb`)

## Changes

**`internal/database/queue_repository.go`**
- `AddToQueue`: added `'completed'` to the `ON CONFLICT … WHERE status NOT IN (…)` exclusion, making it consistent with `AddBatchToQueue`
- `IsFileInQueue`: added `'completed'` to the status IN list so the scanner path also short-circuits on completed items
- New `FindCompletedItemByNzbPath`: returns the most-recently completed item matching by exact path or filename suffix; used by the service layer pre-check

**`internal/importer/service.go`**
- `Service.AddToQueue`: added a pre-check at the top that calls `FindCompletedItemByNzbPath` and returns the existing completed item early, skipping all downstream work (file-size calculation, DB insert, `ensurePersistentNzb`, broadcaster)

## Test Plan

- [ ] `go test ./internal/database/... -run "TestAddToQueue_CompletedItem|TestIsFileInQueue_CompletedItem|TestFindCompletedItemByNzbPath"` — all pass
- [ ] `go test ./internal/...` — no regressions
- [ ] Upload an NZB via the API, let it complete, upload the same file again → API returns 201 with the existing completed item, no new queue row
- [ ] Add an NZB to a watched directory, let it complete, trigger a rescan → file is skipped
- [ ] Explicitly restart a completed item via the UI → still works (restart sets status to `pending` first, which is not blocked by this change)
- [ ] Upload a failing NZB, let it fail, upload again → still re-queues (only `completed` is deduplicated)