### PR TITLE
feat(pool): balance import connections automatically, prioritizing streams

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -153,7 +153,7 @@ import:
     - '.epub'
     - '.pdf'
     - '.cbz'
-  max_import_connections: 5 # Number of concurrent NNTP connections for validation and archive processing
+  max_concurrent_imports: 0 # Cap on NZB imports running at once (0 = unlimited). NNTP connections are balanced automatically: imports use the pool's full capacity and always yield to streaming.
   segment_sample_percentage: 1 # Percentage of segments to sample for validation (1-100)
   import_strategy: 'NONE' # Import strategy: NONE (direct import), SYMLINK (create symlinks), STRM (create .strm files)
   import_dir: '' # Import directory (required when import_strategy is SYMLINK or STRM, must be absolute path)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,7 +102,6 @@ import:
         - .wtv
         - .mk3d
         - .dvr-ms
-    max_import_connections: 5
     max_download_prefetch: 3
     segment_sample_percentage: 1
     import_strategy: NONE

--- a/docs/static/openapi.yaml
+++ b/docs/static/openapi.yaml
@@ -3562,8 +3562,6 @@ components:
           $ref: "#/components/schemas/config.ImportStrategy"
         max_download_prefetch:
           type: integer
-        max_import_connections:
-          type: integer
         max_processor_workers:
           type: integer
         queue_processing_interval_seconds:
@@ -4401,8 +4399,6 @@ components:
         import_strategy:
           $ref: "#/components/schemas/config.ImportStrategy"
         max_download_prefetch:
-          type: integer
-        max_import_connections:
           type: integer
         max_processor_workers:
           type: integer

--- a/docs/static/swagger.json
+++ b/docs/static/swagger.json
@@ -5363,9 +5363,6 @@
                 "max_download_prefetch": {
                     "type": "integer"
                 },
-                "max_import_connections": {
-                    "type": "integer"
-                },
                 "max_processor_workers": {
                     "type": "integer"
                 },
