### PR TITLE
feat(sabnzbd): paginate history via a single UNION query (no schema change)

### DIFF
--- a/internal/api/sabnzbd_handlers.go
+++ b/internal/api/sabnzbd_handlers.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -786,170 +785,51 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	}
 	limit := 100
 	if l := c.Query("limit"); l != "" {
-		if val, err := strconv.Atoi(l); err == nil {
-			if val > 0 {
-				limit = val
-			} else {
-				limit = 100
-			}
+		if val, err := strconv.Atoi(l); err == nil && val > 0 {
+			limit = val
 		}
+	}
+	// Cap the page size so a client cannot force a huge materialization.
+	const maxSABnzbdHistoryLimit = 1000
+	if limit > maxSABnzbdHistoryLimit {
+		limit = maxSABnzbdHistoryLimit
 	}
 
 	// When *arr asks for specific nzo_ids, look them up directly so the response
-	// is independent of the bulk retention window. This is the path Sonarr/Radarr
-	// use to confirm a known download by id, and it must succeed regardless of
-	// how old the entry is — see issue #543.
+	// is independent of pagination. This is the path Sonarr/Radarr use to confirm
+	// a known download by id, and it must succeed regardless of how old the entry
+	// is — see issue #543.
 	if len(nzoIDs) > 0 {
 		return s.respondSABnzbdHistoryByIDs(c, ctx, nzoIDs, categoryFilter, start, limit)
 	}
 
-	// Determine how far back to look in persistent history. Default to 7 days
-	// (10080 minutes) and allow operators to widen further via config. Clients
-	// rebuilding large libraries with multiple *arrs can otherwise outrun the
-	// previous 24h window and lose visibility of completed imports.
-	historyMinutes := 10080
-	if s.configManager != nil {
-		if v := s.configManager.GetConfig().SABnzbd.HistoryRetentionMinutes; v > 0 {
-			historyMinutes = v
-		}
-	}
-
-	// Get recent items from persistent history (buffer for Sonarr)
-	recentHistory, err := s.queueRepo.ListRecentImportHistory(ctx, historyMinutes, categoryFilter)
+	// Serve the deduplicated, time-ordered union of completed-queue + persistent
+	// history + failed-queue with real SQL LIMIT/OFFSET and an exact total. The
+	// merge/dedup/pagination that used to run in memory over hardcoded caps now
+	// happens in one DB query; failed items keep their existing import_queue
+	// lifecycle (FailedItemRetentionHours).
+	totalAvailableCount, err := s.queueRepo.CountSABnzbdHistory(ctx, categoryFilter)
 	if err != nil {
-		recentHistory = []*database.ImportHistory{} // Fallback
+		return s.writeSABnzbdErrorFiber(c, "Failed to count history")
 	}
 
-	// Fetch items from active queue
-	// We use a larger set here to ensure we get everything for deduplication and combined history
-	completedStatus := database.QueueStatusCompleted
-	completedQueueItems, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, "", categoryFilter, 2000, 0, "updated_at", "desc")
+	historyRows, err := s.queueRepo.ListSABnzbdHistory(ctx, categoryFilter, limit, start)
 	if err != nil {
-		return s.writeSABnzbdErrorFiber(c, "Failed to get completed items from queue")
+		return s.writeSABnzbdErrorFiber(c, "Failed to get history")
 	}
 
