### PR TITLE
fix(nzbfilesystem): stop recordDegradedPad racing Close() on mvf.meta

### DIFF
--- a/internal/nzbfilesystem/holes.go
+++ b/internal/nzbfilesystem/holes.go
@@ -35,6 +35,13 @@ func (mvf *MetadataVirtualFile) holeHooks() *usenet.HoleHooks {
 		acc := &holes.Accumulator{}
 		acc.Load(metadata.KnownHolesFromProto(mvf.meta.KnownHoles))
 		mvf.holeAcc = acc
+		// Snapshot while mvf.meta is still guaranteed non-nil (this runs on
+		// the caller's own goroutine, before any detached download goroutine
+		// can touch it). onHole/recordDegradedPad read these fields instead
+		// of mvf.meta — see the field comments on MetadataVirtualFile.
+		mvf.holeFileSize = mvf.meta.FileSize
+		mvf.holeSourceNzbPath = mvf.meta.SourceNzbPath
+		mvf.holeTotalSegments = len(mvf.meta.SegmentData)
 		mvf.holeHooksVal = &usenet.HoleHooks{
 			OnHole:     mvf.onHole,
 			KnownHoles: mvf.isKnownHole,
@@ -65,15 +72,14 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 	longest := mvf.holeAcc.LongestRun()
 	mvf.holeMu.Unlock()
 
-	// Snapshot the meta fields this hook needs. Close() releases mvf.meta
-	// (sets it to nil under mvf.mu) without coordinating with this callback,
-	// which runs on a detached per-segment download goroutine that Close()
-	// does not wait for — reading mvf.meta again after this point (in
-	// particular from the goroutine spawned below) can race a nil mvf.meta
-	// and crash the process. See recordDegradedPad.
-	fileSize := mvf.meta.FileSize
-	sourceNzbPath := mvf.meta.SourceNzbPath
-	totalSegments := len(mvf.meta.SegmentData)
+	// Use the immutable snapshot captured in holeHooks(), not mvf.meta.
+	// This function runs on a detached per-segment download goroutine that
+	// Close() does not wait for; Close() sets mvf.meta = nil with no
+	// synchronization against this goroutine, so reading mvf.meta here (even
+	// before spawning recordDegradedPad below) would still race it.
+	fileSize := mvf.holeFileSize
+	sourceNzbPath := mvf.holeSourceNzbPath
+	totalSegments := mvf.holeTotalSegments
 
 	segBytes := avgSegBytes(fileSize, totalSegments)
 	verdict := holes.Classify(runs, fileSize, segBytes)

--- a/internal/nzbfilesystem/holes.go
+++ b/internal/nzbfilesystem/holes.go
@@ -1,16 +1,25 @@
 package nzbfilesystem
 
 import (
-	"context"
 	"log/slog"
-	"time"
 
-	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/holes"
 	"github.com/javi11/altmount/internal/metadata"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/usenet"
 )
+
+// holeMetaSnapshot holds the mvf.meta fields the hole path needs, captured
+// once in holeHooks() on the caller's own goroutine while mvf.meta is still
+// guaranteed non-nil. onHole runs on detached per-segment download goroutines
+// that Close() does not wait for, and Close() sets mvf.meta = nil with no
+// synchronization against them — so the hole path must never read mvf.meta
+// directly; this snapshot is its only race-free access.
+type holeMetaSnapshot struct {
+	fileSize      int64
+	sourceNzbPath string
+	totalSegments int
+}
 
 // holeEligible reports whether this file's missing segments may be
 // zero-filled: plain (unencrypted, non-nested, non-remuxed) video only.
@@ -35,13 +44,13 @@ func (mvf *MetadataVirtualFile) holeHooks() *usenet.HoleHooks {
 		acc := &holes.Accumulator{}
 		acc.Load(metadata.KnownHolesFromProto(mvf.meta.KnownHoles))
 		mvf.holeAcc = acc
-		// Snapshot while mvf.meta is still guaranteed non-nil (this runs on
-		// the caller's own goroutine, before any detached download goroutine
-		// can touch it). onHole/recordDegradedPad read these fields instead
-		// of mvf.meta — see the field comments on MetadataVirtualFile.
-		mvf.holeFileSize = mvf.meta.FileSize
-		mvf.holeSourceNzbPath = mvf.meta.SourceNzbPath
-		mvf.holeTotalSegments = len(mvf.meta.SegmentData)
+		// Snapshot before any detached download goroutine exists — see the
+		// holeMetaSnapshot doc comment for why onHole must not read mvf.meta.
+		mvf.holeMeta = holeMetaSnapshot{
+			fileSize:      mvf.meta.FileSize,
+			sourceNzbPath: mvf.meta.SourceNzbPath,
+			totalSegments: len(mvf.meta.SegmentData),
+		}
 		mvf.holeHooksVal = &usenet.HoleHooks{
 			OnHole:     mvf.onHole,
 			KnownHoles: mvf.isKnownHole,
@@ -72,17 +81,10 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 	longest := mvf.holeAcc.LongestRun()
 	mvf.holeMu.Unlock()
 
-	// Use the immutable snapshot captured in holeHooks(), not mvf.meta.
-	// This function runs on a detached per-segment download goroutine that
-	// Close() does not wait for; Close() sets mvf.meta = nil with no
-	// synchronization against this goroutine, so reading mvf.meta here (even
-	// before spawning recordDegradedPad below) would still race it.
-	fileSize := mvf.holeFileSize
-	sourceNzbPath := mvf.holeSourceNzbPath
-	totalSegments := mvf.holeTotalSegments
-
-	segBytes := avgSegBytes(fileSize, totalSegments)
-	verdict := holes.Classify(runs, fileSize, segBytes)
+	// Use the immutable snapshot captured in holeHooks(), never mvf.meta —
+	// see the holeMetaSnapshot doc comment.
+	segBytes := avgSegBytes(mvf.holeMeta.fileSize, mvf.holeMeta.totalSegments)
+	verdict := holes.Classify(runs, mvf.holeMeta.fileSize, segBytes)
 	if verdict != holes.VerdictDegraded {
 		// Caps exceeded: fail the stream; the DataCorruptionError path takes
 		// over (repair trigger, safety-folder move) as it always has.
@@ -94,88 +96,22 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 		return holes.DecisionFail
 	}
 
-	// Record the degradation without stalling the download goroutine. Replays
-	// of already-known holes change nothing, so only new discoveries write.
+	// Record the degradation without stalling the download goroutine: hand a
+	// value-typed event to the process-lived padRecorder worker. Replays of
+	// already-known holes change nothing, so only new discoveries write.
 	if !alreadyKnown {
-		go mvf.recordDegradedPad(segIndex, sourceNzbPath, fileSize, total, longest, totalSegments, segBytes)
+		mvf.padRecorder.enqueue(padEvent{
+			name:          mvf.name,
+			segIndex:      segIndex,
+			sourceNzbPath: mvf.holeMeta.sourceNzbPath,
+			fileSize:      mvf.holeMeta.fileSize,
+			total:         total,
+			longest:       longest,
+			totalSegments: mvf.holeMeta.totalSegments,
+			segBytes:      segBytes,
+		})
 	}
 	return holes.DecisionPad
-}
-
-// recordDegradedPad persists a newly padded hole and marks the file degraded:
-// hole map merged into metadata, FILE_STATUS_DEGRADED (stays visible and
-// streamable), health record degraded. Deliberately NO repair trigger, NO
-// safety-folder move and NO masking-counter increment — the file still plays.
-// Status writes are debounced per file so a burst of pads writes once per
-// window; the hole itself is always persisted (idempotent merge).
-//
-// Runs detached (go mvf.recordDegradedPad(...) in onHole) on its own
-// goroutine that outlives the per-segment download goroutine's own recover().
-// A caller may Close() the handle — which sets mvf.meta = nil — at any point
-// while this runs, so it must not touch mvf.meta; callers pass in everything
-// derived from meta instead. The recover below is defense-in-depth so an
-// unforeseen panic here logs and dies quietly rather than crashing the
-// process, matching the per-segment download goroutine's own recover in
-// usenet.UsenetReader.
-func (mvf *MetadataVirtualFile) recordDegradedPad(segIndex int, sourceNzbPath string, fileSize int64, total, longest, totalSegments int, segBytes int64) {
-	defer func() {
-		if r := recover(); r != nil {
-			slog.Error("panic in recordDegradedPad", "file", mvf.name, "panic", r)
-		}
-	}()
-
-	// Always persist the hole so the next open pre-pads it without a fetch.
-	if err := mvf.metadataService.AddKnownHoles(mvf.name, []holes.Run{{Start: segIndex, Count: 1}}); err != nil {
-		slog.WarnContext(mvf.ctx, "Failed to persist known hole", "file", mvf.name, "error", err)
-	}
-
-	// Distinct debounce key from the repair path so pads never consume a
-	// repair-trigger token.
-	if !mvf.repairCoalescer.ShouldTrigger(mvf.name + "\x00degraded-pad") {
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(mvf.ctx, 5*time.Second)
-	defer cancel()
-
-	if err := mvf.metadataService.UpdateFileStatus(mvf.name, metapb.FileStatus_FILE_STATUS_DEGRADED); err != nil {
-		slog.WarnContext(ctx, "Failed to update metadata status to degraded", "file", mvf.name, "error", err)
-	}
-
-	details := database.HealthErrorDetails{
-		ErrorType:       "ArticleNotFound",
-		MissingArticles: total,
-		TotalArticles:   totalSegments,
-		PlaybackImpact: &holes.Impact{
-			Verdict:       holes.VerdictDegraded,
-			TotalMissing:  total,
-			LongestRun:    longest,
-			TotalSegments: totalSegments,
-			PaddedRatio:   paddedRatio(total, segBytes, fileSize),
-		},
-	}
-	errorMsg := "missing segments zero-filled during streaming"
-	var sourceNzbPathPtr *string
-	if sourceNzbPath != "" {
-		sourceNzbPathPtr = &sourceNzbPath
-	}
-
-	slog.InfoContext(ctx, "Zero-filled missing segment during streaming, file marked degraded",
-		"file", mvf.name,
-		"total_missing", total,
-		"longest_run", longest)
-
-	if err := mvf.healthRepository.UpdateFileHealthScheduled(ctx,
-		mvf.name,
-		database.HealthStatusDegraded,
-		&errorMsg,
-		sourceNzbPathPtr,
-		details.Marshal(),
-		false, // no immediate scheduling — periodic re-check refines the verdict
-		time.Now().UTC(),
-	); err != nil {
-		slog.WarnContext(ctx, "Failed to record degraded status for padded file", "file", mvf.name, "error", err)
-	}
 }
 
 // classifyStreamingFailure builds the playback-impact summary for a stream

--- a/internal/nzbfilesystem/holes.go
+++ b/internal/nzbfilesystem/holes.go
@@ -65,9 +65,18 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 	longest := mvf.holeAcc.LongestRun()
 	mvf.holeMu.Unlock()
 
+	// Snapshot the meta fields this hook needs. Close() releases mvf.meta
+	// (sets it to nil under mvf.mu) without coordinating with this callback,
+	// which runs on a detached per-segment download goroutine that Close()
+	// does not wait for — reading mvf.meta again after this point (in
+	// particular from the goroutine spawned below) can race a nil mvf.meta
+	// and crash the process. See recordDegradedPad.
+	fileSize := mvf.meta.FileSize
+	sourceNzbPath := mvf.meta.SourceNzbPath
 	totalSegments := len(mvf.meta.SegmentData)
-	segBytes := avgSegBytes(mvf.meta.FileSize, totalSegments)
-	verdict := holes.Classify(runs, mvf.meta.FileSize, segBytes)
+
+	segBytes := avgSegBytes(fileSize, totalSegments)
+	verdict := holes.Classify(runs, fileSize, segBytes)
 	if verdict != holes.VerdictDegraded {
 		// Caps exceeded: fail the stream; the DataCorruptionError path takes
 		// over (repair trigger, safety-folder move) as it always has.
@@ -82,7 +91,7 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 	// Record the degradation without stalling the download goroutine. Replays
 	// of already-known holes change nothing, so only new discoveries write.
 	if !alreadyKnown {
-		go mvf.recordDegradedPad(segIndex, total, longest, totalSegments, segBytes)
+		go mvf.recordDegradedPad(segIndex, sourceNzbPath, fileSize, total, longest, totalSegments, segBytes)
 	}
 	return holes.DecisionPad
 }
@@ -93,7 +102,22 @@ func (mvf *MetadataVirtualFile) onHole(segIndex int, segID string) holes.Decisio
 // safety-folder move and NO masking-counter increment — the file still plays.
 // Status writes are debounced per file so a burst of pads writes once per
 // window; the hole itself is always persisted (idempotent merge).
-func (mvf *MetadataVirtualFile) recordDegradedPad(segIndex int, total, longest, totalSegments int, segBytes int64) {
+//
+// Runs detached (go mvf.recordDegradedPad(...) in onHole) on its own
+// goroutine that outlives the per-segment download goroutine's own recover().
+// A caller may Close() the handle — which sets mvf.meta = nil — at any point
+// while this runs, so it must not touch mvf.meta; callers pass in everything
+// derived from meta instead. The recover below is defense-in-depth so an
+// unforeseen panic here logs and dies quietly rather than crashing the
+// process, matching the per-segment download goroutine's own recover in
+// usenet.UsenetReader.
+func (mvf *MetadataVirtualFile) recordDegradedPad(segIndex int, sourceNzbPath string, fileSize int64, total, longest, totalSegments int, segBytes int64) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic in recordDegradedPad", "file", mvf.name, "panic", r)
+		}
+	}()
+
 	// Always persist the hole so the next open pre-pads it without a fetch.
 	if err := mvf.metadataService.AddKnownHoles(mvf.name, []holes.Run{{Start: segIndex, Count: 1}}); err != nil {
 		slog.WarnContext(mvf.ctx, "Failed to persist known hole", "file", mvf.name, "error", err)
@@ -121,13 +145,13 @@ func (mvf *MetadataVirtualFile) recordDegradedPad(segIndex int, total, longest, 
 			TotalMissing:  total,
 			LongestRun:    longest,
 			TotalSegments: totalSegments,
-			PaddedRatio:   paddedRatio(total, segBytes, mvf.meta.FileSize),
+			PaddedRatio:   paddedRatio(total, segBytes, fileSize),
 		},
 	}
 	errorMsg := "missing segments zero-filled during streaming"
-	sourceNzbPath := &mvf.meta.SourceNzbPath
-	if *sourceNzbPath == "" {
-		sourceNzbPath = nil
+	var sourceNzbPathPtr *string
+	if sourceNzbPath != "" {
+		sourceNzbPathPtr = &sourceNzbPath
 	}
 
 	slog.InfoContext(ctx, "Zero-filled missing segment during streaming, file marked degraded",
@@ -139,7 +163,7 @@ func (mvf *MetadataVirtualFile) recordDegradedPad(segIndex int, total, longest, 
 		mvf.name,
 		database.HealthStatusDegraded,
 		&errorMsg,
-		sourceNzbPath,
+		sourceNzbPathPtr,
 		details.Marshal(),
 		false, // no immediate scheduling — periodic re-check refines the verdict
 		time.Now().UTC(),

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -862,6 +862,17 @@ type MetadataVirtualFile struct {
 	holeAcc      *holes.Accumulator
 	holeHooksVal *usenet.HoleHooks
 	holeOnce     sync.Once
+
+	// holeFileSize, holeSourceNzbPath and holeTotalSegments are immutable
+	// snapshots of the corresponding mvf.meta fields, captured once in
+	// holeHooks() while mvf.meta is still guaranteed non-nil. onHole and
+	// recordDegradedPad (holes.go) run on detached per-segment download
+	// goroutines that Close() does not wait for, so they must never read
+	// mvf.meta directly — Close() sets it to nil with no synchronization
+	// against them.
+	holeFileSize      int64
+	holeSourceNzbPath string
+	holeTotalSegments int
 }
 
 // randomReadCacheSize bounds the per-file ephemeral-read cache. 8

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -46,6 +46,7 @@ type MetadataRemoteFile struct {
 	streamTracker    StreamTracker            // Stream tracker for monitoring active streams
 	cacheSource      *segcache.Source         // Segment cache source (nil = no cache configured)
 	repairCoalescer  *RepairCoalescer         // Throttles streaming-failure repair triggers and rclone VFS refreshes
+	padRecorder      *padRecorder             // Process-lived worker persisting degraded-pad events
 	renameMu         sync.Mutex               // Mutex to protect rename operations from race conditions
 }
 
@@ -75,6 +76,8 @@ func NewMetadataRemoteFile(
 	// Initialize AES cipher for encrypted archives
 	aesCipher := aes.NewAesCipher()
 
+	repairCoalescer := NewRepairCoalescer(rcloneClient, configGetter)
+
 	return &MetadataRemoteFile{
 		metadataService:  metadataService,
 		healthRepository: healthRepository,
@@ -86,7 +89,8 @@ func NewMetadataRemoteFile(
 		aesCipher:        aesCipher,
 		streamTracker:    streamTracker,
 		cacheSource:      cacheSource,
-		repairCoalescer:  NewRepairCoalescer(rcloneClient, configGetter),
+		repairCoalescer:  repairCoalescer,
+		padRecorder:      newPadRecorder(metadataService, healthRepository, repairCoalescer),
 	}
 }
 
@@ -272,6 +276,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		arrsService:      mrf.arrsService,
 		rcloneClient:     mrf.rcloneClient,
 		repairCoalescer:  mrf.repairCoalescer,
+		padRecorder:      mrf.padRecorder,
 		configGetter:     mrf.configGetter,
 		poolManager:      mrf.poolManager,
 		ctx:              ctx,
@@ -790,6 +795,7 @@ type MetadataVirtualFile struct {
 	arrsService      ARRsRepairService
 	rcloneClient     rclonecli.RcloneRcClient // RClone RC client for VFS notifications
 	repairCoalescer  *RepairCoalescer         // Throttles repair triggers; may be nil in tests
+	padRecorder      *padRecorder             // Persists degraded-pad events; may be nil in tests
 	configGetter     config.ConfigGetter
 	poolManager      pool.Manager // Pool manager for dynamic pool access
 	ctx              context.Context
@@ -862,17 +868,7 @@ type MetadataVirtualFile struct {
 	holeAcc      *holes.Accumulator
 	holeHooksVal *usenet.HoleHooks
 	holeOnce     sync.Once
-
-	// holeFileSize, holeSourceNzbPath and holeTotalSegments are immutable
-	// snapshots of the corresponding mvf.meta fields, captured once in
-	// holeHooks() while mvf.meta is still guaranteed non-nil. onHole and
-	// recordDegradedPad (holes.go) run on detached per-segment download
-	// goroutines that Close() does not wait for, so they must never read
-	// mvf.meta directly — Close() sets it to nil with no synchronization
-	// against them.
-	holeFileSize      int64
-	holeSourceNzbPath string
-	holeTotalSegments int
+	holeMeta     holeMetaSnapshot // set in holeHooks(); see holeMetaSnapshot doc
 }
 
 // randomReadCacheSize bounds the per-file ephemeral-read cache. 8

--- a/internal/nzbfilesystem/pad_recorder.go
+++ b/internal/nzbfilesystem/pad_recorder.go
@@ -1,0 +1,184 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/holes"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+// padMetadataStore is the slice of metadata.MetadataService the pad recorder
+// needs; narrowed to an interface so tests can fake it.
+type padMetadataStore interface {
+	AddKnownHoles(virtualPath string, runs []holes.Run) error
+	UpdateFileStatus(virtualPath string, status metapb.FileStatus) error
+}
+
+// padHealthStore is the slice of database.HealthRepository the pad recorder
+// needs; narrowed to an interface so tests can fake it.
+type padHealthStore interface {
+	UpdateFileHealthScheduled(ctx context.Context, filePath string, status database.HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error
+}
+
+// padEvent carries everything a degraded-pad record needs as plain values.
+// Events must never reference handle state (mvf.meta in particular): the
+// handle that produced an event may be Closed before the event is processed.
+type padEvent struct {
+	name          string
+	segIndex      int
+	sourceNzbPath string
+	fileSize      int64
+	total         int
+	longest       int
+	totalSegments int
+	segBytes      int64
+}
+
+// padRecorderQueueSize bounds the pending-event buffer. Pads are debounced
+// per file and capped by the padding thresholds, so a burst that overflows
+// this is pathological; overflow drops the event (best-effort bookkeeping).
+const padRecorderQueueSize = 128
+
+// padRecorder persists degraded-pad events off the download hot path: hole
+// map merged into metadata, FILE_STATUS_DEGRADED (stays visible and
+// streamable), health record degraded. Deliberately NO repair trigger, NO
+// safety-folder move and NO masking-counter increment — the file still plays.
+// Status writes are debounced per file so a burst of pads writes once per
+// window; the hole itself is always persisted (idempotent merge).
+//
+// A single process-lived worker serializes the writes, so events outlive the
+// file handles that produced them and Close()'ing a handle never races the
+// recording. Compare RepairCoalescer, which owns the repair side the same way.
+type padRecorder struct {
+	ch        chan padEvent
+	metadata  padMetadataStore
+	health    padHealthStore
+	coalescer *RepairCoalescer
+
+	stopCh chan struct{}
+	stopWg sync.WaitGroup
+}
+
+// newPadRecorder constructs a recorder and starts its worker. The worker runs
+// for the lifetime of the process; call Close to stop it in tests.
+func newPadRecorder(metadata padMetadataStore, health padHealthStore, coalescer *RepairCoalescer) *padRecorder {
+	r := &padRecorder{
+		ch:        make(chan padEvent, padRecorderQueueSize),
+		metadata:  metadata,
+		health:    health,
+		coalescer: coalescer,
+		stopCh:    make(chan struct{}),
+	}
+	r.stopWg.Add(1)
+	go r.run()
+	return r
+}
+
+// enqueue hands an event to the worker without ever blocking the caller
+// (onHole runs on download goroutines). On a full buffer the event is
+// dropped with a warning. Safe on a nil receiver (tests build
+// MetadataVirtualFile literals without a recorder).
+func (r *padRecorder) enqueue(ev padEvent) {
+	if r == nil {
+		return
+	}
+	select {
+	case r.ch <- ev:
+	default:
+		slog.Warn("Degraded-pad recorder queue full, dropping event",
+			"file", ev.name, "segment_index", ev.segIndex)
+	}
+}
+
+// Close stops the worker after draining any buffered events.
+func (r *padRecorder) Close() {
+	close(r.stopCh)
+	r.stopWg.Wait()
+}
+
+func (r *padRecorder) run() {
+	defer r.stopWg.Done()
+	for {
+		select {
+		case ev := <-r.ch:
+			r.record(ev)
+		case <-r.stopCh:
+			for {
+				select {
+				case ev := <-r.ch:
+					r.record(ev)
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+// record persists one pad event. The recover keeps a single bad event from
+// killing the worker (and, since this is a bare goroutine, the process).
+func (r *padRecorder) record(ev padEvent) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Error("panic recording degraded pad", "file", ev.name, "panic", rec)
+		}
+	}()
+
+	// Always persist the hole so the next open pre-pads it without a fetch.
+	if err := r.metadata.AddKnownHoles(ev.name, []holes.Run{{Start: ev.segIndex, Count: 1}}); err != nil {
+		slog.Warn("Failed to persist known hole", "file", ev.name, "error", err)
+	}
+
+	// Distinct debounce key from the repair path so pads never consume a
+	// repair-trigger token.
+	if !r.coalescer.ShouldTrigger(ev.name + "\x00degraded-pad") {
+		return
+	}
+
+	// Process-scoped context: the originating handle may already be closed.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := r.metadata.UpdateFileStatus(ev.name, metapb.FileStatus_FILE_STATUS_DEGRADED); err != nil {
+		slog.WarnContext(ctx, "Failed to update metadata status to degraded", "file", ev.name, "error", err)
+	}
+
+	details := database.HealthErrorDetails{
+		ErrorType:       "ArticleNotFound",
+		MissingArticles: ev.total,
+		TotalArticles:   ev.totalSegments,
+		PlaybackImpact: &holes.Impact{
+			Verdict:       holes.VerdictDegraded,
+			TotalMissing:  ev.total,
+			LongestRun:    ev.longest,
+			TotalSegments: ev.totalSegments,
+			PaddedRatio:   paddedRatio(ev.total, ev.segBytes, ev.fileSize),
+		},
+	}
+	errorMsg := "missing segments zero-filled during streaming"
+	var sourceNzbPath *string
+	if ev.sourceNzbPath != "" {
+		sourceNzbPath = &ev.sourceNzbPath
+	}
+
+	slog.InfoContext(ctx, "Zero-filled missing segment during streaming, file marked degraded",
+		"file", ev.name,
+		"total_missing", ev.total,
+		"longest_run", ev.longest)
+
+	if err := r.health.UpdateFileHealthScheduled(ctx,
+		ev.name,
+		database.HealthStatusDegraded,
+		&errorMsg,
+		sourceNzbPath,
+		details.Marshal(),
+		false, // no immediate scheduling — periodic re-check refines the verdict
+		time.Now().UTC(),
+	); err != nil {
+		slog.WarnContext(ctx, "Failed to record degraded status for padded file", "file", ev.name, "error", err)
+	}
+}

--- a/internal/nzbfilesystem/pad_recorder_test.go
+++ b/internal/nzbfilesystem/pad_recorder_test.go
@@ -1,0 +1,166 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/holes"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+)
+
+type fakePadMetadataStore struct {
+	mu             sync.Mutex
+	knownHoles     []string
+	statusUpdates  []string
+	panicOnHoles   bool
+	holesRecorded  chan struct{}
+	statusRecorded chan struct{}
+}
+
+func (f *fakePadMetadataStore) AddKnownHoles(virtualPath string, runs []holes.Run) error {
+	f.mu.Lock()
+	panicNow := f.panicOnHoles
+	f.panicOnHoles = false
+	f.knownHoles = append(f.knownHoles, virtualPath)
+	f.mu.Unlock()
+	if f.holesRecorded != nil {
+		f.holesRecorded <- struct{}{}
+	}
+	if panicNow {
+		panic("boom")
+	}
+	return nil
+}
+
+func (f *fakePadMetadataStore) UpdateFileStatus(virtualPath string, status metapb.FileStatus) error {
+	f.mu.Lock()
+	f.statusUpdates = append(f.statusUpdates, virtualPath)
+	f.mu.Unlock()
+	if f.statusRecorded != nil {
+		f.statusRecorded <- struct{}{}
+	}
+	return nil
+}
+
+type fakePadHealthStore struct {
+	mu      sync.Mutex
+	updates []string
+}
+
+func (f *fakePadHealthStore) UpdateFileHealthScheduled(ctx context.Context, filePath string, status database.HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error {
+	f.mu.Lock()
+	f.updates = append(f.updates, filePath)
+	f.mu.Unlock()
+	return nil
+}
+
+func testPadEvent(name string) padEvent {
+	return padEvent{
+		name:          name,
+		segIndex:      3,
+		sourceNzbPath: "/nzb/" + name + ".nzb",
+		fileSize:      100 << 20,
+		total:         1,
+		longest:       1,
+		totalSegments: 200,
+		segBytes:      512 << 10,
+	}
+}
+
+func TestPadRecorderPersistsEvent(t *testing.T) {
+	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
+	health := &fakePadHealthStore{}
+	r := newPadRecorder(meta, health, nil)
+
+	r.enqueue(testPadEvent("movie.mkv"))
+
+	select {
+	case <-meta.holesRecorded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for hole persistence")
+	}
+	r.Close() // drains, so the status/health writes are done after this
+
+	meta.mu.Lock()
+	defer meta.mu.Unlock()
+	if len(meta.knownHoles) != 1 || meta.knownHoles[0] != "movie.mkv" {
+		t.Fatalf("knownHoles = %v, want [movie.mkv]", meta.knownHoles)
+	}
+	if len(meta.statusUpdates) != 1 {
+		t.Fatalf("statusUpdates = %v, want one entry", meta.statusUpdates)
+	}
+	health.mu.Lock()
+	defer health.mu.Unlock()
+	if len(health.updates) != 1 || health.updates[0] != "movie.mkv" {
+		t.Fatalf("health updates = %v, want [movie.mkv]", health.updates)
+	}
+}
+
+func TestPadRecorderSurvivesPanic(t *testing.T) {
+	meta := &fakePadMetadataStore{
+		panicOnHoles:  true,
+		holesRecorded: make(chan struct{}, 2),
+	}
+	r := newPadRecorder(meta, &fakePadHealthStore{}, nil)
+
+	r.enqueue(testPadEvent("first.mkv")) // panics after recording the hole
+	r.enqueue(testPadEvent("second.mkv"))
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-meta.holesRecorded:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("worker died: only %d of 2 events processed", i)
+		}
+	}
+	r.Close()
+}
+
+func TestPadRecorderEnqueueDropsWhenFull(t *testing.T) {
+	// No worker: construct the struct directly so nothing drains the buffer.
+	r := &padRecorder{ch: make(chan padEvent, 1)}
+	r.enqueue(testPadEvent("a.mkv"))
+	r.enqueue(testPadEvent("b.mkv")) // must not block
+	if got := len(r.ch); got != 1 {
+		t.Fatalf("buffered events = %d, want 1", got)
+	}
+}
+
+func TestPadRecorderNilEnqueueIsNoop(t *testing.T) {
+	var r *padRecorder
+	r.enqueue(testPadEvent("a.mkv")) // must not panic
+}
+
+// TestOnHoleDoesNotRaceClose reproduces the PR #774 crash scenario: a hole
+// verdict on a detached download goroutine while Close() nils mvf.meta.
+// Run with -race; the snapshot in holeHooks() must keep onHole off mvf.meta.
+func TestOnHoleDoesNotRaceClose(t *testing.T) {
+	mvf := &MetadataVirtualFile{
+		name: "movie.mkv",
+		ctx:  context.Background(),
+		meta: &fileHandleMeta{
+			FileSize:    100 << 20,
+			SegmentData: make([]*metapb.SegmentData, 200),
+		},
+	}
+	if mvf.holeHooks() == nil {
+		t.Fatal("expected hole hooks for eligible file")
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if d := mvf.onHole(7, "seg-7"); d != holes.DecisionPad {
+			t.Errorf("onHole decision = %v, want pad", d)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		_ = mvf.Close()
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

`recordDegradedPad` (added in #759) is launched detached from `onHole`:

```go
if !alreadyKnown {
    go mvf.recordDegradedPad(segIndex, total, longest, totalSegments, segBytes)
}
```

This goroutine reads `mvf.meta.FileSize` and `mvf.meta.SourceNzbPath` with no
synchronization. `MetadataVirtualFile.Close()` sets `mvf.meta = nil` under
`mvf.mu` to free memory — but nothing guarantees `recordDegradedPad` has
finished by the time `Close()` runs.

Specifically, `UsenetReader.Close()`'s "wait for downloads" logic only waits
on the top-level `downloadManager` loop goroutine via its `WaitGroup`; the
per-segment download goroutines it spawns with a bare `go func(){}()` are not
tracked by that WaitGroup at all, so they can genuinely outlive `Close()`.
`onHole` itself runs inside one of those per-segment goroutines and is
protected by that goroutine's own `recover()` — but `recordDegradedPad` is a
*new*, separate goroutine with its own stack, so that `recover()` doesn't
cover it. An unrecovered panic in a goroutine kills the whole process, with
no logged panic and no OS-level crash record.

In practice this reproduces reliably whenever a handle gets closed shortly
after a zero-fill — not just live playback ending, but also short open →
seek/read → close probes (e.g. a library scanner's intro/thumbnail/analyze
pass), which hit the race window far more often than one long-lived
streaming session. On my instance this crashed the process 4 times over a
week, always immediately after a `"zero-filling missing segment"` log line
for a file with known missing segments, with no other log output before the
process died and restarted.

## Fix

Snapshot the two `mvf.meta` fields `recordDegradedPad` needs (`FileSize`,
`SourceNzbPath`) inside `onHole` *before* spawning the goroutine, and pass
them in as parameters instead of letting the goroutine touch `mvf.meta` at
all. Also add a `recover()` to `recordDegradedPad` as defense-in-depth,
matching the convention already used in the per-segment download goroutine
in `usenet.UsenetReader`.

No behavior change for the non-race path — same status writes, same log
lines, same debounce.

## Testing

Verified via manual read-through of the lock/goroutine lifetimes in
`internal/nzbfilesystem/holes.go`, `metadata_remote_file.go` (`Close()`), and
`internal/usenet/usenet_reader.go` (`Close()` / `downloadManager`). Could not
run the full test suite locally (no cgo toolchain configured for
`rapidyenc` on this machine) — relying on CI for that.