### PR TITLE
fix(stremio): derive real release name from NZB contents

### DIFF
--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -17,7 +18,9 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/auth"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	"github.com/javi11/altmount/internal/importer/utils/nzbtrim"
+	"github.com/javi11/nzbparser"
 )
 
 // mediaExtensions lists common video/media file extensions for Stremio stream filtering.
@@ -186,6 +189,19 @@ func (s *Server) handleNzbStreams(c *fiber.Ctx) error {
 		nzbData, err = io.ReadAll(f)
 		if err != nil {
 			return RespondInternalError(c, "Failed to read uploaded file", err.Error())
+		}
+	}
+
+	// --- Recover a real release name when the transport name is generic ---
+	// AIOStreams uploads/links the NZB as "download.nzb" (multipart part name or a
+	// download-endpoint URL like ".../download?..."), which loses the real title. That
+	// generic name would then (1) rename the imported media file to "download.mp4" via
+	// RenameToNzbName and (2) collide across releases in the per-filename dedup/cache
+	// below, serving one movie's stream for a different request. When the incoming name
+	// looks obfuscated/generic, derive a meaningful, unique name from the NZB contents.
+	if fileinfo.IsProbablyObfuscated(nzbtrim.TrimNzbExtension(filepath.Base(nzbFilename))) {
+		if derived := deriveNzbNameFromContent(nzbData); derived != "" {
+			nzbFilename = derived + ".nzb"
 		}
 	}
 
@@ -479,6 +495,51 @@ func stremioStreamFromPath(virtualPath, baseURL, downloadKey string) StremioStre
 // isMediaExtension reports whether ext is a common video/media file extension.
 func isMediaExtension(ext string) bool {
 	return mediaExtensions[strings.ToLower(ext)]
+}
+
+// deriveNzbNameFromContent inspects raw NZB bytes for a meaningful release name so the
+// downstream filename, dedup key, and import output do not fall back to a generic transport
+// name (e.g. "download"). It parses locally and never touches the network.
+//
+// Preference order:
+//  1. the <head><meta type="name"> value, when present and not obfuscated;
+//  2. otherwise the largest media <file> subject's release stem (extension stripped).
+//
+// Returns "" when nothing trustworthy is found, so the caller keeps its existing fallback.
+func deriveNzbNameFromContent(nzbData []byte) string {
+	nzb, err := nzbparser.Parse(bytes.NewReader(nzbData))
+	if err != nil {
+		return ""
+	}
+
+	// 1. Explicit release name in NZB metadata.
+	if name := strings.TrimSpace(nzb.Meta["name"]); name != "" && !fileinfo.IsProbablyObfuscated(name) {
+		if safe := sanitizeFilename(name); safe != "" {
+			return safe
+		}
+	}
+
+	// 2. Largest media file's subject name.
+	bestName := ""
+	var bestBytes int64 = -1
+	for i := range nzb.Files {
+		f := nzb.Files[i]
+		if !isMediaExtension(filepath.Ext(f.Filename)) {
+			continue
+		}
+		stem := strings.TrimSuffix(f.Filename, filepath.Ext(f.Filename))
+		if stem == "" || fileinfo.IsProbablyObfuscated(stem) {
+			continue
+		}
+		if f.Bytes > bestBytes {
+			bestBytes = f.Bytes
+			bestName = stem
+		}
+	}
+	if bestName == "" {
+		return ""
+	}
+	return sanitizeFilename(bestName)
 }
 
 func stremioEpisodeSelectorFromRequest(c *fiber.Ctx) *stremioEpisodeSelector {

--- a/internal/api/nzb_stremio_handlers_test.go
+++ b/internal/api/nzb_stremio_handlers_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	"github.com/javi11/altmount/internal/metadata"
+	"github.com/javi11/altmount/internal/testsupport/nzbbuild"
+	"github.com/javi11/nzbparser"
 	"github.com/stretchr/testify/require"
 )
 
@@ -109,4 +112,88 @@ func newStremioStreamsTestServer(t *testing.T, names []string) (*Server, *databa
 		ID:          42,
 		StoragePath: &storagePath,
 	}
