### PR TITLE
fix(stremio): serve requested episode from season packs

### DIFF
--- a/docs/docs/3. Configuration/stremio.md
+++ b/docs/docs/3. Configuration/stremio.md
@@ -187,10 +187,14 @@ Content-Type: multipart/form-data
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `download_key` | Yes | SHA-256 of your AltMount API key |
-| `file` | Yes | The `.nzb` file (max 100 MB) |
+| `download_key` | Yes | SHA-256 of your AltMount API key (alternatively, send the raw key in the `X-Api-Key` header) |
+| `file` | Conditional | The `.nzb` file (max 100 MB). Provide this **or** `nzb_url` |
+| `nzb_url` | Conditional | URL AltMount downloads the NZB from. Provide this **or** `file` |
 | `category` | No | Download category (e.g. `movies`, `tv`) |
 | `timeout` | No | Seconds to wait before returning 408 (default: `300`) |
+| `season` | No | Season number — see [Selecting one episode from a season pack](#selecting-one-episode-from-a-season-pack) |
+| `episode` | No | Episode number (pair with `season`) |
+| `id` | No | Stremio content id (e.g. `tt1234567:1:5`) as an alternative to `season`/`episode` |
 
 **Success response (`200 OK`):**
 
@@ -236,6 +240,34 @@ builder.defineStreamHandler(async ({ type, id }) => {
 > (`nzb_ttl_hours`). Submitting the same filename a second time returns cached stream URLs
 > immediately without re-downloading.
 
+### Selecting one episode from a season pack
+
+When a series request resolves to a **season pack** (a single NZB containing every
+episode), AltMount needs to know which episode to serve — otherwise it cannot tell the
+requested episode from the others in the pack.
+
+Provide the episode context in any one of these forms (checked in this order):
+
+1. explicit `season` **and** `episode` fields;
+2. a combined Stremio content id via `id` (or `stremio_id`), e.g. `tt1234567:1:5`;
+3. `season`/`episode` query parameters embedded in the `nzb_url` value.
+
+AltMount then returns only the matching episode's stream. If a multi-episode pack is
+submitted **without** any episode context, AltMount responds with `400 Bad Request`
+(`"Episode not specified"`) rather than silently returning the first episode — so make
+sure your addon forwards the season/episode (or `id`) from the Stremio request.
+
+Single-file releases (movies, single-episode releases) do not need this and are unaffected.
+
+**AIOStreams / proxy example** — append the Stremio id when handing the NZB to AltMount:
+
+```
+POST <base_url>/api/nzb/streams
+  download_key=<sha256>
+  nzb_url=<season-pack nzb url>
+  id=tt1234567:1:5
+```
+
 ## Endpoint Reference
 
 ### `POST /api/nzb/streams`
@@ -246,10 +278,17 @@ Submit an NZB manually and receive stream URLs. The request blocks (long-polls) 
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `download_key` | Yes | SHA-256 of your API key (lowercase hex) |
-| `file` | Yes | The `.nzb` file to process (max 100 MB) |
+| `download_key` | Yes | SHA-256 of your API key (lowercase hex). Alternatively send the raw key in the `X-Api-Key` header |
+| `file` | Conditional | The `.nzb` file to process (max 100 MB). Provide this **or** `nzb_url` |
+| `nzb_url` | Conditional | URL to download the NZB from. Provide this **or** `file` |
 | `category` | No | Download category (e.g. `movies`, `tv`) |
 | `timeout` | No | Seconds to wait before returning a 408 (default: `300`) |
+| `season` | No | Season number for selecting one episode from a season pack |
+| `episode` | No | Episode number (pair with `season`) |
+| `id` | No | Stremio content id (e.g. `tt1234567:1:5`) as an alternative to `season`/`episode` |
+
+> Fields may be sent as `multipart/form-data` or as URL query parameters. See
+> [Selecting one episode from a season pack](#selecting-one-episode-from-a-season-pack).
 
 ### Response
 
@@ -291,6 +330,19 @@ Submit an NZB manually and receive stream URLs. The request blocks (long-polls) 
 ```
 
 Use `_queue_item_id` / `queue_item_id` from the error details to check progress via the queue API or retry later.
+
+**400 Bad Request** — a multi-episode season pack was submitted without episode context:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code":    "BAD_REQUEST",
+    "message": "Episode not specified",
+    "details": "This release is a multi-episode pack; provide season and episode (or a Stremio id like tt1234567:1:5)."
+  }
+}
+```
 
 ## Caching
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.0
 	github.com/stretchr/testify v1.11.1
+	github.com/valyala/fasthttp v1.51.0
 	github.com/winfsp/cgofuse v1.6.0
 	golang.org/x/crypto v0.46.0
 	golang.org/x/net v0.48.0
@@ -264,7 +265,6 @@ require (
 	github.com/uudashr/gocognit v1.2.0 // indirect
 	github.com/uudashr/iface v1.4.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.51.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/internal/api/nzb_stremio_handlers.go
+++ b/internal/api/nzb_stremio_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -46,7 +47,17 @@ var (
 	stremioSeasonEpisodePattern = regexp.MustCompile(`(?i)s0*(\d{1,2})((?:[ ._-]*e0*\d{1,3})+)`)
 	stremioEpisodeOnlyPattern   = regexp.MustCompile(`(?i)e0*(\d{1,3})`)
 	stremioXEpisodePattern      = regexp.MustCompile(`(?i)(?:^|[^0-9])0*(\d{1,2})x0*(\d{1,3})(?:[^0-9]|$)`)
+	// Looser, boundary-anchored season/episode markers used only as a fallback
+	// when a filename (including its parent directory) carries no explicit
+	// combined SxxExx / NxNN token — e.g. "Season 01/Show E05.mkv".
+	stremioSeasonContextPattern  = regexp.MustCompile(`(?i)\b(?:season|series|s)[ ._-]*0*(\d{1,2})`)
+	stremioEpisodeContextPattern = regexp.MustCompile(`(?i)\b(?:episode|ep|e)[ ._-]*0*(\d{1,3})`)
 )
+
+// errStremioEpisodeAmbiguous is returned by buildStremioStreams when a
+// multi-episode release is resolved without any episode context. Callers turn
+// it into a clear client error instead of silently serving the first episode.
+var errStremioEpisodeAmbiguous = errors.New("stremio: episode not specified for a multi-episode release")
 
 type stremioEpisodeSelector struct {
 	Season  int
@@ -91,6 +102,7 @@ type StremioStreamsResponse struct {
 //	@Param			timeout			formData	int		false	"Processing timeout in seconds (default: 300)"
 //	@Param			season			formData	int		false	"Season number for selecting one episode from a season pack"
 //	@Param			episode			formData	int		false	"Episode number for selecting one episode from a season pack"
+//	@Param			id				formData	string	false	"Stremio content id (e.g. tt1234567:1:5) as an alternative to season/episode"
 //	@Success		200	{object}	StremioStreamsResponse
 //	@Failure		400	{object}	APIResponse
 //	@Failure		401	{object}	APIResponse
@@ -324,8 +336,11 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 
 	switch current.Status {
 	case database.QueueStatusCompleted:
-		streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector)
+		streams, err := s.buildStremioStreams(ctx, current, baseURL, downloadKey, nzbName, selector)
 		if err != nil {
+			if errors.Is(err, errStremioEpisodeAmbiguous) {
+				return respondEpisodeAmbiguous(c)
+			}
 			return RespondInternalError(c, "Failed to list output media files", err.Error())
 		}
 		return c.JSON(StremioStreamsResponse{
@@ -344,7 +359,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 		// If the item is already processing and has a storage path, the streamable
 		// event fired before we subscribed — return the streams immediately.
 		if current.StoragePath != nil && *current.StoragePath != "" {
-			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(ctx, current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 				return c.JSON(StremioStreamsResponse{
 					Streams:     streams,
 					QueueItemID: current.ID,
@@ -373,7 +388,7 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 				// post-processing (symlinks, STRM, health scheduling) completes.
 				if update.StoragePath != "" {
 					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
-					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
+					if streams, err := s.buildStremioStreams(ctx, fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 						return c.JSON(StremioStreamsResponse{
 							Streams:     streams,
 							QueueItemID: itemID,
@@ -387,8 +402,11 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 				if err != nil {
 					return RespondInternalError(c, "Failed to fetch completed item", err.Error())
 				}
-				streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName, selector)
+				streams, err := s.buildStremioStreams(ctx, item, baseURL, downloadKey, nzbName, selector)
 				if err != nil {
+					if errors.Is(err, errStremioEpisodeAmbiguous) {
+						return respondEpisodeAmbiguous(c)
+					}
 					return RespondInternalError(c, "Failed to list output media files", err.Error())
 				}
 				return c.JSON(StremioStreamsResponse{
@@ -413,8 +431,12 @@ func (s *Server) waitAndRespond(c *fiber.Ctx, itemID int64, baseURL, downloadKey
 }
 
 // buildStremioStreams resolves the virtual paths from a completed queue item and
-// returns Stremio stream objects for all media files in the NZB output.
-func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector) ([]StremioStream, error) {
+// returns Stremio stream objects for the media files in the NZB output. When a
+// selector is provided, only files matching the requested episode are returned.
+// When no selector is provided and the output is a multi-episode pack, it returns
+// errStremioEpisodeAmbiguous so callers can respond with a clear error instead of
+// silently serving the first episode.
+func (s *Server) buildStremioStreams(ctx context.Context, item *database.ImportQueueItem, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector) ([]StremioStream, error) {
 	if item.StoragePath == nil || *item.StoragePath == "" {
 		return nil, fmt.Errorf("completed queue item %d has no storage path", item.ID)
 	}
@@ -439,6 +461,14 @@ func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, do
 		return nil, fmt.Errorf("failed to list directory %q: %w", storagePath, err)
 	}
 
+	// Without episode context, refuse to guess which episode of a multi-episode
+	// pack to serve — returning the first file would silently play the wrong one.
+	if selector == nil && countDistinctEpisodes(files) > 1 {
+		slog.WarnContext(ctx, "Stremio release is a multi-episode pack but no episode was specified",
+			"nzb_name", nzbName, "queue_id", item.ID, "file_count", len(files))
+		return nil, errStremioEpisodeAmbiguous
+	}
+
 	streams := make([]StremioStream, 0, len(files))
 	for _, name := range files {
 		if selector != nil && !selector.matches(name) {
@@ -448,7 +478,22 @@ func (s *Server) buildStremioStreams(item *database.ImportQueueItem, baseURL, do
 		streams = append(streams, stremioStreamFromPath(virtualPath, baseURL, downloadKey))
 	}
 
+	if selector != nil && len(streams) == 0 {
+		slog.WarnContext(ctx, "No media file in Stremio release matched the requested episode",
+			"nzb_name", nzbName, "queue_id", item.ID,
+			"season", selector.Season, "episode", selector.Episode,
+			"available_files", files)
+	}
+
 	return streams, nil
+}
+
+// respondEpisodeAmbiguous returns a clear client error when a multi-episode
+// release is requested without episode context, so the caller does not silently
+// play the first episode.
+func respondEpisodeAmbiguous(c *fiber.Ctx) error {
+	return RespondBadRequest(c, "Episode not specified",
+		"This release is a multi-episode pack; provide season and episode (or a Stremio id like tt1234567:1:5).")
 }
 
 func (s *Server) listStremioMediaFiles(storagePath string) ([]string, error) {
@@ -542,20 +587,76 @@ func deriveNzbNameFromContent(nzbData []byte) string {
 	return sanitizeFilename(bestName)
 }
 
-func stremioEpisodeSelectorFromRequest(c *fiber.Ctx) *stremioEpisodeSelector {
-	season, okSeason := positiveIntFormOrQuery(c, "season")
-	episode, okEpisode := positiveIntFormOrQuery(c, "episode")
-	if !okSeason || !okEpisode {
-		return nil
+// parseStremioContentID parses a Stremio content id of the form "tt1234567"
+// (movie) or "tt1234567:1:5" (series, season:episode). It returns the imdb id
+// and the season/episode numbers, which are 0 when absent or unparseable.
+func parseStremioContentID(rawID string) (imdbID string, season, episode int) {
+	parts := strings.SplitN(rawID, ":", 3)
+	imdbID = strings.TrimSpace(parts[0])
+	if len(parts) >= 2 {
+		if v, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil {
+			season = v
+		}
 	}
-	return &stremioEpisodeSelector{Season: season, Episode: episode}
+	if len(parts) >= 3 {
+		if v, err := strconv.Atoi(strings.TrimSpace(parts[2])); err == nil {
+			episode = v
+		}
+	}
+	return imdbID, season, episode
+}
+
+// stremioEpisodeSelectorFromRequest derives the requested season/episode from
+// the request, trying several sources so proxies (e.g. AIOStreams) can forward
+// episode context in whatever form they support. Priority:
+//  1. explicit `season` + `episode` (form or query);
+//  2. a combined Stremio id via `id` / `stremio_id` (form or query), e.g. tt123:1:5;
+//  3. `season`/`episode` embedded in the `nzb_url` query string.
+//
+// Returns nil only when none of the sources yield a positive season+episode.
+func stremioEpisodeSelectorFromRequest(c *fiber.Ctx) *stremioEpisodeSelector {
+	// 1. Explicit discrete fields.
+	if season, okSeason := positiveIntFormOrQuery(c, "season"); okSeason {
+		if episode, okEpisode := positiveIntFormOrQuery(c, "episode"); okEpisode {
+			return &stremioEpisodeSelector{Season: season, Episode: episode}
+		}
+	}
+
+	// 2. Combined Stremio content id.
+	for _, key := range []string{"id", "stremio_id"} {
+		if raw := formOrQuery(c, key); raw != "" {
+			if _, season, episode := parseStremioContentID(raw); season > 0 && episode > 0 {
+				return &stremioEpisodeSelector{Season: season, Episode: episode}
+			}
+		}
+	}
+
+	// 3. season/episode embedded in the nzb_url query string.
+	if nzbURL := formOrQuery(c, "nzb_url"); nzbURL != "" {
+		if u, err := url.Parse(nzbURL); err == nil {
+			q := u.Query()
+			if season, sErr := strconv.Atoi(q.Get("season")); sErr == nil && season > 0 {
+				if episode, eErr := strconv.Atoi(q.Get("episode")); eErr == nil && episode > 0 {
+					return &stremioEpisodeSelector{Season: season, Episode: episode}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// formOrQuery returns the value for key from the request form, falling back to
+// the URL query string.
+func formOrQuery(c *fiber.Ctx, key string) string {
+	if v := c.FormValue(key); v != "" {
+		return v
+	}
+	return c.Query(key)
 }
 
 func positiveIntFormOrQuery(c *fiber.Ctx, key string) (int, bool) {
-	value := c.FormValue(key)
-	if value == "" {
-		value = c.Query(key)
-	}
+	value := formOrQuery(c, key)
 	if value == "" {
 		return 0, false
 	}
@@ -566,12 +667,52 @@ func positiveIntFormOrQuery(c *fiber.Ctx, key string) (int, bool) {
 	return parsed, true
 }
 
+// parseEpisodeFromName extracts a (season, episode) pair from an explicit
+// combined marker (SxxExx or NxNN) in name. It returns ok=false when the name
+// carries no such marker.
+func parseEpisodeFromName(name string) (season, episode int, ok bool) {
+	if m := stremioSeasonEpisodePattern.FindStringSubmatch(name); m != nil {
+		s, err := strconv.Atoi(m[1])
+		if err == nil {
+			if em := stremioEpisodeOnlyPattern.FindStringSubmatch(m[2]); em != nil {
+				if e, err := strconv.Atoi(em[1]); err == nil {
+					return s, e, true
+				}
+			}
+		}
+	}
+	if m := stremioXEpisodePattern.FindStringSubmatch(name); m != nil {
+		s, sErr := strconv.Atoi(m[1])
+		e, eErr := strconv.Atoi(m[2])
+		if sErr == nil && eErr == nil {
+			return s, e, true
+		}
+	}
+	return 0, 0, false
+}
+
+// countDistinctEpisodes returns how many of the given media files parse to a
+// distinct season+episode via an explicit marker. Files with no recognizable
+// marker are ignored, so a movie (with optional samples/extras) counts as 0 or 1.
+func countDistinctEpisodes(files []string) int {
+	seen := make(map[[2]int]struct{})
+	for _, name := range files {
+		if season, episode, ok := parseEpisodeFromName(name); ok {
+			seen[[2]int{season, episode}] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
 func (s *stremioEpisodeSelector) matches(filename string) bool {
 	if s == nil || s.Season <= 0 || s.Episode <= 0 {
 		return true
 	}
 
+	// Primary: explicit combined SxxExx / SxxExxExx markers.
+	hasExplicitMarker := false
 	for _, match := range stremioSeasonEpisodePattern.FindAllStringSubmatch(filename, -1) {
+		hasExplicitMarker = true
 		season, err := strconv.Atoi(match[1])
 		if err != nil || season != s.Season {
 			continue
@@ -584,7 +725,9 @@ func (s *stremioEpisodeSelector) matches(filename string) bool {
 		}
 	}
 
+	// Primary: NxNN (e.g. 1x05).
 	for _, match := range stremioXEpisodePattern.FindAllStringSubmatch(filename, -1) {
+		hasExplicitMarker = true
 		season, seasonErr := strconv.Atoi(match[1])
 		episode, episodeErr := strconv.Atoi(match[2])
 		if seasonErr == nil && episodeErr == nil && season == s.Season && episode == s.Episode {
@@ -592,5 +735,28 @@ func (s *stremioEpisodeSelector) matches(filename string) bool {
 		}
 	}
 
+	// If the name carried an explicit combined marker, trust only that — never
+	// fall back to looser matching (which could treat S02E05 as S01E05).
+	if hasExplicitMarker {
+		return false
+	}
+
+	// Fallback: the season is established by a separate token (often the parent
+	// directory, e.g. "Season 01/Show E05.mkv") plus an episode-only token.
+	seasonMatched := false
+	for _, m := range stremioSeasonContextPattern.FindAllStringSubmatch(filename, -1) {
+		if v, err := strconv.Atoi(m[1]); err == nil && v == s.Season {
+			seasonMatched = true
+			break
+		}
+	}
+	if !seasonMatched {
+		return false
+	}
+	for _, m := range stremioEpisodeContextPattern.FindAllStringSubmatch(filename, -1) {
+		if v, err := strconv.Atoi(m[1]); err == nil && v == s.Episode {
+			return true
+		}
+	}
 	return false
 }

--- a/internal/api/nzb_stremio_handlers_test.go
+++ b/internal/api/nzb_stremio_handlers_test.go
@@ -1,42 +1,69 @@
 package api
 
 import (
+	"context"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/gofiber/fiber/v2"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/importer/parser/fileinfo"
 	"github.com/javi11/altmount/internal/metadata"
 	"github.com/javi11/altmount/internal/testsupport/nzbbuild"
 	"github.com/javi11/nzbparser"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
-func TestBuildStremioStreamsReturnsEverySeasonPackFileWithFilenameIdentity(t *testing.T) {
+func TestBuildStremioStreamsReturnsSingleFileWithFilenameIdentity(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"The.Movie.2024.1080p.mkv",
+	})
+
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", nil)
+	require.NoError(t, err)
+	require.Len(t, streams, 1)
+
+	stream := streams[0]
+	require.Equal(t, "The.Movie.2024.1080p.mkv", stream.Title)
+	require.Equal(t, "The.Movie.2024.1080p.mkv", stream.Name)
+	require.Contains(t, stream.URL, "download_key=download-key")
+
+	parsedURL, err := url.Parse(stream.URL)
+	require.NoError(t, err)
+	require.Equal(t, "/api/files/stream", parsedURL.Path)
+	require.Equal(t, "/complete/TV/Release.Name/The.Movie.2024.1080p.mkv", parsedURL.Query().Get("path"))
+}
+
+// TestBuildStremioStreamsRejectsMultiEpisodePackWithoutSelector guards the core
+// fix: a season pack resolved without episode context must NOT silently return
+// the first episode — it returns errStremioEpisodeAmbiguous instead.
+func TestBuildStremioStreamsRejectsMultiEpisodePackWithoutSelector(t *testing.T) {
 	server, item := newStremioStreamsTestServer(t, []string{
 		"Show.S01E01.mkv",
 		"Show.S01E02.mkv",
 		"Show.S01E03.mkv",
 	})
 
-	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", nil)
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", nil)
+	require.ErrorIs(t, err, errStremioEpisodeAmbiguous)
+	require.Nil(t, streams)
+}
+
+// TestBuildStremioStreamsAllowsMultiPartMovieWithoutSelector ensures the
+// ambiguity guard does not break movies split into multiple non-episode files.
+func TestBuildStremioStreamsAllowsMultiPartMovieWithoutSelector(t *testing.T) {
+	server, item := newStremioStreamsTestServer(t, []string{
+		"The.Movie.2024.1080p.mkv",
+		"The.Movie.2024.1080p-sample.mkv",
+	})
+
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", nil)
 	require.NoError(t, err)
-	require.Len(t, streams, 3)
-
-	for i, stream := range streams {
-		expectedName := []string{"Show.S01E01.mkv", "Show.S01E02.mkv", "Show.S01E03.mkv"}[i]
-		require.Equal(t, expectedName, stream.Title)
-		require.Equal(t, expectedName, stream.Name)
-		require.Contains(t, stream.URL, "download_key=download-key")
-
-		parsedURL, err := url.Parse(stream.URL)
-		require.NoError(t, err)
-		require.Equal(t, "/api/files/stream", parsedURL.Path)
-		require.Equal(t, "/complete/TV/Release.Name/"+expectedName, parsedURL.Query().Get("path"))
-	}
+	require.Len(t, streams, 2)
 }
 
 func TestBuildStremioStreamsFiltersSeasonPackByEpisodeSelector(t *testing.T) {
@@ -47,7 +74,7 @@ func TestBuildStremioStreamsFiltersSeasonPackByEpisodeSelector(t *testing.T) {
 	})
 
 	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
-	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", selector)
 	require.NoError(t, err)
 	require.Len(t, streams, 1)
 	require.Equal(t, "Show.S01E02.mkv", streams[0].Name)
@@ -61,7 +88,7 @@ func TestBuildStremioStreamsFindsMediaFilesInNestedSeasonPackDirectories(t *test
 	})
 
 	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
-	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", selector)
 	require.NoError(t, err)
 	require.Len(t, streams, 1)
 	require.Equal(t, "Show.S01E02.mkv", streams[0].Name)
@@ -77,7 +104,7 @@ func TestBuildStremioStreamsReturnsEmptySliceWhenSelectorDoesNotMatch(t *testing
 	})
 
 	selector := &stremioEpisodeSelector{Season: 1, Episode: 2}
-	streams, err := server.buildStremioStreams(item, "https://alt.example", "download-key", "Release.Name", selector)
+	streams, err := server.buildStremioStreams(context.Background(), item, "https://alt.example", "download-key", "Release.Name", selector)
 	require.NoError(t, err)
 	require.NotNil(t, streams)
 	require.Empty(t, streams)
@@ -92,6 +119,93 @@ func TestStremioEpisodeSelectorMatchesCommonEpisodeFilenameForms(t *testing.T) {
 	require.True(t, selector.matches("Show.S01E01E02.mkv"))
 	require.False(t, selector.matches("Show.S01E01.mkv"))
 	require.False(t, selector.matches("Show.S02E02.mkv"))
+}
+
+// TestStremioEpisodeSelectorMatchesSeasonInDirectoryAndSpelledForms covers the
+// hardened fallback: the season is established by a separate token (often the
+// parent directory) while the filename carries only an episode token.
+func TestStremioEpisodeSelectorMatchesSeasonInDirectoryAndSpelledForms(t *testing.T) {
+	selector := &stremioEpisodeSelector{Season: 1, Episode: 5}
+
+	// season from directory, episode-only in filename
+	require.True(t, selector.matches("Season 01/Show E05.mkv"))
+	require.True(t, selector.matches("S01/Show.E05.mkv"))
+	require.False(t, selector.matches("Series 1/Show - 5.mkv")) // "- 5" carries no episode marker
+	require.True(t, selector.matches("Season 1/Show.Episode.5.mkv"))
+	// explicit combined marker is authoritative and not overridden by the fallback
+	require.True(t, selector.matches("Season 01/Show.S01E05.mkv"))
+	require.False(t, selector.matches("Season 02/Show E05.mkv")) // season mismatch
+	require.False(t, selector.matches("Season 01/Show E06.mkv")) // episode mismatch
+	require.False(t, selector.matches("Show.S02E05.mkv"))        // explicit marker, wrong season
+}
+
+func TestParseStremioContentID(t *testing.T) {
+	tests := []struct {
+		raw     string
+		imdb    string
+		season  int
+		episode int
+	}{
+		{"tt1234567", "tt1234567", 0, 0},
+		{"tt1234567:1:5", "tt1234567", 1, 5},
+		{"tt1234567:1", "tt1234567", 1, 0},
+		{"tt1234567:x:5", "tt1234567", 0, 5},
+		{"", "", 0, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.raw, func(t *testing.T) {
+			imdb, season, episode := parseStremioContentID(tc.raw)
+			require.Equal(t, tc.imdb, imdb)
+			require.Equal(t, tc.season, season)
+			require.Equal(t, tc.episode, episode)
+		})
+	}
+}
+
+func TestCountDistinctEpisodes(t *testing.T) {
+	require.Equal(t, 3, countDistinctEpisodes([]string{"Show.S01E01.mkv", "Show.S01E02.mkv", "Show.S01E03.mkv"}))
+	require.Equal(t, 1, countDistinctEpisodes([]string{"Show.S01E01.mkv"}))
+	require.Equal(t, 0, countDistinctEpisodes([]string{"The.Movie.2024.mkv", "The.Movie.2024-sample.mkv"}))
+	// duplicate episode identity collapses to one
+	require.Equal(t, 1, countDistinctEpisodes([]string{"Season 01/Show.S01E01.mkv", "Show.1x01.mkv"}))
+}
+
+// withQuery builds a Fiber context whose request carries the given raw query
+// string, so request-parsing helpers can be exercised without a live server.
+func withQuery(t *testing.T, rawQuery string) (*fiber.Ctx, func()) {
+	t.Helper()
+	app := fiber.New()
+	fctx := &fasthttp.RequestCtx{}
+	fctx.Request.SetRequestURI("/?" + rawQuery)
+	ctx := app.AcquireCtx(fctx)
+	return ctx, func() { app.ReleaseCtx(ctx) }
+}
+
+func TestStremioEpisodeSelectorFromRequest(t *testing.T) {
+	nzbURL := url.QueryEscape("http://indexer.example/getnzb?id=abc&season=4&episode=8")
+
+	tests := []struct {
+		name  string
+		query string
+		want  *stremioEpisodeSelector
+	}{
+		{"explicit season/episode", "season=1&episode=5", &stremioEpisodeSelector{Season: 1, Episode: 5}},
+		{"combined id", "id=tt1234567:2:7", &stremioEpisodeSelector{Season: 2, Episode: 7}},
+		{"combined stremio_id", "stremio_id=tt1234567:3:9", &stremioEpisodeSelector{Season: 3, Episode: 9}},
+		{"season/episode embedded in nzb_url", "nzb_url=" + nzbURL, &stremioEpisodeSelector{Season: 4, Episode: 8}},
+		{"explicit beats id", "season=1&episode=2&id=tt1234567:5:6", &stremioEpisodeSelector{Season: 1, Episode: 2}},
+		{"movie id yields nil", "id=tt1234567", nil},
+		{"episode without season yields nil", "episode=5", nil},
+		{"nothing yields nil", "", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, release := withQuery(t, tc.query)
+			defer release()
+			got := stremioEpisodeSelectorFromRequest(ctx)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }
 
 func newStremioStreamsTestServer(t *testing.T, names []string) (*Server, *database.ImportQueueItem) {

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -140,23 +141,7 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 	rawID, _ := url.PathUnescape(c.Params("id"))
 
 	// Parse Stremio ID: tt1234567 (movie) or tt1234567:season:episode (series)
-	var season, episode int
-	parts := strings.SplitN(rawID, ":", 3)
-	imdbID := parts[0]
-	if len(parts) >= 2 {
-		val, err := strconv.Atoi(parts[1])
-		if err != nil {
-			return emptyStreamsResponse(c)
-		}
-		season = val
-	}
-	if len(parts) >= 3 {
-		val, err := strconv.Atoi(parts[2])
-		if err != nil {
-			return emptyStreamsResponse(c)
-		}
-		episode = val
-	}
+	imdbID, season, episode := parseStremioContentID(rawID)
 
 	if !strings.HasPrefix(imdbID, "tt") {
 		return emptyStreamsResponse(c)
@@ -368,7 +353,7 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
 		}
 		if cacheValid {
-			if streams, err := s.buildStremioStreams(prev, baseURL, key, nzbName, selector); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(ctx, prev, baseURL, key, nzbName, selector); err == nil && len(streams) > 0 {
 				slog.InfoContext(ctx, "Returning cached Stremio stream for Prowlarr NZB",
 					"nzb_name", nzbName)
 				return c.Redirect(streams[0].URL, fiber.StatusFound)
@@ -478,8 +463,14 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 	}
 
 	redirectToFirst := func(item *database.ImportQueueItem) error {
-		streams, err := s.buildStremioStreams(item, baseURL, downloadKey, nzbName, selector)
-		if err != nil || len(streams) == 0 {
+		streams, err := s.buildStremioStreams(ctx, item, baseURL, downloadKey, nzbName, selector)
+		if err != nil {
+			if errors.Is(err, errStremioEpisodeAmbiguous) {
+				return respondEpisodeAmbiguous(c)
+			}
+			return RespondServiceUnavailable(c, "No streams available", "")
+		}
+		if len(streams) == 0 {
 			return RespondServiceUnavailable(c, "No streams available", "")
 		}
 		return c.Redirect(streams[0].URL, fiber.StatusFound)
@@ -494,7 +485,7 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 		// If the item is already processing and has a storage path, the streamable
 		// event fired before we subscribed — redirect immediately.
 		if current.StoragePath != nil && *current.StoragePath != "" {
-			if streams, err := s.buildStremioStreams(current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(ctx, current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 				return c.Redirect(streams[0].URL, fiber.StatusFound)
 			}
 		}
@@ -517,7 +508,7 @@ func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, do
 				// Redirect as soon as the file is accessible in the VFS — before post-processing.
 				if update.StoragePath != "" {
 					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
-					if streams, err := s.buildStremioStreams(fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
+					if streams, err := s.buildStremioStreams(ctx, fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
 						return c.Redirect(streams[0].URL, fiber.StatusFound)
 					}
 				}


### PR DESCRIPTION
## Problem

When a Stremio series request (e.g. `tt1234567:1:5`) resolves to a **season pack** (an NZB containing every episode of a season), AltMount served the **first** episode instead of the requested one.

The stream builders redirect/return `streams[0]`. Episode filtering (`stremioEpisodeSelector.matches`) silently no-ops (`return true` for every file) whenever the selector is `nil`. On the AIOStreams path (`POST /api/nzb/streams`) the `season`/`episode` params were undocumented and not forwarded, so the selector was `nil` → first episode served. AltMount cannot infer the episode from a season-pack NZB alone; the episode must arrive in the request.

## What changed

- **Reusable ID parser** — `parseStremioContentID` for `tt123` / `tt123:1:5`, replacing the inline parse in the addon stream handler.
- **Receive episode context on all paths** — `stremioEpisodeSelectorFromRequest` now reads season/episode from (1) explicit `season`+`episode`, (2) a combined `id`/`stremio_id`, or (3) `season`/`episode` embedded in the `nzb_url` query string. Gives AIOStreams a single field (`id=tt…:1:5`) to forward.
- **Hardened matching** — conservative fallback for season-in-directory + episode-only (e.g. `Season 01/Show E05.mkv`) and spelled `Season`/`Episode` forms. Explicit `SxxExx`/`NxNN` markers stay authoritative, so `S02E05` is never mistaken for `S01E05`.
- **Fail loudly instead of wrong episode** — `buildStremioStreams` now takes `ctx` and returns `errStremioEpisodeAmbiguous` when a multi-episode pack is resolved with no episode context. Callers surface it as a clear `400 Bad Request` ("Episode not specified …"). Movies and single-file releases are unaffected.
- **Docs & annotations** — documented `season`/`episode`/`id`/`nzb_url`/`X-Api-Key` on `POST /api/nzb/streams`, added a "Selecting one episode from a season pack" section with an AIOStreams example, and added the `id` swagger `@Param`.

## Tests

New/expanded tests: `parseStremioContentID`, `stremioEpisodeSelectorFromRequest` (query/id/nzb_url/precedence/nil), expanded `matches` (directory-season + spelled forms + negatives), `countDistinctEpisodes`, and the ambiguity safeguard (reject multi-episode pack w/o selector, allow multi-part movie).

## Verification

- `go build ./...`, `gofmt`, `go vet ./internal/api/...` — clean
- `golangci-lint run ./internal/api/...` — 0 issues
- `go test -race ./internal/api/` — pass

## Reviewer notes

- **Caveat:** if a proxy forwards *no* episode context, the user now gets a clear 400 rather than the wrong episode — the fix requires the episode to be forwarded (documented). The added param channels make that forwarding work via common conventions.
- `swag` isn't wired into `make`, so the generated `docs/static/swagger.*` artifacts were **not** regenerated here; the `@Param id` annotation is in place for the next regeneration.
- `go.mod`: `github.com/valyala/fasthttp` promoted from indirect to direct (used in the new request-parsing test).