### PR TITLE
fix: obscure webdav password when creating internal rclone mount config

### DIFF
--- a/pkg/rclonecli/client.go
+++ b/pkg/rclonecli/client.go
@@ -390,8 +390,9 @@ func (m *Manager) createConfig(ctx context.Context, configName, webdavURL string
 	req := RCRequest{
 		Command: "config/create",
 		Args: map[string]any{
-			"name": configName,
-			"type": "webdav",
+			"name":    configName,
+			"type":    "webdav",
+			"obscure": true,
 			"parameters": map[string]any{
 				"url":             webdavURL,
 				"vendor":          "other",


### PR DESCRIPTION
## Summary

- `createConfig()` in `pkg/rclonecli/client.go` writes the configured `webdav.password` directly into rclone's `pass` field via `config/create`, but rclone's webdav backend treats `pass` as an obscured value and de-obscures it before sending requests.
- Feeding it a plaintext password makes rclone de-obscure it into garbage, so the internal mount sends the wrong credentials and gets a permanent 401 against AltMount's own WebDAV server whenever `auth.login_required` is enabled with a webdav user/password set.
- Fix: add a top-level `"obscure": true` to the `config/create` RC call (sibling to `name`/`type`/`parameters`, not nested inside `parameters`).

Fixes #691.

## Independent reproduction

Hit this live running AltMount with `auth.login_required: true` and a real webdav user/password configured - internal mount failed permanently:

```
2026/07/23 11:14:07 ERROR : /: Dir.Stat error: couldn't list files: 401 Unauthorized: 401 Unauthorized
2026/07/23 11:14:07 ERROR : IO error: couldn't list files: 401 Unauthorized: 401 Unauthorized
```

Confirmed the exact same credentials work fine outside of rclone (a direct PROPFIND against `/webdav/` with the same Basic-Auth user/pass returns `207 Multi-Status` with real content).

Verified the fix directly against the running RC server before patching, both ways:

```
# Without obscure=true (reproduces the bug):
$ rclone rc --rc-addr=localhost:5573 --rc-user=admin --rc-pass=admin config/create name=testcfg type=webdav parameters='{"url":"http://localhost:8080/webdav","vendor":"other","user":"usenet","pass":"<real password>"}'
$ cat rclone.conf   # pass = <real password>   <- stored as plaintext
$ rclone rc ... operations/list fs=testcfg:   # -> 401 Unauthorized

# With obscure=true as a top-level arg:
$ rclone rc --rc-addr=localhost:5573 --rc-user=admin --rc-pass=admin config/create name=testcfg type=webdav parameters='{...}' obscure=true
$ cat rclone.conf   # pass = <obscured gibberish>
$ rclone rc ... operations/list fs=testcfg:   # -> real directory listing
```

With the patch applied and the mount recreated, the internal mount authenticates and lists real content correctly, and stayed working across a full container restart.

## Test plan

- [x] Reproduced the 401 on an unpatched build with `auth.login_required: true` + webdav user/password set
- [x] Verified the exact fix (`obscure: true` as a top-level RC arg) resolves it via direct RC calls before touching the Go source
- [x] Rebuilt with the one-line patch, confirmed the internal mount authenticates and serves real directory listings
- [x] Confirmed the mount survives a full container restart with the patch in place