### PR TITLE
fix(arrs): remove out-of-scope movie reference after TMDB-id fallback loop

### DIFF
--- a/internal/arrs/scanner/manager.go
+++ b/internal/arrs/scanner/manager.go
@@ -738,9 +738,6 @@ func (m *Manager) triggerRadarrRescanByPath(ctx context.Context, client *radarr.
 				}
 			}
 
-			if targetMovieFileID > 0 {
-				sceneName = movie.MovieFile.SceneName
-			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Removes a 3-line post-loop block in `triggerRadarrRescanByPath` that referenced `movie` after the `for _, movie := range matches` loop had ended, causing `undefined: movie` at compile time.
- `sceneName` is already correctly assigned inside the loop alongside `targetMovieFileID` (line 723), so the redundant post-loop reassignment is dead code.

## Root cause

[CI failure](https://github.com/javi11/altmount/actions/runs/28293417846/job/83829153652):
```
internal/arrs/scanner/manager.go:742:17: undefined: movie
```

The `movie` variable was declared as the loop variable in `for _, movie := range matches` and is not in scope outside the loop body.

## Test plan

- [ ] `go build ./internal/arrs/scanner/...` passes locally (verified)
- [ ] CI green on this PR