### PR TITLE
fix(progress): keep latest progress update when subscriber channel is full

### DIFF
--- a/internal/progress/progress_broadcaster.go
+++ b/internal/progress/progress_broadcaster.go
@@ -42,9 +42,14 @@ type ProgressBroadcaster struct {
 	subSeq      atomic.Uint64
 }
 
-// broadcast delivers update to every subscriber without blocking. If a
-// subscriber's buffered channel is full the update is dropped for that
-// subscriber and dropMsg is logged. Shared by all the broadcast entry points.
+// broadcast delivers update to every subscriber without blocking. Producers
+// (e.g. per-segment progress ticks) can emit updates far faster than a single
+// SSE goroutine can marshal and flush them over the network, so a subscriber's
+// buffered channel can fill up. Only the latest state per queue item matters
+// to consumers, so when a channel is full its oldest buffered update is
+// dropped to make room for the new one instead of discarding the new update -
+// this keeps subscribers converging on current progress rather than getting
+// stuck replaying stale values. dropMsg is logged only if even that retry fails.
 func (pb *ProgressBroadcaster) broadcast(update ProgressUpdate, dropMsg string) {
 	if pb == nil {
 		return
@@ -52,6 +57,19 @@ func (pb *ProgressBroadcaster) broadcast(update ProgressUpdate, dropMsg string) 
 	pb.subMu.RLock()
 	defer pb.subMu.RUnlock()
 	for subID, ch := range pb.subscribers {
+		select {
+		case ch <- update:
+			continue
+		default:
+		}
+
+		// Channel full: drop the oldest queued update, then retry once so the
+		// subscriber ends up with the most recent state.
+		select {
+		case <-ch:
+		default:
+		}
+
 		select {
 		case ch <- update:
 		default:

--- a/internal/progress/progress_broadcaster.go
+++ b/internal/progress/progress_broadcaster.go
@@ -42,14 +42,8 @@ type ProgressBroadcaster struct {
 	subSeq      atomic.Uint64
 }
 
-// broadcast delivers update to every subscriber without blocking. Producers
-// (e.g. per-segment progress ticks) can emit updates far faster than a single
-// SSE goroutine can marshal and flush them over the network, so a subscriber's
-// buffered channel can fill up. Only the latest state per queue item matters
-// to consumers, so when a channel is full its oldest buffered update is
-// dropped to make room for the new one instead of discarding the new update -
-// this keeps subscribers converging on current progress rather than getting
-// stuck replaying stale values. dropMsg is logged only if even that retry fails.
+// broadcast delivers update to every subscriber without blocking, dropping the
+// oldest buffered update instead of the new one if a channel is full.
 func (pb *ProgressBroadcaster) broadcast(update ProgressUpdate, dropMsg string) {
 	if pb == nil {
 		return
@@ -63,8 +57,7 @@ func (pb *ProgressBroadcaster) broadcast(update ProgressUpdate, dropMsg string) 
 		default:
 		}
 
-		// Channel full: drop the oldest queued update, then retry once so the
-		// subscriber ends up with the most recent state.
+		// Full: drop oldest, retry once.
 		select {
 		case <-ch:
 		default:

--- a/internal/progress/progress_broadcaster_test.go
+++ b/internal/progress/progress_broadcaster_test.go
@@ -2,23 +2,16 @@ package progress
 
 import "testing"
 
-// TestBroadcastFullChannelKeepsLatestUpdate verifies that when a subscriber's
-// buffered channel is full, the broadcaster drops the oldest queued update
-// rather than the new one, so the subscriber eventually observes the most
-// recent progress state instead of getting stuck behind stale values.
 func TestBroadcastFullChannelKeepsLatestUpdate(t *testing.T) {
 	pb := NewProgressBroadcaster()
 	subID, ch := pb.Subscribe()
 	defer pb.Unsubscribe(subID)
 
-	// Fill the channel (capacity 10) and send one more to force the
-	// full-channel path.
 	const capacity = 10
 	for i := range capacity + 1 {
 		pb.UpdateProgress(1, i)
 	}
 
-	// Drain the channel and remember the last percentage observed.
 	var last int
 	var count int
 	for {

--- a/internal/progress/progress_broadcaster_test.go
+++ b/internal/progress/progress_broadcaster_test.go
@@ -1,0 +1,41 @@
+package progress
+
+import "testing"
+
+// TestBroadcastFullChannelKeepsLatestUpdate verifies that when a subscriber's
+// buffered channel is full, the broadcaster drops the oldest queued update
+// rather than the new one, so the subscriber eventually observes the most
+// recent progress state instead of getting stuck behind stale values.
+func TestBroadcastFullChannelKeepsLatestUpdate(t *testing.T) {
+	pb := NewProgressBroadcaster()
+	subID, ch := pb.Subscribe()
+	defer pb.Unsubscribe(subID)
+
+	// Fill the channel (capacity 10) and send one more to force the
+	// full-channel path.
+	const capacity = 10
+	for i := range capacity + 1 {
+		pb.UpdateProgress(1, i)
+	}
+
+	// Drain the channel and remember the last percentage observed.
+	var last int
+	var count int
+	for {
+		select {
+		case update := <-ch:
+			last = update.Percentage
+			count++
+			continue
+		default:
+		}
+		break
+	}
+
+	if count != capacity {
+		t.Fatalf("expected channel to hold %d updates, got %d", capacity, count)
+	}
+	if last != capacity {
+		t.Fatalf("expected latest update (percentage=%d) to survive, got %d", capacity, last)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes the `subscriber channel full, skipping update` warning that occurs when a fast-producing progress event (e.g. per-segment import ticks) outpaces a single SSE subscriber's network-bound flush loop.
- Previously, once a subscriber's 10-slot buffered channel filled, every new update for that queue item was dropped (drop-newest semantics), causing the frontend progress bar to freeze on a stale percentage until the consumer drained the backlog.
- Since only the latest state per queue item matters to SSE consumers, `broadcast()` now drops the **oldest** queued update and retries when a channel is full, so subscribers always converge on the current progress instead of stalling.

## Root cause
`ProgressBroadcaster.broadcast()` used a fixed 10-slot buffered channel per subscriber with a non-blocking send that dropped the incoming update on the floor if the channel was full. Producers like `Tracker.Update` can emit updates once per segment during import, far faster than the SSE handler goroutine can `json.Marshal` + `Fprintf` + `Flush()` over the network.

## Test plan
- [x] `go build ./internal/progress/...`
- [x] `go test ./internal/progress/... -race -v` (includes new regression test `TestBroadcastFullChannelKeepsLatestUpdate`)
- [x] `go vet ./internal/progress/...`