### PR TITLE
fix(importer): import obfuscated multi-volume RAR NZBs that fail on duplicate subjects and transient fetches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/javi11/nntppool/v4 v4.13.0
 	github.com/javi11/nxg v0.1.0
-	github.com/javi11/nzbparser v0.5.4
+	github.com/javi11/nzbparser v0.5.5
 	github.com/javi11/rardecode/v2 v2.1.2-0.20260610075131-4664d7a7325a
 	github.com/javi11/sevenzip v1.6.2-0.20251026160715-ca961b7f1239
 	github.com/jinzhu/copier v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/javi11/nntppool/v4 v4.13.0 h1:JEZukeSqeolKHw/M67YtVa2WrvZ8BE8UbkDklaU
 github.com/javi11/nntppool/v4 v4.13.0/go.mod h1:+UtisJLDFLXBSkW9R6uCRgdp3lS/+6pLAk7L+Wt6LMw=
 github.com/javi11/nxg v0.1.0 h1:CTThldYlaVIPIhpkrMw0HcTD0NLrW1uYMoDILjjEOtM=
 github.com/javi11/nxg v0.1.0/go.mod h1:+GvYpp+y1oq+qBOWxFMvfTjtin/0zCeomWfjiPkiu8A=
-github.com/javi11/nzbparser v0.5.4 h1:0aYyORZipp7iX8eNpT/efnzCeVO+9C0sE2HWCGc/JaI=
-github.com/javi11/nzbparser v0.5.4/go.mod h1:ikF7WI3BUGs5IHQJmKzmtTkX29NZW5nvUdo6ZWFZgL4=
+github.com/javi11/nzbparser v0.5.5 h1:kMKyX0xNO7bIeIlQvSPGzdWs71MG2Krf+yojOj+FuUc=
+github.com/javi11/nzbparser v0.5.5/go.mod h1:ikF7WI3BUGs5IHQJmKzmtTkX29NZW5nvUdo6ZWFZgL4=
 github.com/javi11/rardecode/v2 v2.1.2-0.20260610075131-4664d7a7325a h1:7PiZAhAZXhsuNo7s1InjzNS5lhbEaEfxoqkAuW1q44U=
 github.com/javi11/rardecode/v2 v2.1.2-0.20260610075131-4664d7a7325a/go.mod h1:Bv+b+FzxIO1GhbQB6Rl+um+6nGsfcB+1eug62+8P9OM=
 github.com/javi11/sevenzip v1.6.2-0.20251026160715-ca961b7f1239 h1:XbptA/1kHKOeDZChh599BXNGQ9jfuW1RG8y/e5Oclkc=

--- a/internal/importer/archive/rar/utils.go
+++ b/internal/importer/archive/rar/utils.go
@@ -133,13 +133,24 @@ func rarVolumeNumber(filename string) (rarScheme, int, bool) {
 	return archive.VolumeNumber(filename)
 }
 
