### PR TITLE
fix(health): skip repair on streaming failure when health is disabled

### DIFF
--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -93,7 +93,7 @@ type repairTestEnv struct {
 	hw              *HealthWorker
 }
 
-func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error) *repairTestEnv {
+func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...func(*config.Config)) *repairTestEnv {
 	t.Helper()
 
 	db, err := sql.Open("sqlite3", "file::memory:?cache=shared&mode=memory")
@@ -146,6 +146,10 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error) *repairTestEn
 	cfg.Health.CheckIntervalSeconds = 3600
 	cfg.Health.SegmentSamplePercentage = 10
 	cfg.Health.MaxConnectionsForHealthChecks = 1
+
+	for _, fn := range configure {
+		fn(cfg)
+	}
 
 	configManager := config.NewManager(cfg, "")
 
@@ -420,6 +424,51 @@ func TestE2E_ExhaustedRepairTriggered_SweptToCorrupted(t *testing.T) {
 	original, readErr := env.metadataService.ReadFileMetadata(filePath)
 	require.NoError(t, readErr)
 	assert.NotNil(t, original, "sweep must not move metadata of a possibly-good copy")
+}
+
+// TestE2E_RepairDisabled_NoARRRescan verifies that when health.repair.enabled is false, a
+// file that exhausts its health-check retries is finalized as corrupted for visibility but
+// never triggers an Arr rescan and its metadata is left in place (no safety-folder move).
+func TestE2E_RepairDisabled_NoARRRescan(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	tempDir := t.TempDir()
+	repairDisabled := false
+	env := newRepairTestEnv(t, tempDir, nil, func(c *config.Config) {
+		c.Health.Repair.Enabled = &repairDisabled
+	})
+
+	ctx := context.Background()
+	filePath := "series/show.s01e09.mkv"
+	libraryPath := "/media/library/show.s01e09.mkv"
+	maxRetries := 3
+
+	meta := validSegmentMeta(env.metadataService, 1024)
+	require.NoError(t, env.metadataService.WriteFileMetadata(filePath, meta))
+
+	// File already at its last health retry: a single failing cycle would normally
+	// trigger a repair, but repair is disabled.
+	insertFileHealth(t, env.db, filePath, libraryPath, maxRetries-1, maxRetries)
+
+	require.NoError(t, env.hw.runHealthCheckCycle(ctx))
+
+	// ARR must NOT be called when repair is disabled.
+	env.mockARRs.mu.Lock()
+	callCount := len(env.mockARRs.calls)
+	env.mockARRs.mu.Unlock()
+	assert.Equal(t, 0, callCount, "repair disabled must not trigger an ARR rescan")
+
+	// Status finalized as corrupted for visibility.
+	fh, err := env.healthRepo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status)
+
+	// Metadata must be left in place — no safety-folder move when repair is disabled.
+	original, readErr := env.metadataService.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "repair disabled must not move metadata to the corrupted folder")
 }
 
 // TestE2E_FileRepairTriggered_ARRReturnsAlreadySatisfied verifies that when ARR returns

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -737,7 +737,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 	// when it is disabled, corrupt files are left in the corrupted state and we never
 	// re-trigger an Arr rescan.
 	var repairFiles []*database.FileHealth
