### PR TITLE
fix(nzbfilesystem): guard ReadAtContext against use-after-close nil deref

### DIFF
--- a/internal/nzbfilesystem/constants.go
+++ b/internal/nzbfilesystem/constants.go
@@ -62,6 +62,7 @@ var (
 	ErrNoCipherConfig      = errors.New("no cipher configured for encryption")
 	ErrNoEncryptionParams  = errors.New("no NZB data available for encryption parameters")
 	ErrFileIsCorrupted     = errors.New("file is corrupted, there are some missing segments")
+	ErrFileClosed          = errors.New("file closed")
 )
 
 // Database operation error message templates

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1001,6 +1001,10 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 	mvf.mu.Lock()
 	defer mvf.mu.Unlock()
 
+	if mvf.meta == nil {
+		return 0, ErrFileClosed
+	}
+
 	for n < len(p) {
 		if err := mvf.ensureReader(); err != nil {
 			return n, err
@@ -1067,12 +1071,19 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 	if off < 0 {
 		return 0, ErrNegativeOffset
 	}
-	if off >= mvf.meta.FileSize {
-		return 0, io.EOF
-	}
 
 	mvf.mu.Lock()
 	defer mvf.mu.Unlock()
+
+	// mvf.meta is nil-ed by Close() under mvf.mu — a concurrent Close (e.g. from
+	// the FUSE handle release path) can complete between an unlocked check and
+	// lock acquisition, so this must be checked here, not before Lock().
+	if mvf.meta == nil {
+		return 0, ErrFileClosed
+	}
+	if off >= mvf.meta.FileSize {
+		return 0, io.EOF
+	}
 
 	// Determine whether this offset can reuse the shared reader.
 	// Shared path: offset matches the next expected sequential position, OR

--- a/internal/nzbfilesystem/metadata_remote_file_test.go
+++ b/internal/nzbfilesystem/metadata_remote_file_test.go
@@ -294,6 +294,64 @@ func TestReadAtBoundsValidation(t *testing.T) {
 	}
 }
 
+// TestReadAtContextAfterClose verifies that ReadAtContext returns ErrFileClosed
+// instead of panicking once Close() has released mvf.meta. Regression test for
+// a nil-pointer dereference where mvf.meta was read unlocked before mvf.mu was
+// acquired, racing with Close() nil-ing it out under the lock.
+func TestReadAtContextAfterClose(t *testing.T) {
+	mvf := &MetadataVirtualFile{
+		meta: &fileHandleMeta{
+			FileSize: 1000,
+		},
+	}
+
+	if err := mvf.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	buf := make([]byte, 100)
+	n, err := mvf.ReadAtContext(context.Background(), buf, 0)
+	if err != ErrFileClosed {
+		t.Errorf("ReadAtContext() after Close() error = %v, want ErrFileClosed", err)
+	}
+	if n != 0 {
+		t.Errorf("ReadAtContext() after Close() n = %d, want 0", n)
+	}
+}
+
+// TestReadAtContextConcurrentClose races ReadAtContext against Close() to
+// reproduce the interleaving that produced the original nil-pointer panic:
+// ReadAtContext must never dereference mvf.meta after it observes nil, and
+// Close() must never race unsynchronized with a held mvf.meta read. Run with
+// -race to catch any regression.
+func TestReadAtContextConcurrentClose(t *testing.T) {
+	for range 200 {
+		mvf := &MetadataVirtualFile{
+			meta: &fileHandleMeta{
+				FileSize: 1000,
+			},
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, 100)
+			for j := range 20 {
+				_, _ = mvf.ReadAtContext(context.Background(), buf, int64(j%10)*100)
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			_ = mvf.Close()
+		}()
+
+		wg.Wait()
+	}
+}
+
 // TestReadAtNoPoolManager tests ReadAt when pool manager is nil
 func TestReadAtNoPoolManager(t *testing.T) {
 	segments := []*metapb.SegmentData{


### PR DESCRIPTION
## Summary

Fixes a production panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/javi11/altmount/internal/nzbfilesystem.(*MetadataVirtualFile).ReadAtContext
    internal/nzbfilesystem/metadata_remote_file.go:1172
github.com/javi11/altmount/internal/fuse/backend.(*AsyncReadBuffer).fill
    internal/fuse/backend/asyncbuffer.go:395
created by (*AsyncReadBuffer).promoteLocked
```

**Root cause:** `ReadAtContext` read `mvf.meta.FileSize` before acquiring `mvf.mu`. `MetadataVirtualFile.Close()` nils out `mvf.meta` under that same lock. The `AsyncReadBuffer` background fill goroutine keeps calling `src.ReadAtContext` on the file right up until the FUSE handle's `Shutdown → close source → Wait` sequence drains it, so `Close()` could run to completion in the window between the unlocked bounds check and lock acquisition — leaving `ReadAtContext` to dereference a now-nil `mvf.meta` once it got the lock.

**Fix:**
- Moved the file-size bounds check in `ReadAtContext` to after `mvf.mu.Lock()`, and added a `mvf.meta == nil` guard returning a new `ErrFileClosed` sentinel — mirroring the existing defensive pattern already used in `tryServeFromRandomReadCache`.
- Added the same guard to `Read()` for defense in depth/symmetry.
- Added `ErrFileClosed` to `constants.go`.

No changes were needed in `asyncbuffer.go` or the FUSE handle close paths (`hanwen/handle.go`, `cgofuse/fs.go`) — their `Shutdown → close source → Wait` ordering is correct and intentional; this race existed independently of that ordering because `ReadAtContext` itself never re-validated the file survived until the lock was acquired.

## Test plan

- [x] `TestReadAtContextAfterClose` — `ReadAtContext` after `Close()` returns `ErrFileClosed` instead of panicking
- [x] `TestReadAtContextConcurrentClose` — races `ReadAtContext` against `Close()` across 200 iterations to reproduce the original interleaving
- [x] `go build ./...`
- [x] `go vet ./internal/nzbfilesystem/... ./internal/fuse/...`
- [x] `go test -race ./internal/nzbfilesystem/... ./internal/fuse/...`