### PR TITLE
fix(database): stop migration 034 download_id backfill from hanging startup

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -296,14 +296,32 @@ func ensureSchemaIntegrity(db *sql.DB, d Dialect) {
 			slog.Error("Failed to add download_id column to file_health", "err", err)
 		} else {
 			db.Exec("CREATE INDEX IF NOT EXISTS idx_file_health_download_id ON file_health(download_id);")
-			// Backfill from import_history where paths match exactly
-			db.Exec(`UPDATE file_health
+			// Backfill download_id from import_history by matching slash-trimmed paths.
+			// PostgreSQL rejects the two-argument TRIM(x, '/') comma form, so use the
+			// dialect-appropriate normalization function. A temporary expression index
+			// lets the correlated subquery probe import_history by index instead of a
+			// full scan per row (avoids the O(N*M) startup hang on large deployments).
+			trim := "TRIM(%s, '/')"
+			if d == DialectPostgres {
+				trim = "btrim(%s, '/')"
+			}
+			trimVPath := fmt.Sprintf(trim, "import_history.virtual_path")
+			trimFPath := fmt.Sprintf(trim, "file_health.file_path")
+			idxExpr := fmt.Sprintf(trim, "virtual_path")
+
+			if _, err := db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_import_history_trim_vpath ON import_history(%s);", idxExpr)); err != nil {
+				slog.Warn("Failed to create temporary backfill index", "err", err)
+			}
+			if _, err := db.Exec(fmt.Sprintf(`UPDATE file_health
 				SET download_id = (
 					SELECT download_id FROM import_history
-					WHERE TRIM(import_history.virtual_path, '/') = TRIM(file_health.file_path, '/')
+					WHERE %s = %s
 					LIMIT 1
 				)
-				WHERE download_id IS NULL`)
+				WHERE download_id IS NULL`, trimVPath, trimFPath)); err != nil {
+				slog.Error("Failed to backfill download_id in file_health", "err", err)
+			}
+			db.Exec("DROP INDEX IF EXISTS idx_import_history_trim_vpath;")
 		}
 	}
 }

