### PR TITLE
fix(config): correct inaccurate configuration UI descriptions

### DIFF
--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -207,7 +207,8 @@ export function HealthConfigSection({
 										min="1"
 									/>
 									<p className="label break-words text-[10px] text-base-content/50">
-										Wait time before the first repair re-notification.
+										Base wait time between repair re-notifications, applied on every retry (doubled
+										each time if exponential back-off is enabled).
 									</p>
 								</fieldset>
 
@@ -430,8 +431,7 @@ export function HealthConfigSection({
 												Ghost File Detection
 											</span>
 											<span className="mt-0.5 block break-words text-[11px] text-base-content/50 leading-snug">
-												Reads one byte from each checked segment to confirm the Usenet data still
-												exists.
+												Reserved for a future data-integrity check. Currently has no effect.
 											</span>
 										</div>
 									</label>

--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -120,7 +120,7 @@ export function StreamingConfigSection({
 						</div>
 						<div className="mt-1 break-words text-[11px] leading-relaxed opacity-80">
 							Higher values improve stability on slow connections but increase initial memory usage.
-							Default (30) is recommended for most 4K streaming scenarios.
+							Default (60) is recommended for most 4K streaming scenarios.
 						</div>
 					</div>
 				</div>
@@ -270,7 +270,7 @@ export function StreamingConfigSection({
 									Each cached entry corresponds to one decoded Usenet article (~750 KB). On a cache
 									hit the data is served directly from disk with no network round-trip. Eviction
 									runs automatically every 5 minutes, removing expired entries and enforcing the
-									size limit via LRU. Files that are currently open are never evicted.
+									size limit by evicting least-recently-used entries first.
 								</div>
 							</div>
 						</div>

--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -345,8 +345,8 @@ export function StremioConfigSection({
 									}}
 								/>
 								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
-									Newznab category IDs. Press Enter or comma to add. Defaults: 2000 (Movies), 2040
-									(Movies/HD), 2060 (Movies/4K), 5000 (TV), 5040 (TV/HD).
+									Newznab category IDs. Press Enter or comma to add. Defaults: 2000, 2010, 2030,
+									2040, 2045, 2060 (Movies) and 5000, 5010, 5030, 5040 (TV).
 								</p>
 							</fieldset>
 

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -494,31 +494,18 @@ export function ImportConfigSection({
 								className="btn btn-sm btn-outline border-base-300 text-base-content/80 hover:opacity-100"
 								disabled={isReadOnly}
 								onClick={() => {
-									const videoDefaults = [
-										".mp4",
+									// Mirrors the backend default whitelist in
+									// internal/config/manager.go (ImportConfig.AllowedFileExtensions).
+									const defaultExtensions = [
 										".mkv",
+										".mp4",
 										".avi",
+										".ts",
+										".m4v",
 										".mov",
 										".wmv",
-										".flv",
-										".webm",
-										".m4v",
 										".mpg",
 										".mpeg",
-										".m2ts",
-										".ts",
-										".vob",
-										".3gp",
-										".3g2",
-										".h264",
-										".h265",
-										".hevc",
-										".ogv",
-										".ogm",
-										".strm",
-										".iso",
-										".img",
-										".divx",
 										".xvid",
 										".rm",
 										".rmvb",
@@ -527,11 +514,17 @@ export function ImportConfigSection({
 										".wtv",
 										".mk3d",
 										".dvr-ms",
+										".mp3",
+										".flac",
+										".m4a",
+										".epub",
+										".pdf",
+										".cbz",
 									];
-									handleInputChange("allowed_file_extensions", videoDefaults);
+									handleInputChange("allowed_file_extensions", defaultExtensions);
 								}}
 							>
-								Reset to Video Defaults
+								Reset to Defaults
 							</button>
 							<button
 								type="button"

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -744,7 +744,7 @@ export const CONFIG_SECTIONS: Record<ConfigSection | "system", ConfigSectionInfo
 	},
 	streaming: {
 		title: "Streaming & Downloads",
-		description: "File streaming, chunking and download worker configuration",
+		description: "Segment prefetch and on-disk segment cache for smoother media playback.",
 		icon: "Download",
 		canEdit: true,
 	},


### PR DESCRIPTION
## Summary

The Configuration UI's helper text in several places described backend behavior that didn't match the actual implementation. Every behavioral/default claim across all 15 configuration sections was traced against `internal/config/manager.go` and the relevant backend logic; the ones below were confirmed wrong and corrected. Everything else was verified accurate and left unchanged.

- **Streaming**: prefetch "Default (30)" → the real default (`streaming.max_prefetch`) is **60**.
- **Streaming**: section subtitle mentioned "chunking" and "download worker" configuration, which actually live in the Mount and Import sections respectively — reworded to describe what this section (prefetch + segment cache) actually contains.
- **Streaming**: segment cache "How It Works" claimed "Files that are currently open are never evicted" — the eviction logic (`segcache/cache.go`) is pure LRU by last-access time with no open-handle tracking at all. Removed the false claim.
- **Import**: "Reset to Video Defaults" button populated a 32-item video-only extension list that didn't match the backend's real 23-item default whitelist (`internal/config/manager.go`, includes audio/book extensions too). Renamed to "Reset to Defaults" and fixed the list to match exactly.
- **Stremio**: Prowlarr categories helper text listed 5 example category IDs; the backend default is actually 10 IDs. Updated to list all 10.
- **Health**: "Base Interval (Minutes)" said "wait time before the first repair re-notification" — `internal/health/worker.go` actually applies this interval on *every* retry, doubled each time when exponential backoff is enabled. Reworded accordingly.
- **Health**: "Ghost File Detection" claimed segment data is read to confirm it exists — the backing `verify_data` config field (`GetVerifyData()`) has zero call sites anywhere in the backend; toggling it currently does nothing. Reworded to be honest about that, and a follow-up task was flagged separately to either implement or remove the dead setting.

## Test plan

- [x] `bun run check` (biome) — passes with no fixes needed
- [x] `bun run build` (tsc + Vite) — builds successfully
- [ ] Manual check in the running app:
  - Streaming section shows "Default (60)" in the prefetch note
  - Import → Filters → "Reset to Defaults" button populates the 23 backend-default extensions
  - Stremio → Prowlarr → Categories helper lists all 10 default IDs
  - Health → Repair section wording reads correctly