### PR TITLE
feat(config): warn on config keys this version does not use

### DIFF
--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/javi11/altmount/internal/utils"
 	"github.com/javi11/nntppool/v4"
 	"github.com/jinzhu/copier"
@@ -1348,6 +1349,8 @@ func (m *Manager) ReloadConfig() error {
 		return fmt.Errorf("error reading config file %s: %w", m.configFile, err)
 	}
 
+	warnUnknownConfigKeys()
+
 	// Create default config and unmarshal into it
 	config := DefaultConfig()
 	if err := viper.Unmarshal(config); err != nil {
@@ -1766,6 +1769,23 @@ func SaveToFile(config *Config, filename string) error {
 }
 
 // LoadConfig loads configuration from file and merges with defaults
+// warnUnknownConfigKeys logs config keys that do not map to any field on Config.
+// These are almost always settings removed or renamed in a past release: viper
+// ignores them silently, so a stale key looks live while having no effect.
+//
+// This warns rather than fails — rejecting unknown keys would break upgrades for
+// anyone whose config still carries a retired setting.
+func warnUnknownConfigKeys() {
+	probe := DefaultConfig()
+	err := viper.Unmarshal(probe, func(dc *mapstructure.DecoderConfig) {
+		dc.ErrorUnused = true
+	})
+	if err != nil {
+		slog.Warn("Configuration contains keys this version does not use; they have no effect and can be removed",
+			"detail", err)
+	}
+}
+
 func LoadConfig(configFile string) (*Config, error) {
 	config := DefaultConfig()
 
@@ -1807,6 +1827,8 @@ func LoadConfig(configFile string) (*Config, error) {
 			return nil, fmt.Errorf("error reading config file: %w", err)
 		}
 	}
+
+	warnUnknownConfigKeys()
 
 	// Unmarshal the config
 	if err := viper.Unmarshal(config); err != nil {

--- a/internal/config/unknown_keys_test.go
+++ b/internal/config/unknown_keys_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// captureWarn runs fn with slog routed to a buffer and returns what was logged.
+func captureWarn(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(prev)
+	fn()
+	return buf.String()
+}
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestWarnUnknownConfigKeys_ReportsRetiredKey(t *testing.T) {
+	path := writeConfig(t, `
+import:
+  max_processor_workers: 4
+  max_import_connections: 60
+`)
+	viper.Reset()
+	viper.SetConfigFile(path)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	out := captureWarn(t, warnUnknownConfigKeys)
+	if !strings.Contains(out, "max_import_connections") {
+		t.Errorf("warning did not name the retired key; got: %s", out)
+	}
+}
+
+func TestWarnUnknownConfigKeys_SilentOnValidConfig(t *testing.T) {
+	path := writeConfig(t, `
+import:
+  max_processor_workers: 4
+  segment_sample_percentage: 25
+`)
+	viper.Reset()
+	viper.SetConfigFile(path)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	if out := captureWarn(t, warnUnknownConfigKeys); out != "" {
+		t.Errorf("expected no warning for a valid config, got: %s", out)
+	}
+}


### PR DESCRIPTION
Viper ignores unknown keys silently, so a setting removed or renamed in a past release stays in `config.yaml` looking live while having no effect. The value can be edited, the service restarted, and nothing changes — with no signal the key is dead.

This decodes a throwaway copy with mapstructure's `ErrorUnused` and logs the result. It warns rather than fails: rejecting unknown keys would break startup for anyone whose config still carries a retired setting.

### Real example

Run against an existing config, it reported one removed key and two renamed ones the operator had not noticed:

```
WARN Configuration contains keys this version does not use; they have no effect and can be removed
  detail="decoding failed due to the following error(s):
    'rclone' has invalid keys: read_chunk_size, read_chunk_size_limit
    'import' has invalid keys: max_import_connections"
```

`max_import_connections` was removed in #763 in favour of `max_concurrent_imports`; `read_chunk_size` / `read_chunk_size_limit` were renamed to `vfs_read_chunk_size` / `vfs_read_chunk_size_limit`. In that config the rclone values had been silently inert since the rename.

### Scope

+19 lines in `internal/config/manager.go`, no deletions — one helper and two call sites (`LoadConfig` and `ReloadConfig`, both after `ReadInConfig`). `manager.go` is not gofmt-clean upstream, so it was deliberately left unformatted to keep the diff to the change itself.

### Tests

- `TestWarnUnknownConfigKeys_ReportsRetiredKey` — a retired key is named in the warning
- `TestWarnUnknownConfigKeys_SilentOnValidConfig` — a valid config warns nothing

The first fails if `ErrorUnused` is disabled.