### PR TITLE
fix: track background goroutines in their owner's waitgroup/context

### DIFF
--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -352,10 +352,24 @@ func (hw *HealthWorker) PerformBackgroundCheck(ctx context.Context, filePath str
 		return fmt.Errorf("health worker is not running")
 	}
 
-	// Start health check in background
-	go func() {
+	// Start health check in background. Tracked in hw.wg (like the main worker
+	// loop) so Stop() actually waits for it instead of returning while this is
+	// still running against the health repo / NNTP pool, and watches stopChan
+	// so a worker shutdown cancels it promptly rather than waiting out the
+	// full 10-minute timeout.
+	hw.wg.Go(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
+
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-hw.stopChan:
+				cancel()
+			case <-done:
+			}
+		}()
 
 		checkErr := hw.performDirectCheck(ctx, filePath)
 		if checkErr != nil {
@@ -379,7 +393,7 @@ func (hw *HealthWorker) PerformBackgroundCheck(ctx context.Context, filePath str
 				slog.ErrorContext(ctx, "Failed to update status after failed check", "file_path", filePath, "error", updateErr)
 			}
 		}
-	}()
+	})
 
 	return nil
 }

--- a/internal/importer/queue/manager.go
+++ b/internal/importer/queue/manager.go
@@ -220,9 +220,20 @@ func (m *Manager) ExecuteItem(ctx context.Context, itemID int64) error {
 
 	m.log.InfoContext(ctx, "Manually triggering processing for queue item", "queue_id", itemID)
 
+	// Derive from the manager's own lifecycle context (m.ctx), not the incoming
+	// request ctx, so a client disconnect doesn't cut this run off early — but
+	// still ties into Stop()'s cancellation, and is tracked in m.wg like every
+	// other worker goroutine so Stop() actually waits for it instead of
+	// reporting a clean shutdown while this is still running.
+	m.mu.RLock()
+	baseCtx := m.ctx
+	m.mu.RUnlock()
+
+	m.wg.Add(1)
 	go func() {
-		// Use a separate context for the execution to avoid early termination
-		itemCtx, cancel := context.WithCancel(context.Background())
+		defer m.wg.Done()
+
+		itemCtx, cancel := context.WithCancel(baseCtx)
 		m.cancelMu.Lock()
 		m.cancelFuncs[item.ID] = cancel
 		m.cancelMu.Unlock()
@@ -231,6 +242,7 @@ func (m *Manager) ExecuteItem(ctx context.Context, itemID int64) error {
 			m.cancelMu.Lock()
 			delete(m.cancelFuncs, item.ID)
 			m.cancelMu.Unlock()
+			cancel()
 		}()
 
 		resultingPath, processingErr := m.processor.ProcessItem(itemCtx, item)

--- a/internal/pool/manager.go
+++ b/internal/pool/manager.go
@@ -217,9 +217,13 @@ func (m *manager) SetProviders(providers []nntppool.Provider) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Shut down existing pool and metrics tracker if present
+	// Shut down existing pool, quota watcher, and metrics tracker if present.
+	// Stopping the quota watcher here (symmetric with ClearPool below) rather
+	// than relying on startQuotaWatcher()'s already-running no-op guard keeps
+	// its stop/start pairing explicit around each pool replacement.
 	if m.pool != nil {
 		m.logger.InfoContext(m.ctx, "Shutting down existing NNTP connection pool")
+		m.stopQuotaWatcher()
 		if m.metricsTracker != nil {
 			m.metricsTracker.Stop()
 			m.metricsTracker = nil


### PR DESCRIPTION
## Summary
Found during an independent source-level resource-leak audit of this repo. Three separate spots spawn a goroutine that outlives its owner's own shutdown signal, meaning `Stop()`/`SetProviders()` can report clean completion while work is still running underneath:

1. **`HealthWorker.PerformBackgroundCheck`** (`internal/health/worker.go`): span up a bare `go func()` rooted on a fresh `context.Background()` with its own 10-minute timeout — registered in neither `hw.wg` nor any shutdown signal, unlike the main worker loop (which correctly uses `hw.wg.Go(...)`). `Stop()` returned immediately while a background check kept running against the health repo/NNTP pool, racing a subsequent teardown. Every call to this path also bypassed the worker's own configured concurrency cap (`getMaxConcurrentJobs()`) entirely, since it's a fully independent goroutine.
   - Fix: now spawned via `hw.wg.Go(...)` (same convention as the main loop) and watches `hw.stopChan` via a small internal watcher so a worker shutdown cancels the check promptly instead of waiting out the full 10-minute timeout.

2. **`Manager.ExecuteItem`** (`internal/importer/queue/manager.go`): identical pattern — an untracked goroutine rooted on `context.Background()`, so `Manager.Stop()`'s `m.wg.Wait()` never waited for a manually-triggered import to finish.
   - Fix: added to `m.wg`, and now derives its context from the manager's own lifecycle context (`m.ctx`) instead of `context.Background()` — still isolated from the incoming HTTP request context (so a client disconnecting the browser tab doesn't cut the run short, preserving the original intent noted in a comment there), but now properly cancelled when the manager itself stops.

3. **`pool.manager.SetProviders`** (`internal/pool/manager.go`): tore down the existing NNTP pool without stopping the quota watcher goroutine first — relying entirely on `startQuotaWatcher()`'s "already running" no-op guard to avoid a double-start. This happens to be harmless today only because the watcher always re-reads the current pool under lock rather than closing over a specific pool instance; a future refactor that captured the pool by reference would silently start operating on a stale/closed pool.
   - Fix: `stopQuotaWatcher()` is now called symmetrically alongside the existing pool teardown in `SetProviders`, matching how `ClearPool()` already does it.

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] `golangci-lint run` clean
- [x] `go test ./internal/health/... ./internal/importer/queue/... ./internal/pool/...` — all pass
- These are lifecycle/shutdown-path fixes; normal request-serving behavior is unaffected. The main risk area is shutdown ordering, which the existing test suites for these packages already exercise.