-	// Combine and deduplicate by NZB Name
-	// Priority goes to items still in the queue (as they have more metadata)
-	seenNames := make(map[string]bool)
-	finalItems := make([]*database.ImportQueueItem, 0)
-	// Track items sourced from the live queue with status=Completed. Only these
-	// are eligible to be rewritten as Failed when their reported path is
-	// missing on disk (#596). Persistent-history rows represent past successful
-	// imports whose files may have been legitimately deleted later (e.g. ARR
-	// upgrade/cleanup), so they must not be retroactively marked Failed.
-	liveCompleted := make(map[*database.ImportQueueItem]bool)
-
-	for _, item := range completedQueueItems {
-		if item.SkipArrNotification {
-			continue
-		}
-		name := filepath.Base(item.NzbPath)
-		// Filter by nzo_ids if requested (check both integer ID and DownloadID)
-		if len(nzoIDs) > 0 {
-			match := nzoIDs[fmt.Sprintf("%d", item.ID)]
-			if !match && item.DownloadID != nil {
-				match = nzoIDs[*item.DownloadID]
-			}
-			if !match {
-				continue
-			}
-		}
-		if !seenNames[name] {
-			finalItems = append(finalItems, item)
-			liveCompleted[item] = true
-			seenNames[name] = true
-		}
-	}
-
-	for _, item := range recentHistory {
-		id := item.ID
-		if item.NzbID != nil {
-			id = *item.NzbID
-		}
-
-		// Filter by nzo_ids if requested
-		if len(nzoIDs) > 0 {
-			match := nzoIDs[fmt.Sprintf("%d", id)]
-			if !match && item.DownloadID != nil {
-				match = nzoIDs[*item.DownloadID]
-			}
-			if !match {
-				continue
-			}
-		}
-
-		if !seenNames[item.NzbName] {
-			qItem := &database.ImportQueueItem{
-				ID:          id,
-				DownloadID:  item.DownloadID,
-				NzbPath:     item.NzbName,
-				Status:      database.QueueStatusCompleted,
-				FileSize:    &item.FileSize,
-				CompletedAt: &item.CompletedAt,
-				Category:    item.Category,
-				StoragePath: &item.VirtualPath,
-			}
-			finalItems = append(finalItems, qItem)
-			seenNames[item.NzbName] = true
-		}
-	}
-
-	// Get failed items from active queue
-	failedStatus := database.QueueStatusFailed
-	failed, err := s.queueRepo.ListQueueItems(ctx, &failedStatus, "", categoryFilter, 1000, 0, "updated_at", "desc")
-	if err != nil {
-		return s.writeSABnzbdErrorFiber(c, "Failed to get failed items")
-	}
-
-	// Combine failed items for noofslots calculation
-	for _, item := range failed {
-		if item.SkipArrNotification {
-			continue
-		}
-		name := filepath.Base(item.NzbPath)
-		// Filter by nzo_ids if requested
-		if len(nzoIDs) > 0 {
-			match := nzoIDs[fmt.Sprintf("%d", item.ID)]
-			if !match && item.DownloadID != nil {
-				match = nzoIDs[*item.DownloadID]
-			}
-			if !match {
-				continue
-			}
-		}
-		if !seenNames[name] {
-			finalItems = append(finalItems, item)
-			seenNames[name] = true
-		}
-	}
-
-	sort.SliceStable(finalItems, func(i, j int) bool {
-		return sabnzbdHistorySortTime(finalItems[i]).After(sabnzbdHistorySortTime(finalItems[j]))
-	})
-
-	// Total available items before pagination
-	totalAvailableCount := len(finalItems)
-
-	// Apply pagination (start and limit)
-	if start < len(finalItems) {
-		finalItems = finalItems[start:]
-	} else {
-		finalItems = []*database.ImportQueueItem{}
-	}
-
-	if limit > 0 && len(finalItems) > limit {
-		finalItems = finalItems[:limit]
-	}
-
-	// Combine and convert to SABnzbd format
-	slots := make([]SABnzbdHistorySlot, 0, len(finalItems))
+	slots := make([]SABnzbdHistorySlot, 0, len(historyRows))
 	var totalBytes int64
 	itemBasePath := s.calculateItemBasePath()
 
