### PR TITLE
fix(docker): inject version ldflags in CI image build (#780)

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -199,6 +199,8 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VERSION=dev-${{ github.sha }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
 
   build-dev-arm64:
     name: Build Dev Image (ARM64)
@@ -278,6 +280,8 @@ jobs:
           build-args: |
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
             VERSION=dev-${{ github.sha }}
+            COMMIT=${{ github.sha }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
 
   create-manifest:
     name: Create Multi-Arch Manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
 
   build-image-amd64:
     runs-on: ubuntu-latest
-    needs: [test, build-frontend]
+    needs: [test, build-frontend, prepare-release]
     if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:
       contents: write
@@ -217,10 +217,14 @@ jobs:
           cache-to: type=gha,mode=max,scope=amd64
           provenance: false
           sbom: false
+          build-args: |
+            VERSION=${{ needs.prepare-release.outputs.version }}
+            COMMIT=${{ needs.prepare-release.outputs.commit }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
 
   build-image-arm64:
     runs-on: ubuntu-24.04-arm
-    needs: [test, build-frontend]
+    needs: [test, build-frontend, prepare-release]
     if: ${{ github.event_name != 'workflow_dispatch' || !inputs.skip_docker }}
     permissions:
       contents: write
@@ -288,6 +292,10 @@ jobs:
           cache-to: type=gha,mode=max,scope=arm64
           provenance: false
           sbom: false
+          build-args: |
+            VERSION=${{ needs.prepare-release.outputs.version }}
+            COMMIT=${{ needs.prepare-release.outputs.commit }}
+            BUILD_TIMESTAMP=${{ github.event.head_commit.timestamp }}
 
   create-manifest:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -49,10 +49,17 @@ COPY ./frontend/embed_docker.go ./frontend/embed_docker.go
 COPY ./frontend/dist ./frontend/dist
 
 # Build web binary with enhanced cache mount for native architecture
+# Version metadata is injected via ldflags so the running binary reports the
+# real release version instead of the "dev" default (see internal/version).
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_TIMESTAMP=unknown
 RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     --mount=type=cache,target=/tmp/go-build-cache,sharing=locked \
     CGO_ENABLED=1 GOOS=linux \
-    go build -a -ldflags '-linkmode external -extldflags "-static"' -o altmount cmd/altmount/main.go
+    go build -a \
+    -ldflags "-linkmode external -extldflags \"-static\" -X 'github.com/javi11/altmount/internal/version.Version=${VERSION}' -X 'github.com/javi11/altmount/internal/version.GitCommit=${COMMIT}' -X 'github.com/javi11/altmount/internal/version.Timestamp=${BUILD_TIMESTAMP}'" \
+    -o altmount cmd/altmount/main.go
 
 # Final stage - use custom base image with pre-installed packages
 ARG TARGETARCH

--- a/internal/version/version_ldflags_test.go
+++ b/internal/version/version_ldflags_test.go
@@ -1,0 +1,44 @@
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDockerfilesInjectVersionLdflags guards against the regression from
+// issue #780, where docker/Dockerfile.ci built the binary without the
+// version ldflags. That left version.Version at its "dev" default in every
+// published image (including :latest), so the Updates panel always reported
+// the running version as "dev".
+//
+// Any Dockerfile that builds the Go binary must inject all three version
+// symbols so the running binary reports its real release version.
+func TestDockerfilesInjectVersionLdflags(t *testing.T) {
+	symbols := []string{
+		"github.com/javi11/altmount/internal/version.Version=",
+		"github.com/javi11/altmount/internal/version.GitCommit=",
+		"github.com/javi11/altmount/internal/version.Timestamp=",
+	}
+
+	dockerfiles := []string{
+		filepath.Join("..", "..", "docker", "Dockerfile"),
+		filepath.Join("..", "..", "docker", "Dockerfile.ci"),
+	}
+
+	for _, df := range dockerfiles {
+		t.Run(df, func(t *testing.T) {
+			data, err := os.ReadFile(df)
+			if err != nil {
+				t.Fatalf("failed to read %s: %v", df, err)
+			}
+			content := string(data)
+			for _, sym := range symbols {
+				if !strings.Contains(content, sym) {
+					t.Errorf("%s does not inject version ldflag %q; the built binary would report the default %q version", df, sym, Version)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #780 — the Updates panel reported the running version as **dev** even when the correct release image (e.g. `altmount:latest` = v0.3.1) was pulled.

### Root cause

`docker/Dockerfile.ci` — the Dockerfile used for **all published images** (`:latest`, version tags, and dev) — built the Go binary **without** the version ldflags. Its `ARG VERSION` was only declared in the final stage (for the OCI label), never in the `backend-builder` stage, so `internal/version.Version` stayed at its `"dev"` default in every release image.

The self-contained `docker/Dockerfile` injects the ldflags correctly; `Dockerfile.ci` had silently drifted from it. Because the `latest` update channel compares `version.Version` against the GitHub release tag, a `"dev"` value both displayed wrong and produced a perpetual "update available" state.

### Changes

- **`docker/Dockerfile.ci`**: declare `ARG VERSION/COMMIT/BUILD_TIMESTAMP` in the `backend-builder` stage and inject them via `-ldflags`, matching `docker/Dockerfile`.
- **`.github/workflows/release.yml`**: pass `VERSION`/`COMMIT`/`BUILD_TIMESTAMP` build-args to both image jobs (added `prepare-release` to their `needs` to reference its outputs).
- **`.github/workflows/dev-image.yml`**: pass `COMMIT`/`BUILD_TIMESTAMP` so the dev channel's commit comparison also works (it already passed `VERSION`, which was previously ignored).
- **`internal/version/version_ldflags_test.go`**: guard test that fails if either Dockerfile stops injecting the version symbols, preventing this drift from recurring.

### Verification

- `go test ./internal/version/` passes; the guard test fails against the pre-fix `Dockerfile.ci`.
- Confirmed a `go build` with the version ldflags embeds the injected version string.

> Note: this fixes the build going forward — the corrected version will appear once a new release image is published with this change.