--- a/internal/database/migration_034_test.go
+++ b/internal/database/migration_034_test.go
@@ -1,0 +1,152 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openMigratedTo opens a fresh file-backed SQLite DB (so every pooled connection
+// sees the same schema) and applies goose migrations up to the given version.
+func openMigratedTo(t *testing.T, version int64) *sql.DB {
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	goose.SetBaseFS(embedMigrations)
+	require.NoError(t, goose.SetDialect("sqlite3"))
+	goose.SetLogger(goose.NopLogger())
+
+	require.NoError(t, goose.UpTo(db, "migrations/sqlite", version))
+	return db
+}
+
+// TestMigration034_BackfillsDownloadID verifies that migration 034 correctly
+// populates file_health.download_id from import_history, matching on paths after
+// normalizing leading/trailing slashes, and leaves unmatched rows NULL.
+func TestMigration034_BackfillsDownloadID(t *testing.T) {
+	ctx := context.Background()
+
+	// Apply everything up to (but not including) 034.
+	db := openMigratedTo(t, 33)
+
+	// Seed import_history with the download_id "source of truth" for each path.
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO import_history (nzb_name, file_name, virtual_path, download_id) VALUES
+			('n', 'a.mkv', '/movies/a.mkv',  'dl-a'),
+			('n', 'b.mkv', 'shows/b.mkv/',   'dl-b'),
+			('n', 'd.mkv', '/tv/d.mkv/',     'dl-d')
+	`)
+	require.NoError(t, err)
+
+	// Seed file_health rows whose paths differ from import_history only in
+	// leading/trailing slashes, plus one row with no matching history.
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO file_health (file_path, status) VALUES
+			('movies/a.mkv',  'pending'),
+			('/shows/b.mkv',  'pending'),
+			('tv/d.mkv',      'pending'),
+			('movies/none.mkv','pending')
+	`)
+	require.NoError(t, err)
+
+	// Apply migration 034 (adds download_id column + backfill).
+	require.NoError(t, goose.UpTo(db, "migrations/sqlite", 34))
+
+	tests := []struct {
+		name     string
+		filePath string
+		want     sql.NullString
+	}{
+		{"leading-slash difference", "movies/a.mkv", sql.NullString{String: "dl-a", Valid: true}},
+		{"trailing-slash difference", "/shows/b.mkv", sql.NullString{String: "dl-b", Valid: true}},
+		{"both-slash difference", "tv/d.mkv", sql.NullString{String: "dl-d", Valid: true}},
+		{"no history match stays NULL", "movies/none.mkv", sql.NullString{Valid: false}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sql.NullString
+			err := db.QueryRowContext(ctx,
+				"SELECT download_id FROM file_health WHERE file_path = ?", tt.filePath).Scan(&got)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// The temporary backfill index must not survive the migration.
+	var idxCount int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_import_history_trim_vpath'").Scan(&idxCount))
+	assert.Equal(t, 0, idxCount, "temporary backfill index should be dropped by the migration")
+}
+
+// TestMigration034_BackfillUsesExpressionIndex is the regression guard for the
+// startup hang: it proves that the per-row lookup performed by the backfill is a
+// full table SCAN without the expression index (the O(N*M) hazard), and an
+// index SEARCH once the expression index exists.
+func TestMigration034_BackfillUsesExpressionIndex(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE import_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			virtual_path TEXT NOT NULL,
+			download_id TEXT
+		);
+	`)
+	require.NoError(t, err)
+
+	// This mirrors the correlated subquery executed once per file_health row.
+	const lookup = `EXPLAIN QUERY PLAN
+		SELECT download_id FROM import_history
+		WHERE TRIM(virtual_path, '/') = TRIM(?, '/') LIMIT 1`
+
+	explain := func() string {
+		rows, err := db.QueryContext(ctx, lookup, "movies/a.mkv")
+		require.NoError(t, err)
+		defer rows.Close()
+		var b strings.Builder
+		for rows.Next() {
+			var id, parent, notused int
+			var detail string
+			require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+			b.WriteString(detail)
+			b.WriteString("\n")
+		}
+		require.NoError(t, rows.Err())
+		return b.String()
+	}
+
+	// Without the expression index: full scan of import_history per row → O(N*M).
+	before := explain()
+	assert.Contains(t, before, "SCAN",
+		"without the expression index the lookup must be a full scan (the hang)")
+	assert.NotContains(t, before, "idx_import_history_trim_vpath")
+
+	// With the expression index (as migration 034 now creates): index search.
+	_, err = db.ExecContext(ctx,
+		"CREATE INDEX idx_import_history_trim_vpath ON import_history(TRIM(virtual_path, '/'));")
+	require.NoError(t, err)
+
+	after := explain()
+	assert.Contains(t, after, "idx_import_history_trim_vpath",
+		"with the expression index the lookup must use it (fixes the O(N*M) hang)")
+	assert.Contains(t, after, "SEARCH")
+}

--- a/internal/database/migrations/postgres/034_add_download_id_to_file_health.sql
+++ b/internal/database/migrations/postgres/034_add_download_id_to_file_health.sql
@@ -3,14 +3,25 @@ ALTER TABLE file_health ADD COLUMN download_id TEXT DEFAULT NULL;
 
 CREATE INDEX idx_file_health_download_id ON file_health(download_id);
 
+-- Temporary expression index so the backfill can probe import_history by its
+-- normalized (slash-trimmed) path via an index lookup instead of full-scanning
+-- the table once per file_health row. Without it the correlated subquery below
+-- is O(N*M) and silently hangs startup on large deployments. The index is only
+-- useful for this one-time backfill, so it is dropped afterwards.
+-- NOTE: PostgreSQL does not support the two-argument TRIM(x, '/') comma form;
+-- btrim(x, '/') is the correct equivalent of TRIM(BOTH '/' FROM x).
+CREATE INDEX idx_import_history_trim_vpath ON import_history(btrim(virtual_path, '/'));
+
 UPDATE file_health
 SET download_id = (
-    SELECT download_id 
-    FROM import_history 
-    WHERE TRIM(import_history.virtual_path, '/') = TRIM(file_health.file_path, '/')
+    SELECT download_id
+    FROM import_history
+    WHERE btrim(import_history.virtual_path, '/') = btrim(file_health.file_path, '/')
     LIMIT 1
 )
 WHERE download_id IS NULL;
+
+DROP INDEX idx_import_history_trim_vpath;
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_file_health_download_id;

--- a/internal/database/migrations/sqlite/034_add_download_id_to_file_health.sql
+++ b/internal/database/migrations/sqlite/034_add_download_id_to_file_health.sql
@@ -3,14 +3,23 @@ ALTER TABLE file_health ADD COLUMN download_id TEXT DEFAULT NULL;
 
 CREATE INDEX idx_file_health_download_id ON file_health(download_id);
 
+-- Temporary expression index so the backfill can probe import_history by its
+-- normalized (slash-trimmed) path via an index lookup instead of full-scanning
+-- the table once per file_health row. Without it the correlated subquery below
+-- is O(N*M) and silently hangs startup on large deployments. The index is only
+-- useful for this one-time backfill, so it is dropped afterwards.
+CREATE INDEX idx_import_history_trim_vpath ON import_history(TRIM(virtual_path, '/'));
+
 UPDATE file_health
 SET download_id = (
-    SELECT download_id 
-    FROM import_history 
+    SELECT download_id
+    FROM import_history
     WHERE TRIM(import_history.virtual_path, '/') = TRIM(file_health.file_path, '/')
     LIMIT 1
 )
 WHERE download_id IS NULL;
+
+DROP INDEX idx_import_history_trim_vpath;
 
 -- +goose Down
 DROP INDEX IF EXISTS idx_file_health_download_id;


### PR DESCRIPTION
## Problem

After upgrading to the latest build, users report the container gets **stuck during startup** — logs stop right after the linuxserver.io init (`[ls.io-init] done.`) and the `AltMount server started` line never appears.

Root cause is the newly-added **migration 034** (`feat(health): persist download_id ... and backfill from history`). Its backfill wraps **both** join columns in `TRIM()`:

```sql
UPDATE file_health SET download_id = (
    SELECT download_id FROM import_history
    WHERE TRIM(import_history.virtual_path, '/') = TRIM(file_health.file_path, '/')
    LIMIT 1
) WHERE download_id IS NULL;
```

Because both sides are `TRIM()`-wrapped, **no index can be used** — it's a correlated subquery doing a full scan of `import_history` per `file_health` row, i.e. **O(N×M)**. It runs synchronously inside `goose.Up` during `NewDB` at startup ([serve.go:71](cmd/altmount/cmd/serve.go#L71) → `runMigrations` → `goose.Up`), so on the first upgrade it silently hangs for minutes-to-forever on mature deployments.

Two more issues found alongside it:
- The **Postgres** variant used the invalid two-argument `TRIM(x, '/')` comma form, which **hard-errors** on PostgreSQL (`trim` needs `TRIM(BOTH '/' FROM x)` / `btrim`).
- The same slow query is duplicated in the `ensureSchemaIntegrity` fallback guard.

## Fix

- **SQLite & Postgres migration 034:** create a **temporary expression index** on the normalized `import_history` path around the backfill, then drop it. The per-row lookup becomes an index `SEARCH` instead of a full `SCAN`, collapsing O(N×M) → ~O(N log M). Estimated impact: minutes-to-forever → ~1–5s even on very large DBs.
- **Postgres:** replace `TRIM(x, '/')` with `btrim(x, '/')` in both the index and the backfill.
- **`ensureSchemaIntegrity` guard** (`internal/database/db.go`): apply the same temp-index optimization with dialect-aware trim.

The migration stays inside goose's transaction, so any user whose container was killed mid-migration rolled back cleanly and re-applies the fast version on next start. Schema result is identical, so users who already applied 034 are unaffected.

## Tests

New `internal/database/migration_034_test.go`:
- `TestMigration034_BackfillsDownloadID` — runs the **real goose migrations** up to 033, seeds `import_history`/`file_health` rows differing only by leading/trailing slashes plus a no-match row, applies 034, and asserts each `download_id` is backfilled correctly (or stays NULL) and the temp index is dropped.
- `TestMigration034_BackfillUsesExpressionIndex` — the startup-hang guard: `EXPLAIN QUERY PLAN` shows a full **SCAN** without the expression index and an index **SEARCH ... USING idx_import_history_trim_vpath** with it.

Verification: `go test -race ./internal/database/`, `go build ./...`, `go vet ./...` all clean.

## Reviewer notes

- The Postgres path is verified by review only (no live PostgreSQL in the dev env); `btrim` is standard and the functional index expression matches the query expression.
- Two copies of the backfill SQL now exist (migration file + Go guard) because SQL migrations can't call Go — both are optimized and kept in sync.
- The `[migrations] no migrations found` line some users see in logs is benign linuxserver.io base-image noise, unrelated to this DB migration.