### PR TITLE
fix(stremio): prevent duplicate NZB queue entries from concurrent requests

### DIFF
--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -207,77 +208,83 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 	nzbName := nzbtrim.TrimNzbExtension(safeFilename)
 	tempPath := filepath.Join(uploadDir, safeFilename)
 
-	// --- Short-circuit: return cached streams if NZB was already processed ---
-	// Respect the configurable TTL: 0 means cache forever, >0 means re-process after N hours.
+	// --- Find or add NZB to queue, deduplicated per filename ---
+	// stremioPlayGroup serialises all callers with the same safeFilename: the first
+	// one runs the full find-or-add path; concurrent duplicates (e.g. two users
+	// requesting the same release simultaneously) wait and share the returned queue
+	// item ID, preventing the TOCTOU race that previously created duplicate entries.
 	ttlHours := cfg.Stremio.NzbTTLHours
 
-	completedStatus := database.QueueStatusCompleted
-	existing, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, safeFilename, "", 1, 0, "updated_at", "desc")
-	if err == nil && len(existing) > 0 {
-		prev := existing[0]
-		cacheValid := prev.StoragePath != nil && *prev.StoragePath != ""
-		if cacheValid && ttlHours > 0 && prev.CompletedAt != nil {
-			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
-		}
-		if cacheValid {
-			if streams, err := s.buildStremioStreams(prev, baseURL, downloadKey, nzbName, selector); err == nil {
-				slog.InfoContext(ctx, "Returning cached Stremio streams for already-processed NZB",
+	rawID, sfErr, _ := s.stremioPlayGroup.Do(safeFilename, func() (interface{}, error) {
+		// Detach from the caller's request context so one client disconnecting
+		// does not abort work that other concurrent callers are also waiting on.
+		workCtx := context.WithoutCancel(ctx)
+
+		completedStatus := database.QueueStatusCompleted
+
+		// Check completed cache inside the critical section so two concurrent
+		// callers can't both miss it and both enqueue the same NZB.
+		if existing, e := s.queueRepo.ListQueueItems(workCtx, &completedStatus, safeFilename, "", 1, 0, "updated_at", "desc"); e == nil && len(existing) > 0 {
+			prev := existing[0]
+			cacheValid := prev.StoragePath != nil && *prev.StoragePath != ""
+			if cacheValid && ttlHours > 0 && prev.CompletedAt != nil {
+				cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
+			}
+			if cacheValid {
+				slog.InfoContext(workCtx, "Returning cached Stremio streams for already-processed NZB",
 					"nzb_name", nzbName, "queue_id", prev.ID)
-				return c.JSON(StremioStreamsResponse{
-					Streams:     streams,
-					QueueItemID: prev.ID,
-					QueueStatus: string(prev.Status),
-					Cached:      true,
-				})
+				return prev.ID, nil
 			}
 		}
-	}
 
-	// --- Short-circuit: join existing active queue item instead of re-adding ---
-	if inQueue, _ := s.queueRepo.IsFileInQueue(ctx, tempPath); inQueue {
-		activeItems, err := s.queueRepo.ListQueueItems(ctx, nil, safeFilename, "", 1, 0, "updated_at", "desc")
-		if err == nil && len(activeItems) > 0 {
-			return s.waitAndRespond(c, activeItems[0].ID, baseURL, downloadKey, nzbName, selector, timeoutSecs)
+		// Join an existing active queue item instead of re-adding.
+		if activeItems, e := s.queueRepo.ListQueueItems(workCtx, nil, safeFilename, "", 1, 0, "updated_at", "desc"); e == nil && len(activeItems) > 0 {
+			it := activeItems[0]
+			switch it.Status {
+			case database.QueueStatusPending, database.QueueStatusProcessing, database.QueueStatusPaused:
+				return it.ID, nil
+			}
 		}
+
+		// --- Save NZB to temp directory and add to queue ---
+		if s.importerService == nil {
+			return nil, fmt.Errorf("importer service not available")
+		}
+
+		if err := os.MkdirAll(uploadDir, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create upload directory: %w", err)
+		}
+		if err := os.WriteFile(tempPath, nzbData, 0644); err != nil {
+			return nil, fmt.Errorf("failed to save NZB file: %w", err)
+		}
+
+		if category == "" {
+			category = "stremio"
+		}
+		var basePath *string
+		if completeDir := cfg.SABnzbd.CompleteDir; completeDir != "" {
+			basePath = &completeDir
+		}
+
+		priority := database.QueuePriorityHigh
+		item, err := s.importerService.AddToQueue(workCtx, tempPath, basePath, &category, &priority, nil, nil)
+		if err != nil {
+			os.Remove(tempPath)
+			return nil, fmt.Errorf("failed to add NZB to queue: %w", err)
+		}
+
+		slog.InfoContext(workCtx, "NZB added to queue for Stremio stream processing",
+			"queue_id", item.ID,
+			"nzb_path", tempPath,
+			"timeout_secs", timeoutSecs)
+
+		return item.ID, nil
+	})
+	if sfErr != nil {
+		return RespondInternalError(c, "Failed to process NZB", sfErr.Error())
 	}
 
-	// --- Save NZB to temp directory ---
-	if err := os.MkdirAll(uploadDir, 0755); err != nil {
-		return RespondInternalError(c, "Failed to create upload directory", err.Error())
-	}
-
-	if err := os.WriteFile(tempPath, nzbData, 0644); err != nil {
-		return RespondInternalError(c, "Failed to save NZB file", err.Error())
-	}
-
-	// --- Add NZB to queue with high priority ---
-	if s.importerService == nil {
-		os.Remove(tempPath)
-		return RespondServiceUnavailable(c, "Importer service not available", "")
-	}
-
-	if category == "" {
-		category = "stremio"
-	}
-
-	var basePath *string
-	if completeDir := cfg.SABnzbd.CompleteDir; completeDir != "" {
-		basePath = &completeDir
-	}
-
-	priority := database.QueuePriorityHigh
-	item, err := s.importerService.AddToQueue(ctx, tempPath, basePath, &category, &priority, nil, nil)
-	if err != nil {
-		os.Remove(tempPath)
-		return RespondInternalError(c, "Failed to add NZB to queue", err.Error())
-	}
-
-	slog.InfoContext(ctx, "NZB added to queue for Stremio stream processing",
-		"queue_id", item.ID,
-		"nzb_path", tempPath,
-		"timeout_secs", timeoutSecs)
-
-	return s.waitAndRespond(c, item.ID, baseURL, downloadKey, nzbName, selector, timeoutSecs)
+	return s.waitAndRespond(c, rawID.(int64), baseURL, downloadKey, nzbName, selector, timeoutSecs)
 }
 
 // waitAndRespond subscribes to the progress broadcaster and waits for the queue item to

--- a/internal/database/queue_repository.go
+++ b/internal/database/queue_repository.go
@@ -235,11 +235,13 @@ func (r *QueueRepository) AddStoragePath(ctx context.Context, itemID int64, stor
 // IsFileInQueue checks if a file is already in the queue (pending, processing, or paused).
 // It matches by exact nzb_path first, and also by filename suffix to handle the case where
 // ensurePersistentNzb has already moved the file and updated nzb_path from the temp path to
-// the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42/x.nzb).
+// the persistent storage path (e.g. /tmp/altmount-uploads/x.nzb → /.nzbs/stremio/42-x.nzb).
+// The LIKE pattern uses "%-filename" (dash wildcard) rather than "%/filename" so it also
+// matches the "<id>-<base>.nzb" naming that ensurePersistentNzb applies on collision.
 func (r *QueueRepository) IsFileInQueue(ctx context.Context, filePath string) (bool, error) {
 	filename := filepath.Base(filePath)
 	query := `SELECT 1 FROM import_queue WHERE (nzb_path = ? OR nzb_path LIKE ?) AND status IN ('pending', 'processing', 'paused') LIMIT 1`
-	likePattern := "%/" + filename
+	likePattern := "%-" + filename
 
 	var exists int
 	err := r.db.QueryRowContext(ctx, query, filePath, likePattern).Scan(&exists)

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -778,6 +778,15 @@ func (s *Service) FindAndUpdatePendingUpload(ctx context.Context, filename strin
 		return nil, err
 	}
 	items = append(items, oldItems...)
+	// Also search the Stremio upload staging directory: handleNzbStreams writes there
+	// before calling AddToQueue, so without this scan Stremio-submitted NZBs are never
+	// found by FindAndUpdatePendingUpload and always create a new queue entry.
+	stremioUploadDir := filepath.Join(os.TempDir(), "altmount-uploads")
+	stremioItems, err := s.database.Repository.GetPendingQueueItemsByPathPrefix(ctx, stremioUploadDir+string(filepath.Separator))
+	if err != nil {
+		return nil, err
+	}
+	items = append(items, stremioItems...)
 
 	for _, it := range items {
 		// Persisted name is "<base><ext>" or, on collision, "<id>-<base><ext>".


### PR DESCRIPTION
## Summary

- **TOCTOU race (primary):** `handleNzbStreams` checked `IsFileInQueue` and then called `AddToQueue` in two separate, non-atomic steps. Two concurrent callers for the same NZB URL (e.g. two users playing the same movie) both read "not in queue" before either had written to the DB, then each added a separate queue entry. Fixed by wrapping the entire find-or-add block in `s.stremioPlayGroup.Do(safeFilename, ...)` so concurrent requests share one execution and one queue item.
- **`IsFileInQueue` LIKE pattern missed ID-prefixed paths:** `ensurePersistentNzb` renames files to `<id>-<base>.nzb` on persistence, but the old pattern `"%/<base>.nzb"` didn't match the renamed form. Changed to `"%-<base>.nzb"` so sequential duplicate requests are also caught after the file is moved.
- **`FindAndUpdatePendingUpload` searched the wrong directory:** The function scanned `os.TempDir()/.altmount-queue` and the legacy `.nzbs/` folder, but `handleNzbStreams` writes to `os.TempDir()/altmount-uploads` — a completely different path, so Stremio-submitted NZBs were never found as pending duplicates. Added `altmount-uploads` to the scan list.

## Root Cause Detail

The three bugs compound: multiple users trigger concurrent sends (race condition bypasses the singleflight the AIOStreams side only holds per-user), and even sequential re-requests from the same user after the queue item has been persisted (LIKE mismatch + wrong directory scan) fail to deduplicate. Every re-request for a popular title would add a new queue entry.

## Test Plan

- [x] All existing tests pass with `-race` flag: `go test -race ./internal/api/... ./internal/database/... ./internal/importer/...`
- [ ] Manual: send two concurrent `POST /api/nzb/streams` requests with the same `nzb_url` — confirm only one queue item is created
- [ ] Manual: send a second request after the first has moved to processing — confirm `IsFileInQueue` returns `true` and the second request joins the existing item