-	for i, item := range finalItems {
+	for i, row := range historyRows {
+		item := sabnzbdHistoryRowToQueueItem(row)
 		finalPath, exists := s.calculateHistoryStoragePath(item, itemBasePath)
 		slot := ToSABnzbdHistorySlot(item, start+i, finalPath)
-		if !exists && liveCompleted[item] {
+		// #596: only rows still present in the live completed queue may be
+		// rewritten to Failed when their reported path is missing on disk.
+		// Persistent-history and failed rows must never be retroactively failed.
+		if !exists && row.Source == "completed_queue" {
 			markHistorySlotMissing(&slot, finalPath)
 		}
 		slots = append(slots, slot)
@@ -970,6 +850,24 @@ func (s *Server) handleSABnzbdHistory(c *fiber.Ctx) error {
 	}
 
 	return s.writeSABnzbdResponseFiber(c, response)
+}
+
+// sabnzbdHistoryRowToQueueItem adapts a unified history row into the
+// ImportQueueItem shape used by ToSABnzbdHistorySlot.
+func sabnzbdHistoryRowToQueueItem(row *database.SABnzbdHistoryRow) *database.ImportQueueItem {
+	completedAt := row.CompletedAt
+	return &database.ImportQueueItem{
+		ID:           row.ID,
+		DownloadID:   row.DownloadID,
+		NzbPath:      row.Name,
+		Status:       row.Status,
+		FileSize:     row.FileSize,
+		CompletedAt:  completedAt,
+		Category:     row.Category,
+		StoragePath:  row.StoragePath,
+		Metadata:     row.Metadata,
+		ErrorMessage: row.ErrorMessage,
+	}
 }
 
 // respondSABnzbdHistoryByIDs returns a SABnzbd history response containing only
@@ -1108,19 +1006,6 @@ func importHistoryToQueueItem(h *database.ImportHistory) *database.ImportQueueIt
 		Category:    h.Category,
 		StoragePath: &virtualPath,
 	}
-}
-
-func sabnzbdHistorySortTime(item *database.ImportQueueItem) time.Time {
-	if item == nil {
-		return time.Time{}
-	}
-	if !item.UpdatedAt.IsZero() {
-		return item.UpdatedAt
-	}
-	if item.CompletedAt != nil {
-		return *item.CompletedAt
-	}
-	return item.CreatedAt
 }
 
 // handleSABnzbdHistoryDelete handles deleting items from history

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1224,6 +1224,100 @@ func (r *Repository) ListRecentImportHistory(ctx context.Context, minutes int, c
 	return history, rows.Err()
 }
 
