### PR TITLE
fix(security): harden auth comparisons, CORS default, and remove dead salt code

### DIFF
--- a/internal/api/parsers.go
+++ b/internal/api/parsers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"strconv"
 	"time"
 
@@ -95,7 +96,7 @@ func (s *Server) validateAPIKey(c *fiber.Ctx, apiKey string) bool {
 	if s.configManager != nil {
 		cfg := s.configManager.GetConfig()
 		if cfg.API.KeyOverride != "" && len(cfg.API.KeyOverride) == 32 {
-			if apiKey == cfg.API.KeyOverride {
+			if subtle.ConstantTimeCompare([]byte(apiKey), []byte(cfg.API.KeyOverride)) == 1 {
 				return true
 			}
 		}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -189,22 +189,29 @@ func (s *Server) SetupRoutes(app *fiber.App) {
 	// Apply global middleware — derive allowed CORS origins from COOKIE_DOMAIN env var,
 	// explicit api.allowed_origins config, or fall back to wildcard.
 	corsOrigins := "*"
+	originsConfigured := false
 
 	if cookieDomain := os.Getenv("COOKIE_DOMAIN"); cookieDomain != "" {
 		// Allow both http and https on the configured domain
 		corsOrigins = "http://" + cookieDomain + ",https://" + cookieDomain
+		originsConfigured = true
 	}
 
 	if cfg != nil && len(cfg.API.AllowedOrigins) > 0 {
 		// Explicit config overrides the env-derived value
 		corsOrigins = strings.Join(cfg.API.AllowedOrigins, ",")
+		originsConfigured = true
 	}
 
+	// AllowCredentials must never be combined with a wildcard AllowOrigins — that pairing
+	// is invalid per the Fetch/CORS spec, and some client/proxy stacks paper over it by
+	// reflecting the caller's real Origin, effectively granting any site credentialed
+	// access. Only allow credentials once a real, explicit origin list is configured.
 	api.Use(cors.New(cors.Config{
 		AllowOrigins:     corsOrigins,
 		AllowHeaders:     "Origin, Content-Type, Accept, Authorization",
 		AllowMethods:     "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-		AllowCredentials: true,
+		AllowCredentials: originsConfigured,
 	}))
 	api.Use(recover.New())
 

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"strings"
-
 	"github.com/go-pkgz/auth/v2/token"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
@@ -92,8 +90,8 @@ func RequireAuthWithSkip(tokenService *token.Service, userRepo *database.UserRep
 		// Check if current path should skip authentication
 		path := c.Path()
 		for _, skipPath := range skipPaths {
-			if strings.HasPrefix(path, skipPath) {
-				// Skip authentication for this path
+			if path == skipPath {
+				// Skip authentication for this exact path
 				return c.Next()
 			}
 		}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -35,8 +33,7 @@ type Config struct {
 	CookieSameSite         http.SameSite // SameSite cookie attribute
 
 	// Direct authentication
-	DirectAuthEnabled bool   // Enable direct username/password authentication
-	DirectAuthSalt    string // Salt for direct authentication
+	DirectAuthEnabled bool // Enable direct username/password authentication
 
 	// Application settings
 	Issuer   string // JWT issuer
@@ -78,17 +75,6 @@ func LoadConfigFromEnv() (*Config, error) {
 		// Explicit env var disables auto-detection and forces a fixed value
 		config.CookieSecureAutoDetect = false
 		config.CookieSecure = secure != "false"
-	}
-
-	if salt := os.Getenv("DIRECT_AUTH_SALT"); salt != "" {
-		config.DirectAuthSalt = salt
-	} else {
-		// Generate a random salt for direct authentication
-		salt, err := generateRandomSalt()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate random salt: %w", err)
-		}
-		config.DirectAuthSalt = salt
 	}
 
 	if directAuth := os.Getenv("DIRECT_AUTH_ENABLED"); directAuth == "false" {
@@ -441,11 +427,3 @@ func (d *directCredChecker) Check(user, password string) (bool, error) {
 	return true, nil
 }
 
-// generateRandomSalt generates a cryptographically random salt for authentication
-func generateRandomSalt() (string, error) {
-	bytes := make([]byte, 32)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", fmt.Errorf("failed to generate random bytes: %w", err)
-	}
-	return hex.EncodeToString(bytes), nil
-}

--- a/internal/webdav/adapter.go
+++ b/internal/webdav/adapter.go
@@ -2,6 +2,7 @@ package webdav
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"log/slog"
 	"mime"
@@ -314,7 +315,9 @@ func NewHandler(
 		} else {
 			// Check against dynamic credentials
 			currentUser, currentPass := authCreds.GetCredentials()
-			if username == currentUser && password == currentPass {
+			userMatch := subtle.ConstantTimeCompare([]byte(username), []byte(currentUser)) == 1
+			passMatch := subtle.ConstantTimeCompare([]byte(password), []byte(currentPass)) == 1
+			if userMatch && passMatch {
 				authenticated = true
 				effectiveUser = username
 				slog.DebugContext(r.Context(), "WebDAV basic auth succeeded", "user", effectiveUser)


### PR DESCRIPTION
## Summary
Found while doing an independent source-level security/resource-leak audit of this repo. This PR bundles the small, low-risk fixes from that pass; two higher-impact findings (an SSRF path via the SABnzbd ARR-credential auth flow, and `IsAdmin` not being enforced on any destructive route) are intentionally **not** in this PR — they change real request-handling behavior and deserve a design discussion, so I'll open them as separate issues instead of forcing a fix.

- **Constant-time credential comparisons**: `internal/api/parsers.go`'s API-key-override check and `internal/webdav/adapter.go`'s Basic Auth check both used plain `==`, which short-circuits on the first differing byte. Switched both to `crypto/subtle.ConstantTimeCompare`. The WebDAV path is the more realistic target — it's hit on every request from every media client, a real sample count to average network jitter over.
- **Exact-match auth-skip paths**: `RequireAuthWithSkip` (`internal/auth/middleware.go`) matched configured skip-paths with `strings.HasPrefix` instead of exact equality. All configured skip paths (`/auth/login`, `/auth/register`, etc.) are exact endpoints, so this was never intentional prefix matching — just a latent landmine where a future route like `/auth/login-audit` would silently bypass auth by string-prefix coincidence.
- **CORS default**: `internal/api/server.go` defaulted `AllowOrigins` to `"*"` while also setting `AllowCredentials: true` whenever neither `COOKIE_DOMAIN` nor `api.allowed_origins` was configured — a very plausible default/quickstart deployment. Wildcard-origin + credentialed-CORS is a combination the Fetch/CORS spec exists to forbid; depending on how the CORS middleware version in use handles it, this can mean any origin gets credentialed access to the API. Credentials are now only allowed once an explicit origin is configured.
- **Removed dead `DirectAuthSalt`**: generated (or read from `DIRECT_AUTH_SALT`) and stored on `auth.Config`, but never read anywhere else in the codebase. bcrypt already salts stored password hashes on its own, so this field only implied an extra security layer that didn't actually exist. Removed the field, its generation function, and now-unused imports.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run` clean on touched packages
- [x] `go test ./internal/api/... ./internal/auth/... ./internal/webdav/...` — all pass (no existing webdav/auth test files)
- No behavior change intended beyond the CORS-credentials default; every other change is a drop-in comparison-function swap or dead-code removal.