### PR TITLE
fix(dashboard): show Stremio API streams in active-streams playback panel

### DIFF
--- a/frontend/src/components/system/ActivityHub.tsx
+++ b/frontend/src/components/system/ActivityHub.tsx
@@ -55,6 +55,7 @@ export function ActivityHub() {
 	const getClientApp = (ua?: string) => {
 		if (!ua) return { name: "Unknown Client", icon: User };
 		const lowUA = ua.toLowerCase();
+		if (lowUA.includes("stremio")) return { name: "Stremio", icon: Play };
 		if (lowUA.includes("plex")) return { name: "Plex", icon: Play };
 		if (lowUA.includes("infuse")) return { name: "Infuse", icon: Play };
 		if (lowUA.includes("vlc")) return { name: "VLC", icon: FileVideo };
@@ -79,9 +80,9 @@ export function ActivityHub() {
 	const groupedStreams = useMemo(() => {
 		if (!allStreams) return [];
 
-		// Filter to show only active streaming sessions (WebDAV or FUSE)
+		// Filter to show only active streaming sessions (WebDAV, FUSE, or API/Stremio)
 		const streamingOnly = allStreams.filter((s) => {
-			const isSystemSource = s.source === "WebDAV" || s.source === "FUSE";
+			const isSystemSource = s.source === "WebDAV" || s.source === "FUSE" || s.source === "API";
 			const isStreaming = s.status === "Streaming";
 
 			// Heuristic: Filter out metadata probes and very short system scans


### PR DESCRIPTION
## Summary

- Stremio streams played via `/api/files/stream` are registered in the stream tracker with `source = "API"`, but the Dashboard Playback tab filtered to only `source === "WebDAV" || source === "FUSE"`, silently dropping them.
- Added `"API"` to the `isSystemSource` predicate in `ActivityHub.tsx` so Stremio streams appear in the Playback tab like any other active stream.
- Added `"stremio"` to the user-agent detection so the client app label shows **Stremio** instead of the generic **Media Player** fallback.

## What changed

**`frontend/src/components/system/ActivityHub.tsx`**
- `isSystemSource` now includes `s.source === "API"` (3 chars, one condition added)
- `getClientApp()` checks for `"stremio"` in the user-agent string before the generic fallbacks

## No backend changes

The stream tracker backend was already working correctly — streams via `/api/files/stream` are registered and returned by `GET /api/files/active-streams`. The bug was entirely in the frontend filter.

## Test plan

- [ ] Play something via the Stremio addon or `curl /api/files/stream?path=...&download_key=...`
- [ ] Open Dashboard → Playback tab — stream appears with a "Stremio" client label
- [ ] Verify WebDAV and FUSE streams still appear (no regression)
- [ ] `bun run check` passes (only pre-existing unrelated warning)