+}
+
+// buildNzbBytes renders the given files (and optional meta) to NZB bytes as they
+// would arrive over the wire, so deriveNzbNameFromContent can re-parse them.
+func buildNzbBytes(t *testing.T, meta map[string]string, files ...nzbbuild.File) []byte {
+	t.Helper()
+	n := nzbbuild.Build(files...)
+	if meta != nil {
+		n.Meta = meta
+	}
+	data, err := nzbparser.Write(n)
+	require.NoError(t, err)
+	return data
+}
+
+func seg(id string, bytes int) nzbbuild.Segment { return nzbbuild.Segment{ID: id, Bytes: bytes} }
+
+func TestDeriveNzbNameFromContent(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want string
+	}{
+		{
+			name: "meta name is preferred when present and clean",
+			data: buildNzbBytes(t,
+				map[string]string{"name": "The.Great.Movie.2024.1080p.WEB-DL"},
+				nzbbuild.File{Subject: `[1/1] "obfuscatedgarbage.mkv" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("a@x", 1000)}},
+			),
+			want: "The.Great.Movie.2024.1080p.WEB-DL",
+		},
+		{
+			name: "largest media file subject wins when no usable meta",
+			data: buildNzbBytes(t, nil,
+				nzbbuild.File{Subject: `[1/3] "Sample.The.Movie.mp4" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("s@x", 1000)}},
+				nzbbuild.File{Subject: `[2/3] "The.Sheep.Detectives.2026.2160p.mkv" yEnc (1/2)`, Segments: []nzbbuild.Segment{seg("m1@x", 500000), seg("m2@x", 500000)}},
+				nzbbuild.File{Subject: `[3/3] "The.Sheep.Detectives.2026.2160p.par2" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("p@x", 2000)}},
+			),
+			want: "The.Sheep.Detectives.2026.2160p",
+		},
+		{
+			name: "obfuscated meta falls through to media file",
+			data: buildNzbBytes(t,
+				map[string]string{"name": "deadbeefdeadbeefdeadbeefdeadbeef"},
+				nzbbuild.File{Subject: `[1/1] "The.Clean.Release.2025.1080p.mkv" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("c@x", 5000)}},
+			),
+			want: "The.Clean.Release.2025.1080p",
+		},
+		{
+			name: "all obfuscated returns empty",
+			data: buildNzbBytes(t, nil,
+				nzbbuild.File{Subject: `[1/2] "abcdef0123456789abcdef0123456789.mkv" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("o@x", 1000)}},
+				nzbbuild.File{Subject: `[2/2] "abcdef0123456789abcdef0123456789.par2" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("op@x", 500)}},
+			),
+			want: "",
+		},
+		{
+			name: "no media files returns empty",
+			data: buildNzbBytes(t, nil,
+				nzbbuild.File{Subject: `[1/1] "The.Release.2024.par2" yEnc (1/1)`, Segments: []nzbbuild.Segment{seg("np@x", 500)}},
+			),
+			want: "",
+		},
+		{
+			name: "invalid nzb bytes returns empty",
+			data: []byte("not an nzb"),
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveNzbNameFromContent(tc.data)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestGenericDownloadNameIsObfuscated guards the trigger condition in handleNzbStreams:
+// the generic transport name "download" must be classified obfuscated so the
+// content-derived name override kicks in.
+func TestGenericDownloadNameIsObfuscated(t *testing.T) {
+	require.True(t, fileinfo.IsProbablyObfuscated("download"),
+		`expected "download" to be treated as obfuscated so the name override triggers`)
 }


### PR DESCRIPTION
## Problem

When AIOStreams pushes an NZB to AltMount's Stremio endpoint (`POST /api/nzb/streams`), the release always landed as `download.nzb` → imported as `download.mp4` under `/complete/stremio/download/`, and playing a *second, different* movie served the *first* one back.

## Root cause (single, unified)

AltMount named each NZB from the transport only. AIOStreams always sends a generic name — either the multipart part name `download.nzb`, or a download-endpoint URL like `.../download?...` whose `filepath.Base` is `download`. That generic `download` caused **both** symptoms:

1. **Wrong output name** — the importer's `RenameToNzbName` (default `true`) rewrote the real media file to `download.mp4`, discarding the true subject name. The written *content* was the correct movie; only the name was wrong.
2. **"Plays another file"** — `handleNzbStreams` deduplicates/caches per filename (`stremioPlayGroup.Do(safeFilename)` + `ListQueueItems(&completed, safeFilename, …)`). Since every Stremio NZB is named `download.nzb`, a request for movie B was treated as a cache hit for the already-completed movie A within the TTL, returning A's stream. All releases also collided on the same virtual path.

## Fix

The real name already lives inside the NZB. When the incoming transport name looks obfuscated/generic (which `download` is), derive a meaningful, unique name from the NZB contents **before** the naming/dedup/queue logic:

- New pure helper `deriveNzbNameFromContent(nzbData)` parses the NZB locally (no NNTP) and prefers the `<head><meta type="name">` value, else the largest media `<file>` subject's release stem.
- Reuses existing utilities: `nzbparser.Parse`, `fileinfo.IsProbablyObfuscated`, `isMediaExtension`, `sanitizeFilename`, `nzbtrim`.
- A genuinely good incoming name is preserved (override only triggers on obfuscated/generic names).

Downstream — `safeFilename`, `nzbName`, `tempPath`, the singleflight/dedup key, and `AddToQueue` — then use the unique real name, and `RenameToNzbName` produces the correct output (e.g. `The.Sheep.Detectives.2026.2160p….mp4`). Distinct movies no longer collide in cache or on disk.

## Deliberately out of scope

- No changes to `parser.determineNzbType` or `processor.processSingleFile` — file/content selection works; only naming was broken.
- `RenameToNzbName` stays on; feeding it a correct name is the fix.

## Testing

- New table-driven unit tests for `deriveNzbNameFromContent` (meta preference, largest-media selection, obfuscation fallthrough, no-media/empty cases, invalid bytes) plus a guard that `"download"` is classified obfuscated.
- `go build ./...` ✓, `go test ./internal/api/... -race` ✓, `go vet` ✓, `gofmt` clean.
- Manual end-to-end (recommended before release): issue two `/api/nzb/streams` requests for different releases with generic `download.nzb` transport names; confirm each imports under its real title and the second is not served the first's stream (distinct `_queue_item_id` / storage paths).