+// SABnzbdHistoryRow is one flattened row of the unified SABnzbd history view
+// (completed queue + persistent history + failed queue). Source lets the caller
+// reconstruct the "#596 missing-path -> Failed" behavior, which applies only to
+// rows still present in the live completed queue.
+type SABnzbdHistoryRow struct {
+	Source       string // "completed_queue" | "history" | "failed_queue"
+	ID           int64
+	DownloadID   *string
+	Name         string // nzb_path for queue rows, nzb_name for history rows
+	Status       QueueStatus
+	FileSize     *int64
+	CompletedAt  *time.Time
+	Category     *string
+	StoragePath  *string
+	Metadata     *string
+	ErrorMessage *string
+}
+
+// sabnzbdHistoryUnion builds the deduplicated UNION-ALL body shared by
+// ListSABnzbdHistory and CountSABnzbdHistory, plus its bound args (the category
+// filter, repeated once per arm). A completed import can exist in both
+// import_queue (status=completed, never auto-pruned) and import_history; the
+// anti-join drops the history copy when the live completed queue row is present,
+// so each import is counted once. Failed items live only in import_queue and are
+// unaffected. Portable across SQLite + Postgres (no window functions, no
+// basename/regexp); ? placeholders and FALSE are rewritten by the dialect layer.
+func sabnzbdHistoryUnion(category string) (string, []any) {
+	body := `
+		SELECT 'completed_queue' AS source, q.id, q.download_id, q.nzb_path AS name, q.status,
+		       q.file_size, q.completed_at, q.category, q.storage_path, q.metadata, q.error_message,
+		       COALESCE(q.completed_at, q.updated_at, q.created_at) AS sort_time
+		  FROM import_queue q
+		 WHERE q.status = 'completed' AND q.skip_arr_notification = FALSE
+		   AND (? = '' OR LOWER(q.category) = LOWER(?))
+		UNION ALL
+		SELECT 'history', COALESCE(h.nzb_id, h.id), h.download_id, h.nzb_name, 'completed',
+		       h.file_size, h.completed_at, h.category, h.virtual_path, h.metadata, NULL,
+		       h.completed_at
+		  FROM import_history h
+		  LEFT JOIN import_queue q
+		    ON q.id = h.nzb_id AND q.status = 'completed' AND q.skip_arr_notification = FALSE
+		 WHERE q.id IS NULL
+		   AND (? = '' OR LOWER(h.category) = LOWER(?))
+		UNION ALL
+		SELECT 'failed_queue', q.id, q.download_id, q.nzb_path, q.status,
+		       q.file_size, q.completed_at, q.category, q.storage_path, q.metadata, q.error_message,
+		       COALESCE(q.completed_at, q.updated_at, q.created_at)
+		  FROM import_queue q
+		 WHERE q.status = 'failed' AND q.skip_arr_notification = FALSE
+		   AND (? = '' OR LOWER(q.category) = LOWER(?))`
+	args := []any{category, category, category, category, category, category}
+	return body, args
+}
+
+// ListSABnzbdHistory returns one time-ordered, deduplicated page of the SABnzbd
+// history view using real SQL LIMIT/OFFSET.
+func (r *Repository) ListSABnzbdHistory(ctx context.Context, category string, limit, offset int) ([]*SABnzbdHistoryRow, error) {
+	body, args := sabnzbdHistoryUnion(category)
+	query := `SELECT source, id, download_id, name, status, file_size, completed_at, category, storage_path, metadata, error_message
+		FROM (` + body + `) t
+		ORDER BY sort_time DESC, id DESC
+		LIMIT ? OFFSET ?`
+	args = append(args, limit, offset)
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sabnzbd history: %w", err)
+	}
+	defer rows.Close()
+
+	var out []*SABnzbdHistoryRow
+	for rows.Next() {
+		var row SABnzbdHistoryRow
+		if err := rows.Scan(&row.Source, &row.ID, &row.DownloadID, &row.Name, &row.Status,
+			&row.FileSize, &row.CompletedAt, &row.Category, &row.StoragePath, &row.Metadata, &row.ErrorMessage); err != nil {
+			return nil, fmt.Errorf("failed to scan sabnzbd history row: %w", err)
+		}
+		out = append(out, &row)
+	}
+	return out, rows.Err()
+}
+
+// CountSABnzbdHistory returns the exact pre-pagination total for the SABnzbd
+// history view (for noofslots).
+func (r *Repository) CountSABnzbdHistory(ctx context.Context, category string) (int, error) {
+	body, args := sabnzbdHistoryUnion(category)
+	query := `SELECT COUNT(*) FROM (` + body + `) t`
+	var count int
+	if err := r.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("failed to count sabnzbd history: %w", err)
+	}
+	return count, nil
+}
+
 // GetImportDailyStats retrieves import statistics for the specified number of days
 func (r *Repository) GetImportDailyStats(ctx context.Context, days int) ([]*ImportDailyStat, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -days).Format("2006-01-02")

