### PR TITLE
fix(frontend): remove duplicated nested RAR extraction config UI

### DIFF
--- a/frontend/src/components/config/WorkersConfigSection.tsx
+++ b/frontend/src/components/config/WorkersConfigSection.tsx
@@ -244,67 +244,6 @@ export function ImportConfigSection({
 								</div>
 							</label>
 						</div>
-
-						<label className="flex min-w-0 cursor-pointer items-start gap-3 rounded-xl border border-error/30 bg-error/5 p-4">
-							<input
-								type="checkbox"
-								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
-								checked={formData.allow_nested_rar_extraction ?? true}
-								disabled={isReadOnly}
-								onChange={(e) => handleInputChange("allow_nested_rar_extraction", e.target.checked)}
-							/>
-							<div className="min-w-0 flex-1">
-								<span className="block whitespace-normal break-words font-bold text-xs">
-									Nested RAR Extraction
-								</span>
-								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-									Extract nested RAR archives found inside other RAR or 7zip archives. Disable if
-									nested extraction causes issues with your files.
-								</span>
-							</div>
-						</label>
-
-						<div className="divider text-base-content/70" />
-
-						<label className="label cursor-pointer items-start justify-start gap-4">
-							<input
-								type="checkbox"
-								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
-								checked={formData.rename_to_nzb_name ?? true}
-								disabled={isReadOnly}
-								onChange={(e) => handleInputChange("rename_to_nzb_name", e.target.checked)}
-							/>
-							<div className="min-w-0 flex-1">
-								<span className="block whitespace-normal break-words font-bold text-xs">
-									Rename to NZB Name
-								</span>
-								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-									When an import produces a single file, rename it using the NZB release name
-									instead of the original (often obfuscated) filename.
-								</span>
-							</div>
-						</label>
-
-						<div className="divider text-base-content/70" />
-
-						<label className="label cursor-pointer items-start justify-start gap-4">
-							<input
-								type="checkbox"
-								className="toggle toggle-primary toggle-sm mt-1 shrink-0"
-								checked={formData.filter_sample_files ?? true}
-								disabled={isReadOnly}
-								onChange={(e) => handleInputChange("filter_sample_files", e.target.checked)}
-							/>
-							<div className="min-w-0 flex-1">
-								<span className="block whitespace-normal break-words font-bold text-xs">
-									Filter Sample Files
-								</span>
-								<span className="mt-1 block whitespace-normal break-words text-base-content/50 text-xs leading-relaxed">
-									Automatically reject files that appear to be samples or proofs (e.g.,
-									movie.sample.mkv). Files larger than 200MB are never filtered.
-								</span>
-							</div>
-						</label>
 					</div>
 				</div>
 


### PR DESCRIPTION
## Summary
- `WorkersConfigSection` (Import Processing config page) rendered the **Nested RAR Extraction**, **Rename to NZB Name**, and **Filter Sample Files** toggles twice — a leftover old-style block duplicated the newer grid layout above it.
- Removed the dead duplicate block, keeping the current grid-based toggles.

## Test plan
- [x] `bunx tsc --noEmit` passes with no errors
- [x] Verified only the intended file changed (`git status`)
- [ ] Manually load the Import config page and confirm each toggle now appears exactly once