### PR TITLE
fix(importer): reject path-traversal entries in RAR/7z archives

### DIFF
--- a/internal/importer/archive/rar/aggregator.go
+++ b/internal/importer/archive/rar/aggregator.go
@@ -306,6 +306,19 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 			internalSubDir = "."
 		}
 
+		// The archive's own internal path is attacker-controlled content (a RAR header
+		// inside an NZB an indexer can serve with no review). Reject any subdirectory
+		// that would escape virtualDir once cleaned, rather than letting filepath.Join
+		// silently walk the constructed path outside this release's own folder.
+		cleanedSubDir := filepath.ToSlash(filepath.Clean(internalSubDir))
+		if cleanedSubDir == ".." || strings.HasPrefix(cleanedSubDir, "../") {
+			slog.WarnContext(ctx, "Skipping RAR entry with path-traversal internal path",
+				"internal_path", rarContent.InternalPath,
+				"resolved_subdir", cleanedSubDir)
+			continue
+		}
+		internalSubDir = cleanedSubDir
+
 		var virtualFilePath string
 		if internalSubDir == "." || internalSubDir == "" {
 			virtualFilePath = filepath.Join(virtualDir, baseFilename)

--- a/internal/importer/archive/sevenzip/aggregator.go
+++ b/internal/importer/archive/sevenzip/aggregator.go
@@ -237,6 +237,19 @@ func ProcessArchive(ctx context.Context, opts ProcessArchiveOptions) error {
 			internalSubDir = "."
 		}
 
+		// The archive's own internal path is attacker-controlled content (a 7z header
+		// inside an NZB an indexer can serve with no review). Reject any subdirectory
+		// that would escape virtualDir once cleaned, rather than letting filepath.Join
+		// silently walk the constructed path outside this release's own folder.
+		cleanedSubDir := filepath.ToSlash(filepath.Clean(internalSubDir))
+		if cleanedSubDir == ".." || strings.HasPrefix(cleanedSubDir, "../") {
+			slog.WarnContext(ctx, "Skipping 7zip entry with path-traversal internal path",
+				"internal_path", sevenZipContent.InternalPath,
+				"resolved_subdir", cleanedSubDir)
+			continue
+		}
+		internalSubDir = cleanedSubDir
+
 		var virtualFilePath string
 		if internalSubDir == "." || internalSubDir == "" {
 			virtualFilePath = filepath.Join(virtualDir, baseFilename)


### PR DESCRIPTION
## Summary
Found during an independent source-level security audit of this repo.

Both the RAR and 7z aggregators (`internal/importer/archive/rar/aggregator.go`, `internal/importer/archive/sevenzip/aggregator.go`) build a virtual filesystem path for each extracted entry using `InternalPath`, which comes directly from the archive's own header — fully attacker-controlled content inside an NZB that Radarr/Sonarr can auto-grab from any indexer with zero human review. Neither aggregator rejected a `..`-containing internal path before handing it to `filepath.Join`, which **cleans** the result rather than rejecting it.

Concretely: a crafted archive entry with an internal path like `../../other-release/movie.mkv` could walk the constructed virtual path outside its own import folder, potentially shadowing or overwriting metadata records elsewhere in the DB-backed virtual tree that WebDAV/FUSE serve library content from — breaking the implicit "each import stays inside its own virtual directory" invariant the rest of the pipeline (dedup checks, health/library-sync logic) relies on.

## Fix
After computing the internal subdirectory (and after any ISO/normalization renames collapse it to `.`), both aggregators now `filepath.Clean` it and skip the entry (with a warning log identifying the offending archive path) if the cleaned result is `..` or starts with `../` — before it's ever used to build a path via `filepath.Join`.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] `go test ./internal/importer/archive/...` — all pass
- No behavior change for well-formed archives; only affects entries whose internal path would otherwise escape the release's own virtual directory.