--- a/internal/database/sabnzbd_history_test.go
+++ b/internal/database/sabnzbd_history_test.go
@@ -1,0 +1,150 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupImportHistorySchema creates the import_history table (production shape,
+// no status column — this is the no-schema-change design).
+func setupImportHistorySchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+	schema := `
+		CREATE TABLE import_history (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			download_id TEXT DEFAULT NULL,
+			nzb_id INTEGER,
+			nzb_name TEXT NOT NULL,
+			file_name TEXT NOT NULL,
+			file_size BIGINT,
+			virtual_path TEXT NOT NULL,
+			category TEXT,
+			metadata TEXT DEFAULT NULL,
+			indexer TEXT DEFAULT NULL,
+			completed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("Failed to create import_history schema: %v", err)
+	}
+}
+
+func newSABHistoryRepo(t *testing.T) (*Repository, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	setupQueueSchema(t, db)
+	setupImportHistorySchema(t, db)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewRepository(db, DialectSQLite), db
+}
+
+// insertQ inserts a queue row with the fields the history union reads.
+func insertQ(t *testing.T, db *sql.DB, id int64, status, category string, completedAt time.Time, skipArr bool) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO import_queue (id, nzb_path, status, priority, category, file_size, storage_path,
+			skip_arr_notification, created_at, updated_at, completed_at)
+		VALUES (?, ?, ?, 1, ?, 100, ?, ?, ?, ?, ?)`,
+		id, fmt.Sprintf("%d-item.nzb", id), status, category, fmt.Sprintf("%s/%d", category, id),
+		skipArr, completedAt.UTC().Format("2006-01-02 15:04:05"),
+		completedAt.UTC().Format("2006-01-02 15:04:05"), completedAt.UTC().Format("2006-01-02 15:04:05"))
+	require.NoError(t, err)
+}
+
+// insertH inserts an import_history row (nzbID<=0 => NULL nzb_id).
+func insertH(t *testing.T, db *sql.DB, id, nzbID int64, category string, completedAt time.Time) {
+	t.Helper()
+	var nzb any
+	if nzbID > 0 {
+		nzb = nzbID
+	}
+	_, err := db.Exec(`
+		INSERT INTO import_history (id, nzb_id, nzb_name, file_name, file_size, virtual_path, category, completed_at)
+		VALUES (?, ?, ?, ?, 100, ?, ?, ?)`,
+		id, nzb, fmt.Sprintf("h%d.nzb", id), fmt.Sprintf("h%d.mkv", id),
+		fmt.Sprintf("%s/h%d", category, id), category, completedAt.UTC().Format("2006-01-02 15:04:05"))
+	require.NoError(t, err)
+}
+
+func TestSABnzbdHistory_DedupAndSources(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	// Completed item present in BOTH queue and history (history.nzb_id = queue.id).
+	insertQ(t, db, 5, "completed", "tv", base.Add(5*time.Minute), false)
+	insertH(t, db, 100, 5, "tv", base.Add(5*time.Minute))
+	// History-only completed (its queue row was cleared): nzb_id has no live row.
+	insertH(t, db, 101, 99, "tv", base.Add(3*time.Minute))
+	// Failed queue item (never in history).
+	insertQ(t, db, 6, "failed", "tv", base.Add(4*time.Minute), false)
+	// skip_arr item must be excluded.
+	insertQ(t, db, 7, "completed", "tv", base.Add(6*time.Minute), true)
+
+	total, err := repo.CountSABnzbdHistory(ctx, "")
+	require.NoError(t, err)
+	// item 5 (once, deduped), history 101, failed 6 = 3. skip_arr 7 excluded.
+	assert.Equal(t, 3, total)
+
+	rows, err := repo.ListSABnzbdHistory(ctx, "", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 3)
+
+	bySource := map[string]int{}
+	for _, r := range rows {
+		bySource[r.Source]++
+	}
+	assert.Equal(t, 1, bySource["completed_queue"], "item 5 comes from the live queue, history dup dropped")
+	assert.Equal(t, 1, bySource["history"], "history-only item survives")
+	assert.Equal(t, 1, bySource["failed_queue"], "failed item included")
+
+	// Ordering: newest sort_time first (item5@+5, failed6@+4, history101@+3).
+	assert.Equal(t, "completed_queue", rows[0].Source)
+	assert.Equal(t, "failed_queue", rows[1].Source)
+	assert.Equal(t, QueueStatusFailed, rows[1].Status)
+	assert.Equal(t, "history", rows[2].Source)
+}
+
+func TestSABnzbdHistory_PaginationAndCategory(t *testing.T) {
+	repo, db := newSABHistoryRepo(t)
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	// 5 completed tv items (ids 1..5, increasing time), 2 movies items.
+	for i := int64(1); i <= 5; i++ {
+		insertQ(t, db, i, "completed", "tv", base.Add(time.Duration(i)*time.Minute), false)
+	}
+	insertQ(t, db, 10, "completed", "movies", base.Add(time.Minute), false)
+	insertQ(t, db, 11, "completed", "movies", base.Add(2*time.Minute), false)
+
+	tvTotal, err := repo.CountSABnzbdHistory(ctx, "tv")
+	require.NoError(t, err)
+	assert.Equal(t, 5, tvTotal)
+
+	// Page through tv in 2s: expect ids 5,4,3,2,1 (newest first), no overlap.
+	seen := map[int64]bool{}
+	var order []int64
+	for _, start := range []int{0, 2, 4} {
+		page, err := repo.ListSABnzbdHistory(ctx, "tv", 2, start)
+		require.NoError(t, err)
+		for _, r := range page {
+			assert.False(t, seen[r.ID], "id %d on two pages", r.ID)
+			seen[r.ID] = true
+			order = append(order, r.ID)
+		}
+	}
+	assert.Equal(t, []int64{5, 4, 3, 2, 1}, order)
+
+	// start beyond total → empty.
+	empty, err := repo.ListSABnzbdHistory(ctx, "tv", 2, 999)
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+}


