### PR TITLE
feat(health): exclude configured categories from library-sync health checks

### DIFF
--- a/frontend/src/components/config/HealthConfigSection.tsx
+++ b/frontend/src/components/config/HealthConfigSection.tsx
@@ -86,6 +86,18 @@ export function HealthConfigSection({
 		setValidationError(validateFormData(newData));
 	};
 
+	const handleToggleExcludedCategory = (categoryName: string) => {
+		const current = formData.excluded_categories ?? [];
+		const isExcluded = current.some((name) => name.toLowerCase() === categoryName.toLowerCase());
+		const next = isExcluded
+			? current.filter((name) => name.toLowerCase() !== categoryName.toLowerCase())
+			: [...current, categoryName];
+		const newData = { ...formData, excluded_categories: next };
+		setFormData(newData);
+		setHasChanges(JSON.stringify(newData) !== JSON.stringify(config.health));
+		setValidationError(validateFormData(newData));
+	};
+
 	const handleRepairChange = (
 		field: keyof HealthConfig["repair"],
 		value: boolean | number | undefined,
@@ -402,6 +414,49 @@ export function HealthConfigSection({
 									</div>
 								</div>
 							</div>
+						</div>
+					)}
+				</div>
+
+				{/* Category Exclusions */}
+				<div className="space-y-4 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="min-w-0">
+						<h4 className="break-words font-bold text-base-content text-sm">Excluded Categories</h4>
+						<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+							Files under the selected categories are never registered for health checking by the
+							periodic library sync. Existing records are left untouched.
+						</p>
+					</div>
+
+					{config.sabnzbd?.categories?.length ? (
+						<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+							{config.sabnzbd.categories.map((category) => {
+								const isExcluded = (formData.excluded_categories ?? []).some(
+									(name) => name.toLowerCase() === category.name.toLowerCase(),
+								);
+								return (
+									<label
+										key={category.name}
+										className="flex cursor-pointer items-center gap-3 rounded-xl border border-base-300/60 bg-base-100/40 p-3"
+									>
+										<input
+											type="checkbox"
+											className="checkbox checkbox-primary checkbox-sm shrink-0"
+											checked={isExcluded}
+											disabled={isReadOnly}
+											onChange={() => handleToggleExcludedCategory(category.name)}
+										/>
+										<span className="min-w-0 flex-1 break-words font-semibold text-xs">
+											{category.name}
+										</span>
+									</label>
+								);
+							})}
+						</div>
+					) : (
+						<div className="rounded-xl border border-base-300/60 bg-base-100/40 p-4 text-[11px] text-base-content/50">
+							No SABnzbd categories are configured yet. Add categories under the SABnzbd settings to
+							exclude them from health checking.
 						</div>
 					)}
 				</div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -118,6 +118,9 @@ export interface HealthConfig {
 	verify_data?: boolean; // Verify 1 byte of data for each segment
 	read_timeout_seconds?: number; // Timeout for data verification
 	acceptable_missing_segments_percentage?: number;
+	// SABnzbd category names whose files are never registered for health checking
+	// by the library-sync discovery pass. Matching is by the category's directory.
+	excluded_categories?: string[];
 	repair: RepairConfig;
 	// What happens when the health checker or a streaming read confirms real
 	// (non-degraded) corruption: "repair" (default) triggers an Arr rescan;

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -206,6 +206,12 @@ func (c *Config) GetHealthEnabled() bool {
 	return *c.Health.Enabled
 }
 
+// GetHealthExcludedCategories returns the SABnzbd category names whose files
+// must not be registered for health checking by the library-sync pass.
+func (c *Config) GetHealthExcludedCategories() []string {
+	return c.Health.ExcludedCategories
+}
+
 // GetHealthDeleteOnCorruption reports whether confirmed corruption should delete the
 // file instead of triggering an Arr repair (health.corruption_action == "delete").
 func (c *Config) GetHealthDeleteOnCorruption() bool {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -361,7 +361,12 @@ type HealthConfig struct {
 	CheckAllSegments                    *bool        `yaml:"check_all_segments" mapstructure:"check_all_segments" json:"check_all_segments,omitempty"`
 	ReadTimeoutSeconds                  int          `yaml:"read_timeout_seconds" mapstructure:"read_timeout_seconds" json:"read_timeout_seconds,omitempty"`
 	AcceptableMissingSegmentsPercentage float64      `yaml:"acceptable_missing_segments_percentage" mapstructure:"acceptable_missing_segments_percentage" json:"acceptable_missing_segments_percentage"`
-	Repair                              RepairConfig `yaml:"repair" mapstructure:"repair" json:"repair"`
+	// ExcludedCategories lists SABnzbd category names whose files must never be
+	// registered for health checking by the library-sync discovery pass. Matching
+	// is by the category's configured directory under CompleteDir and is
+	// case-insensitive. Empty means no categories are excluded.
+	ExcludedCategories []string     `yaml:"excluded_categories" mapstructure:"excluded_categories" json:"excluded_categories,omitempty"`
+	Repair             RepairConfig `yaml:"repair" mapstructure:"repair" json:"repair"`
 	// CorruptionAction controls what happens when the health checker or a streaming read
 	// confirms real (non-degraded) corruption: "repair" (default) triggers an Arr rescan;
 	// "delete" removes the file's metadata/NZB/health record and cleans up now-empty

--- a/internal/health/library_sync.go
+++ b/internal/health/library_sync.go
@@ -654,6 +654,10 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 
 	concurrency := cfg.GetLibrarySyncConcurrency()
 
+	// Categories excluded from health checking must never be registered by the
+	// discovery pass. Resolve their mount-relative prefixes once up front.
+	excludedPrefixes := buildExcludedCategoryPrefixes(cfg)
+
 	// Create a worker pool for parallel metadata reading
 	p := pool.New().WithMaxGoroutines(concurrency)
 
@@ -668,6 +672,11 @@ func (lsw *LibrarySyncWorker) SyncLibrary(ctx context.Context, dryRun bool) *Dry
 
 		// Capture loop variable for goroutine
 		path := mountRelativePath
+
+		// Skip files under health-excluded categories: never (re)register them.
+		if pathHasExcludedPrefix(path, excludedPrefixes) {
+			continue
+		}
 
 		p.Go(func() {
 			// Check if needs to be added or repaired
@@ -1516,6 +1525,83 @@ func (lsw *LibrarySyncWorker) getLibraryPath(metaPath string, filesInUse map[str
 	}
 
 	return nil
+}
+
+// resolveCategoryDir resolves a SABnzbd category name to its configured
+// directory, mirroring importer.Service.resolveCategoryPath semantics: an
+// explicit Dir wins; otherwise the Default category maps to DefaultCategoryDir
+// and any other category maps to its own name.
+func resolveCategoryDir(cfg *config.Config, category string) string {
+	if len(cfg.SABnzbd.Categories) == 0 {
+		if strings.EqualFold(category, config.DefaultCategoryName) {
+			return config.DefaultCategoryDir
+		}
+		return category
+	}
+
+	for _, cat := range cfg.SABnzbd.Categories {
+		if strings.EqualFold(cat.Name, category) {
+			if cat.Dir != "" {
+				return cat.Dir
+			}
+			if strings.EqualFold(category, config.DefaultCategoryName) {
+				return config.DefaultCategoryDir
+			}
+			return category
+		}
+	}
+
+	return category
+}
+
+// buildExcludedCategoryPrefixes returns the set of mount-relative, lower-cased,
+// forward-slash path prefixes (<CompleteDir>/<categoryDir>) for every category
+// listed in health.excluded_categories. Files whose mount-relative path falls
+// under one of these prefixes are skipped by the library-sync discovery pass.
+func buildExcludedCategoryPrefixes(cfg *config.Config) []string {
+	if cfg == nil {
+		return nil
+	}
+
+	names := cfg.GetHealthExcludedCategories()
+	if len(names) == 0 {
+		return nil
+	}
+
+	completeDir := strings.Trim(filepath.ToSlash(cfg.SABnzbd.CompleteDir), "/")
+
+	prefixes := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		dir := strings.Trim(filepath.ToSlash(resolveCategoryDir(cfg, name)), "/")
+		if dir == "" {
+			continue
+		}
+		prefix := dir
+		if completeDir != "" {
+			prefix = completeDir + "/" + dir
+		}
+		prefixes = append(prefixes, strings.ToLower(prefix))
+	}
+	return prefixes
+}
+
+// pathHasExcludedPrefix reports whether mountRelPath equals, or is nested under,
+// any of the given (already lower-cased) prefixes. Matching is on full path
+// segments so "complete/tv" does not match "complete/tv-extras/...".
+func pathHasExcludedPrefix(mountRelPath string, prefixes []string) bool {
+	if len(prefixes) == 0 {
+		return false
+	}
+	p := strings.ToLower(strings.Trim(filepath.ToSlash(mountRelPath), "/"))
+	for _, prefix := range prefixes {
+		if p == prefix || strings.HasPrefix(p, prefix+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 // buildProtectedImportDirs returns the set of clean absolute paths under

--- a/internal/health/library_sync_excluded_categories_test.go
+++ b/internal/health/library_sync_excluded_categories_test.go
@@ -1,0 +1,138 @@
+package health
+
+import (
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildExcludedCategoryPrefixes(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		expected []string
+	}{
+		{
+			name:     "nil config",
+			cfg:      nil,
+			expected: nil,
+		},
+		{
+			name: "no excluded categories",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: nil},
+			},
+			expected: nil,
+		},
+		{
+			name: "explicit dir with complete dir",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{"tv"}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "complete",
+					Categories:  []config.SABnzbdCategory{{Name: "tv", Dir: "series"}},
+				},
+			},
+			expected: []string{"complete/series"},
+		},
+		{
+			name: "category without dir falls back to name",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{"tv"}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "complete",
+					Categories:  []config.SABnzbdCategory{{Name: "tv"}},
+				},
+			},
+			expected: []string{"complete/tv"},
+		},
+		{
+			name: "default category falls back to default dir",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{config.DefaultCategoryName}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "complete",
+					Categories:  []config.SABnzbdCategory{{Name: config.DefaultCategoryName}},
+				},
+			},
+			expected: []string{"complete/" + config.DefaultCategoryDir},
+		},
+		{
+			name: "empty complete dir yields bare category dir",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{"movies"}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "",
+					Categories:  []config.SABnzbdCategory{{Name: "movies", Dir: "movies"}},
+				},
+			},
+			expected: []string{"movies"},
+		},
+		{
+			name: "no categories configured, non-default name uses itself",
+			cfg: &config.Config{
+				Health:  config.HealthConfig{ExcludedCategories: []string{"tv"}},
+				SABnzbd: config.SABnzbdConfig{CompleteDir: "complete"},
+			},
+			expected: []string{"complete/tv"},
+		},
+		{
+			name: "prefixes are lower-cased",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{"TV"}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "Complete",
+					Categories:  []config.SABnzbdCategory{{Name: "TV", Dir: "Series"}},
+				},
+			},
+			expected: []string{"complete/series"},
+		},
+		{
+			name: "empty and unknown names are skipped/passed through",
+			cfg: &config.Config{
+				Health: config.HealthConfig{ExcludedCategories: []string{"", "unknown"}},
+				SABnzbd: config.SABnzbdConfig{
+					CompleteDir: "complete",
+					Categories:  []config.SABnzbdCategory{{Name: "tv", Dir: "series"}},
+				},
+			},
+			// "" skipped; "unknown" has no configured category so it maps to itself.
+			expected: []string{"complete/unknown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildExcludedCategoryPrefixes(tt.cfg)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestPathHasExcludedPrefix(t *testing.T) {
+	prefixes := []string{"complete/tv", "complete/movies"}
+
+	tests := []struct {
+		name     string
+		path     string
+		prefixes []string
+		expected bool
+	}{
+		{"nil prefixes", "complete/tv/show/file.mkv", nil, false},
+		{"exact match", "complete/tv", prefixes, true},
+		{"nested match", "complete/tv/ShowName/S01E01.mkv", prefixes, true},
+		{"second prefix match", "complete/movies/Film/file.mkv", prefixes, true},
+		{"case-insensitive path", "Complete/TV/ShowName/file.mkv", prefixes, true},
+		{"leading slash tolerated", "/complete/tv/show/file.mkv", prefixes, true},
+		{"segment boundary: tv-extras not matched", "complete/tv-extras/file.mkv", prefixes, false},
+		{"different category not matched", "complete/music/file.mkv", prefixes, false},
+		{"prefix as substring only not matched", "complete/tvshows/file.mkv", prefixes, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pathHasExcludedPrefix(tt.path, tt.prefixes))
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a `health.excluded_categories` list that lets you disable health checking for specific SABnzbd categories. Files under an excluded category are never registered for health checks by the periodic **library-sync** discovery pass.

## Why

Previously the only control was the single global `health.enabled` flag — there was no way to keep some categories (e.g. low-value or high-churn content) out of the health-check queue while keeping it on for the rest.

## How

- **Config** ([internal/config](internal/config)): new `HealthConfig.ExcludedCategories []string` field (`excluded_categories`) + `GetHealthExcludedCategories()` accessor.
- **Health** ([internal/health/library_sync.go](internal/health/library_sync.go)): resolve each excluded category to its mount-relative `<CompleteDir>/<categoryDir>` prefix (mirrors the importer's `resolveCategoryPath` semantics) and skip matching files in the `syncMediaFiles` add-loop. Matching is segment-safe and case-insensitive (`complete/tv` does not match `complete/tv-extras`).
- **Frontend**: `excluded_categories` added to the `HealthConfig` type and a new **"Excluded Categories"** checkbox card in the Health config section, populated from the configured SABnzbd categories.

## Scope / deliberate non-changes

- **Import-time path unchanged**: `Coordinator.ScheduleHealthCheck` still schedules checks as before. Exclusion is enforced only in the library-sync discovery pass.
- **Existing records untouched**: sync simply stops (re)registering excluded-category files — it does not purge already-tracked records ("stop adding only").
- **Cleanup passes unaffected**: filtering happens only in the add-loop, so orphan/metadata/library cleanup keeps its existing behavior (no accidental orphaning of excluded files).

## Testing

- New table-driven tests: [internal/health/library_sync_excluded_categories_test.go](internal/health/library_sync_excluded_categories_test.go) covering prefix building (explicit dir, name fallback, Default category, empty `CompleteDir`, lower-casing, unknown/empty names) and path matching (nested, case-insensitive, leading slash, segment-boundary).
- `make` (backend build + full Go test suite) — green.
- Frontend `tsc --noEmit`, `bun run build`, and `bun run check` — clean.

## Usage

```yaml
health:
  excluded_categories: ["tv", "movies"]
```