-	if hw.configGetter().GetRepairEnabled() {
+	if cfg.GetRepairEnabled() {
 		repairFiles, err = hw.healthRepo.GetFilesForRepairNotification(ctx, maxJobs)
 		if err != nil {
 			return fmt.Errorf("failed to get files for repair notification: %w", err)

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -430,8 +430,26 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 	update.ErrorMessage = errorMsg
 	update.ErrorDetails = event.Details
 
+	// When automatic repair is disabled, never trigger or re-trigger an Arr rescan: a file
+	// that has exhausted its health-check retries (or is already in repair_triggered from a
+	// time when repair was enabled) is finalized as corrupted for visibility, with no
+	// metadata safety-folder move. Regular health-check retries below are left intact.
+	repairEnabled := hw.configGetter().GetRepairEnabled()
+	markCorruptedNoRepair := func() (*database.HealthStatusUpdate, func() error) {
+		update.Type = database.UpdateTypeCorrupted
+		update.Status = database.HealthStatusCorrupted
+		return update, func() error {
+			slog.InfoContext(ctx, "File corrupted but repair is disabled; marking corrupted without triggering repair",
+				"file_path", fh.FilePath, "status", fh.Status)
+			return nil
+		}
+	}
+
 	switch fh.Status {
 	case database.HealthStatusRepairTriggered:
+		if !repairEnabled {
+			return markCorruptedNoRepair()
+		}
 		if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
 			sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
 		} else {
@@ -474,6 +492,11 @@ func (hw *HealthWorker) prepareUpdateForResult(ctx context.Context, fh *database
 			if fh.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
 				sideEffect = hw.markCorruptedRepairExhausted(ctx, fh, update, errorMsg)
 				return update, sideEffect
+			}
+
+			// Repair disabled: finalize as corrupted instead of triggering an Arr rescan.
+			if !repairEnabled {
+				return markCorruptedNoRepair()
 			}
 
 			update.Type = database.UpdateTypeRepairTrigger
@@ -710,10 +733,15 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		return fmt.Errorf("failed to get unhealthy files: %w", err)
 	}
 
-	// Get files that need repair notifications
-	repairFiles, err := hw.healthRepo.GetFilesForRepairNotification(ctx, maxJobs)
-	if err != nil {
-		return fmt.Errorf("failed to get files for repair notification: %w", err)
+	// Get files that need repair notifications. Only when automatic repair is enabled —
+	// when it is disabled, corrupt files are left in the corrupted state and we never
+	// re-trigger an Arr rescan.
+	var repairFiles []*database.FileHealth
+	if hw.configGetter().GetRepairEnabled() {
+		repairFiles, err = hw.healthRepo.GetFilesForRepairNotification(ctx, maxJobs)
+		if err != nil {
+			return fmt.Errorf("failed to get files for repair notification: %w", err)
+		}
 	}
 
 	totalFiles := len(unhealthyFiles) + len(repairFiles)

--- a/internal/nzbfilesystem/health_disabled_test.go
+++ b/internal/nzbfilesystem/health_disabled_test.go
@@ -1,0 +1,161 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"runtime"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/usenet"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupStreamHealthEnv builds an in-memory health repository and a metadata service rooted
+// in a temp dir, so the streaming-failure handler (updateFileHealthOnError) can be exercised
+// end-to-end against real persistence.
+func setupStreamHealthEnv(t *testing.T) (*database.HealthRepository, *sql.DB, *metadata.MetadataService) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", "file::memory:?cache=shared&mode=memory")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE file_health (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			file_path TEXT NOT NULL UNIQUE,
+			library_path TEXT,
+			status TEXT NOT NULL,
+			last_checked DATETIME,
+			last_error TEXT,
+			retry_count INTEGER DEFAULT 0,
+			max_retries INTEGER DEFAULT 3,
+			repair_retry_count INTEGER DEFAULT 0,
+			max_repair_retries INTEGER DEFAULT 3,
+			source_nzb_path TEXT,
+			error_details TEXT,
+			metadata TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			release_date DATETIME,
+			scheduled_check_at DATETIME,
+			priority INTEGER DEFAULT 0,
+			streaming_failure_count INTEGER DEFAULT 0,
+			is_masked BOOLEAN DEFAULT FALSE,
+			indexer TEXT DEFAULT NULL
+		);
+	`)
+	require.NoError(t, err)
+
+	return database.NewHealthRepository(db, database.DialectSQLite), db, metadata.NewMetadataService(t.TempDir())
+}
+
+// newStreamFailureMVF wires a MetadataVirtualFile to the given real services with a nil
+// repairCoalescer (ShouldTrigger returns true, EnqueueRefresh is a no-op).
+func newStreamFailureMVF(ctx context.Context, name string, repo *database.HealthRepository, ms *metadata.MetadataService, seg []*metapb.SegmentData, cfg *config.Config) *MetadataVirtualFile {
+	return &MetadataVirtualFile{
+		name:             name,
+		ctx:              ctx,
+		meta:             &fileHandleMeta{FileSize: 1024, SegmentData: seg},
+		metadataService:  ms,
+		healthRepository: repo,
+		configGetter:     func() *config.Config { return cfg },
+	}
+}
+
+func writeStreamMeta(t *testing.T, ms *metadata.MetadataService, filePath string) []*metapb.SegmentData {
+	t.Helper()
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		[]*metapb.SegmentData{{Id: "a@b.example.com", SegmentSize: 1024, StartOffset: 0, EndOffset: 1023}},
+		metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	require.NoError(t, ms.WriteFileMetadata(filePath, meta))
+	return meta.SegmentData
+}
+
+// TestUpdateFileHealthOnError_HealthDisabled_NoRepair pins the bug fix: a mid-stream
+// DataCorruptionError while the health system is disabled records the file as corrupted for
+// visibility but does NOT trigger a repair (no repair_triggered status, no metadata move).
+func TestUpdateFileHealthOnError_HealthDisabled_NoRepair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e01.mkv"
+	libraryPath := "/media/library/stream.s01e01.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	// Pre-existing imported health record (with library_path) — the enabled path would move it.
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, libraryPath,
+	)
+	require.NoError(t, err)
+
+	disabled := false
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &disabled
+	cfg.MountPath = ""
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{UnderlyingErr: errors.New("article not found"), NoRetry: true}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusCorrupted, fh.Status,
+		"health disabled must record corrupted, not repair_triggered")
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.NotNil(t, original, "health disabled must not move metadata to the corrupted folder")
+}
+
+// TestUpdateFileHealthOnError_HealthEnabled_TriggersRepair guards the unchanged behavior:
+// with the health system enabled, a mid-stream failure triggers the repair (repair_triggered
+// status + metadata moved to the corrupted folder).
+func TestUpdateFileHealthOnError_HealthEnabled_TriggersRepair(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks not supported on Windows")
+	}
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/stream.s01e02.mkv"
+	libraryPath := "/media/library/stream.s01e02.mkv"
+	seg := writeStreamMeta(t, ms, filePath)
+
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at) VALUES (?, ?, 'healthy', datetime('now'))`,
+		filePath, libraryPath,
+	)
+	require.NoError(t, err)
+
+	enabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &enabled
+	cfg.MountPath = ""
+
+	mvf := newStreamFailureMVF(ctx, filePath, repo, ms, seg, cfg)
+	mvf.updateFileHealthOnError(&usenet.DataCorruptionError{UnderlyingErr: errors.New("article not found"), NoRetry: true}, true)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, database.HealthStatusRepairTriggered, fh.Status,
+		"health enabled must trigger repair")
+
+	original, readErr := ms.ReadFileMetadata(filePath)
+	require.NoError(t, readErr)
+	assert.Nil(t, original, "health enabled must move metadata to the corrupted folder")
+}

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -2065,8 +2065,11 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	ctx, cancel := context.WithTimeout(mvf.ctx, 5*time.Second)
 	defer cancel()
 