-// groupHasVolumeGap reports whether a RAR volume set is missing a leading or
-// interior volume, judged purely from filename numbering (no network access).
-// It is deliberately conservative — when the numbering scheme is mixed or any
-// member is unrecognized it returns false so a healthy set is never skipped on
-// a false positive. A missing *trailing* volume is undetectable by numbering
-// (the expected count is unknown) and also returns false; that case is handled
-// downstream by segment-integrity validation.
+// volumeGapTolerance is the maximum fraction of a RAR volume set that may be
+// missing (interior volumes) while analysis is still attempted. A set missing
+// more than this is treated as doomed and skipped before paying for network
+// I/O; smaller gaps proceed so downstream segment-integrity and content-
+// coverage validation can decide. A *leading* volume gap (the archive header
+// is missing) is never tolerated — the set cannot be read at all.
+const volumeGapTolerance = 0.05
+
+// groupHasVolumeGap reports whether a RAR volume set is missing enough leading
+// or interior volumes that analysis should be skipped, judged purely from
+// filename numbering (no network access). It is deliberately conservative —
+// when the numbering scheme is mixed or any member is unrecognized it returns
+// false so a healthy set is never skipped on a false positive. A missing
+// *leading* volume always counts (the archive header is gone). A small interior
+// gap (within volumeGapTolerance of the volume span) is tolerated and left to
+// downstream validation, so a large multi-volume set is not discarded over a
+// couple of missing volumes. A missing *trailing* volume is undetectable by
+// numbering (the expected count is unknown) and also returns false.
 func groupHasVolumeGap(files []parser.ParsedFile) bool {
 	if len(files) <= 1 {
 		return false
@@ -167,17 +178,28 @@ func groupHasVolumeGap(files []parser.ParsedFile) bool {
 		expectedStart = 0
 	}
 	if nums[0] > expectedStart {
-		return true // leading volume(s) missing
+		return true // leading volume(s) missing — archive header gone, can't read
 	}
+
+	// Count unique ordinals present across the volume span and skip only when the
+	// missing fraction exceeds the tolerance. This keeps the fast-skip for clearly
+	// broken sets (most volumes absent) while letting a nearly-complete set proceed
+	// to analysis, where segment/coverage checks make the final call.
+	unique := 1
 	for i := 1; i < len(nums); i++ {
-		if nums[i] == nums[i-1] {
-			continue // duplicate ordinal (defensive); not a gap
-		}
-		if nums[i] != nums[i-1]+1 {
-			return true // interior gap
+		if nums[i] != nums[i-1] {
+			unique++
 		}
 	}
-	return false
+	span := nums[len(nums)-1] - expectedStart + 1
+	if span <= 0 {
+		return false
+	}
+	missing := span - unique
+	if missing <= 0 {
+		return false
+	}
+	return float64(missing) > volumeGapTolerance*float64(span)
 }
 
 // groupHasFirstVolume reports whether a RAR group contains the volume that begins

--- a/internal/importer/archive/rar/utils_test.go
+++ b/internal/importer/archive/rar/utils_test.go
@@ -157,7 +157,9 @@ func TestGroupHasVolumeGap(t *testing.T) {
 		{"old roll missing first volume", files("m.r00", "m.r01"), true},
 		{"old roll interior gap", files("m.rar", "m.r00", "m.r02"), true},
 		{"old roll full rollover into s contiguous", files(oldRollSet("m", 12)...), false},
-		{"old roll rollover missing s00", files(oldRollSetSkip("m", 12, "m.s00")...), true},
+		// A single interior volume missing from a 114-volume set (~0.9%) is within
+		// tolerance: proceed to analysis rather than pre-skipping a near-complete set.
+		{"old roll rollover missing s00 tolerated", files(oldRollSetSkip("m", 12, "m.s00")...), false},
 		{"numeric contiguous", files("a.001", "a.002", "a.003"), false},
 		{"numeric gap", files("a.001", "a.003"), true},
 		{"numeric missing first", files("a.002", "a.003"), true},
@@ -165,6 +167,10 @@ func TestGroupHasVolumeGap(t *testing.T) {
 		{"mixed schemes not flagged", files("m.rar", "m.part02.rar"), false},
 		{"unrecognized member not flagged", files("m.r00", "obfuscated"), false},
 		{"empty", nil, false},
+		// Large part set missing 2 of 257 volumes (~0.8%): within tolerance, proceed.
+		{"large part set small interior gap tolerated", files(partSetSkip("m", 257, 42, 199)...), false},
+		// Large part set with most volumes absent: clearly doomed, skip.
+		{"large part set mostly missing skipped", files("m.part001.rar", "m.part250.rar"), true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -221,6 +227,23 @@ func oldRollSet(base string, sCount int) []string {
 }
 
 // oldRollSetSkip returns oldRollSet with the named volume removed, simulating a gap.
+// partSetSkip builds a .partNNN.rar set of `count` volumes (1-based, 3-digit
+// padded) omitting the given volume numbers, to model near-complete large sets.
+func partSetSkip(base string, count int, skip ...int) []string {
+	drop := make(map[int]struct{}, len(skip))
+	for _, n := range skip {
+		drop[n] = struct{}{}
+	}
+	names := make([]string, 0, count)
+	for i := 1; i <= count; i++ {
+		if _, ok := drop[i]; ok {
+			continue
+		}
+		names = append(names, fmt.Sprintf("%s.part%03d.rar", base, i))
+	}
+	return names
+}
+
 func oldRollSetSkip(base string, sCount int, skip string) []string {
 	all := oldRollSet(base, sCount)
 	out := all[:0:0]

--- a/internal/importer/parser/parser.go
+++ b/internal/importer/parser/parser.go
@@ -40,6 +40,14 @@ import (
 // budget, which adapts to pool capacity and stream activity.
 const maxFetchGoroutines = 100
 
+// First-segment fetches retry transient failures (connection exhaustion,
+// timeouts) so a momentary hiccup doesn't permanently drop a volume from a
+// large multi-volume set. A real article-not-found is not retried.
+const (
+	maxFirstSegmentFetchAttempts = 3
+	firstSegmentRetryBackoff     = 300 * time.Millisecond
+)
+
 // FirstSegmentData holds cached data from the first segment of an NZB file
 // This avoids redundant fetching when both PAR2 extraction and file parsing need the same data
 type FirstSegmentData struct {
@@ -773,26 +781,52 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 
 			firstSegment := fileToFetch.Segments[0]
 
-			// Take a token from the global import connection budget before the
-			// per-attempt timeout starts, so queue wait never burns the deadline.
-			releaseConn, err := p.poolManager.AcquireImportConnection(ctx)
-			if err != nil {
-				return fetchResult{}, err
+			// Fetch the first segment, retrying transient failures. A genuine
+			// article-not-found (430/423) is permanent, so we stop immediately.
+			// But transient errors — connection exhaustion ("all providers
+			// exhausted"), timeouts, resets — must NOT be treated like a missing
+			// article: dropping a volume over a transient hiccup shatters large
+			// multi-volume sets (one lost first segment → no PAR2 name → the
+			// volume is excluded → the archive looks incomplete). Retry those a
+			// few times before giving up.
+			var (
+				result   *nntppool.ArticleBody
+				fetchErr error
+			)
+			for attempt := 1; attempt <= maxFirstSegmentFetchAttempts; attempt++ {
+				// Take a token from the global import connection budget before the
+				// per-attempt timeout starts, so queue wait never burns the deadline.
+				releaseConn, acquireErr := p.poolManager.AcquireImportConnection(ctx)
+				if acquireErr != nil {
+					// Budget acquisition only fails when the context is done — fatal.
+					return fetchResult{}, acquireErr
+				}
+
+				// Create context with timeout
+				c, cancel := context.WithTimeout(ctx, time.Second*30)
+				// Get body for the first segment (v4 returns decoded bytes + YEnc metadata)
+				result, fetchErr = cp.Body(c, firstSegment.ID)
+				cancel()
+				releaseConn()
+
+				// Success or permanent miss: stop retrying.
+				if fetchErr == nil || stderrors.Is(fetchErr, nntppool.ErrArticleNotFound) {
+					break
+				}
+				// Transient failure: brief backoff (unless the context is done) then retry.
+				if attempt < maxFirstSegmentFetchAttempts {
+					select {
+					case <-ctx.Done():
+					case <-time.After(time.Duration(attempt) * firstSegmentRetryBackoff):
+					}
+				}
 			}
-			defer releaseConn()
-
-			// Create context with timeout
-			c, cancel := context.WithTimeout(ctx, time.Second*30)
-			defer cancel()
-
-			// Get body for the first segment (v4 returns decoded bytes + YEnc metadata)
-			result, err := cp.Body(c, firstSegment.ID)
-			if err != nil {
+			if fetchErr != nil {
 				p.log.DebugContext(ctx, "missing segment",
 					"segment_id", firstSegment.ID,
-					"error", err,
+					"error", fetchErr,
 				)
-				notFound := stderrors.Is(err, nntppool.ErrArticleNotFound)
+				notFound := stderrors.Is(fetchErr, nntppool.ErrArticleNotFound)
 				return fetchResult{
 					segmentID:  firstSegment.ID,
 					isNotFound: notFound,
@@ -802,7 +836,7 @@ func (p *Parser) fetchAllFirstSegments(ctx context.Context, files []nzbparser.Nz
 						IsArticleNotFound:   notFound,
 						OriginalIndex:       originalIndex,
 					},
-					err: fmt.Errorf("failed to get body: %w", err),
+					err: fmt.Errorf("failed to get body: %w", fetchErr),
 				}, nil
 			}
 

--- a/internal/importer/parser/parser_retry_test.go
+++ b/internal/importer/parser/parser_retry_test.go
@@ -1,0 +1,129 @@
+package parser
+
+import (
+	"context"
+	"testing"
+
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/nntppool/v4"
+	"github.com/javi11/nzbparser"
+)
+
+// TestParseNzbRetriesTransientFirstSegmentFetch is the regression test for
+// obfuscated multi-volume imports that failed because a couple of volumes'
+// first-segment fetches hit a TRANSIENT error ("all providers exhausted") and
+// were treated as permanently missing, shattering the set. A transient failure
+// must be retried; the volume must survive once a retry succeeds.
+func TestParseNzbRetriesTransientFirstSegmentFetch(t *testing.T) {
+	const name = "Movie.2020.1080p.BluRay.mkv"
+
+	fp := fakepool.New()
+	// Fail the first two attempts transiently, then succeed on the third
+	// (maxFirstSegmentFetchAttempts == 3).
+	fp.SetBehavior("seg-0", fakepool.SegmentBehavior{
+		FailFirst: 2,
+		Bytes:     make([]byte, 16),
+	})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(2))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{
+				Filename: name,
+				Segments: nzbparser.NzbSegments{
+					{Bytes: 12345, Number: 1, ID: "seg-0"},
+				},
+			},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 {
+		t.Fatalf("len(parsed.Files) = %d, want 1 (volume recovered by retry)", len(parsed.Files))
+	}
+	if got := parsed.Files[0].Filename; got != name {
+		t.Fatalf("kept file = %q, want %q", got, name)
+	}
+	// 2 transient failures + 1 success = 3 Body calls for the single first segment.
+	if calls := fp.BodyCalls(); calls != 3 {
+		t.Errorf("BodyCalls = %d, want 3 (two retries then success)", calls)
+	}
+}
+
+// TestParseNzbDropsFileWhenTransientRetriesExhausted verifies that a file whose
+// first segment keeps failing past the retry budget is dropped, while healthy
+// siblings still import — and that all attempts were made (retry, not one-shot).
+func TestParseNzbDropsFileWhenTransientRetriesExhausted(t *testing.T) {
+	const (
+		brokenName  = "Broken.2020.1080p.BluRay.mkv"
+		healthyName = "Good.2020.1080p.BluRay.mkv"
+	)
+
+	fp := fakepool.New()
+	// Never succeeds within the retry budget (3 attempts).
+	fp.SetBehavior("broken-0", fakepool.SegmentBehavior{FailFirst: 99, Bytes: make([]byte, 16)})
+	fp.SetBehavior("good-0", fakepool.SegmentBehavior{Bytes: make([]byte, 16)})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(2))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{Filename: brokenName, Segments: nzbparser.NzbSegments{{Bytes: 12345, Number: 1, ID: "broken-0"}}},
+			{Filename: healthyName, Segments: nzbparser.NzbSegments{{Bytes: 12345, Number: 1, ID: "good-0"}}},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 || parsed.Files[0].Filename != healthyName {
+		t.Fatalf("parsed.Files = %+v, want only %q", parsed.Files, healthyName)
+	}
+	// broken-0: 3 attempts (all fail) + good-0: 1 = 4 Body calls total.
+	if calls := fp.BodyCalls(); calls != 4 {
+		t.Errorf("BodyCalls = %d, want 4 (broken retried 3x, good once)", calls)
+	}
+}
+
+// TestParseNzbDoesNotRetryArticleNotFound verifies that a genuine missing
+// article (430/423) is NOT retried — it is a permanent miss, so retrying would
+// only waste network round-trips.
+func TestParseNzbDoesNotRetryArticleNotFound(t *testing.T) {
+	const (
+		missingName = "Missing.2020.1080p.BluRay.mkv"
+		healthyName = "Good.2020.1080p.BluRay.mkv"
+	)
+
+	fp := fakepool.New()
+	fp.SetBehavior("missing-0", fakepool.SegmentBehavior{Err: nntppool.ErrArticleNotFound})
+	fp.SetBehavior("good-0", fakepool.SegmentBehavior{Bytes: make([]byte, 16)})
+
+	pm := newFakeFullPoolManager(fp)
+	p := NewParser(pm, stormConfigGetter(2))
+
+	n := &nzbparser.Nzb{
+		Files: nzbparser.NzbFiles{
+			{Filename: missingName, Segments: nzbparser.NzbSegments{{Bytes: 12345, Number: 1, ID: "missing-0"}}},
+			{Filename: healthyName, Segments: nzbparser.NzbSegments{{Bytes: 12345, Number: 1, ID: "good-0"}}},
+		},
+	}
+
+	parsed, err := p.ParseNzb(context.Background(), n, "test.nzb", nil, ParseOptions{})
+	if err != nil {
+		t.Fatalf("ParseNzb error = %v", err)
+	}
+	if len(parsed.Files) != 1 || parsed.Files[0].Filename != healthyName {
+		t.Fatalf("parsed.Files = %+v, want only %q", parsed.Files, healthyName)
+	}
+	// missing-0: 1 attempt (no retry on 430) + good-0: 1 = 2 Body calls total.
+	if calls := fp.BodyCalls(); calls != 2 {
+		t.Errorf("BodyCalls = %d, want 2 (no retry on ErrArticleNotFound)", calls)
+	}
+}

--- a/internal/testsupport/fakepool/fakepool.go
+++ b/internal/testsupport/fakepool/fakepool.go
@@ -52,6 +52,11 @@ import (
 // compile-time assertion: Client must satisfy the narrow interface.
 var _ pool.NntpClient = (*Client)(nil)
 
+// errTransientFakepool is the default error returned during a SegmentBehavior
+// FailFirst window — a transient failure that is NOT nntppool.ErrArticleNotFound,
+// so retry logic must treat it as retryable rather than a permanent miss.
+var errTransientFakepool = errors.New("fakepool: transient failure (all providers exhausted)")
+
 // SegmentBehavior describes how the fake should respond to a single
 // message-ID. The zero value returns an empty body with no delay.
 type SegmentBehavior struct {
@@ -73,6 +78,16 @@ type SegmentBehavior struct {
 	// onMeta callbacks. Use this to inject yEnc header metadata (FileName,
 	// PartSize, FileSize, etc.) without needing a real NNTP server.
 	YEnc nntppool.YEncMeta
+
+	// FailFirst makes the first N calls to this message-ID return FailErr (a
+	// transient error) before subsequent calls succeed normally. Use it to
+	// exercise retry logic that must distinguish transient failures from a
+	// permanent article-not-found. Zero disables this behavior.
+	FailFirst int
+
+	// FailErr is the transient error returned during the FailFirst window.
+	// Defaults to a generic "all providers exhausted"-style error when nil.
+	FailErr error
 }
 
 // Client is a fake nntppool.Client suitable for unit and concurrency tests.
@@ -368,6 +383,17 @@ func (c *Client) serveBody(ctx context.Context, messageID string, w io.Writer, o
 	b := c.behaviorFor(messageID)
 	if err := waitOrCancel(ctx, b.Latency); err != nil {
 		return nil, err
+	}
+	// Transient-failure window: fail the first FailFirst calls to this message,
+	// then serve normally. The per-ID counter was already incremented in Body.
+	if b.FailFirst > 0 {
+		if n, ok := c.perIDCalls.Load(messageID); ok && n.(*atomic.Int64).Load() <= int64(b.FailFirst) {
+			failErr := b.FailErr
+			if failErr == nil {
+				failErr = errTransientFakepool
+			}
+			return nil, failErr
+		}
 	}
 	if b.Err != nil {
 		// Mirror nntppool: on error the result may still carry partial


### PR DESCRIPTION
## Summary

Fixes import of large obfuscated multi-volume RAR NZBs (e.g. a 257-volume password-encrypted release) that failed with `no files were successfully processed (all files failed validation)` even though every segment downloads fine in SABnzbd. The investigation surfaced **two independent root causes**, both fixed here.

### 1. Duplicate-subject volumes were discarded (`chore(deps): bump nzbparser to v0.5.5`)

The release is an obfuscated post: its 257 RAR volumes are genuinely distinct files (distinct message-ids/content) but **share a byte-identical subject** line. `nzbparser.Parse` defaults to `RemoveDuplicates: true`, whose `MakeUnique` deduped files keyed on `file.Subject` alone — collapsing all same-subject volumes to one. Result: only 13 files survived (11 PAR2 + 2 RAR) → `parts=2` → false "missing volume(s)" → failure.

nzbparser **v0.5.5** now keys dedup on the first segment's message-id (globally unique per Usenet article), preserving genuine-duplicate removal. This PR bumps the dependency; parsing now keeps all volumes (`files=13` → `266`).

### 2. Transient first-segment fetch failures shattered the set (`fix(importer): …`)

With all volumes surviving, a couple of volumes' first-segment fetches hit a **transient** error (`nntp: all providers exhausted` — connection exhaustion under the burst of ~266 concurrent fetches on a single provider with a small import budget), **not** a real 430. `fetchAllFirstSegments` treated any `Body()` error as a permanent missing article (no retry), so those volumes were dropped, never got a PAR2 name, and the set was left with a gap that `groupHasVolumeGap` hard-skipped before analysis → `ErrNoFilesProcessed`.

- **Retry:** `fetchAllFirstSegments` now retries transient `Body()` failures (3 attempts, linear backoff). Only a real `nntppool.ErrArticleNotFound` marks a volume missing; import-connection acquisition failure stays fatal.
- **Gap tolerance:** `groupHasVolumeGap` tolerates a small interior gap (≤5% of the volume span) and proceeds to analysis, where segment/coverage validation makes the final call. A missing *leading* volume (archive header) still always skips.

## Testing

- `internal/testsupport/fakepool`: added `SegmentBehavior.FailFirst`/`FailErr` (fail N calls then succeed) for retry testing.
- New `internal/importer/parser/parser_retry_test.go`: transient→recovered, retries-exhausted→dropped (siblings kept), `ErrArticleNotFound`→not-retried — each asserted via exact `Body` call counts.
- Updated `TestGroupHasVolumeGap`: the 1-of-114 "missing s00" case now correctly proceeds (tolerated); added large-set (2-of-257 tolerated, mostly-missing skipped) cases.
- `go vet`, all importer + testsupport tests, and full `make` are green.

## Reviewer notes

- Behavior change: `groupHasVolumeGap` no longer hard-skips a nearly-complete set over a couple of missing interior volumes — the downstream 80%/99% coverage checks remain authoritative. Leading-volume gaps are unchanged (still skip).
- The nzbparser fix is released as `v0.5.5` from `github.com/javi11/nzbparser` `main`.