### PR DESCRIPTION
## What

Fix pagination of the SABnzbd-compatible `mode=history` API by moving the merge + dedup + pagination into **one SQL query over the existing tables**. No schema change, no migration.

## Why

The handler merged three sources — completed rows from `import_queue`, a 7-day window of `import_history`, and failed rows from `import_queue` — deduped and **sliced them in memory over hardcoded caps (2000 / 1000)**. So clients (Sonarr/Radarr) could never page past the caps, and `noofslots` didn't reflect the true total.

## How

- **New repo methods** `ListSABnzbdHistory` + `CountSABnzbdHistory`: a `UNION ALL` of `import_queue`(completed) + `import_history` + `import_queue`(failed), deduped by an anti-join on `import_history.nzb_id = import_queue.id` (a completed import can live in both tables — the live queue row wins, the history copy is dropped), `ORDER BY completed_at DESC, id DESC`, real `LIMIT/OFFSET`, and an exact `COUNT`. Portable across SQLite + Postgres (no window functions, no basename/regexp; `?` and `FALSE` handled by the dialect layer).
- **Handler bulk path rewritten** to use them; `limit` capped at 1000.
- **#596 preserved** — only rows sourced from the live completed queue are flipped to `Failed` when their reported path is missing on disk.
- **`nzo_ids` reconciliation path unchanged.**

## What does NOT change

- No new tables/columns, no migration.
- **Failures** keep living in `import_queue` with their existing `FailedItemRetentionHours` lifecycle (default 24h) — same as before.
- Completed/failed queue rows, retention config, the UI, and Stremio are all untouched.

## Behavior note

Dedup shifts from filename-based to queue-id-based (`import_history.nzb_id`). This is more correct than the old name dedup (which was partly ineffective because queue paths carry a `{id}-` prefix that `import_history.nzb_name` strips): a completed import in both tables now reliably shows once, and two genuinely distinct jobs that share a filename both show (as real SABnzbd does). The old fixed history window (7 days) is gone — pagination now spans the full history.

## Test plan

- `go test ./internal/database/... ./internal/api/...` — green; `go vet` clean; `go build ./...` clean
- New tests: dedup across queue+history (single row, correct source), failed-item inclusion, skip_arr exclusion, category filter, paged enumeration with no overlap/gaps and newest-first ordering, `start` beyond total
- Manual: `mode=history` with `start`/`limit` (no page overlap, constant `noofslots` across pages)