### PR TITLE
feat(stremio): configure Prowlarr indexers for addon searches

### DIFF
--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -1,7 +1,12 @@
-import { Check, Copy, ExternalLink, Save, Tv, X } from "lucide-react";
+import { Check, Copy, ExternalLink, RefreshCw, Save, Tv, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { copyToClipboard } from "../../lib/utils";
-import type { ConfigResponse, ProwlarrConfig, StremioConfig } from "../../types/config";
+import type {
+	ConfigResponse,
+	ProwlarrConfig,
+	ProwlarrIndexer,
+	StremioConfig,
+} from "../../types/config";
 import { LoadingSpinner } from "../ui/LoadingSpinner";
 
 interface TagInputProps {
@@ -84,6 +89,7 @@ const DEFAULT_PROWLARR: ProwlarrConfig = {
 	host: "http://localhost:9696",
 	api_key: "",
 	categories: [2000, 2010, 2030, 2040, 2045, 2060, 5000, 5010, 5030, 5040],
+	indexers: [],
 	languages: [],
 	qualities: [],
 };
@@ -110,6 +116,9 @@ export function StremioConfigSection({
 	});
 	const [hasChanges, setHasChanges] = useState(false);
 	const [urlCopied, setUrlCopied] = useState(false);
+	const [indexers, setIndexers] = useState<ProwlarrIndexer[]>([]);
+	const [loadingIndexers, setLoadingIndexers] = useState(false);
+	const [indexersError, setIndexersError] = useState<string | null>(null);
 
 	useEffect(() => {
 		setFormData({
@@ -141,6 +150,37 @@ export function StremioConfigSection({
 		const updated = { ...formData, prowlarr: { ...formData.prowlarr, ...patch } };
 		setFormData(updated);
 		markChanged(updated);
+	};
+
+	const loadIndexers = useCallback(async () => {
+		setLoadingIndexers(true);
+		setIndexersError(null);
+		try {
+			const response = await fetch("/api/prowlarr/indexers", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					host: formData.prowlarr?.host ?? "",
+					api_key: formData.prowlarr?.api_key ?? "",
+				}),
+			});
+			const data = await response.json();
+			if (data.success) {
+				setIndexers((data.data as ProwlarrIndexer[]) ?? []);
+			} else {
+				setIndexersError(data.error?.message || data.error || "Failed to load indexers");
+			}
+		} catch (_error) {
+			setIndexersError("Network error while loading indexers");
+		} finally {
+			setLoadingIndexers(false);
+		}
+	}, [formData.prowlarr?.host, formData.prowlarr?.api_key]);
+
+	const toggleIndexer = (id: number) => {
+		const current = formData.prowlarr?.indexers ?? [];
+		const next = current.includes(id) ? current.filter((i) => i !== id) : [...current, id];
+		updateProwlarr({ indexers: next });
 	};
 
 	const handleSave = async () => {
@@ -347,6 +387,68 @@ export function StremioConfigSection({
 								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
 									Newznab category IDs. Press Enter or comma to add. Defaults: 2000, 2010, 2030,
 									2040, 2045, 2060 (Movies) and 5000, 5010, 5030, 5040 (TV).
+								</p>
+							</fieldset>
+
+							<fieldset className="fieldset min-w-0">
+								<legend className="fieldset-legend">Indexers</legend>
+								<div className="flex flex-wrap items-center gap-3">
+									<button
+										type="button"
+										className="btn btn-sm btn-outline"
+										onClick={loadIndexers}
+										disabled={isReadOnly || loadingIndexers || !formData.prowlarr?.host}
+									>
+										{loadingIndexers ? (
+											<LoadingSpinner size="sm" />
+										) : (
+											<RefreshCw className="h-4 w-4" />
+										)}
+										{loadingIndexers ? "Loading..." : "Load from Prowlarr"}
+									</button>
+									{(formData.prowlarr?.indexers?.length ?? 0) > 0 && (
+										<span className="text-base-content/60 text-xs">
+											{formData.prowlarr?.indexers?.length} selected
+										</span>
+									)}
+								</div>
+
+								{indexersError && (
+									<div className="alert alert-error mt-3 py-2">
+										<X className="h-4 w-4" />
+										<span className="text-xs">{indexersError}</span>
+									</div>
+								)}
+
+								{indexers.length > 0 && (
+									<div className="mt-3 flex max-h-64 flex-col gap-1 overflow-y-auto rounded-box border border-base-300 bg-base-100 p-2">
+										{indexers.map((idx) => {
+											const selected = formData.prowlarr?.indexers?.includes(idx.id) ?? false;
+											return (
+												<label
+													key={idx.id}
+													className="flex cursor-pointer items-center gap-3 rounded-lg px-2 py-1.5 hover:bg-base-200"
+												>
+													<input
+														type="checkbox"
+														className="checkbox checkbox-sm checkbox-primary"
+														checked={selected}
+														disabled={isReadOnly}
+														onChange={() => toggleIndexer(idx.id)}
+													/>
+													<span className="min-w-0 flex-1 truncate text-sm">{idx.name}</span>
+													{!idx.enable && (
+														<span className="badge badge-ghost badge-xs">disabled</span>
+													)}
+												</label>
+											);
+										})}
+									</div>
+								)}
+
+								<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+									Restrict searches to specific Prowlarr indexers. Leave all unchecked to search{" "}
+									<strong>every</strong> indexer. Only usenet indexers are listed.
 								</p>
 							</fieldset>
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -666,8 +666,17 @@ export interface ProwlarrConfig {
 	host: string;
 	api_key: string;
 	categories: number[];
+	indexers?: number[];
 	languages: string[];
 	qualities: string[];
+}
+
+// A single Prowlarr indexer returned by POST /api/prowlarr/indexers
+export interface ProwlarrIndexer {
+	id: number;
+	name: string;
+	enable: boolean;
+	protocol: string;
 }
 
 // Stremio integration configuration

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -330,6 +330,9 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	api.Post("/config/reload", s.handleReloadConfig)
 	api.Post("/config/validate", s.handleValidateConfig)
 
+	// Prowlarr helper endpoints (Stremio addon configuration)
+	api.Post("/prowlarr/indexers", s.handleListProwlarrIndexers)
+
 	// FUSE endpoints
 	api.Post("/fuse/start", s.handleStartFuseMount)
 	api.Post("/fuse/stop", s.handleStopFuseMount)

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -186,7 +186,7 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		if tvdbID != "" {
 			slog.InfoContext(ctx, "Searching Prowlarr using TVDB ID for series",
 				"imdb_id", imdbID, "tvdb_id", tvdbID, "season", season, "episode", episode)
-			results, err = client.SearchByTVDB(ctx, tvdbID, prowlarrType, prowlarrCfg.Categories, season, episode)
+			results, err = client.SearchByTVDB(ctx, tvdbID, prowlarrType, prowlarrCfg.Categories, prowlarrCfg.Indexers, season, episode)
 			if err != nil {
 				slog.WarnContext(ctx, "Prowlarr TVDB search failed; falling back to IMDb search",
 					"error", err, "imdb_id", imdbID, "tvdb_id", tvdbID)
@@ -196,7 +196,7 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 	}
 
 	if len(results) == 0 {
-		results, err = client.Search(ctx, imdbID, prowlarrType, prowlarrCfg.Categories, season, episode)
+		results, err = client.Search(ctx, imdbID, prowlarrType, prowlarrCfg.Categories, prowlarrCfg.Indexers, season, episode)
 		if err != nil {
 			slog.WarnContext(ctx, "Prowlarr search failed", "error", err, "imdb_id", imdbID, "tvdb_id", tvdbID)
 			return emptyStreamsResponse(c)
@@ -547,4 +547,57 @@ func (s *Server) validateDownloadKey(ctx context.Context, key string) bool {
 		}
 	}
 	return false
+}
+
+// prowlarrIndexersRequest carries optional connection overrides so the config UI
+// can list indexers before the Prowlarr settings are saved.
+type prowlarrIndexersRequest struct {
+	Host   string `json:"host"`
+	APIKey string `json:"api_key"`
+}
+
+// handleListProwlarrIndexers returns the usenet indexers configured in Prowlarr
+// so the Stremio config UI can present them for selection. Host and API key may
+// be supplied in the body (to test unsaved values) or fall back to saved config.
+//
+//	@Summary		List Prowlarr indexers
+//	@Description	Returns the usenet indexers configured in Prowlarr for the Stremio addon.
+//	@Tags			Config
+//	@Accept			json
+//	@Produce		json
+//	@Param			body	body		prowlarrIndexersRequest	false	"Optional Prowlarr connection overrides"
+//	@Success		200		{object}	APIResponse
+//	@Failure		400		{object}	APIResponse
+//	@Security		BearerAuth
+//	@Router			/prowlarr/indexers [post]
+func (s *Server) handleListProwlarrIndexers(c *fiber.Ctx) error {
+	if s.configManager == nil {
+		return RespondServiceUnavailable(c, "Configuration not available", "")
+	}
+
+	var req prowlarrIndexersRequest
+	// Body is optional; ignore parse errors and fall back to saved config.
+	_ = c.BodyParser(&req)
+
+	cfg := s.configManager.GetConfig()
+	host := strings.TrimSpace(req.Host)
+	if host == "" {
+		host = cfg.Stremio.Prowlarr.Host
+	}
+	apiKey := strings.TrimSpace(req.APIKey)
+	if apiKey == "" {
+		apiKey = cfg.Stremio.Prowlarr.APIKey
+	}
+
+	if host == "" || apiKey == "" {
+		return RespondValidationError(c, "Prowlarr host and API key are required", "")
+	}
+
+	client := prowlarr.NewClient(host, apiKey, httpclient.NewForExternal(cfg.Network, 30*time.Second))
+	indexers, err := client.GetIndexers(c.Context())
+	if err != nil {
+		return RespondBadRequest(c, "Failed to list Prowlarr indexers", err.Error())
+	}
+
+	return RespondSuccess(c, indexers)
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -216,6 +216,7 @@ type ProwlarrAPIResponse struct {
 	APIKey     string   `json:"api_key"`
 	APIKeySet  bool     `json:"api_key_set"`
 	Categories []int    `json:"categories,omitempty"`
+	Indexers   []int    `json:"indexers,omitempty"`
 	Languages  []string `json:"languages,omitempty"`
 	Qualities  []string `json:"qualities,omitempty"`
 }
@@ -388,6 +389,7 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 			APIKey:     cfg.Stremio.Prowlarr.APIKey,
 			APIKeySet:  cfg.Stremio.Prowlarr.APIKey != "",
 			Categories: cfg.Stremio.Prowlarr.Categories,
+			Indexers:   cfg.Stremio.Prowlarr.Indexers,
 			Languages:  cfg.Stremio.Prowlarr.Languages,
 			Qualities:  cfg.Stremio.Prowlarr.Qualities,
 		},

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -151,6 +151,9 @@ type ProwlarrConfig struct {
 	// Categories filters search results by Newznab category IDs.
 	// Defaults to 5000 (Movies), 5010 (Movies/Foreign), 5030 (TV), 5040 (TV/HD).
 	Categories []int `yaml:"categories" mapstructure:"categories" json:"categories,omitempty"`
+	// Indexers optionally restricts searches to specific Prowlarr indexer IDs.
+	// Empty = search across all configured indexers.
+	Indexers []int `yaml:"indexers" mapstructure:"indexers" json:"indexers,omitempty"`
 	// Languages is an optional list of keywords; releases must contain at least one to pass.
 	// Empty = no filtering. Examples: ["Esp", "🇪🇸", "Spanish", "DUAL"]
 	Languages []string `yaml:"languages" mapstructure:"languages" json:"languages,omitempty"`

--- a/internal/prowlarr/client.go
+++ b/internal/prowlarr/client.go
@@ -52,6 +52,43 @@ type NZBResult struct {
 	Indexer     string
 }
 
+// Indexer describes a single Prowlarr indexer, used to let users pick which
+// indexers the Stremio addon should search.
+type Indexer struct {
+	ID       int64  `json:"id"`
+	Name     string `json:"name"`
+	Enable   bool   `json:"enable"`
+	Protocol string `json:"protocol"`
+}
+
+// GetIndexers returns the usenet indexers configured in Prowlarr, sorted by name.
+// Torrent indexers are omitted because AltMount only queues usenet releases.
+func (c *Client) GetIndexers(ctx context.Context) ([]Indexer, error) {
+	outputs, err := c.prowlarr.GetIndexersContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("prowlarr: get indexers failed: %w", err)
+	}
+
+	indexers := make([]Indexer, 0, len(outputs))
+	for _, o := range outputs {
+		if o == nil || string(o.Protocol) != "usenet" {
+			continue
+		}
+		indexers = append(indexers, Indexer{
+			ID:       o.ID,
+			Name:     o.Name,
+			Enable:   o.Enable,
+			Protocol: string(o.Protocol),
+		})
+	}
+
+	sort.Slice(indexers, func(i, j int) bool {
+		return strings.ToLower(indexers[i].Name) < strings.ToLower(indexers[j].Name)
+	})
+
+	return indexers, nil
+}
+
 // matchesAnyKeyword returns true when title contains at least one of the
 // keywords (case-insensitive). Returns true when keywords is empty (no filter).
 func matchesAnyKeyword(title string, keywords []string) bool {
@@ -205,18 +242,20 @@ func InferReleaseMeta(title string) ReleaseMeta {
 // Search queries Prowlarr for NZB releases matching the given IMDB ID and categories.
 // searchType should be "movie", "tvsearch", or "search".
 // season and episode are optional (pass 0 to omit); used for tvsearch to scope results to a specific episode.
+// indexers optionally restricts the search to specific indexer IDs (empty = all indexers).
 // Results are returned sorted by publish date descending (newest first).
-func (c *Client) Search(ctx context.Context, imdbID, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
-	return c.searchWithID(ctx, "ImdbId", imdbID, searchType, categories, season, episode)
+func (c *Client) Search(ctx context.Context, imdbID, searchType string, categories, indexers []int, season, episode int) ([]NZBResult, error) {
+	return c.searchWithID(ctx, "ImdbId", imdbID, searchType, categories, indexers, season, episode)
 }
 
 // SearchByTVDB queries Prowlarr for NZB releases using TVDB ID and categories.
 // This is primarily used by TV series lookups when indexers support TvdbId but not ImdbId.
-func (c *Client) SearchByTVDB(ctx context.Context, tvdbID, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
-	return c.searchWithID(ctx, "TvdbId", tvdbID, searchType, categories, season, episode)
+// indexers optionally restricts the search to specific indexer IDs (empty = all indexers).
+func (c *Client) SearchByTVDB(ctx context.Context, tvdbID, searchType string, categories, indexers []int, season, episode int) ([]NZBResult, error) {
+	return c.searchWithID(ctx, "TvdbId", tvdbID, searchType, categories, indexers, season, episode)
 }
 
-func (c *Client) searchWithID(ctx context.Context, idField, idValue, searchType string, categories []int, season, episode int) ([]NZBResult, error) {
+func (c *Client) searchWithID(ctx context.Context, idField, idValue, searchType string, categories, indexers []int, season, episode int) ([]NZBResult, error) {
 	var query strings.Builder
 	if idValue != "" {
 		query.WriteString("{" + idField + ":" + idValue + "}")
@@ -233,10 +272,16 @@ func (c *Client) searchWithID(ctx context.Context, idField, idValue, searchType 
 		cats[i] = int64(cat)
 	}
 
+	idxs := make([]int64, len(indexers))
+	for i, idx := range indexers {
+		idxs[i] = int64(idx)
+	}
+
 	input := starrprowlarr.SearchInput{
 		Query:      query.String(),
 		Type:       searchType,
 		Categories: cats,
+		IndexerIDs: idxs,
 	}
 
 	releases, err := c.prowlarr.SearchContext(ctx, input)


### PR DESCRIPTION
## What

Adds the ability to configure **which Prowlarr indexers** the Stremio addon searches. Indexers are selected by name — fetched live from Prowlarr — rather than by typing opaque numeric IDs. Leaving the selection empty searches **all** indexers (current behavior).

## Why

The Stremio integration previously searched every Prowlarr indexer with no way to scope it. Users with many indexers (or a mix of fast/slow or region-specific ones) want to limit searches to a curated subset for speed and result quality.

## Changes

**Backend**
- `internal/config/manager.go` — new `ProwlarrConfig.Indexers []int` field (empty = all indexers).
- `internal/prowlarr/client.go` — new `Indexer` type and `GetIndexers(ctx)` (returns usenet indexers only, sorted by name); `indexers` threaded through `Search` / `SearchByTVDB` / `searchWithID` into `SearchInput.IndexerIDs`.
- `internal/api/stremio_addon_handlers.go` — new `handleListProwlarrIndexers`. Accepts optional `{host, api_key}` in the body so the UI can list indexers before settings are saved, falling back to saved config.
- `internal/api/server.go` — registered `POST /api/prowlarr/indexers` (JWT-protected).
- `internal/api/types.go` — `Indexers` exposed in `ProwlarrAPIResponse` so the UI reflects the saved selection.

**Frontend**
- `frontend/src/types/config.ts` — `indexers?: number[]` on `ProwlarrConfig` plus a `ProwlarrIndexer` type.
- `frontend/src/components/config/StremioConfigSection.tsx` — new "Indexers" fieldset with a **Load from Prowlarr** button, a scrollable checkbox list (name + "disabled" badge for inactive indexers), a selected count, and error handling.

## Reviewer notes

- Torrent indexers are intentionally omitted from `GetIndexers` since AltMount only queues usenet releases.
- The config PATCH path wraps the payload as `{ stremio: { prowlarr: { indexers: [...] } } }`, so the new field round-trips through `BodyParser` with no extra merge logic.
- No unit tests added — `internal/prowlarr` currently has no test file. Happy to add coverage for `GetIndexers` / the indexer-ID plumbing if desired.

## Verification

- `go build ./internal/...` ✅ · `go vet` ✅
- `bun run check` (biome) ✅ · `npx tsc --noEmit` ✅ · `bun run build` ✅