### PR TITLE
fix(importer): regenerate raw NZB from store when retrying a completed import

### DIFF
--- a/internal/importer/ensure_persistent_nzb_test.go
+++ b/internal/importer/ensure_persistent_nzb_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/metadata"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
 )
 
 // newMinimalServiceForPersistTest builds just enough of *Service to exercise
@@ -113,6 +115,84 @@ func TestEnsurePersistentNzb_UsesOSTempQueueDir(t *testing.T) {
 	// Assert: the file actually exists at the new path
 	_, statErr := os.Stat(item.NzbPath)
 	assert.NoError(t, statErr, "moved file should exist at new path")
+}
+
+// newServiceForRegenerateTest builds a *Service with a real metadata.MetadataService so
+// regenerateNzbFile can write/read an actual .nzbz store, plus a configGetter whose
+// Database.Path resolves to a fresh configDir the test controls.
+func newServiceForRegenerateTest(t *testing.T) (svc *Service, configDir string) {
+	t.Helper()
+
+	svc = newMinimalServiceForPersistTest(t)
+	configDir = t.TempDir()
+	svc.configGetter = config.ConfigGetter(func() *config.Config {
+		return &config.Config{
+			Database: config.DatabaseConfig{
+				Path: filepath.Join(configDir, "test.db"),
+			},
+		}
+	})
+	svc.metadataService = metadata.NewMetadataService(t.TempDir())
+	return svc, configDir
+}
+
+// sampleNzbStoreForTest returns a minimal but valid *metapb.NzbStore, mirroring
+// internal/metadata/store_test.go's sampleStore().
+func sampleNzbStoreForTest() *metapb.NzbStore {
+	return &metapb.NzbStore{Files: []*metapb.NzbFileEntry{
+		{Subject: "Movie.mkv yEnc (1/1)", Poster: "p@x", Date: 1000, Groups: []string{"a.b.test"},
+			Segments: []*metapb.NzbSeg{{Id: "m1@x", Number: 1, Bytes: 1000}}},
+	}}
+}
+
+func TestEnsurePersistentNzb_RegeneratesFromStore_WhenRawFileMissing(t *testing.T) {
+	// Arrange: item.NzbPath already points inside the persistent temp queue dir (as it would
+	// after a prior successful import), but the raw file was deleted by handleProcessingSuccess.
+	queueDir := filepath.Join(os.TempDir(), ".altmount-queue")
+	require.NoError(t, os.MkdirAll(queueDir, 0755))
+	missingPath := filepath.Join(queueDir, "regen-movie.nzb")
+	t.Cleanup(func() { os.Remove(missingPath) })
+
+	item := &database.ImportQueueItem{ID: 7, NzbPath: missingPath}
+
+	svc, configDir := newServiceForRegenerateTest(t)
+
+	// The store must live at exactly the path processor.go writes it to / handleDownloadNZB
+	// reconstructs it from: configDir/.nzbs/{category}/{queueID}-{nzbBase}.nzbz.
+	storeRef := filepath.Join(configDir, ".nzbs", "7-regen-movie.nzbz")
+	require.NoError(t, svc.metadataService.Store().WriteStore(storeRef, sampleNzbStoreForTest()))
+
+	// Act
+	err := svc.ensurePersistentNzb(context.Background(), item)
+	require.NoError(t, err)
+
+	// Assert: the raw NZB now exists on disk again, still inside the persistent queue dir.
+	_, statErr := os.Stat(item.NzbPath)
+	assert.NoError(t, statErr, "regenerated file should exist on disk")
+	assert.True(t, strings.HasPrefix(item.NzbPath, queueDir),
+		"regenerated path should stay inside the persistent temp queue dir, got %q", item.NzbPath)
+
+	regenerated, err := os.ReadFile(item.NzbPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(regenerated), "Movie.mkv", "regenerated NZB should contain the file entry from the store")
+}
+
+func TestEnsurePersistentNzb_RegenerateFails_WhenNoStoreFound(t *testing.T) {
+	// Arrange: raw file missing, and no .nzbz store was ever written for this item.
+	queueDir := filepath.Join(os.TempDir(), ".altmount-queue")
+	require.NoError(t, os.MkdirAll(queueDir, 0755))
+	missingPath := filepath.Join(queueDir, "regen-nostore.nzb")
+
+	item := &database.ImportQueueItem{ID: 8, NzbPath: missingPath}
+
+	svc, _ := newServiceForRegenerateTest(t)
+
+	// Act
+	err := svc.ensurePersistentNzb(context.Background(), item)
+
+	// Assert: clear, actionable error instead of a raw "no such file" from a bare file open.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no store was found")
 }
 
 func TestEnsurePersistentNzb_AlreadyInTempQueueDir_IsNoop(t *testing.T) {

--- a/internal/importer/service.go
+++ b/internal/importer/service.go
@@ -1019,7 +1019,14 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 	// Simple check: if path starts with persistent dir (with separator) or equals it, assume it's fine.
 	// The trailing separator prevents a false match like /tmp/.altmount-queue-other/ matching /tmp/.altmount-queue.
 	if strings.HasPrefix(absNzbPath, absNzbDir+string(os.PathSeparator)) || absNzbPath == absNzbDir {
-		return nil
+		if _, err := os.Stat(item.NzbPath); err == nil {
+			return nil
+		}
+		// The raw NZB was deleted after a prior successful import (handleProcessingSuccess
+		// removes it on purpose once the .nzbz store exists). A retry/reprocess reaches this
+		// point with a stale nzb_path, so regenerate the raw file from the store instead of
+		// failing to open a file that no longer exists.
+		return s.regenerateNzbFile(ctx, item)
 	}
 
 	if item.ID == 0 {
@@ -1072,6 +1079,79 @@ func (s *Service) ensurePersistentNzb(ctx context.Context, item *database.Import
 	}
 
 	s.log.InfoContext(ctx, "Moved NZB to persistent storage", "old_path", oldPath, "new_path", newPath)
+	return nil
+}
+
+// regenerateNzbFile rebuilds the raw .nzb file for item from its .nzbz metadata store when the
+// raw file has been deleted (handleProcessingSuccess removes it after a successful import) but
+// the item is being reprocessed. It reconstructs the store path the same way processor.go writes
+// it and handleDownloadNZB reads it (configDir/.nzbs/{category}/{queueID}-{nzbBase}.nzbz), writes
+// the regenerated XML back into the persistent temp queue dir, and updates nzb_path in the DB.
+func (s *Service) regenerateNzbFile(ctx context.Context, item *database.ImportQueueItem) error {
+	if s.metadataService == nil {
+		return fmt.Errorf("raw NZB file is missing and no metadata service is available to regenerate it")
+	}
+
+	cfg := s.configGetter()
+	configDir := filepath.Dir(cfg.Database.Path)
+	if !filepath.IsAbs(configDir) {
+		if abs, err := filepath.Abs(configDir); err == nil {
+			configDir = abs
+		}
+	}
+
+	var categoryStr string
+	if item.Category != nil && *item.Category != "" {
+		categoryStr = strings.ReplaceAll(*item.Category, `\`, "/")
+		categoryStr = strings.Trim(categoryStr, "/")
+		for _, part := range strings.Split(categoryStr, "/") {
+			if part == ".." || part == "." {
+				categoryStr = ""
+				break
+			}
+		}
+	}
+
+	nzbBase := nzbtrim.TrimNzbExtension(filepath.Base(item.NzbPath))
+	storeRef := filepath.Join(configDir, ".nzbs", categoryStr, fmt.Sprintf("%d-%s.nzbz", item.ID, nzbBase))
+
+	nzbXML, err := s.metadataService.Store().RegenerateNZB(storeRef)
+	if err != nil {
+		return fmt.Errorf("failed to regenerate NZB from store: %w", err)
+	}
+	if nzbXML == nil {
+		return fmt.Errorf("raw NZB file is missing and no store was found at %q to regenerate it", storeRef)
+	}
+
+	nzbDir := filepath.Join(os.TempDir(), ".altmount-queue")
+	if err := os.MkdirAll(nzbDir, 0755); err != nil {
+		return fmt.Errorf("failed to create persistent NZB directory: %w", err)
+	}
+
+	ext := nzbfile.PlainExtension
+	base := nzbtrim.TrimNzbExtension(sanitizeFilename(nzbBase))
+	taken := func(p string) bool {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+		if existing, err := s.database.Repository.GetQueueItemByNzbPath(ctx, p); err == nil && existing != nil && existing.ID != item.ID {
+			return true
+		}
+		return false
+	}
+	newPath := persistentNzbPath(nzbDir, base, ext, item.ID, taken)
+
+	if err := os.WriteFile(newPath, nzbXML, 0644); err != nil {
+		return fmt.Errorf("failed to write regenerated NZB to %q: %w", newPath, err)
+	}
+
+	oldPath := item.NzbPath
+	item.NzbPath = newPath
+	if err := s.database.Repository.UpdateQueueItemNzbPath(ctx, item.ID, newPath); err != nil {
+		return fmt.Errorf("failed to update DB with regenerated NZB path: %w", err)
+	}
+
+	s.log.InfoContext(ctx, "Regenerated raw NZB from metadata store", "old_path", oldPath, "new_path", newPath, "store_ref", storeRef)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Retrying/reprocessing an already-**completed** import fails with `failed to open file: open /tmp/.altmount-queue/<name>.nzb: no such file or directory`.
- Root cause: `handleProcessingSuccess` deletes the raw `.nzb` from the temp queue dir after a successful import (on purpose, since the `.nzbz` metadata store can regenerate it), but never updates or clears `import_queue.nzb_path` in the DB. A later retry re-reads the stale path and tries to reopen a file that no longer exists. (The raw file is never persisted to `/config/.nzbs/` long-term — that directory only holds the derived `.nzbz` store.)
- The regeneration logic already existed for the download/export endpoints (`handleDownloadNZB`) but wasn't wired into the retry/reprocess path.

## Changes

- `internal/importer/service.go`:
  - `ensurePersistentNzb` now checks the raw file still exists on disk before treating an already-persistent path as a no-op; if missing, it calls the new `regenerateNzbFile`.
  - `regenerateNzbFile` reconstructs the `.nzbz` store path the same way `processor.go` writes it and `handleDownloadNZB` already reads it (`configDir/.nzbs/{category}/{queueID}-{nzbBase}.nzbz`), regenerates the raw NZB XML via `metadataService.Store().RegenerateNZB`, writes it back into the persistent temp queue dir, and updates `nzb_path` via the existing `UpdateQueueItemNzbPath`.
- `internal/importer/ensure_persistent_nzb_test.go`: added tests covering (a) successful regeneration from an existing store, and (b) a clear error when no store exists either.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/importer/...` (all packages pass, including 2 new tests)
- [ ] Manual: import an NZB via the WebUI, let it complete, confirm the raw file under `/tmp/.altmount-queue/` is gone, then retry/reprocess it via the WebUI and confirm it succeeds instead of failing with "failed to open file"