### PR TITLE
fix(database): reconcile partially applied migration 034

### DIFF
--- a/internal/database/db.go
+++ b/internal/database/db.go
@@ -143,6 +143,9 @@ func runMigrations(db *sql.DB, d Dialect) error {
 	}
 
 	fixDevBranchMigrationConflict(db, d)
+	if err := fixDownloadIDMigrationConflict(db, d); err != nil {
+		return fmt.Errorf("failed to reconcile migration 034: %w", err)
+	}
 
 	if err := goose.Up(db, migrationsDir); err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
@@ -151,6 +154,80 @@ func runMigrations(db *sql.DB, d Dialect) error {
 	ensureSchemaIntegrity(db, d)
 
 	return nil
+}
+
+// fixDownloadIDMigrationConflict repairs databases where an older build added
+// file_health.download_id via ensureSchemaIntegrity without recording migration
+// 034. Without this reconciliation, migration 034 fails on the duplicate column
+// and the application enters a restart loop.
+func fixDownloadIDMigrationConflict(db *sql.DB, d Dialect) error {
+	if !hasTable(db, d, "goose_db_version") || !hasColumn(db, d, "file_health", "download_id") {
+		return nil
+	}
+
+	appliedValue := "1"
+	if d == DialectPostgres {
+		appliedValue = "true"
+	}
+
+	var applied bool
+	appliedQuery := fmt.Sprintf("SELECT EXISTS(SELECT 1 FROM goose_db_version WHERE version_id = 34 AND is_applied = %s)", appliedValue)
+	if err := db.QueryRow(appliedQuery).Scan(&applied); err != nil {
+		return fmt.Errorf("check migration state: %w", err)
+	}
+	if applied {
+		return nil
+	}
+
+	// Only reconcile the known partial-upgrade state. Recording version 034 on an
+	// older schema could cause goose to skip prerequisite migrations.
+	var currentVersion int64
+	if err := db.QueryRow(fmt.Sprintf("SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version WHERE is_applied = %s", appliedValue)).Scan(&currentVersion); err != nil {
+		return fmt.Errorf("read current migration version: %w", err)
+	}
+	if currentVersion != 33 {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin reconciliation: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("CREATE INDEX IF NOT EXISTS idx_file_health_download_id ON file_health(download_id)"); err != nil {
+		return fmt.Errorf("create download_id index: %w", err)
+	}
+
+	trim := "TRIM(%s, '/')"
+	if d == DialectPostgres {
+		trim = "btrim(%s, '/')"
+	}
+	trimVPath := fmt.Sprintf(trim, "import_history.virtual_path")
+	trimFPath := fmt.Sprintf(trim, "file_health.file_path")
+	idxExpr := fmt.Sprintf(trim, "virtual_path")
+
+	if _, err := tx.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_import_history_trim_vpath ON import_history(%s)", idxExpr)); err != nil {
+		return fmt.Errorf("create temporary backfill index: %w", err)
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`UPDATE file_health
+		SET download_id = (
+			SELECT download_id FROM import_history
+			WHERE %s = %s
+			LIMIT 1
+		)
+		WHERE download_id IS NULL`, trimVPath, trimFPath)); err != nil {
+		return fmt.Errorf("backfill download_id: %w", err)
+	}
+	if _, err := tx.Exec("DROP INDEX IF EXISTS idx_import_history_trim_vpath"); err != nil {
+		return fmt.Errorf("drop temporary backfill index: %w", err)
+	}
+	insertVersion := fmt.Sprintf("INSERT INTO goose_db_version (version_id, is_applied, tstamp) VALUES (34, %s, CURRENT_TIMESTAMP)", appliedValue)
+	if _, err := tx.Exec(insertVersion); err != nil {
+		return fmt.Errorf("record migration 034: %w", err)
+	}
+
+	return tx.Commit()
 }
 
 // hasColumn checks if a column exists in a table.

--- a/internal/database/migration_034_test.go
+++ b/internal/database/migration_034_test.go
@@ -91,6 +91,30 @@ func TestMigration034_BackfillsDownloadID(t *testing.T) {
 		"SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_import_history_trim_vpath'").Scan(&idxCount))
 	assert.Equal(t, 0, idxCount, "temporary backfill index should be dropped by the migration")
 }
+func TestRunMigrations_ReconcilesExistingDownloadIDColumn(t *testing.T) {
+	ctx := context.Background()
+	db := openMigratedTo(t, 33)
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO import_history (nzb_name, file_name, virtual_path, download_id)
+		VALUES ('n', 'a.mkv', '/movies/a.mkv', 'dl-a');
+		INSERT INTO file_health (file_path, status) VALUES ('movies/a.mkv', 'pending');
+		ALTER TABLE file_health ADD COLUMN download_id TEXT DEFAULT NULL;
+	`)
+	require.NoError(t, err)
+
+	require.NoError(t, runMigrations(db, DialectSQLite))
+
+	var downloadID sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT download_id FROM file_health WHERE file_path = 'movies/a.mkv'").Scan(&downloadID))
+	assert.Equal(t, sql.NullString{String: "dl-a", Valid: true}, downloadID)
+
+	var applied bool
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT EXISTS(SELECT 1 FROM goose_db_version WHERE version_id = 34 AND is_applied = 1)").Scan(&applied))
+	assert.True(t, applied)
+}
 
 // TestMigration034_BackfillUsesExpressionIndex is the regression guard for the
 // startup hang: it proves that the per-row lookup performed by the backfill is a


### PR DESCRIPTION
## Summary

Repair startup for databases where an older image added the file_health.download_id column through ensureSchemaIntegrity without recording Goose migration 034.

When a newer image starts, Goose sees version 034 as pending and executes ALTER TABLE file_health ADD COLUMN download_id. Because the column already exists, migration startup fails with duplicate column name: download_id and the container enters a restart loop.

## Fix

Before running normal Goose migrations, detect the exact partial-upgrade state:

- goose_db_version exists
- file_health.download_id already exists
- migration 034 is not recorded as applied
- the current applied migration version is exactly 33

For that state, complete migration 034 transactionally:

1. Ensure idx_file_health_download_id exists.
2. Create the temporary normalized-path expression index used by the optimized backfill.
3. Backfill download_id from import_history using slash-trimmed paths.
4. Drop the temporary expression index.
5. Record migration 034 as applied.
6. Continue with the normal Goose migration sequence.

The version-33 guard prevents recording migration 034 on an older schema and accidentally skipping prerequisite migrations. SQL boolean syntax and path normalization are selected per dialect for SQLite and PostgreSQL.

## User impact

Affected containers currently fail every startup with:

    ERROR 034_add_download_id_to_file_health.sql: ... duplicate column name: download_id

After upgrading to an image containing this change, startup repairs the migration ledger and schema automatically. No database deletion or manual SQL intervention is required.

## Tests

Added TestRunMigrations_ReconcilesExistingDownloadIDColumn, which recreates the partial-upgrade state at migration version 33 and verifies that:

- runMigrations succeeds
- the existing column is preserved
- download_id values are backfilled
- migration 034 is recorded as applied

Validation completed locally:

- go test ./internal/database
- go test ./...
- git diff --check