@@ -6628,9 +6625,6 @@
                     "$ref": "#/definitions/config.ImportStrategy"
                 },
                 "max_download_prefetch": {
-                    "type": "integer"
-                },
-                "max_import_connections": {
                     "type": "integer"
                 },
                 "max_processor_workers": {

--- a/docs/static/swagger.yaml
+++ b/docs/static/swagger.yaml
@@ -318,8 +318,6 @@ definitions:
         $ref: '#/definitions/config.ImportStrategy'
       max_download_prefetch:
         type: integer
-      max_import_connections:
-        type: integer
       max_processor_workers:
         type: integer
       queue_processing_interval_seconds:
@@ -1155,8 +1153,6 @@ definitions:
       import_strategy:
         $ref: '#/definitions/config.ImportStrategy'
       max_download_prefetch:
-        type: integer
-      max_import_connections:
         type: integer
       max_processor_workers:
         type: integer

--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -105,28 +105,6 @@ export function ImportConfigSection({
 						</fieldset>
 
 						<fieldset className="fieldset min-w-0">
-							<legend className="fieldset-legend">Max Connections (per Worker)</legend>
-							<input
-								type="number"
-								className="input input-bordered w-full min-w-0 max-w-full bg-base-100 font-mono text-sm"
-								value={formData.max_import_connections}
-								readOnly={isReadOnly}
-								min={1}
-								onChange={(e) =>
-									handleInputChange(
-										"max_import_connections",
-										Number.parseInt(e.target.value, 10) || 10,
-									)
-								}
-							/>
-							<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/70 text-xs">
-								Socket limit per active worker.
-							</p>
-						</fieldset>
-					</div>
-
-					<div className="grid min-w-0 grid-cols-1 gap-6 sm:grid-cols-2">
-						<fieldset className="fieldset min-w-0">
 							<legend className="fieldset-legend font-semibold">Max Download Prefetch</legend>
 							<input
 								type="number"

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -218,7 +218,6 @@ export interface ImportConfig {
 	max_processor_workers: number;
 	queue_processing_interval_seconds: number; // Interval in seconds for queue processing
 	allowed_file_extensions: string[];
-	max_import_connections: number;
 	max_download_prefetch: number;
 	segment_sample_percentage: number; // Percentage of segments to check (1-100)
 	read_timeout_seconds: number;

--- a/internal/api/provider_speedtest_storm_test.go
+++ b/internal/api/provider_speedtest_storm_test.go
@@ -34,10 +34,12 @@ func (m *countingPoolManager) GetPool() (pool.NntpClient, error) {
 	m.getPoolCalls.Add(1)
 	return nil, nil
 }
-func (m *countingPoolManager) HasPool() bool                              { m.hasPoolCalls.Add(1); return false }
-func (m *countingPoolManager) SetProviders(_ []nntppool.Provider) error   { return nil }
-func (m *countingPoolManager) ClearPool() error                           { return nil }
-func (m *countingPoolManager) GetMetrics() (pool.MetricsSnapshot, error)  { return pool.MetricsSnapshot{}, nil }
+func (m *countingPoolManager) HasPool() bool                            { m.hasPoolCalls.Add(1); return false }
+func (m *countingPoolManager) SetProviders(_ []nntppool.Provider) error { return nil }
+func (m *countingPoolManager) ClearPool() error                         { return nil }
+func (m *countingPoolManager) GetMetrics() (pool.MetricsSnapshot, error) {
+	return pool.MetricsSnapshot{}, nil
+}
 func (m *countingPoolManager) ResetMetrics(_ context.Context, _, _ bool) error {
 	return nil
 }
@@ -54,7 +56,12 @@ func (m *countingPoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *countingPoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *countingPoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *countingPoolManager) SetAdmissionCap(_ int) {}
+func (m *countingPoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *countingPoolManager) SetImportConnCapacity(_ int)                 {}
+func (m *countingPoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *countingPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *countingPoolManager) NotifyStreamChange()                         {}
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -146,7 +146,6 @@ type ImportAPIResponse struct {
 	MaxProcessorWorkers            int                   `json:"max_processor_workers"`
 	QueueProcessingIntervalSeconds int                   `json:"queue_processing_interval_seconds"` // Interval in seconds
 	AllowedFileExtensions          []string              `json:"allowed_file_extensions"`
-	MaxImportConnections           int                   `json:"max_import_connections"`
 	MaxDownloadPrefetch            int                   `json:"max_download_prefetch"`
 	ReadTimeoutSeconds             int                   `json:"read_timeout_seconds"`
 	SegmentSamplePercentage        int                   `json:"segment_sample_percentage"` // Percentage of segments to check (1-100)
@@ -412,7 +411,6 @@ func ToImportAPIResponse(importConfig config.ImportConfig) ImportAPIResponse {
 		MaxProcessorWorkers:            importConfig.MaxProcessorWorkers,
 		QueueProcessingIntervalSeconds: importConfig.QueueProcessingIntervalSeconds,
 		AllowedFileExtensions:          importConfig.AllowedFileExtensions,
-		MaxImportConnections:           importConfig.MaxImportConnections,
 		MaxDownloadPrefetch:            importConfig.MaxDownloadPrefetch,
 		ReadTimeoutSeconds:             importConfig.ReadTimeoutSeconds,
 		SegmentSamplePercentage:        importConfig.SegmentSamplePercentage,

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -116,31 +116,37 @@ func (c *Config) GetImportDamagePolicyTolerant() bool {
 	return c.Import.DamagePolicy != "strict"
 }
 
-// GetMaxImportConnections returns max import connections with a default fallback.
-func (c *Config) GetMaxImportConnections() int {
-	if c.Import.MaxImportConnections <= 0 {
-		return 5 // Default: 5 connections
+// TotalProviderConnections returns the pool's total connection capacity: the
+// sum of MaxConnections across enabled, non-backup providers. When no primary
+// providers are configured it falls back to the enabled backup providers' sum
+// so the capacity is not zero while a usable pool exists. Returns 0 when no
+// providers are configured at all.
+func (c *Config) TotalProviderConnections() int {
+	primary := 0
+	backup := 0
+	for _, p := range c.Providers {
+		if p.Enabled != nil && !*p.Enabled {
+			continue
+		}
+		if p.IsBackupProvider != nil && *p.IsBackupProvider {
+			backup += p.MaxConnections
+		} else {
+			primary += p.MaxConnections
+		}
 	}
-	return c.Import.MaxImportConnections
+	if primary > 0 {
+		return primary
+	}
+	return backup
 }
 
-// GetMaxConcurrentImports returns the global cap on concurrent NZB imports
-// when no stream is active. 0 means unlimited (current default behaviour).
+// GetMaxConcurrentImports returns the global cap on concurrent NZB imports.
+// 0 means unlimited (the default).
 func (c *Config) GetMaxConcurrentImports() int {
 	if c.Import.MaxConcurrentImports < 0 {
 		return 0
 	}
 	return c.Import.MaxConcurrentImports
-}
-
-// GetMaxConcurrentImportsWhileStreaming returns the cap on concurrent NZB
-// imports while at least one stream is active. 0 means unlimited (current
-// default behaviour).
-func (c *Config) GetMaxConcurrentImportsWhileStreaming() int {
-	if c.Import.MaxConcurrentImportsWhileStreaming < 0 {
-		return 0
-	}
-	return c.Import.MaxConcurrentImportsWhileStreaming
 }
 
 // GetMaxDownloadPrefetch returns max download prefetch with a default fallback.

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -295,14 +295,11 @@ type ImportConfig struct {
 	MaxProcessorWorkers            int      `yaml:"max_processor_workers" mapstructure:"max_processor_workers" json:"max_processor_workers"`
 	QueueProcessingIntervalSeconds int      `yaml:"queue_processing_interval_seconds" mapstructure:"queue_processing_interval_seconds" json:"queue_processing_interval_seconds"`
 	AllowedFileExtensions          []string `yaml:"allowed_file_extensions" mapstructure:"allowed_file_extensions" json:"allowed_file_extensions"`
-	MaxImportConnections           int      `yaml:"max_import_connections" mapstructure:"max_import_connections" json:"max_import_connections"`
 	// MaxConcurrentImports caps the number of NZB imports that may run
-	// end-to-end at the same time when no stream is active. 0 = unlimited.
-	MaxConcurrentImports int `yaml:"max_concurrent_imports" mapstructure:"max_concurrent_imports" json:"max_concurrent_imports"`
-	// MaxConcurrentImportsWhileStreaming caps concurrent imports while at
-	// least one stream is active, so streams are not starved by imports.
-	// 0 = unlimited.
-	MaxConcurrentImportsWhileStreaming int            `yaml:"max_concurrent_imports_while_streaming" mapstructure:"max_concurrent_imports_while_streaming" json:"max_concurrent_imports_while_streaming"`
+	// end-to-end at the same time. 0 = unlimited. NNTP connection use is
+	// balanced automatically: imports share the pool's full capacity and
+	// yield to streams (priority lane + adaptive connection budget).
+	MaxConcurrentImports               int            `yaml:"max_concurrent_imports" mapstructure:"max_concurrent_imports" json:"max_concurrent_imports"`
 	MaxDownloadPrefetch                int            `yaml:"max_download_prefetch" mapstructure:"max_download_prefetch" json:"max_download_prefetch"`
 	SegmentSamplePercentage            int            `yaml:"segment_sample_percentage" mapstructure:"segment_sample_percentage" json:"segment_sample_percentage"`
 	ReadTimeoutSeconds                 int            `yaml:"read_timeout_seconds" mapstructure:"read_timeout_seconds" json:"read_timeout_seconds"`
@@ -660,10 +657,6 @@ func (c *Config) Validate() error {
 
 	if c.Import.QueueProcessingIntervalSeconds > 300 {
 		return fmt.Errorf("import queue_processing_interval_seconds must not exceed 300 seconds")
-	}
-
-	if c.Import.MaxImportConnections <= 0 {
-		return fmt.Errorf("import max_import_connections must be greater than 0")
 	}
 
 	if c.Import.MaxDownloadPrefetch <= 0 {
@@ -1584,7 +1577,6 @@ func DefaultConfig(configDir ...string) *Config {
 				".xvid", ".rm", ".rmvb", ".asf", ".asx", ".wtv", ".mk3d", ".dvr-ms",
 				".mp3", ".flac", ".m4a", ".epub", ".pdf", ".cbz",
 			},
-			MaxImportConnections:     5,   // Default: 5 concurrent NNTP connections for validation and archive processing
 			MaxDownloadPrefetch:      10,  // Default: 10 segments prefetched ahead for archive analysis
 			SegmentSamplePercentage:  1,   // Default: 1% segment sampling
 			ReadTimeoutSeconds:       300, // Default: 5 minutes read timeout

--- a/internal/config/manager_test.go
+++ b/internal/config/manager_test.go
@@ -31,7 +31,6 @@ func TestConfig_Validate_MountPaths(t *testing.T) {
 				Import: ImportConfig{
 					MaxProcessorWorkers:            2,
 					QueueProcessingIntervalSeconds: 5,
-					MaxImportConnections:           5,
 					MaxDownloadPrefetch:            3,
 					SegmentSamplePercentage:        1,
 					ImportStrategy:                 ImportStrategyNone,
@@ -62,7 +61,6 @@ func TestConfig_Validate_MountPaths(t *testing.T) {
 				Import: ImportConfig{
 					MaxProcessorWorkers:            2,
 					QueueProcessingIntervalSeconds: 5,
-					MaxImportConnections:           5,
 					MaxDownloadPrefetch:            3,
 					SegmentSamplePercentage:        1,
 					ImportStrategy:                 ImportStrategyNone,
@@ -92,7 +90,6 @@ func TestConfig_Validate_MountPaths(t *testing.T) {
 				Import: ImportConfig{
 					MaxProcessorWorkers:            2,
 					QueueProcessingIntervalSeconds: 5,
-					MaxImportConnections:           5,
 					MaxDownloadPrefetch:            3,
 					SegmentSamplePercentage:        1,
 					ImportStrategy:                 ImportStrategyNone,
@@ -135,7 +132,6 @@ func TestConfig_Validate_QueueCleanupRuleAction(t *testing.T) {
 			Import: ImportConfig{
 				MaxProcessorWorkers:            2,
 				QueueProcessingIntervalSeconds: 5,
-				MaxImportConnections:           5,
 				MaxDownloadPrefetch:            3,
 				SegmentSamplePercentage:        1,
 				ImportStrategy:                 ImportStrategyNone,

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -47,7 +47,12 @@ func (m *mockPoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *mockPoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *mockPoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *mockPoolManager) SetAdmissionCap(_ int) {}
+func (m *mockPoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *mockPoolManager) SetImportConnCapacity(_ int)                 {}
+func (m *mockPoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *mockPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *mockPoolManager) NotifyStreamChange()                         {}
 

--- a/internal/importer/archive/rar/processor.go
+++ b/internal/importer/archive/rar/processor.go
@@ -57,7 +57,9 @@ func (rh *rarProcessor) AnalyzeRarContentFromNzb(ctx context.Context, rarFiles [
 	}
 
 	cfg := rh.configGetter()
-	maxConcurrentVolumes := cfg.Import.MaxImportConnections
+	// Reader-parallelism bound only — actual connection use is gated by the
+	// pool manager's global import connection budget inside each reader.
+	maxConcurrentVolumes := max(min(cfg.TotalProviderConnections(), len(rarFiles)), 1)
 	maxPrefetch := cfg.Import.MaxDownloadPrefetch
 	readTimeout := time.Duration(cfg.Import.ReadTimeoutSeconds) * time.Second
 	if readTimeout == 0 {
@@ -695,7 +697,9 @@ func (rh *rarProcessor) detectAndProcessNestedRars(ctx context.Context, outerCon
 // For encrypted outer RARs, it creates NestedSource entries.
 func (rh *rarProcessor) processNestedRarContent(ctx context.Context, innerRarContents []Content) ([]Content, error) {
 	cfg := rh.configGetter()
-	maxConcurrentVolumes := cfg.Import.MaxImportConnections
+	// Reader-parallelism bound only — actual connection use is gated by the
+	// pool manager's global import connection budget inside each reader.
+	maxConcurrentVolumes := max(min(cfg.TotalProviderConnections(), len(innerRarContents)), 1)
 	maxPrefetch := cfg.Import.MaxDownloadPrefetch
 	readTimeout := time.Duration(cfg.Import.ReadTimeoutSeconds) * time.Second
 	if readTimeout == 0 {

--- a/internal/importer/filesystem/decrypting_fs.go
+++ b/internal/importer/filesystem/decrypting_fs.go
@@ -234,7 +234,8 @@ func (df *DecryptingFile) createPlainReader(ctx context.Context, start, end int6
 	}
 
 	rg := usenet.GetSegmentsInRange(ctx, start, end, loader)
-	return usenet.NewUsenetReader(ctx, df.poolManager.GetPool, rg, df.maxPrefetch, df.poolManager, df.name, nil)
+	return usenet.NewUsenetReader(ctx, df.poolManager.GetPool, rg, df.maxPrefetch, df.poolManager, df.name, nil,
+		usenet.WithImportProfile(df.poolManager))
 }
 
 // createDecryptingReader creates a reader with AES-CBC decryption.
@@ -255,7 +256,8 @@ func (df *DecryptingFile) createDecryptingReader(ctx context.Context, start int6
 		}
 
 		rg := usenet.GetSegmentsInRange(ctx, rStart, rEnd, loader)
-		return usenet.NewUsenetReader(ctx, df.poolManager.GetPool, rg, df.maxPrefetch, df.poolManager, df.name, nil)
+		return usenet.NewUsenetReader(ctx, df.poolManager.GetPool, rg, df.maxPrefetch, df.poolManager, df.name, nil,
+			usenet.WithImportProfile(df.poolManager))
 	}
 
 	var rh *utils.RangeHeader

--- a/internal/importer/filesystem/usenet_fs.go
+++ b/internal/importer/filesystem/usenet_fs.go
@@ -340,7 +340,8 @@ func (uf *UsenetFile) newNetworkReader(ctx context.Context, start, end int64) (i
 	}
 
 	rg := usenet.GetSegmentsInRange(ctx, start, end, loader)
-	return usenet.NewUsenetReader(ctx, uf.poolManager.GetPool, rg, uf.maxPrefetch, uf.poolManager, uf.name, nil)
+	return usenet.NewUsenetReader(ctx, uf.poolManager.GetPool, rg, uf.maxPrefetch, uf.poolManager, uf.name, nil,
+		usenet.WithImportProfile(uf.poolManager))
 }
 
 // newWarmPrefixReader builds a reader that serves the file's warm first-segment

--- a/internal/importer/filesystem/warm_cache_test.go
+++ b/internal/importer/filesystem/warm_cache_test.go
@@ -43,7 +43,12 @@ func (m *fsFakePoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *fsFakePoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *fsFakePoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *fsFakePoolManager) SetAdmissionCap(_ int) {}
+func (m *fsFakePoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *fsFakePoolManager) SetImportConnCapacity(_ int)                 {}
+func (m *fsFakePoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *fsFakePoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *fsFakePoolManager) NotifyStreamChange()                         {}
 

--- a/internal/importer/parser/par2/descriptor.go
+++ b/internal/importer/parser/par2/descriptor.go
@@ -120,7 +120,8 @@ func readFileDescriptors(
 
 	// Create UsenetReader (provides retry, prefetch, and metrics for free)
 	rg := usenet.GetSegmentsInRange(ctx, 0, totalSize-1, loader)
-	r, err := usenet.NewUsenetReader(ctx, poolManager.GetPool, rg, 5, poolManager, "", nil)
+	r, err := usenet.NewUsenetReader(ctx, poolManager.GetPool, rg, 5, poolManager, "", nil,
+		usenet.WithImportProfile(poolManager))
 	if err != nil {
 		return descriptors, fmt.Errorf("failed to create usenet reader: %w", err)
 	}

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -34,6 +34,12 @@ import (
 	concpool "github.com/sourcegraph/conc/pool"
 )
 
+// maxFetchGoroutines bounds how many fetch goroutines a single parse phase
+// spawns. It is a memory/scheduler bound only — the actual number of in-flight
+// NNTP body fetches is governed by the pool manager's global import connection
+// budget, which adapts to pool capacity and stream activity.
+const maxFetchGoroutines = 100
+
 // FirstSegmentData holds cached data from the first segment of an NZB file
 // This avoids redundant fetching when both PAR2 extraction and file parsing need the same data
 type FirstSegmentData struct {
@@ -696,7 +702,9 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 		err        error
 	}
 
-	maxFetch := max(min(len(files), p.getConfig().GetMaxImportConnections()), 1)
+	// Goroutine bound only — the real fetch bound is the pool manager's global
+	// import connection budget, acquired per Body call below.
+	maxFetch := max(min(min(len(files), p.getConfig().TotalProviderConnections()), maxFetchGoroutines), 1)
 	concPool := concpool.NewWithResults[fetchResult]().WithMaxGoroutines(maxFetch).WithContext(ctx)
 
 	// Atomic counter for progress tracking — incremented by each goroutine on completion
@@ -764,6 +772,14 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 			}
 
 			firstSegment := fileToFetch.Segments[0]
+
+			// Take a token from the global import connection budget before the
+			// per-attempt timeout starts, so queue wait never burns the deadline.
+			releaseConn, err := p.poolManager.AcquireImportConnection(ctx)
+			if err != nil {
+				return fetchResult{}, err
+			}
+			defer releaseConn()
 
 			// Create context with timeout
 			c, cancel := context.WithTimeout(ctx, time.Second*30)
@@ -1017,7 +1033,9 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 		return
 	}
 
-	maxFetch := max(min(len(targets), p.getConfig().GetMaxImportConnections()), 1)
+	// Goroutine bound only — the real fetch bound is the pool manager's global
+	// import connection budget, acquired per Body call below.
+	maxFetch := max(min(min(len(targets), p.getConfig().TotalProviderConnections()), maxFetchGoroutines), 1)
 	pool := concpool.New().WithMaxGoroutines(maxFetch).WithContext(ctx)
 	for _, d := range targets {
 		pool.Go(func(ctx context.Context) error {
@@ -1041,6 +1059,12 @@ func (p *Parser) complete16KBReads(ctx context.Context, cache []*FirstSegmentDat
 			g, gctx := errgroup.WithContext(ctx)
 			for i, seg := range segsNeeded {
 				g.Go(func() error {
+					// Budget token first, so queue wait never burns the deadline.
+					releaseConn, err := p.poolManager.AcquireImportConnection(gctx)
+					if err != nil {
+						return nil // best-effort
+					}
+					defer releaseConn()
 					segCtx, segCancel := context.WithTimeout(gctx, time.Second*30)
 					defer segCancel()
 					sr, err := cp.Body(segCtx, seg.ID)

--- a/internal/importer/parser/parser_storm_test.go
+++ b/internal/importer/parser/parser_storm_test.go
@@ -14,15 +14,18 @@ import (
 	"github.com/javi11/nzbparser"
 )
 
-// parser_storm_test.go pins the per-import invariants on the parser side.
-// The parser bounds fan-out within a single import job via
-// MaxImportConnections; cross-job budgeting is out of scope here.
+// parser_storm_test.go pins the connection-budget invariants on the parser
+// side. Since the removal of the per-import max_import_connections cap, the
+// parser's fan-out is bounded GLOBALLY (across all concurrent imports) by the
+// pool manager's import connection budget.
 
 // fakeFullPoolManager satisfies the full pool.Manager surface so the
 // parser can call GetPool, HasPool, and the metric inc helpers without
-// nil-deref.
+// nil-deref. When budget is set, AcquireImportConnection delegates to it,
+// mirroring the real manager.
 type fakeFullPoolManager struct {
 	client pool.NntpClient
+	budget *pool.ImportBudget
 }
 
 func newFakeFullPoolManager(client pool.NntpClient) *fakeFullPoolManager {
@@ -52,15 +55,36 @@ func (m *fakeFullPoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *fakeFullPoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *fakeFullPoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *fakeFullPoolManager) SetAdmissionCap(_ int) {}
+func (m *fakeFullPoolManager) AcquireImportConnection(ctx context.Context) (func(), error) {
+	if m.budget != nil {
+		return m.budget.Acquire(ctx)
+	}
+	return func() {}, nil
+}
+func (m *fakeFullPoolManager) SetImportConnCapacity(total int) {
+	if m.budget != nil {
+		m.budget.SetCapacity(total)
+	}
+}
+func (m *fakeFullPoolManager) ImportConnCapacity() int {
+	if m.budget != nil {
+		return m.budget.Capacity()
+	}
+	return 0
+}
 func (m *fakeFullPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *fakeFullPoolManager) NotifyStreamChange()                         {}
 
-// stormConfigGetter returns a ConfigGetter whose MaxImportConnections is
-// exactly N. This is the per-import-job cap on wire-call burstiness.
-func stormConfigGetter(maxImportConnections int) config.ConfigGetter {
+// stormConfigGetter returns a ConfigGetter whose provider capacity is exactly
+// totalConnections. The parser sizes its fetch goroutine pool from
+// TotalProviderConnections; the wire-call bound comes from the budget.
+func stormConfigGetter(totalConnections int) config.ConfigGetter {
 	cfg := config.DefaultConfig()
-	cfg.Import.MaxImportConnections = maxImportConnections
+	enabled := true
+	cfg.Providers = []config.ProviderConfig{
+		{MaxConnections: totalConnections, Enabled: &enabled},
+	}
 	return func() *config.Config { return cfg }
 }
 
@@ -81,16 +105,16 @@ func buildSyntheticNzbFiles(numFiles int) []nzbparser.NzbFile {
 	return files
 }
 
-// TestStorm_ImporterFanOutRespectsMaxImportConnections pins the per-job
-// invariant: the parser's first-segment fan-out for a SINGLE import MUST
-// stay bounded by MaxImportConnections. Cross-job bounding is out of
-// scope for the parser.
-func TestStorm_ImporterFanOutRespectsMaxImportConnections(t *testing.T) {
+// TestStorm_ImporterFanOutRespectsConnectionBudget pins the budget invariant:
+// the parser's first-segment fan-out MUST stay bounded by the pool manager's
+// import connection budget, and a single import MUST be able to fan out past
+// the old fixed per-import cap of 5 when capacity allows.
+func TestStorm_ImporterFanOutRespectsConnectionBudget(t *testing.T) {
 	t.Parallel()
 	const (
-		filesPerImport       = 20
-		maxImportConnections = 6
-		bodyLatency          = 60 * time.Millisecond
+		filesPerImport = 20
+		budgetCapacity = 8
+		bodyLatency    = 100 * time.Millisecond
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -104,37 +128,42 @@ func TestStorm_ImporterFanOutRespectsMaxImportConnections(t *testing.T) {
 	}
 
 	mgr := newFakeFullPoolManager(fp)
-	parser := NewParser(mgr, stormConfigGetter(maxImportConnections))
+	mgr.budget = pool.NewImportBudget()
+	mgr.budget.SetCapacity(budgetCapacity)
+	parser := NewParser(mgr, stormConfigGetter(budgetCapacity))
 
 	files := buildSyntheticNzbFiles(filesPerImport)
 	_, _, _ = parser.fetchAllFirstSegments(ctx, files, nil, ParseOptions{})
 
 	mif := fp.MaxInFlight()
-	t.Logf("single import × %d files (MaxImportConnections=%d) "+
-		"produced MaxInFlight=%d Body calls (invariant: MaxInFlight <= MaxImportConnections)",
-		filesPerImport, maxImportConnections, mif)
+	t.Logf("single import × %d files (budget capacity=%d) "+
+		"produced MaxInFlight=%d Body calls (invariant: MaxInFlight <= capacity)",
+		filesPerImport, budgetCapacity, mif)
 
-	if mif > int32(maxImportConnections) {
-		t.Errorf("INVARIANT regression: MaxInFlight=%d, want <= %d (MaxImportConnections). "+
-			"fetchAllFirstSegments must size its concPool by MaxImportConnections — "+
-			"if this fails, a single import is fanning out past its configured cap "+
-			"and will saturate the slot semaphore on its own.",
-			mif, maxImportConnections)
+	if mif > int32(budgetCapacity) {
+		t.Errorf("INVARIANT regression: MaxInFlight=%d, want <= %d (budget capacity). "+
+			"Every parser Body call must hold an AcquireImportConnection token — "+
+			"if this fails, imports can saturate the pool past the adaptive budget.",
+			mif, budgetCapacity)
+	}
+	// With 20 slow files and capacity 8, fan-out must exceed the old fixed
+	// per-import cap of 5 — the whole point of removing max_import_connections.
+	if mif <= 5 {
+		t.Errorf("regression: MaxInFlight=%d, expected > 5. A single import should "+
+			"expand to the pool's capacity, not the removed fixed cap.", mif)
 	}
 }
 
-// TestStorm_ImporterParallelImportsAreNotInternallyGated asserts that the
-// parser itself does not bound cross-import fan-out. N concurrent imports
-// each fan out up to MaxImportConnections, so MaxInFlight scales as
-// N × MaxImportConnections. Cross-job admission control, if introduced,
-// belongs at a higher layer — not inside the parser.
-func TestStorm_ImporterParallelImportsAreNotInternallyGated(t *testing.T) {
+// TestStorm_ParallelImportsShareGlobalBudget asserts the cross-job bound the
+// old design lacked: N concurrent imports share ONE budget, so global
+// MaxInFlight stays <= capacity instead of scaling as N × per-import cap.
+func TestStorm_ParallelImportsShareGlobalBudget(t *testing.T) {
 	t.Parallel()
 	const (
-		concurrentImports    = 4
-		filesPerImport       = 5
-		maxImportConnections = 4
-		bodyLatency          = 60 * time.Millisecond
+		concurrentImports = 4
+		filesPerImport    = 6
+		budgetCapacity    = 5
+		bodyLatency       = 60 * time.Millisecond
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -148,7 +177,9 @@ func TestStorm_ImporterParallelImportsAreNotInternallyGated(t *testing.T) {
 	}
 
 	mgr := newFakeFullPoolManager(fp)
-	parser := NewParser(mgr, stormConfigGetter(maxImportConnections))
+	mgr.budget = pool.NewImportBudget()
+	mgr.budget.SetCapacity(budgetCapacity)
+	parser := NewParser(mgr, stormConfigGetter(budgetCapacity))
 
 	var wg sync.WaitGroup
 	for i := 0; i < concurrentImports; i++ {
@@ -162,17 +193,14 @@ func TestStorm_ImporterParallelImportsAreNotInternallyGated(t *testing.T) {
 	wg.Wait()
 
 	mif := fp.MaxInFlight()
-	t.Logf("%d concurrent imports × %d files (MaxImportConnections=%d) "+
-		"produced MaxInFlight=%d (parser does NOT internally cap cross-import fan-out)",
-		concurrentImports, filesPerImport, maxImportConnections, mif)
+	t.Logf("%d concurrent imports × %d files (budget capacity=%d) "+
+		"produced global MaxInFlight=%d (invariant: MaxInFlight <= capacity)",
+		concurrentImports, filesPerImport, budgetCapacity, mif)
 
-	// The parser must NOT silently re-introduce an internal slot. If MaxInFlight
-	// stays <= maxImportConnections under N concurrent imports, the parser is
-	// gating internally — regression.
-	minExpected := int32(maxImportConnections + 1)
-	if mif < minExpected {
-		t.Errorf("regression: MaxInFlight=%d, expected > %d. Parser appears to be "+
-			"gating cross-import fan-out internally.",
-			mif, maxImportConnections)
+	if mif > int32(budgetCapacity) {
+		t.Errorf("INVARIANT regression: global MaxInFlight=%d across %d concurrent "+
+			"imports, want <= %d. The import connection budget must bound total "+
+			"in-flight fetches pool-wide, not per job.",
+			mif, concurrentImports, budgetCapacity)
 	}
 }

--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -176,7 +176,7 @@ func (proc *Processor) checkCancellation(ctx context.Context) error {
 // round-trips. Returns (brokenFileIndexes, knownMissingSegmentIDs, error).
 // Both maps are nil when no pool is available.
 // Returns ErrNoFilesProcessed (wrapped) when all eligible regular files are broken.
-func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID, maxConnections int) (map[int]struct{}, map[string]struct{}, error) {
+func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, cfg *config.Config, queueID int) (map[int]struct{}, map[string]struct{}, error) {
 	if !proc.poolManager.HasPool() {
 		return nil, nil, nil
 	}
@@ -207,10 +207,8 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 
 	// Stat is a cheap single round-trip on the pool's normal lane; excess
 	// requests queue and yield to streaming (priority lane). Run sweeps at the
-	// pool's full connection capacity rather than MaxImportConnections (which
-	// caps sustained body downloads) so multi-part releases don't crawl
-	// 5-at-a-time.
-	concurrency := fastFailConcurrency(cfg, maxConnections)
+	// pool's full connection capacity so multi-part releases don't crawl.
+	concurrency := fastFailConcurrency(cfg)
 
 	// Phase 1: cheap release-level probe. Sample the whole release once
 	// (≤55 Stats) and fail fast. Healthy releases — the common case — pay only
@@ -368,22 +366,11 @@ func longestSampledRun(segments []*metapb.SegmentData, missingIDs []string) int 
 
 // fastFailConcurrency returns the goroutine cap for the fast-fail Stat sweep.
 // Stats are cheap and queue on the pool's normal lane, so we use the pool's
-// full connection capacity (sum of enabled providers' max connections) rather
-// than the import body-download cap. Falls back to fallback when no capacity is
-// configured and is bounded to keep goroutine counts sane.
-func fastFailConcurrency(cfg *config.Config, fallback int) int {
+// full connection capacity, bounded to keep goroutine counts sane.
+func fastFailConcurrency(cfg *config.Config) int {
 	const maxConcurrency = 100
 
-	capacity := 0
-	for _, p := range cfg.Providers {
-		if p.Enabled == nil || *p.Enabled {
-			capacity += p.MaxConnections
-		}
-	}
-
-	if capacity <= 0 {
-		capacity = fallback
-	}
+	capacity := cfg.TotalProviderConnections()
 	if capacity <= 0 {
 		capacity = 1
 	}
@@ -412,7 +399,6 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 	cfg := proc.configGetter()
 
 	// Determine max connections to use
-	maxConnections := cfg.Import.MaxImportConnections
 
 	// Determine allowed file extensions to use
 	allowedExtensions := cfg.Import.AllowedFileExtensions
@@ -457,7 +443,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		proc.updateProgressWithStage(queueID, 0, "Checking segment availability")
 		var missingIDs map[string]struct{}
 		var fastFailErr error
-		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID, maxConnections)
+		brokenIdx, missingIDs, fastFailErr = proc.preParseFastFail(ctx, n, cfg, queueID)
 		if fastFailErr != nil {
 			return "", nil, NewNonRetryableError("fast-fail segment check failed", fastFailErr)
 		}
@@ -525,8 +511,7 @@ func (proc *Processor) ProcessNzbFile(ctx context.Context, filePath, relativePat
 		"virtual_dir", virtualDir,
 		"type", parsed.Type,
 		"total_size", parsed.TotalSize,
-		"files", len(parsed.Files),
-		"max_connections", maxConnections)
+		"files", len(parsed.Files))
 
 	// Step 3: Separate files by type (regular, archive, PAR2)
 	regularFiles, archiveFiles, par2Files := filesystem.SeparateFiles(parsed.Files, parsed.Type)

--- a/internal/importer/processor_test.go
+++ b/internal/importer/processor_test.go
@@ -48,7 +48,12 @@ func (m processorTestPoolManager) SetProviderIDs(map[string]string) {}
 func (m processorTestPoolManager) AcquireImportSlot(context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m processorTestPoolManager) SetAdmissionCaps(int, int)                 {}
+func (m processorTestPoolManager) SetAdmissionCap(int) {}
+func (m processorTestPoolManager) AcquireImportConnection(context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m processorTestPoolManager) SetImportConnCapacity(int)                 {}
+func (m processorTestPoolManager) ImportConnCapacity() int                   { return 0 }
 func (m processorTestPoolManager) SetStreamSource(pool.StreamActivitySource) {}
 func (m processorTestPoolManager) NotifyStreamChange()                       {}
 
@@ -67,7 +72,7 @@ func TestPreParseFastFailSkipsOnlyMissingEpisode(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -107,7 +112,7 @@ func TestPreParseFastFailMarksWholeRarSetBroken(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -146,7 +151,7 @@ func TestPreParseFastFailAllRarSetsBrokenReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -167,7 +172,7 @@ func TestPreParseFastFailDoesNotStatPar2(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -198,7 +203,7 @@ func TestPreParseFastFailAllMissingReturnsNoFilesProcessed(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("preParseFastFail error = %v, want ErrNoFilesProcessed", err)
 	}
@@ -226,7 +231,7 @@ func TestPreParseFastFailHealthyReleaseSkipsPerFileSweep(t *testing.T) {
 	n := buildTestNzb(files)
 	cfg := config.DefaultConfig() // default 1% sampling, capped at 55
 
-	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, missingIDs, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -247,39 +252,34 @@ func TestFastFailConcurrency(t *testing.T) {
 	enabled := true
 	disabled := false
 	tests := []struct {
-		name     string
-		cfg      *config.Config
-		fallback int
-		want     int
+		name string
+		cfg  *config.Config
+		want int
 	}{
 		{
-			name:     "sums enabled providers (nil Enabled counts as enabled)",
-			cfg:      &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &enabled}, {MaxConnections: 20}}},
-			fallback: 5,
-			want:     30,
+			name: "sums enabled providers (nil Enabled counts as enabled)",
+			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &enabled}, {MaxConnections: 20}}},
+			want: 30,
 		},
 		{
-			name:     "skips disabled providers",
-			cfg:      &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &disabled}, {MaxConnections: 20, Enabled: &enabled}}},
-			fallback: 5,
-			want:     20,
+			name: "skips disabled providers",
+			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 10, Enabled: &disabled}, {MaxConnections: 20, Enabled: &enabled}}},
+			want: 20,
 		},
 		{
-			name:     "falls back when no capacity configured",
-			cfg:      &config.Config{},
-			fallback: 7,
-			want:     7,
+			name: "floors at 1 when no capacity configured",
+			cfg:  &config.Config{},
+			want: 1,
 		},
 		{
-			name:     "caps at 100",
-			cfg:      &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 500, Enabled: &enabled}}},
-			fallback: 5,
-			want:     100,
+			name: "caps at 100",
+			cfg:  &config.Config{Providers: []config.ProviderConfig{{MaxConnections: 500, Enabled: &enabled}}},
+			want: 100,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := fastFailConcurrency(tt.cfg, tt.fallback); got != tt.want {
+			if got := fastFailConcurrency(tt.cfg); got != tt.want {
 				t.Fatalf("fastFailConcurrency = %d, want %d", got, tt.want)
 			}
 		})
@@ -619,7 +619,7 @@ func TestPreParseFastFailTolerantImportsDegradedVideo(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if err != nil {
 		t.Fatalf("preParseFastFail returned error: %v", err)
 	}
@@ -641,7 +641,7 @@ func TestPreParseFastFailStrictFailsDegradedVideo(t *testing.T) {
 	cfg.Import.SegmentSamplePercentage = 100
 	cfg.Import.DamagePolicy = "strict"
 
-	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	brokenIdx, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		// Single file, and it's broken → all eligible broken → ErrNoFilesProcessed.
 		t.Fatalf("strict policy: err = %v, want ErrNoFilesProcessed", err)
@@ -662,7 +662,7 @@ func TestPreParseFastFailTolerantStillFailsLongRun(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Import.SegmentSamplePercentage = 100
 
-	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1, 1)
+	_, _, err := proc.preParseFastFail(context.Background(), n, cfg, 1)
 	if !errors.Is(err, multifile.ErrNoFilesProcessed) {
 		t.Fatalf("tolerant policy with long run: err = %v, want ErrNoFilesProcessed", err)
 	}

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -258,14 +258,11 @@ func NewService(config ServiceConfig, metadataService *metadata.MetadataService,
 		paused:          false,
 	}
 
-	// Push initial admission caps to the pool so imports are gated from the
-	// start. Zero values keep the controller disabled, matching prior behaviour.
+	// Push the initial admission cap to the pool so imports are gated from the
+	// start. Zero keeps the controller disabled, matching prior behaviour.
 	if poolManager != nil && configGetter != nil {
 		if cfg := configGetter(); cfg != nil {
-			poolManager.SetAdmissionCaps(
-				cfg.GetMaxConcurrentImports(),
-				cfg.GetMaxConcurrentImportsWhileStreaming(),
-			)
+			poolManager.SetAdmissionCap(cfg.GetMaxConcurrentImports())
 		}
 	}
 
@@ -431,15 +428,13 @@ func (s *Service) RegisterConfigChangeHandler(configManager any) {
 			}
 		}
 
-		// Push updated import-admission caps to the pool. Zero values keep
+		// Push the updated import-admission cap to the pool. Zero keeps
 		// the admission gate disabled (unlimited).
 		if s.poolManager != nil {
-			capIdle := newConfig.GetMaxConcurrentImports()
-			capWhileStreaming := newConfig.GetMaxConcurrentImportsWhileStreaming()
-			s.poolManager.SetAdmissionCaps(capIdle, capWhileStreaming)
-			s.log.InfoContext(s.ctx, "Import admission caps updated",
-				"max_concurrent_imports", capIdle,
-				"max_concurrent_imports_while_streaming", capWhileStreaming)
+			cap := newConfig.GetMaxConcurrentImports()
+			s.poolManager.SetAdmissionCap(cap)
+			s.log.InfoContext(s.ctx, "Import admission cap updated",
+				"max_concurrent_imports", cap)
 		}
 	})
 }

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -38,7 +38,12 @@ func (m fastFailPoolManager) SetProviderIDs(map[string]string) {}
 func (m fastFailPoolManager) AcquireImportSlot(context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m fastFailPoolManager) SetAdmissionCaps(int, int)                 {}
+func (m fastFailPoolManager) SetAdmissionCap(int) {}
+func (m fastFailPoolManager) AcquireImportConnection(context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m fastFailPoolManager) SetImportConnCapacity(int)                 {}
+func (m fastFailPoolManager) ImportConnCapacity() int                   { return 0 }
 func (m fastFailPoolManager) SetStreamSource(pool.StreamActivitySource) {}
 func (m fastFailPoolManager) NotifyStreamChange()                       {}
 

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -394,7 +394,12 @@ func (m *mockPoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
 
-func (m *mockPoolManager) SetAdmissionCaps(_ int, _ int) {}
+func (m *mockPoolManager) SetAdmissionCap(_ int) {}
+func (m *mockPoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *mockPoolManager) SetImportConnCapacity(_ int) {}
+func (m *mockPoolManager) ImportConnCapacity() int     { return 0 }
 
 func (m *mockPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 

--- a/internal/nzbfilesystem/streamtest_helpers_test.go
+++ b/internal/nzbfilesystem/streamtest_helpers_test.go
@@ -34,18 +34,20 @@ func newFakePoolManager(c pool.NntpClient) *fakePoolManager {
 	return &fakePoolManager{client: c}
 }
 
-func (m *fakePoolManager) GetPool() (pool.NntpClient, error)            { return m.client, nil }
-func (m *fakePoolManager) SetProviders(_ []nntppool.Provider) error     { return nil }
-func (m *fakePoolManager) ClearPool() error                              { return nil }
-func (m *fakePoolManager) HasPool() bool                                 { return true }
-func (m *fakePoolManager) GetMetrics() (pool.MetricsSnapshot, error)     { return pool.MetricsSnapshot{}, nil }
+func (m *fakePoolManager) GetPool() (pool.NntpClient, error)        { return m.client, nil }
+func (m *fakePoolManager) SetProviders(_ []nntppool.Provider) error { return nil }
+func (m *fakePoolManager) ClearPool() error                         { return nil }
+func (m *fakePoolManager) HasPool() bool                            { return true }
+func (m *fakePoolManager) GetMetrics() (pool.MetricsSnapshot, error) {
+	return pool.MetricsSnapshot{}, nil
+}
 func (m *fakePoolManager) ResetMetrics(_ context.Context, _, _ bool) error { return nil }
-func (m *fakePoolManager) ResetProviderErrors(_ context.Context) error   { return nil }
-func (m *fakePoolManager) IncArticlesDownloaded()                        {}
-func (m *fakePoolManager) UpdateDownloadProgress(_ string, _ int64)      {}
-func (m *fakePoolManager) IncArticlesPosted()                            {}
-func (m *fakePoolManager) AddProvider(_ nntppool.Provider) error         { return nil }
-func (m *fakePoolManager) RemoveProvider(_ string) error                 { return nil }
+func (m *fakePoolManager) ResetProviderErrors(_ context.Context) error     { return nil }
+func (m *fakePoolManager) IncArticlesDownloaded()                          {}
+func (m *fakePoolManager) UpdateDownloadProgress(_ string, _ int64)        {}
+func (m *fakePoolManager) IncArticlesPosted()                              {}
+func (m *fakePoolManager) AddProvider(_ nntppool.Provider) error           { return nil }
+func (m *fakePoolManager) RemoveProvider(_ string) error                   { return nil }
 func (m *fakePoolManager) ResetProviderQuota(_ context.Context, _ string) error {
 	return nil
 }
@@ -53,7 +55,12 @@ func (m *fakePoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *fakePoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *fakePoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *fakePoolManager) SetAdmissionCap(_ int) {}
+func (m *fakePoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *fakePoolManager) SetImportConnCapacity(_ int)                 {}
+func (m *fakePoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *fakePoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *fakePoolManager) NotifyStreamChange()                         {}
 

--- a/internal/pool/admission.go
+++ b/internal/pool/admission.go
@@ -2,7 +2,6 @@ package pool
 
 import (
 	"context"
-	"sync"
 )
 
 // StreamActivitySource reports how many streams are currently active.
@@ -11,190 +10,42 @@ type StreamActivitySource interface {
 	ActiveStreams() int
 }
 
-// ImportAdmission is an adaptive counting semaphore that gates how many NZB
-// imports may run concurrently end-to-end. It exposes two caps:
+// ImportAdmission is a counting semaphore that gates how many NZB imports may
+// run concurrently end-to-end. A cap of 0 means "unlimited" (the controller is
+// a no-op), which is the default so deployments behave as before until the
+// max_concurrent_imports config knob is set.
 //
-//   - capIdle: maximum concurrent imports when no stream is active.
-//   - capWhileStreaming: maximum concurrent imports while any stream is active.
-//
-// A cap value of 0 means "unlimited" for that mode. When both caps are 0 the
-// admission controller is a no-op, which is the default so existing
-// deployments behave exactly as before until the new config knobs are set.
-//
-// The controller uses a FIFO waiter queue with manual select / channel signalling
-// so we can support ctx cancellation without dropping wake-ups (the classic
-// "lost wakeup" hazard with sync.Cond.Wait + cancellation).
+// Connection-level balancing between imports and streams is handled separately
+// by ImportBudget; this gate only bounds whole-import parallelism (CPU, disk,
+// queue pressure).
 type ImportAdmission struct {
-	mu                sync.Mutex
-	capIdle           int
-	capWhileStreaming int
-	inFlight          int
-	waiters           []*waiter
-	streamSource      StreamActivitySource
+	sem adaptiveSemaphore
+	cap int
 }
 
-type waiter struct {
-	// ch is closed (or sent on) exactly once when the waiter is granted a slot.
-	// Buffered with capacity 1 so a granter never blocks; on a race with ctx
-	// cancellation, the cancelling goroutine drains and forwards the grant to
-	// the next waiter to avoid losing the wake-up.
-	ch chan struct{}
-}
-
-// NewImportAdmission constructs an admission controller with both caps disabled
-// (0/0 = unlimited). Use SetCaps and SetStreamSource to configure it.
+// NewImportAdmission constructs an admission controller with the cap disabled
+// (0 = unlimited). Use SetCap to configure it.
 func NewImportAdmission() *ImportAdmission {
-	return &ImportAdmission{}
+	a := &ImportAdmission{}
+	a.sem.capLocked = func() int { return a.cap }
+	return a
 }
 
-// SetCaps updates both caps. If capWhileStreaming > capIdle and capIdle > 0,
-// the streaming cap is clamped to capIdle. After updating, queued waiters are
-// woken if the effective cap grew.
-func (a *ImportAdmission) SetCaps(capIdle, capWhileStreaming int) {
-	if capIdle < 0 {
-		capIdle = 0
+// SetCap updates the cap. Queued waiters are woken if the cap grew.
+// A cap of 0 disables the gate (unlimited).
+func (a *ImportAdmission) SetCap(cap int) {
+	if cap < 0 {
+		cap = 0
 	}
-	if capWhileStreaming < 0 {
-		capWhileStreaming = 0
-	}
-	if capIdle > 0 && capWhileStreaming > capIdle {
-		capWhileStreaming = capIdle
-	}
-
-	a.mu.Lock()
-	a.capIdle = capIdle
-	a.capWhileStreaming = capWhileStreaming
-	a.wakeWaitersLocked()
-	a.mu.Unlock()
-}
-
-// SetStreamSource wires the activity signal. nil sources are tolerated and
-// effectively pin behaviour to capIdle.
-func (a *ImportAdmission) SetStreamSource(src StreamActivitySource) {
-	a.mu.Lock()
-	a.streamSource = src
-	a.wakeWaitersLocked()
-	a.mu.Unlock()
-}
-
-// NotifyStreamChange should be called when the stream count changes so the
-// controller can wake or hold waiters according to the new effective cap.
-func (a *ImportAdmission) NotifyStreamChange() {
-	a.mu.Lock()
-	a.wakeWaitersLocked()
-	a.mu.Unlock()
+	a.sem.mu.Lock()
+	a.cap = cap
+	a.sem.wakeWaitersLocked()
+	a.sem.mu.Unlock()
 }
 
 // Acquire blocks until an admission slot is available or ctx is cancelled.
 // The returned release function MUST be called exactly once when the import is
-// done. When both caps are 0 the call is a fast-path no-op.
+// done. When the cap is 0 the call is a fast-path no-op.
 func (a *ImportAdmission) Acquire(ctx context.Context) (release func(), err error) {
-	a.mu.Lock()
-	if a.disabledLocked() {
-		a.mu.Unlock()
-		return noopRelease, nil
-	}
-
-	if a.inFlight < a.currentCapLocked() {
-		a.inFlight++
-		a.mu.Unlock()
-		return a.releaseOnce(), nil
-	}
-
-	w := &waiter{ch: make(chan struct{}, 1)}
-	a.waiters = append(a.waiters, w)
-	a.mu.Unlock()
-
-	select {
-	case <-w.ch:
-		// Granted. inFlight was already incremented by the granter.
-		return a.releaseOnce(), nil
-	case <-ctx.Done():
-		// We may have been granted concurrently. Resolve the race under the
-		// lock: if the channel has a pending wake, consume it and forward it
-		// to the next waiter; otherwise remove ourselves from the queue.
-		a.mu.Lock()
-		select {
-		case <-w.ch:
-			// Already granted. Hand the slot to the next waiter.
-			a.inFlight-- // undo the grant
-			a.wakeWaitersLocked()
-		default:
-			a.removeWaiterLocked(w)
-		}
-		a.mu.Unlock()
-		return noopRelease, ctx.Err()
-	}
+	return a.sem.Acquire(ctx)
 }
-
-// disabledLocked reports true when both caps are 0 (controller is a no-op).
-func (a *ImportAdmission) disabledLocked() bool {
-	return a.capIdle == 0 && a.capWhileStreaming == 0
-}
-
-// currentCapLocked returns the cap that applies right now. A cap of 0 means
-// unlimited; we return a very large number so the comparison `inFlight < cap`
-// is effectively always true.
-func (a *ImportAdmission) currentCapLocked() int {
-	cap := a.capIdle
-	if a.streamSource != nil && a.streamSource.ActiveStreams() > 0 {
-		cap = a.capWhileStreaming
-	}
-	if cap <= 0 {
-		// Unlimited.
-		return 1 << 30
-	}
-	return cap
-}
-
-// wakeWaitersLocked wakes waiters in FIFO order while there is headroom under
-// the current cap. Each wake-up increments inFlight, so callers that receive
-// the signal must call their release exactly once.
-func (a *ImportAdmission) wakeWaitersLocked() {
-	if a.disabledLocked() {
-		// Drain any waiters (shouldn't exist when both caps are 0, but be safe).
-		for _, w := range a.waiters {
-			select {
-			case w.ch <- struct{}{}:
-				a.inFlight++
-			default:
-			}
-		}
-		a.waiters = nil
-		return
-	}
-
-	cap := a.currentCapLocked()
-	for len(a.waiters) > 0 && a.inFlight < cap {
-		w := a.waiters[0]
-		a.waiters = a.waiters[1:]
-		a.inFlight++
-		// Buffered chan capacity 1 — never blocks.
-		w.ch <- struct{}{}
-	}
-}
-
-func (a *ImportAdmission) removeWaiterLocked(target *waiter) {
-	for i, w := range a.waiters {
-		if w == target {
-			a.waiters = append(a.waiters[:i], a.waiters[i+1:]...)
-			return
-		}
-	}
-}
-
-func (a *ImportAdmission) releaseOnce() func() {
-	var once sync.Once
-	return func() {
-		once.Do(func() {
-			a.mu.Lock()
-			if a.inFlight > 0 {
-				a.inFlight--
-			}
-			a.wakeWaitersLocked()
-			a.mu.Unlock()
-		})
-	}
-}
-
-func noopRelease() {}

--- a/internal/pool/admission_test.go
+++ b/internal/pool/admission_test.go
@@ -31,7 +31,7 @@ func waitFor(d time.Duration, cond func() bool) bool {
 
 func TestImportAdmission_DisabledIsNoOp(t *testing.T) {
 	a := NewImportAdmission()
-	// caps (0, 0) -> disabled: every Acquire returns immediately, no queueing.
+	// cap 0 -> disabled: every Acquire returns immediately, no queueing.
 	for i := range 100 {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		release, err := a.Acquire(ctx)
@@ -42,16 +42,16 @@ func TestImportAdmission_DisabledIsNoOp(t *testing.T) {
 		release()
 	}
 
-	a.mu.Lock()
-	if a.inFlight != 0 {
-		t.Fatalf("disabled controller leaked inFlight=%d", a.inFlight)
+	a.sem.mu.Lock()
+	if a.sem.inFlight != 0 {
+		t.Fatalf("disabled controller leaked inFlight=%d", a.sem.inFlight)
 	}
-	a.mu.Unlock()
+	a.sem.mu.Unlock()
 }
 
 func TestImportAdmission_BlocksAtCap(t *testing.T) {
 	a := NewImportAdmission()
-	a.SetCaps(2, 1)
+	a.SetCap(2)
 
 	r1, err := a.Acquire(context.Background())
 	if err != nil {
@@ -93,7 +93,7 @@ func TestImportAdmission_BlocksAtCap(t *testing.T) {
 
 func TestImportAdmission_FIFO(t *testing.T) {
 	a := NewImportAdmission()
-	a.SetCaps(1, 1)
+	a.SetCap(1)
 
 	// Hold the single slot.
 	hold, err := a.Acquire(context.Background())
@@ -138,59 +138,9 @@ func TestImportAdmission_FIFO(t *testing.T) {
 	}
 }
 
-func TestImportAdmission_StreamAwareCap(t *testing.T) {
-	src := &stubStreamSource{}
+func TestImportAdmission_GrowOnSetCapWakesWaiters(t *testing.T) {
 	a := NewImportAdmission()
-	a.SetStreamSource(src)
-	a.SetCaps(3, 1)
-
-	// No streams -> capIdle=3.
-	r1, _ := a.Acquire(context.Background())
-	r2, _ := a.Acquire(context.Background())
-	r3, _ := a.Acquire(context.Background())
-
-	// Activate streams. Existing in-flight imports remain.
-	src.set(1)
-	a.NotifyStreamChange()
-
-	// A fourth must block because capWhileStreaming=1 and inFlight=3.
-	blocked := make(chan struct{})
-	go func() {
-		r, err := a.Acquire(context.Background())
-		if err == nil {
-			close(blocked)
-			r()
-		}
-	}()
-	select {
-	case <-blocked:
-		t.Fatal("Acquire should be blocked while streams active and inFlight > capWhileStreaming")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	// Release two: inFlight=1 == capWhileStreaming, still no admission.
-	r1()
-	r2()
-	select {
-	case <-blocked:
-		t.Fatal("Acquire should still be blocked at capWhileStreaming")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	// Stop streaming — cap returns to 3 and the waiter is granted.
-	src.set(0)
-	a.NotifyStreamChange()
-	select {
-	case <-blocked:
-	case <-time.After(time.Second):
-		t.Fatal("Acquire should have been granted after streams ended")
-	}
-	r3()
-}
-
-func TestImportAdmission_GrowOnSetCapsWakesWaiters(t *testing.T) {
-	a := NewImportAdmission()
-	a.SetCaps(1, 1)
+	a.SetCap(1)
 
 	hold, _ := a.Acquire(context.Background())
 
@@ -214,21 +164,21 @@ func TestImportAdmission_GrowOnSetCapsWakesWaiters(t *testing.T) {
 
 	// Wait for them to enqueue.
 	if !waitFor(time.Second, func() bool {
-		a.mu.Lock()
-		defer a.mu.Unlock()
-		return len(a.waiters) == n
+		a.sem.mu.Lock()
+		defer a.sem.mu.Unlock()
+		return len(a.sem.waiters) == n
 	}) {
 		t.Fatalf("expected %d waiters", n)
 	}
 
-	// Grow capIdle to fit them all without releasing the holder.
-	a.SetCaps(1+n, 1)
+	// Grow the cap to fit them all without releasing the holder.
+	a.SetCap(1 + n)
 
 	for i := range n {
 		select {
 		case <-granted:
 		case <-time.After(time.Second):
-			t.Fatalf("waiter %d not granted after SetCaps grew the cap", i)
+			t.Fatalf("waiter %d not granted after SetCap grew the cap", i)
 		}
 	}
 
@@ -242,7 +192,7 @@ func TestImportAdmission_GrowOnSetCapsWakesWaiters(t *testing.T) {
 
 func TestImportAdmission_CtxCancelRemovesWaiter(t *testing.T) {
 	a := NewImportAdmission()
-	a.SetCaps(1, 1)
+	a.SetCap(1)
 
 	hold, _ := a.Acquire(context.Background())
 
@@ -255,9 +205,9 @@ func TestImportAdmission_CtxCancelRemovesWaiter(t *testing.T) {
 
 	// Wait for the waiter to be enqueued.
 	if !waitFor(time.Second, func() bool {
-		a.mu.Lock()
-		defer a.mu.Unlock()
-		return len(a.waiters) == 1
+		a.sem.mu.Lock()
+		defer a.sem.mu.Unlock()
+		return len(a.sem.waiters) == 1
 	}) {
 		t.Fatal("waiter never enqueued")
 	}
@@ -273,14 +223,14 @@ func TestImportAdmission_CtxCancelRemovesWaiter(t *testing.T) {
 	}
 
 	// Waiter slot must be reclaimed; inFlight must remain 1 (the holder).
-	a.mu.Lock()
-	if len(a.waiters) != 0 {
-		t.Fatalf("expected 0 waiters after cancel, got %d", len(a.waiters))
+	a.sem.mu.Lock()
+	if len(a.sem.waiters) != 0 {
+		t.Fatalf("expected 0 waiters after cancel, got %d", len(a.sem.waiters))
 	}
-	if a.inFlight != 1 {
-		t.Fatalf("expected inFlight=1, got %d", a.inFlight)
+	if a.sem.inFlight != 1 {
+		t.Fatalf("expected inFlight=1, got %d", a.sem.inFlight)
 	}
-	a.mu.Unlock()
+	a.sem.mu.Unlock()
 
 	hold()
 }
@@ -289,7 +239,7 @@ func TestImportAdmission_CtxCancelRaceForwardsGrant(t *testing.T) {
 	// Race condition: a waiter is granted at the same moment its ctx cancels.
 	// We must not consume the grant and starve the next waiter.
 	a := NewImportAdmission()
-	a.SetCaps(1, 1)
+	a.SetCap(1)
 
 	hold, _ := a.Acquire(context.Background())
 
@@ -317,9 +267,9 @@ func TestImportAdmission_CtxCancelRaceForwardsGrant(t *testing.T) {
 	}()
 
 	if !waitFor(time.Second, func() bool {
-		a.mu.Lock()
-		defer a.mu.Unlock()
-		return len(a.waiters) == 2
+		a.sem.mu.Lock()
+		defer a.sem.mu.Unlock()
+		return len(a.sem.waiters) == 2
 	}) {
 		t.Fatal("expected 2 waiters")
 	}

--- a/internal/pool/budget.go
+++ b/internal/pool/budget.go
@@ -1,0 +1,98 @@
+package pool
+
+import (
+	"context"
+)
+
+// streamHeadroom is how many connections are set aside per active stream when
+// shrinking the import budget. Deliberately a constant, not config: the whole
+// point of the budget is automatic balancing without knobs. Streams get hard
+// priority via the pool's priority request lane regardless; the headroom just
+// keeps free connections available so a stream never waits for an import
+// article to finish.
+const streamHeadroom = 2
+
+// ImportBudget bounds the total number of in-flight import segment (body)
+// fetches pool-wide, across all concurrent imports. Its capacity tracks the
+// pool's total connection count and automatically shrinks while streams are
+// active:
+//
+//	effective cap = capacity − min(streamHeadroom × activeStreams, capacity−1)
+//
+// so imports expand to the full pool when idle, yield headroom to streams
+// under playback, and always keep at least 1 connection so a lone import can
+// make progress. A capacity of 0 disables the budget (no-op), which keeps
+// pool-less paths and test fakes deadlock-free.
+type ImportBudget struct {
+	sem          adaptiveSemaphore
+	capacity     int
+	streamSource StreamActivitySource
+}
+
+// NewImportBudget constructs a budget with capacity 0 (disabled). Use
+// SetCapacity and SetStreamSource to configure it.
+func NewImportBudget() *ImportBudget {
+	b := &ImportBudget{}
+	b.sem.capLocked = b.effectiveCapLocked
+	return b
+}
+
+// effectiveCapLocked computes the current cap. Called with sem.mu held.
+func (b *ImportBudget) effectiveCapLocked() int {
+	if b.capacity <= 0 {
+		return 0 // disabled
+	}
+	reserve := 0
+	if b.streamSource != nil {
+		reserve = streamHeadroom * b.streamSource.ActiveStreams()
+	}
+	if reserve > b.capacity-1 {
+		reserve = b.capacity - 1
+	}
+	return b.capacity - reserve
+}
+
+// SetCapacity updates the total connection capacity (sum of provider
+// connections). Queued waiters are woken if the effective cap grew; on shrink,
+// in-flight fetches drain naturally.
+func (b *ImportBudget) SetCapacity(totalConns int) {
+	if totalConns < 0 {
+		totalConns = 0
+	}
+	b.sem.mu.Lock()
+	b.capacity = totalConns
+	b.sem.wakeWaitersLocked()
+	b.sem.mu.Unlock()
+}
+
+// Capacity returns the configured total capacity (not the stream-adjusted
+// effective cap). Useful for sizing worker pools.
+func (b *ImportBudget) Capacity() int {
+	b.sem.mu.Lock()
+	defer b.sem.mu.Unlock()
+	return b.capacity
+}
+
+// SetStreamSource wires the activity signal. nil sources are tolerated and
+// pin the effective cap to the full capacity.
+func (b *ImportBudget) SetStreamSource(src StreamActivitySource) {
+	b.sem.mu.Lock()
+	b.streamSource = src
+	b.sem.wakeWaitersLocked()
+	b.sem.mu.Unlock()
+}
+
+// NotifyStreamChange should be called when the stream count changes so the
+// budget can wake or hold waiters according to the new effective cap.
+func (b *ImportBudget) NotifyStreamChange() {
+	b.sem.mu.Lock()
+	b.sem.wakeWaitersLocked()
+	b.sem.mu.Unlock()
+}
+
+// Acquire blocks until a connection token is available or ctx is cancelled.
+// The returned release function MUST be called exactly once when the fetch is
+// done. When the capacity is 0 the call is a fast-path no-op.
+func (b *ImportBudget) Acquire(ctx context.Context) (release func(), err error) {
+	return b.sem.Acquire(ctx)
+}

--- a/internal/pool/budget_test.go
+++ b/internal/pool/budget_test.go
@@ -1,0 +1,278 @@
+package pool
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestImportBudget_ZeroCapacityIsNoOp(t *testing.T) {
+	b := NewImportBudget()
+	for i := range 50 {
+		release, err := b.Acquire(context.Background())
+		if err != nil {
+			t.Fatalf("Acquire %d failed: %v", i, err)
+		}
+		release()
+	}
+	b.sem.mu.Lock()
+	if b.sem.inFlight != 0 {
+		t.Fatalf("disabled budget leaked inFlight=%d", b.sem.inFlight)
+	}
+	b.sem.mu.Unlock()
+}
+
+func TestImportBudget_BlocksAtCapacityAndWakesOnRelease(t *testing.T) {
+	b := NewImportBudget()
+	b.SetCapacity(2)
+
+	r1, err := b.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	r2, err := b.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		r, err := b.Acquire(context.Background())
+		if err != nil {
+			t.Errorf("acquire 3: %v", err)
+			return
+		}
+		close(acquired)
+		r()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("third Acquire should block at capacity 2")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	r1()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("third Acquire did not unblock after release")
+	}
+	r2()
+}
+
+func TestImportBudget_StreamsShrinkEffectiveCap(t *testing.T) {
+	src := &stubStreamSource{}
+	b := NewImportBudget()
+	b.SetStreamSource(src)
+	b.SetCapacity(8)
+
+	// 2 streams -> reserve 2*streamHeadroom=4 -> effective cap 4.
+	src.set(2)
+	b.NotifyStreamChange()
+
+	var releases []func()
+	for i := range 4 {
+		r, err := b.Acquire(context.Background())
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		releases = append(releases, r)
+	}
+
+	blocked := make(chan struct{})
+	go func() {
+		r, err := b.Acquire(context.Background())
+		if err == nil {
+			close(blocked)
+			r()
+		}
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("fifth Acquire should block at effective cap 4 (capacity 8, 2 streams)")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Streams stop -> effective cap returns to 8, waiter granted.
+	src.set(0)
+	b.NotifyStreamChange()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("waiter not granted after streams ended")
+	}
+	for _, r := range releases {
+		r()
+	}
+}
+
+func TestImportBudget_FloorOfOneUnderManyStreams(t *testing.T) {
+	src := &stubStreamSource{}
+	b := NewImportBudget()
+	b.SetStreamSource(src)
+	b.SetCapacity(4)
+
+	// Reservation would exceed capacity — cap must floor at 1, not 0.
+	src.set(100)
+	b.NotifyStreamChange()
+
+	r1, err := b.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire under floor: %v", err)
+	}
+
+	blocked := make(chan struct{})
+	go func() {
+		r, err := b.Acquire(context.Background())
+		if err == nil {
+			close(blocked)
+			r()
+		}
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("second Acquire should block at floored cap 1")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	r1()
+	select {
+	case <-blocked:
+	case <-time.After(time.Second):
+		t.Fatal("waiter not granted after release at floored cap")
+	}
+}
+
+func TestImportBudget_SetCapacityGrowWakesWaiters(t *testing.T) {
+	b := NewImportBudget()
+	b.SetCapacity(1)
+
+	hold, _ := b.Acquire(context.Background())
+
+	granted := make(chan struct{})
+	go func() {
+		r, err := b.Acquire(context.Background())
+		if err == nil {
+			close(granted)
+			r()
+		}
+	}()
+
+	if !waitFor(time.Second, func() bool {
+		b.sem.mu.Lock()
+		defer b.sem.mu.Unlock()
+		return len(b.sem.waiters) == 1
+	}) {
+		t.Fatal("waiter never enqueued")
+	}
+
+	b.SetCapacity(2)
+	select {
+	case <-granted:
+	case <-time.After(time.Second):
+		t.Fatal("waiter not granted after capacity grew")
+	}
+	hold()
+}
+
+func TestImportBudget_ShrinkBelowInFlightBlocksNewGrants(t *testing.T) {
+	b := NewImportBudget()
+	b.SetCapacity(3)
+
+	var releases []func()
+	for i := range 3 {
+		r, err := b.Acquire(context.Background())
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		releases = append(releases, r)
+	}
+
+	// Shrink to 1 while 3 are in flight — existing tokens drain naturally.
+	b.SetCapacity(1)
+
+	granted := make(chan struct{})
+	go func() {
+		r, err := b.Acquire(context.Background())
+		if err == nil {
+			close(granted)
+			r()
+		}
+	}()
+
+	// Releasing two still leaves inFlight=1 == cap, so no grant yet.
+	releases[0]()
+	releases[1]()
+	select {
+	case <-granted:
+		t.Fatal("Acquire granted while inFlight >= shrunken cap")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Releasing the last one frees a slot under the new cap.
+	releases[2]()
+	select {
+	case <-granted:
+	case <-time.After(time.Second):
+		t.Fatal("waiter not granted after inFlight drained below the new cap")
+	}
+}
+
+func TestImportBudget_CtxCancelWhileQueued(t *testing.T) {
+	b := NewImportBudget()
+	b.SetCapacity(1)
+
+	hold, _ := b.Acquire(context.Background())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.Acquire(ctx)
+		done <- err
+	}()
+
+	if !waitFor(time.Second, func() bool {
+		b.sem.mu.Lock()
+		defer b.sem.mu.Unlock()
+		return len(b.sem.waiters) == 1
+	}) {
+		t.Fatal("waiter never enqueued")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected ctx error on cancel, got nil")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Acquire did not return after ctx cancellation")
+	}
+
+	b.sem.mu.Lock()
+	if len(b.sem.waiters) != 0 {
+		t.Fatalf("expected 0 waiters after cancel, got %d", len(b.sem.waiters))
+	}
+	if b.sem.inFlight != 1 {
+		t.Fatalf("expected inFlight=1, got %d", b.sem.inFlight)
+	}
+	b.sem.mu.Unlock()
+
+	hold()
+}
+
+func TestImportBudget_CapacitySnapshot(t *testing.T) {
+	b := NewImportBudget()
+	if got := b.Capacity(); got != 0 {
+		t.Fatalf("Capacity() = %d, want 0", got)
+	}
+	b.SetCapacity(42)
+	if got := b.Capacity(); got != 42 {
+		t.Fatalf("Capacity() = %d, want 42", got)
+	}
+	b.SetCapacity(-5)
+	if got := b.Capacity(); got != 0 {
+		t.Fatalf("Capacity() = %d, want 0 after negative set", got)
+	}
+}

--- a/internal/pool/config.go
+++ b/internal/pool/config.go
@@ -11,12 +11,20 @@ import (
 func RegisterConfigHandlers(ctx context.Context, configManager *config.Manager, poolManager Manager) {
 	// Initial ID mapping
 	updateProviderIDMap(configManager.GetConfig(), poolManager)
+	// Initial import connection budget: the pool's total connection capacity.
+	poolManager.SetImportConnCapacity(configManager.GetConfig().TotalProviderConnections())
 
 	configManager.OnConfigChange(func(oldConfig, newConfig *config.Config) {
 		slog.InfoContext(ctx, "Configuration updated")
 
 		updateProviderIDMap(newConfig, poolManager)
 		handleProviderChanges(ctx, oldConfig, newConfig, poolManager)
+
+		// Keep the import connection budget in sync with provider capacity.
+		if capacity := newConfig.TotalProviderConnections(); capacity != oldConfig.TotalProviderConnections() {
+			slog.InfoContext(ctx, "Import connection budget updated", "capacity", capacity)
+			poolManager.SetImportConnCapacity(capacity)
+		}
 
 		// Log changes that still require restart
 		if oldConfig.Metadata.RootPath != newConfig.Metadata.RootPath {

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -65,20 +65,33 @@ type Manager interface {
 	// AcquireImportSlot blocks until an admission slot is available for an
 	// NZB import to start, or ctx is cancelled. The returned release function
 	// must be called exactly once when the import has finished (success or
-	// failure). When admission caps are unconfigured (both 0) it is a no-op.
+	// failure). When the admission cap is unconfigured (0) it is a no-op.
 	AcquireImportSlot(ctx context.Context) (release func(), err error)
 
-	// SetAdmissionCaps configures the two import-concurrency caps:
-	// capIdle applies when no stream is active; capWhileStreaming applies
-	// while any stream is active. A cap of 0 means unlimited.
-	SetAdmissionCaps(capIdle, capWhileStreaming int)
+	// SetAdmissionCap configures the cap on concurrently running NZB imports.
+	// A cap of 0 means unlimited.
+	SetAdmissionCap(cap int)
 
-	// SetStreamSource wires the activity signal so admission can adapt to
-	// whether any stream is currently active.
+	// AcquireImportConnection blocks until the global import connection
+	// budget grants a token for one segment (body) fetch, or ctx is
+	// cancelled. The returned release function must be called exactly once
+	// when the fetch is done. No-op while the budget capacity is unset (0).
+	AcquireImportConnection(ctx context.Context) (release func(), err error)
+
+	// SetImportConnCapacity sets the import connection budget to the pool's
+	// total connection count (sum of provider max connections).
+	SetImportConnCapacity(total int)
+
+	// ImportConnCapacity returns the current budget capacity snapshot,
+	// useful for sizing import worker pools.
+	ImportConnCapacity() int
+
+	// SetStreamSource wires the activity signal so the import connection
+	// budget can shrink while streams are active.
 	SetStreamSource(src StreamActivitySource)
 
 	// NotifyStreamChange must be called by the stream source whenever its
-	// active stream count changes, so the admission gate can re-evaluate.
+	// active stream count changes, so the budget can re-evaluate.
 	NotifyStreamChange()
 }
 
@@ -107,6 +120,7 @@ type manager struct {
 	logger           *slog.Logger
 	quotaWatchCancel context.CancelFunc
 	admission        *ImportAdmission
+	budget           *ImportBudget
 }
 
 // NewManager creates a new pool manager
@@ -116,6 +130,7 @@ func NewManager(ctx context.Context, repo StatsRepository) Manager {
 		repo:      repo,
 		logger:    slog.Default().With("component", "pool"),
 		admission: NewImportAdmission(),
+		budget:    NewImportBudget(),
 	}
 }
 
@@ -458,23 +473,39 @@ func (m *manager) AcquireImportSlot(ctx context.Context) (func(), error) {
 	return m.admission.Acquire(ctx)
 }
 
-// SetAdmissionCaps configures the import-concurrency caps. capIdle applies
-// when no stream is active; capWhileStreaming applies while any stream is
-// active. A cap of 0 means unlimited.
-func (m *manager) SetAdmissionCaps(capIdle, capWhileStreaming int) {
-	m.admission.SetCaps(capIdle, capWhileStreaming)
+// SetAdmissionCap configures the cap on concurrently running NZB imports.
+// A cap of 0 means unlimited.
+func (m *manager) SetAdmissionCap(cap int) {
+	m.admission.SetCap(cap)
+}
+
+// AcquireImportConnection blocks until the import connection budget grants a
+// token or ctx is cancelled. See ImportBudget.Acquire.
+func (m *manager) AcquireImportConnection(ctx context.Context) (func(), error) {
+	return m.budget.Acquire(ctx)
+}
+
+// SetImportConnCapacity sets the import connection budget to the pool's total
+// connection count.
+func (m *manager) SetImportConnCapacity(total int) {
+	m.budget.SetCapacity(total)
+}
+
+// ImportConnCapacity returns the current budget capacity snapshot.
+func (m *manager) ImportConnCapacity() int {
+	return m.budget.Capacity()
 }
 
 // SetStreamSource wires the source used to determine whether streams are
 // currently active.
 func (m *manager) SetStreamSource(src StreamActivitySource) {
-	m.admission.SetStreamSource(src)
+	m.budget.SetStreamSource(src)
 }
 
-// NotifyStreamChange forwards a stream-count change to the admission gate so
-// it can wake or hold waiters according to the new effective cap.
+// NotifyStreamChange forwards a stream-count change to the import connection
+// budget so it can wake or hold waiters according to the new effective cap.
 func (m *manager) NotifyStreamChange() {
-	m.admission.NotifyStreamChange()
+	m.budget.NotifyStreamChange()
 }
 
 // SetProviderIDs sets a mapping between pool names and configuration IDs

--- a/internal/pool/semaphore.go
+++ b/internal/pool/semaphore.go
@@ -1,0 +1,128 @@
+package pool
+
+import (
+	"context"
+	"sync"
+)
+
+// adaptiveSemaphore is a FIFO counting semaphore whose capacity is computed
+// on demand by capLocked, so it can change between acquisitions (config
+// updates, stream activity). A computed cap of 0 means "disabled": Acquire is
+// a fast-path no-op and any queued waiters are drained.
+//
+// It uses a FIFO waiter queue with manual select / channel signalling so we
+// can support ctx cancellation without dropping wake-ups (the classic
+// "lost wakeup" hazard with sync.Cond.Wait + cancellation).
+type adaptiveSemaphore struct {
+	mu       sync.Mutex
+	inFlight int
+	waiters  []*waiter
+	// capLocked returns the current effective capacity. Called with mu held.
+	// 0 means disabled (unlimited, no accounting).
+	capLocked func() int
+}
+
+type waiter struct {
+	// ch is closed (or sent on) exactly once when the waiter is granted a slot.
+	// Buffered with capacity 1 so a granter never blocks; on a race with ctx
+	// cancellation, the cancelling goroutine drains and forwards the grant to
+	// the next waiter to avoid losing the wake-up.
+	ch chan struct{}
+}
+
+// Acquire blocks until a slot is available or ctx is cancelled. The returned
+// release function MUST be called exactly once when the work is done. When
+// the current cap is 0 the call is a fast-path no-op.
+func (s *adaptiveSemaphore) Acquire(ctx context.Context) (release func(), err error) {
+	s.mu.Lock()
+	cap := s.capLocked()
+	if cap == 0 {
+		s.mu.Unlock()
+		return noopRelease, nil
+	}
+
+	if s.inFlight < cap {
+		s.inFlight++
+		s.mu.Unlock()
+		return s.releaseOnce(), nil
+	}
+
+	w := &waiter{ch: make(chan struct{}, 1)}
+	s.waiters = append(s.waiters, w)
+	s.mu.Unlock()
+
+	select {
+	case <-w.ch:
+		// Granted. inFlight was already incremented by the granter.
+		return s.releaseOnce(), nil
+	case <-ctx.Done():
+		// We may have been granted concurrently. Resolve the race under the
+		// lock: if the channel has a pending wake, consume it and forward it
+		// to the next waiter; otherwise remove ourselves from the queue.
+		s.mu.Lock()
+		select {
+		case <-w.ch:
+			// Already granted. Hand the slot to the next waiter.
+			s.inFlight-- // undo the grant
+			s.wakeWaitersLocked()
+		default:
+			s.removeWaiterLocked(w)
+		}
+		s.mu.Unlock()
+		return noopRelease, ctx.Err()
+	}
+}
+
+// wakeWaitersLocked wakes waiters in FIFO order while there is headroom under
+// the current cap. Each wake-up increments inFlight, so callers that receive
+// the signal must call their release exactly once.
+func (s *adaptiveSemaphore) wakeWaitersLocked() {
+	cap := s.capLocked()
+	if cap == 0 {
+		// Disabled — drain any waiters as free grants; their releases are
+		// no-ops on the accounting side because inFlight is decremented on
+		// release and re-clamped at 0.
+		for _, w := range s.waiters {
+			select {
+			case w.ch <- struct{}{}:
+				s.inFlight++
+			default:
+			}
+		}
+		s.waiters = nil
+		return
+	}
+
+	for len(s.waiters) > 0 && s.inFlight < cap {
+		w := s.waiters[0]
+		s.waiters = s.waiters[1:]
+		s.inFlight++
+		// Buffered chan capacity 1 — never blocks.
+		w.ch <- struct{}{}
+	}
+}
+
+func (s *adaptiveSemaphore) removeWaiterLocked(target *waiter) {
+	for i, w := range s.waiters {
+		if w == target {
+			s.waiters = append(s.waiters[:i], s.waiters[i+1:]...)
+			return
+		}
+	}
+}
+
+func (s *adaptiveSemaphore) releaseOnce() func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.mu.Lock()
+			if s.inFlight > 0 {
+				s.inFlight--
+			}
+			s.wakeWaitersLocked()
+			s.mu.Unlock()
+		})
+	}
+}
+
+func noopRelease() {}

--- a/internal/usenet/usenet_reader.go
+++ b/internal/usenet/usenet_reader.go
@@ -66,6 +66,24 @@ func WithHoleHooks(h *HoleHooks) ReaderOption {
 	}
 }
 
+// ConnBudget grants connection tokens for import segment fetches.
+// Implemented by pool.Manager (AcquireImportConnection).
+type ConnBudget interface {
+	AcquireImportConnection(ctx context.Context) (release func(), err error)
+}
+
+// WithImportProfile marks the reader as import-owned: segment fetches use the
+// pool's normal request lane (so they always yield to streaming reads, which
+// use the priority lane) and each fetch is gated by the global import
+// connection budget. Without this option the reader behaves as a streaming
+// reader: priority lane, no budget. A nil budget only switches the lane.
+func WithImportProfile(budget ConnBudget) ReaderOption {
+	return func(r *UsenetReader) {
+		r.priority = false
+		r.budget = budget
+	}
+}
+
 type DataCorruptionError struct {
 	UnderlyingErr error
 	BytesRead     int64
@@ -101,6 +119,8 @@ type UsenetReader struct {
 	streamID       string
 	segmentStore   SegmentStore // optional, nil = no caching
 	holeHooks      *HoleHooks   // optional, nil = missing segments fail the read
+	priority       bool         // true (streaming) = priority lane; false (import) = normal lane
+	budget         ConnBudget   // optional; gates import fetches on the global connection budget
 	cond           *sync.Cond   // Signals downloadManager when reader advances
 
 	// Prefetch-based download tracking
@@ -140,6 +160,7 @@ func NewUsenetReader(
 		metricsTracker: metricsTracker,
 		streamID:       streamID,
 		segmentStore:   segmentStore,
+		priority:       true, // streaming profile by default; WithImportProfile demotes
 	}
 	for _, opt := range opts {
 		opt(ur)
@@ -408,6 +429,18 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 		)
 	}
 
+	// Import readers take a token from the global import connection budget for
+	// the whole fetch (held across retries — it represents one connection's
+	// worth of work). Acquired before any per-attempt timeout is created so
+	// queue wait never burns the fetch deadline. Streaming readers skip this.
+	if b.budget != nil {
+		release, err := b.budget.AcquireImportConnection(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer release()
+	}
+
 	segStart := time.Now()
 	var resultBytes []byte
 	err := retry.Do(
@@ -417,7 +450,15 @@ func (b *UsenetReader) downloadSegmentWithRetry(ctx context.Context, seg *segmen
 			defer cancel()
 
 			fetchStart := time.Now()
-			result, err := cp.BodyPriority(attemptCtx, seg.Id)
+			var result *nntppool.ArticleBody
+			var err error
+			if b.priority {
+				// Streaming: priority lane — connections serve these first.
+				result, err = cp.BodyPriority(attemptCtx, seg.Id)
+			} else {
+				// Import: normal lane — always yields to streaming reads.
+				result, err = cp.Body(attemptCtx, seg.Id)
+			}
 			fetchDur := time.Since(fetchStart)
 			if err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/usenet/usenet_reader_lane_test.go
+++ b/internal/usenet/usenet_reader_lane_test.go
@@ -1,0 +1,131 @@
+package usenet
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/javi11/altmount/internal/pool"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+)
+
+// usenet_reader_lane_test.go pins the lane and budget invariants introduced by
+// automatic import connection balancing:
+//   - streaming readers (default) fetch via BodyPriority (priority lane);
+//   - import readers (WithImportProfile) fetch via Body (normal lane) and
+//     bracket every fetch with an import connection budget token.
+
+// recordingBudget counts acquire/release pairs and tracks the in-flight high
+// water mark.
+type recordingBudget struct {
+	acquires    atomic.Int64
+	inFlight    atomic.Int64
+	maxInFlight atomic.Int64
+}
+
+func (b *recordingBudget) AcquireImportConnection(_ context.Context) (func(), error) {
+	b.acquires.Add(1)
+	n := b.inFlight.Add(1)
+	for {
+		old := b.maxInFlight.Load()
+		if n <= old || b.maxInFlight.CompareAndSwap(old, n) {
+			break
+		}
+	}
+	return func() { b.inFlight.Add(-1) }, nil
+}
+
+func drainReader(t *testing.T, ur *UsenetReader) {
+	t.Helper()
+	if _, err := io.Copy(io.Discard, ur); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+}
+
+func TestUsenetReader_StreamingUsesPriorityLane(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const nSegs, segSize = 4, 64
+	fp := fakepool.New()
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+	ur := newReaderForTest(t, ctx, fp, rg, nSegs)
+
+	drainReader(t, ur)
+
+	if got := fp.BodyPriorityCalls(); got != nSegs {
+		t.Errorf("BodyPriorityCalls = %d, want %d (streaming must use the priority lane)", got, nSegs)
+	}
+	if got := fp.BodyCalls(); got != 0 {
+		t.Errorf("BodyCalls = %d, want 0 (streaming must not use the normal lane)", got)
+	}
+}
+
+func TestUsenetReader_ImportProfileUsesNormalLaneAndBudget(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const nSegs, segSize = 4, 64
+	fp := fakepool.New()
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+
+	budget := &recordingBudget{}
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, nSegs, noopMetrics{}, "test-import", nil,
+		WithImportProfile(budget))
+	if err != nil {
+		t.Fatalf("NewUsenetReader: %v", err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+
+	drainReader(t, ur)
+
+	if got := fp.BodyCalls(); got != nSegs {
+		t.Errorf("BodyCalls = %d, want %d (import must use the normal lane)", got, nSegs)
+	}
+	if got := fp.BodyPriorityCalls(); got != 0 {
+		t.Errorf("BodyPriorityCalls = %d, want 0 (import must not use the priority lane)", got)
+	}
+	if got := budget.acquires.Load(); got != nSegs {
+		t.Errorf("budget acquires = %d, want %d (every fetch must take a token)", got, nSegs)
+	}
+	if got := budget.inFlight.Load(); got != 0 {
+		t.Errorf("budget in-flight after drain = %d, want 0 (every token must be released)", got)
+	}
+}
+
+func TestUsenetReader_ImportBudgetBoundsInFlightFetches(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const nSegs, segSize = 12, 64
+	fp := fakepool.New()
+	rg := buildEagerRange(ctx, t, nSegs, segSize)
+
+	// Real budget with capacity 2: the reader's prefetch fan-out must never
+	// exceed it on the wire.
+	budget := pool.NewImportBudget()
+	budget.SetCapacity(2)
+	getter := func() (pool.NntpClient, error) { return fp, nil }
+	ur, err := NewUsenetReader(ctx, getter, rg, nSegs, noopMetrics{}, "test-import", nil,
+		WithImportProfile(budgetAdapter{budget}))
+	if err != nil {
+		t.Fatalf("NewUsenetReader: %v", err)
+	}
+	t.Cleanup(func() { _ = ur.Close() })
+
+	drainReader(t, ur)
+
+	if mif := fp.MaxInFlight(); mif > 2 {
+		t.Errorf("MaxInFlight = %d, want <= 2 (budget capacity)", mif)
+	}
+}
+
+// budgetAdapter exposes pool.ImportBudget through the reader's ConnBudget
+// interface, mirroring how pool.Manager delegates to its budget.
+type budgetAdapter struct{ b *pool.ImportBudget }
+
+func (a budgetAdapter) AcquireImportConnection(ctx context.Context) (func(), error) {
+	return a.b.Acquire(ctx)
+}

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -226,6 +226,11 @@ func (m *validationTestPoolManager) SetProviderIDs(_ map[string]string) {}
 func (m *validationTestPoolManager) AcquireImportSlot(_ context.Context) (func(), error) {
 	return func() {}, nil
 }
-func (m *validationTestPoolManager) SetAdmissionCaps(_ int, _ int)               {}
+func (m *validationTestPoolManager) SetAdmissionCap(_ int) {}
+func (m *validationTestPoolManager) AcquireImportConnection(_ context.Context) (func(), error) {
+	return func() {}, nil
+}
+func (m *validationTestPoolManager) SetImportConnCapacity(_ int)                 {}
+func (m *validationTestPoolManager) ImportConnCapacity() int                     { return 0 }
 func (m *validationTestPoolManager) SetStreamSource(_ pool.StreamActivitySource) {}
 func (m *validationTestPoolManager) NotifyStreamChange()                         {}


### PR DESCRIPTION
## What

Removes `import.max_import_connections` (fixed per-import cap of 5) and `max_concurrent_imports_while_streaming`, replacing them with automatic connection balancing between imports and streaming.

## How it works

- **Pool-wide import connection budget** (`internal/pool/budget.go`): an adaptive semaphore bounding total in-flight import segment fetches across *all* concurrent imports. Capacity = sum of enabled non-backup providers' `max_connections`, kept in sync on config changes. While streams are active the effective cap shrinks by 2 connections per stream (floor 1), so streams always have instant headroom. Capacity 0 disables the gate (pool-less paths stay deadlock-free).
- **Priority-lane fix**: import-owned `UsenetReader`s (RAR/PAR2 analysis via `usenet_fs`/`decrypting_fs`/`par2` descriptor) were calling `BodyPriority`, competing with streams on the priority lane. They now use `usenet.WithImportProfile(poolManager)`: normal-lane `Body` + one budget token per fetch. Streaming keeps `BodyPriority`, and since nntppool connections always serve priority requests first, a stream read genuinely gets the next free connection.
- **Parser gating**: first-segment and 16KB-completion fetches acquire a budget token *before* creating their per-attempt timeout ctx, so queue wait never burns the fetch deadline. Goroutine fan-out and RAR volume parallelism are sized from pool capacity (clamped) instead of the removed knob.
- **Admission simplification**: `ImportAdmission` is now a single `max_concurrent_imports` cap (job-level parallelism); connection-level stream priority is handled by the budget. Both gates share an extracted `adaptiveSemaphore` with the FIFO waiter queue and lost-wakeup-safe cancellation from #595.

## Why

- N concurrent imports could previously use N×5 connections (the old storm test documented this gap), while a lone import on an idle pool was throttled to 5.
- Imports on an idle pool now use full capacity; under playback they shrink automatically — no tuning needed.

## Behavior changes / reviewer notes

- **Idle imports get much faster** (5 → full pool capacity). Users who set `max_import_connections` low to throttle imports should use `max_concurrent_imports` instead.
- **Back-compat**: old `config.yaml` files still load — viper ignores the removed keys. Stale frontends sending the removed JSON field won't error (non-strict decoding). UI field, API response field, and OpenAPI/Swagger schemas removed.
- `streamHeadroom = 2` is a package constant by design — the point of this change is removing knobs; the priority lane is the hard guarantee, headroom is an optimization.

## Test plan

- [x] New `internal/pool/budget_test.go`: capacity blocking, FIFO wake, ctx-cancel grant-forwarding race, capacity grow/shrink, stream shrink with floor 1, disabled no-op
- [x] New `internal/usenet/usenet_reader_lane_test.go`: streaming → `BodyPriority` only; import profile → `Body` only with budget bracketing; real budget bounds max in-flight
- [x] Rewritten `parser_storm_test.go`: global in-flight ≤ budget capacity across 4 concurrent imports; single import fans out past the old cap of 5
- [x] `make` (full build + all Go tests) passes; `go test -race ./...` clean
- [x] `bun run check` and `bun run build` clean