### PR TITLE
fix(strm): strip .meta extension from stream URL in directory STRM generation

### DIFF
--- a/internal/importer/postprocessor/strm_generator.go
+++ b/internal/importer/postprocessor/strm_generator.go
@@ -94,7 +94,7 @@ func (c *Coordinator) CreateStrmFiles(ctx context.Context, item *database.Import
 		// double-prefix the category/CompleteDir on Windows (issue #585).
 		strmResultingPath := buildLibraryRelPath(relPath, cfg.SABnzbd.CompleteDir, category)
 
-		if err := c.CreateSingleStrmFile(ctx, strmResultingPath, relPathWithMeta, cfg.WebDAV.Port); err != nil {
+		if err := c.CreateSingleStrmFile(ctx, strmResultingPath, relPath, cfg.WebDAV.Port); err != nil {
 			c.log.ErrorContext(ctx, "Failed to create STRM file",
 				"path", relPath,
 				"error", err)


### PR DESCRIPTION
## Summary

- Generated `.strm` files for multi-file releases contained `.meta` in the stream URL path (e.g. `?path=complete/TestFile/TestFile.mkv.meta`), making them unplayable in VLC and other media players.
- Root cause: in the `WalkDir` branch of `CreateStrmFiles`, `relPathWithMeta` (the raw disk-relative path including the `.meta` suffix) was being passed as `originalVirtualPath` to `CreateSingleStrmFile` instead of `relPath` (the correct virtual path with `.meta` stripped).
- Fix: one-line change in `internal/importer/postprocessor/strm_generator.go` to pass `relPath` instead of `relPathWithMeta`.

## What changed

`internal/importer/postprocessor/strm_generator.go` line 97: pass `relPath` (without `.meta`) as the virtual path used to build the stream URL.

## Note

This fix affects **newly generated** `.strm` files only. Existing files with the bad URL need to be deleted and re-generated (re-processing the queue item will recreate them correctly).

Fixes #744