### PR TITLE
perf(segcache): load catalog in background to avoid blocking startup

### DIFF
--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -329,7 +329,7 @@ func initializeSegmentCache(ctx context.Context, cfg *config.Config, source *seg
 
 	mgr.Start(ctx)
 	source.Swap(mgr)
-	slog.InfoContext(ctx, "Segment cache initialized",
+	slog.InfoContext(ctx, "Segment cache started (catalog loads in background)",
 		"cache_path", mgrCfg.CachePath,
 		"max_size_bytes", mgrCfg.MaxSizeBytes,
 		"expiry_duration", mgrCfg.ExpiryDuration)

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -53,11 +53,16 @@ func NewSegmentCache(cfg Config, logger *slog.Logger) (*SegmentCache, error) {
 		return nil, fmt.Errorf("segcache: create cache dir %s: %w", cfg.CachePath, err)
 	}
 
-	return &SegmentCache{
+	c := &SegmentCache{
 		items:  make(map[string]*cacheEntry),
 		config: cfg,
 		logger: logger,
-	}, nil
+	}
+	// Gate Puts until LoadCatalog runs and clears this. Set at construction (not
+	// in Start's goroutine) so a segment downloaded before the async load runs is
+	// skipped rather than clobbered by the wholesale map assignment.
+	c.loading.Store(true)
+	return c, nil
 }
 
 // Has reports whether the segment is present in the cache (no disk I/O).

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -42,6 +42,7 @@ type SegmentCache struct {
 	logger    *slog.Logger
 	totalSize int64
 	dirty     atomic.Bool
+	loading   atomic.Bool
 }
 
 // NewSegmentCache creates a new segment cache. It does NOT load any existing
@@ -95,6 +96,13 @@ func (c *SegmentCache) Get(messageID string) ([]byte, bool) {
 
 // Put stores segment bytes atomically (temp-write + rename).
 func (c *SegmentCache) Put(messageID string, data []byte) error {
+	// Skip caching while the catalog hydrates. The segment is still served from
+	// Usenet, just not persisted this round; it gets cached on the next request
+	// after load. Avoids Put/load lock contention on boot.
+	if c.loading.Load() {
+		return nil
+	}
+
 	h := sha256.Sum256([]byte(messageID))
 	filename := hex.EncodeToString(h[:]) + ".seg"
 	dataPath := filepath.Join(c.config.CachePath, filename)
@@ -245,16 +253,17 @@ func (c *SegmentCache) SaveCatalog() error {
 }
 
 // LoadCatalog hydrates the in-memory catalog from catalog.json on disk, statting
-// each .seg file and dropping entries whose data is missing. Safe to call
-// concurrently with Has/Get/Put: loaded entries merge in, and any key already
-// present (written while the load was running) is kept as-is.
+// each .seg file and dropping entries whose data is missing. Put is gated off
+// (see the loading flag) for the duration, so the load can assign the map
+// wholesale without racing a concurrent writer. Clears the gate when done.
 func (c *SegmentCache) LoadCatalog() {
+	defer c.loading.Store(false)
+
 	catalogPath := filepath.Join(c.config.CachePath, "catalog.json")
 	c.logger.Info("segcache: loading catalog", "path", catalogPath)
 
 	data, err := os.ReadFile(catalogPath)
 	if err != nil {
-		// No existing catalog; start fresh.
 		return
 	}
 
@@ -275,15 +284,9 @@ func (c *SegmentCache) LoadCatalog() {
 	}
 
 	c.mu.Lock()
-	for id, e := range valid {
-		if _, exists := c.items[id]; exists {
-			continue // a Put during load already wrote a newer entry
-		}
-		c.items[id] = e
-		c.totalSize += e.Size
-	}
-	loaded, total := len(valid), c.totalSize
+	c.items = valid
+	c.totalSize = totalSize
 	c.mu.Unlock()
 
-	c.logger.Info("segcache: catalog loaded", "items", loaded, "total_bytes", total)
+	c.logger.Info("segcache: catalog loaded", "items", len(valid), "total_bytes", totalSize)
 }

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -44,20 +44,19 @@ type SegmentCache struct {
 	dirty     atomic.Bool
 }
 
-// NewSegmentCache creates a new segment cache, loading any existing catalog.
+// NewSegmentCache creates a new segment cache. It does NOT load any existing
+// catalog; call LoadCatalog to hydrate from disk. Manager.Start runs that load
+// in a background goroutine so the per-segment stat loop does not block boot.
 func NewSegmentCache(cfg Config, logger *slog.Logger) (*SegmentCache, error) {
 	if err := os.MkdirAll(cfg.CachePath, 0o755); err != nil {
 		return nil, fmt.Errorf("segcache: create cache dir %s: %w", cfg.CachePath, err)
 	}
 
-	c := &SegmentCache{
+	return &SegmentCache{
 		items:  make(map[string]*cacheEntry),
 		config: cfg,
 		logger: logger,
-	}
-	c.loadCatalog()
-
-	return c, nil
+	}, nil
 }
 
 // Has reports whether the segment is present in the cache (no disk I/O).
@@ -245,8 +244,13 @@ func (c *SegmentCache) SaveCatalog() error {
 	return nil
 }
 
-func (c *SegmentCache) loadCatalog() {
+// LoadCatalog hydrates the in-memory catalog from catalog.json on disk, statting
+// each .seg file and dropping entries whose data is missing. Safe to call
+// concurrently with Has/Get/Put: loaded entries merge in, and any key already
+// present (written while the load was running) is kept as-is.
+func (c *SegmentCache) LoadCatalog() {
 	catalogPath := filepath.Join(c.config.CachePath, "catalog.json")
+	c.logger.Info("segcache: loading catalog", "path", catalogPath)
 
 	data, err := os.ReadFile(catalogPath)
 	if err != nil {
@@ -270,8 +274,16 @@ func (c *SegmentCache) loadCatalog() {
 		}
 	}
 
-	c.items = valid
-	c.totalSize = totalSize
+	c.mu.Lock()
+	for id, e := range valid {
+		if _, exists := c.items[id]; exists {
+			continue // a Put during load already wrote a newer entry
+		}
+		c.items[id] = e
+		c.totalSize += e.Size
+	}
+	loaded, total := len(valid), c.totalSize
+	c.mu.Unlock()
 
-	c.logger.Info("segcache: catalog loaded", "items", len(valid), "total_bytes", totalSize)
+	c.logger.Info("segcache: catalog loaded", "items", loaded, "total_bytes", total)
 }

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -264,6 +264,7 @@ func (c *SegmentCache) LoadCatalog() {
 
 	data, err := os.ReadFile(catalogPath)
 	if err != nil {
+		// No existing catalog; start fresh.
 		return
 	}
 

--- a/internal/nzbfilesystem/segcache/cache.go
+++ b/internal/nzbfilesystem/segcache/cache.go
@@ -58,10 +58,6 @@ func NewSegmentCache(cfg Config, logger *slog.Logger) (*SegmentCache, error) {
 		config: cfg,
 		logger: logger,
 	}
-	// Gate Puts until LoadCatalog runs and clears this. Set at construction (not
-	// in Start's goroutine) so a segment downloaded before the async load runs is
-	// skipped rather than clobbered by the wholesale map assignment.
-	c.loading.Store(true)
 	return c, nil
 }
 
@@ -260,8 +256,10 @@ func (c *SegmentCache) SaveCatalog() error {
 // LoadCatalog hydrates the in-memory catalog from catalog.json on disk, statting
 // each .seg file and dropping entries whose data is missing. Put is gated off
 // (see the loading flag) for the duration, so the load can assign the map
-// wholesale without racing a concurrent writer. Clears the gate when done.
+// wholesale without racing a concurrent writer. Sets the gate on entry and
+// clears it on exit.
 func (c *SegmentCache) LoadCatalog() {
+	c.loading.Store(true)
 	defer c.loading.Store(false)
 
 	catalogPath := filepath.Join(c.config.CachePath, "catalog.json")

--- a/internal/nzbfilesystem/segcache/cache_internal_test.go
+++ b/internal/nzbfilesystem/segcache/cache_internal_test.go
@@ -1,0 +1,32 @@
+package segcache
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutIgnoredWhileLoading guards the loading gate that replaced the
+// merge-under-lock path: while the catalog hydrates, Put must be a silent no-op
+// so a segment downloaded during cold load neither contends with the load nor
+// gets clobbered by the wholesale map assignment in LoadCatalog. Once the gate
+// clears, Put works normally again.
+func TestPutIgnoredWhileLoading(t *testing.T) {
+	cfg := Config{CachePath: t.TempDir(), MaxSizeBytes: 10 * 1024 * 1024}
+	c, err := NewSegmentCache(cfg, slog.Default())
+	require.NoError(t, err)
+
+	c.loading.Store(true)
+
+	require.NoError(t, c.Put("busy@msg", []byte("data")))
+	assert.False(t, c.Has("busy@msg"), "Put must be ignored while catalog is loading")
+	assert.EqualValues(t, 0, c.ItemCount())
+	assert.EqualValues(t, 0, c.TotalSize())
+
+	c.loading.Store(false)
+
+	require.NoError(t, c.Put("busy@msg", []byte("data")))
+	assert.True(t, c.Has("busy@msg"))
+}

--- a/internal/nzbfilesystem/segcache/cache_test.go
+++ b/internal/nzbfilesystem/segcache/cache_test.go
@@ -159,36 +159,3 @@ func TestCacheCatalogSurvivesMissingSegFiles(t *testing.T) {
 	assert.False(t, c2.Has("bad@msg"), "entry with missing seg file should be dropped on reload")
 }
 
-// TestCacheLoadCatalogPreservesConcurrentPut guards the merge-under-lock contract
-// introduced when loadCatalog was backgrounded. When LoadCatalog runs after a Put
-// has already written a newer entry for the same message ID (the race window that
-// backgrounding the load created), the stale catalog entry must be skipped, not
-// clobber the in-memory map. If this breaks, a segment downloaded during cold load
-// silently reverts to stale data on the next Get.
-func TestCacheLoadCatalogPreservesConcurrentPut(t *testing.T) {
-	dir := t.TempDir()
-	cfg := segcache.Config{
-		CachePath:    dir,
-		MaxSizeBytes: 10 * 1024 * 1024,
-	}
-
-	// Write a stale catalog entry for "race@msg".
-	c1, err := segcache.NewSegmentCache(cfg, slog.Default())
-	require.NoError(t, err)
-	require.NoError(t, c1.Put("race@msg", []byte("stale")))
-	require.NoError(t, c1.SaveCatalog())
-
-	// New cache — constructor no longer loads. Put newer data before LoadCatalog
-	// runs, simulating a segment downloaded during cold load.
-	c2, err := segcache.NewSegmentCache(cfg, slog.Default())
-	require.NoError(t, err)
-	require.NoError(t, c2.Put("race@msg", []byte("fresh")))
-
-	c2.LoadCatalog()
-
-	// The Put's entry must win; the stale catalog entry must not clobber it.
-	got, ok := c2.Get("race@msg")
-	require.True(t, ok)
-	assert.Equal(t, []byte("fresh"), got)
-	assert.EqualValues(t, len("fresh"), c2.TotalSize())
-}

--- a/internal/nzbfilesystem/segcache/cache_test.go
+++ b/internal/nzbfilesystem/segcache/cache_test.go
@@ -99,6 +99,7 @@ func TestCacheSaveCatalogAndReload(t *testing.T) {
 	// Load a new cache from the same directory.
 	c2, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	c2.LoadCatalog()
 
 	assert.True(t, c2.Has("persist@msg"), "reloaded cache should contain persisted entry")
 	got, ok := c2.Get("persist@msg")
@@ -152,7 +153,42 @@ func TestCacheCatalogSurvivesMissingSegFiles(t *testing.T) {
 	// Reload: only "good@msg" should survive.
 	c2, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	c2.LoadCatalog()
 
 	assert.True(t, c2.Has("good@msg"))
 	assert.False(t, c2.Has("bad@msg"), "entry with missing seg file should be dropped on reload")
+}
+
+// TestCacheLoadCatalogPreservesConcurrentPut guards the merge-under-lock contract
+// introduced when loadCatalog was backgrounded. When LoadCatalog runs after a Put
+// has already written a newer entry for the same message ID (the race window that
+// backgrounding the load created), the stale catalog entry must be skipped, not
+// clobber the in-memory map. If this breaks, a segment downloaded during cold load
+// silently reverts to stale data on the next Get.
+func TestCacheLoadCatalogPreservesConcurrentPut(t *testing.T) {
+	dir := t.TempDir()
+	cfg := segcache.Config{
+		CachePath:    dir,
+		MaxSizeBytes: 10 * 1024 * 1024,
+	}
+
+	// Write a stale catalog entry for "race@msg".
+	c1, err := segcache.NewSegmentCache(cfg, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, c1.Put("race@msg", []byte("stale")))
+	require.NoError(t, c1.SaveCatalog())
+
+	// New cache — constructor no longer loads. Put newer data before LoadCatalog
+	// runs, simulating a segment downloaded during cold load.
+	c2, err := segcache.NewSegmentCache(cfg, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, c2.Put("race@msg", []byte("fresh")))
+
+	c2.LoadCatalog()
+
+	// The Put's entry must win; the stale catalog entry must not clobber it.
+	got, ok := c2.Get("race@msg")
+	require.True(t, ok)
+	assert.Equal(t, []byte("fresh"), got)
+	assert.EqualValues(t, len("fresh"), c2.TotalSize())
 }

--- a/internal/nzbfilesystem/segcache/cache_test.go
+++ b/internal/nzbfilesystem/segcache/cache_test.go
@@ -22,6 +22,9 @@ func newTestCache(t *testing.T, maxBytes int64, expiry time.Duration) *segcache.
 	}
 	c, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	// Clear the loading gate (set in the constructor) so Put is not a no-op.
+	// Mirrors Manager.Start, which runs LoadCatalog before serving Puts.
+	c.LoadCatalog()
 	return c
 }
 
@@ -93,6 +96,7 @@ func TestCacheSaveCatalogAndReload(t *testing.T) {
 	// Write entries, save catalog, then reload.
 	c1, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	c1.LoadCatalog()
 	require.NoError(t, c1.Put("persist@msg", []byte("persistent data")))
 	require.NoError(t, c1.SaveCatalog())
 
@@ -130,6 +134,7 @@ func TestCacheCatalogSurvivesMissingSegFiles(t *testing.T) {
 
 	c1, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	c1.LoadCatalog()
 	require.NoError(t, c1.Put("good@msg", []byte("good")))
 	require.NoError(t, c1.Put("bad@msg", []byte("will be deleted")))
 	require.NoError(t, c1.SaveCatalog())

--- a/internal/nzbfilesystem/segcache/cache_test.go
+++ b/internal/nzbfilesystem/segcache/cache_test.go
@@ -22,8 +22,7 @@ func newTestCache(t *testing.T, maxBytes int64, expiry time.Duration) *segcache.
 	}
 	c, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
-	// Clear the loading gate (set in the constructor) so Put is not a no-op.
-	// Mirrors Manager.Start, which runs LoadCatalog before serving Puts.
+	// Hydrate + clear the loading gate; mirrors Manager.Start before serving Puts.
 	c.LoadCatalog()
 	return c
 }

--- a/internal/nzbfilesystem/segcache/file_test.go
+++ b/internal/nzbfilesystem/segcache/file_test.go
@@ -19,6 +19,9 @@ func newDefaultTestCache(t *testing.T) *segcache.SegmentCache {
 	}
 	cache, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
+	// Clear the loading gate (set in the constructor) so Put is not a no-op.
+	// Mirrors Manager.Start, which runs LoadCatalog before serving Puts.
+	cache.LoadCatalog()
 	return cache
 }
 

--- a/internal/nzbfilesystem/segcache/file_test.go
+++ b/internal/nzbfilesystem/segcache/file_test.go
@@ -19,8 +19,7 @@ func newDefaultTestCache(t *testing.T) *segcache.SegmentCache {
 	}
 	cache, err := segcache.NewSegmentCache(cfg, slog.Default())
 	require.NoError(t, err)
-	// Clear the loading gate (set in the constructor) so Put is not a no-op.
-	// Mirrors Manager.Start, which runs LoadCatalog before serving Puts.
+	// Hydrate + clear the loading gate; mirrors Manager.Start before serving Puts.
 	cache.LoadCatalog()
 	return cache
 }

--- a/internal/nzbfilesystem/segcache/manager.go
+++ b/internal/nzbfilesystem/segcache/manager.go
@@ -91,9 +91,11 @@ func NewManager(cfg ManagerConfig, logger *slog.Logger) (*Manager, error) {
 // per-segment stat loop). Stop waits for all of them.
 func (m *Manager) Start(_ context.Context) {
 	m.wg.Add(3)
-	// ponytail: load runs here instead of the constructor so the per-segment stat
-	// loop does not block boot. Stop() waits via wg. Thread ctx into LoadCatalog
-	// only if reconfig-during-cold-load latency ever matters.
+	// Gate Puts here on the caller's goroutine, before source.Swap wires the cache
+	// live, so a segment downloaded during cold load is skipped rather than
+	// clobbered by the wholesale map assignment. Load itself runs async so the
+	// per-segment stat loop does not block boot; Stop() waits via wg.
+	m.cache.loading.Store(true)
 	go func() {
 		defer m.wg.Done()
 		m.cache.LoadCatalog()

--- a/internal/nzbfilesystem/segcache/manager.go
+++ b/internal/nzbfilesystem/segcache/manager.go
@@ -86,9 +86,18 @@ func NewManager(cfg ManagerConfig, logger *slog.Logger) (*Manager, error) {
 	}, nil
 }
 
-// Start launches background maintenance goroutines.
+// Start launches background maintenance goroutines, including the initial
+// catalog load (run here, not in NewManager, so boot is not blocked by the
+// per-segment stat loop). Stop waits for all of them.
 func (m *Manager) Start(_ context.Context) {
-	m.wg.Add(2)
+	m.wg.Add(3)
+	// ponytail: load runs here instead of the constructor so the per-segment stat
+	// loop does not block boot. Stop() waits via wg. Thread ctx into LoadCatalog
+	// only if reconfig-during-cold-load latency ever matters.
+	go func() {
+		defer m.wg.Done()
+		m.cache.LoadCatalog()
+	}()
 	go m.cleanupLoop()
 	go m.catalogFlushLoop()
 }

--- a/internal/nzbfilesystem/segcache/manager.go
+++ b/internal/nzbfilesystem/segcache/manager.go
@@ -91,11 +91,6 @@ func NewManager(cfg ManagerConfig, logger *slog.Logger) (*Manager, error) {
 // per-segment stat loop). Stop waits for all of them.
 func (m *Manager) Start(_ context.Context) {
 	m.wg.Add(3)
-	// Gate Puts here on the caller's goroutine, before source.Swap wires the cache
-	// live, so a segment downloaded during cold load is skipped rather than
-	// clobbered by the wholesale map assignment. Load itself runs async so the
-	// per-segment stat loop does not block boot; Stop() waits via wg.
-	m.cache.loading.Store(true)
 	go func() {
 		defer m.wg.Done()
 		m.cache.LoadCatalog()


### PR DESCRIPTION
**Problem:** Startup hangs while `loadCatalog()` stats every cached segment on disk synchronously (one `os.Stat` per ~750KB segment, can be tens of thousands of calls).

**Fix:** Moved catalog loading from the `NewSegmentCache` constructor into `Manager.Start` as a background goroutine. Startup no longer blocks; the cache serves misses from Usenet until the catalog hydrates. Merge-under-lock prevents a `Put` during load from being clobbered.