+	cfg := mvf.configGetter()
+	healthEnabled := cfg.GetHealthEnabled()
+
 	// Any file with missing segments or corruption is marked as corrupted in metadata
-	// and DB to trigger the repair cycle via the health worker.
+	// and DB so it stays visible on the Health page, regardless of whether repair runs.
 	metadataStatus := metapb.FileStatus_FILE_STATUS_CORRUPTED
 
 	// Update metadata status (blocking with timeout)
@@ -2085,47 +2088,61 @@ func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usene
 	errorDetails := fmt.Sprintf(`{"missing_articles": %d, "total_articles": %d, "error_type": "ArticleNotFound"}`,
 		1, len(mvf.meta.SegmentData))
 
-	// Mark as repair_triggered with high priority to trigger the replacement immediately.
-	// We skip the re-verification phase because a streaming failure is a definitive indicator of corruption.
-	slog.InfoContext(ctx, "Streaming failure detected, triggering immediate ARR repair", "file", mvf.name)
-	dbStatus := database.HealthStatusRepairTriggered
+	// The repair action (repair_triggered status + metadata safety-folder move + Arr
+	// redownload) only runs when the health system is enabled. When it is disabled we
+	// record the corruption for visibility but take no repair action whatsoever.
+	var dbStatus database.HealthStatus
+	scheduleImmediately := false
+	if healthEnabled {
+		// Mark as repair_triggered with high priority to trigger the replacement immediately.
+		// We skip the re-verification phase because a streaming failure is a definitive indicator of corruption.
+		slog.InfoContext(ctx, "Streaming failure detected, triggering immediate ARR repair", "file", mvf.name)
+		dbStatus = database.HealthStatusRepairTriggered
+		// noRetry signals a definitive corruption (e.g. article-not-found); force immediate
+		// pick-up by the HealthWorker so the replacement is scheduled without re-verification.
+		scheduleImmediately = noRetry
 
-	// If the file has already been imported (has a library path), move metadata to the safety folder
-	// so that the ARR rescan definitively sees the file as missing and triggers a redownload.
-	if health, err := mvf.healthRepository.GetFileHealth(ctx, mvf.name); err == nil && health != nil {
-		if health.LibraryPath != nil && *health.LibraryPath != "" {
-			cfg := mvf.configGetter()
-			relativePath := strings.TrimPrefix(mvf.name, cfg.MountPath)
-			relativePath = strings.TrimPrefix(relativePath, "/")
-			slog.InfoContext(ctx, "Moving metadata file for corrupted item to safety folder to trigger replacement", "file_path", mvf.name)
-			if moveErr := mvf.metadataService.MoveToCorrupted(ctx, relativePath); moveErr == nil {
-				// Successfully moved metadata, enqueue a coalesced rclone VFS
-				// refresh. Multiple files in the same directory collapse into a
-				// single RC call; concurrent failures across directories are
-				// batched into one call as well. EnqueueRefresh is a no-op on a
-				// nil coalescer (test harness).
-				mvf.repairCoalescer.EnqueueRefresh(filepath.Dir(mvf.name))
-			} else {
-				slog.WarnContext(ctx, "Failed to move corrupted metadata file, proceeding with repair trigger status", "error", moveErr)
+		// If the file has already been imported (has a library path), move metadata to the safety folder
+		// so that the ARR rescan definitively sees the file as missing and triggers a redownload.
+		if health, err := mvf.healthRepository.GetFileHealth(ctx, mvf.name); err == nil && health != nil {
+			if health.LibraryPath != nil && *health.LibraryPath != "" {
+				relativePath := strings.TrimPrefix(mvf.name, cfg.MountPath)
+				relativePath = strings.TrimPrefix(relativePath, "/")
+				slog.InfoContext(ctx, "Moving metadata file for corrupted item to safety folder to trigger replacement", "file_path", mvf.name)
+				if moveErr := mvf.metadataService.MoveToCorrupted(ctx, relativePath); moveErr == nil {
+					// Successfully moved metadata, enqueue a coalesced rclone VFS
+					// refresh. Multiple files in the same directory collapse into a
+					// single RC call; concurrent failures across directories are
+					// batched into one call as well. EnqueueRefresh is a no-op on a
+					// nil coalescer (test harness).
+					mvf.repairCoalescer.EnqueueRefresh(filepath.Dir(mvf.name))
+				} else {
+					slog.WarnContext(ctx, "Failed to move corrupted metadata file, proceeding with repair trigger status", "error", moveErr)
+				}
 			}
 		}
+	} else {
+		// Health system disabled: record the corruption for visibility only and skip
+		// every repair action (no repair_triggered status, no metadata move, no Arr redownload).
+		slog.InfoContext(ctx, "Streaming failure detected but health system disabled, marking corrupted without triggering repair", "file", mvf.name)
+		dbStatus = database.HealthStatusCorrupted
 	}
 
-	// Update database with high priority (scheduled for immediate pick-up by HealthWorker)
+	// Update database health tracking. scheduleImmediately (noRetry) forces immediate
+	// pick-up by the HealthWorker, which is only desired when a repair was actually triggered.
 	if err := mvf.healthRepository.UpdateFileHealthScheduled(ctx,
 		mvf.name,
 		dbStatus,
 		&errorMsg,
 		sourceNzbPath,
 		&errorDetails,
-		true, // noRetry=true forces it to be picked up for repair immediately
+		scheduleImmediately,
 		time.Now().UTC(),
 	); err != nil {
 		slog.WarnContext(ctx, "Failed to update health database for streaming failure", "file", mvf.name, "error", err)
 	}
 
 	// Increment failure count for tracking/masking if enabled
-	cfg := mvf.configGetter()
 	if cfg.Streaming.FailureMasking.Enabled == nil || *cfg.Streaming.FailureMasking.Enabled {
 		isMasked, _, err := mvf.healthRepository.IncrementStreamingFailureCount(ctx, mvf.name, cfg.Streaming.FailureMasking.Threshold)
 		if err != nil {


### PR DESCRIPTION
## Problem

A title imports successfully and plays back via Stremio, but partway through playback an NNTP article is no longer available on the providers. The streaming read raises a `DataCorruptionError` and AltMount reacts by **triggering a repair** — marking the file `repair_triggered`, moving its `.meta` into `corrupted_metadata/` so the Arr sees it as missing, and asking the Arr to redownload — **even when the health/repair system is disabled in config**.

Root cause: the streaming-failure handler (`updateFileHealthOnError`) never consulted any enable flag, and the `health.repair.enabled` toggle was dead code (defined but never read anywhere).

## Changes

- **Streaming path** (`internal/nzbfilesystem/metadata_remote_file.go`): gate the repair trigger on `health.enabled`. When health is disabled, the file is still recorded as `corrupted` for UI visibility and streaming-failure masking still works, but it is **not** set to `repair_triggered`, the `.meta` is **not** moved to `corrupted_metadata/`, and no Arr redownload is requested. Enabled behavior is unchanged.
- **Health worker** (`internal/health/worker.go`): now honors `health.repair.enabled` (previously dead code). When repair is disabled, the worker skips the repair-notification batch and finalizes corrupt files as `corrupted` instead of triggering an Arr rescan (`TriggerFileRescan`) or moving metadata. Regular health-check retries are unaffected.
- **Tests**: added regression coverage for both paths (`health_disabled_test.go` for the streaming handler; `TestE2E_RepairDisabled_NoARRRescan` for the worker).

## Behavior summary

| Config | Mid-stream failure outcome |
|--------|----------------------------|
| `health.enabled: true` (default) | `repair_triggered` + metadata move + Arr redownload (unchanged) |
| `health.enabled: false` | marked `corrupted` for visibility, masking kept, **no repair** |
| `health.repair.enabled: false` (worker) | corrupt files finalized as `corrupted`, **no Arr rescan** |

## Reviewer notes

- Per design choice, the **streaming** trigger is gated on `health.enabled` only. With `health.enabled: true` **and** `health.repair.enabled: false`, the streaming path still records `repair_triggered`/moves metadata, while the worker no longer re-triggers the Arr. Tightening the streaming path to also respect `repair.enabled` is a one-line follow-up if desired.

## Verification

- `go test -race ./internal/nzbfilesystem/... ./internal/health/...` — green; logs confirm each gated branch fires.
- `go vet`, `gofmt`, and `golangci-lint` on the changed packages — clean (0 issues).
- Note: repo-wide `make` currently fails on 3 **pre-existing** golangci-lint issues in untouched files (`internal/arrs/service_test.go`, `internal/database/health_repository.go`) that already fail on `main`; not addressed here.