### PR TITLE
feat(nzbfilesystem): trigger immediate ARR repair search on playback holes

### DIFF
--- a/internal/database/health_repository.go
+++ b/internal/database/health_repository.go
@@ -362,12 +362,104 @@ func (r *HealthRepository) GetFilesForRepairNotification(ctx context.Context, li
 		}
 		files = append(files, &health)
 	}
-
 	if err = rows.Err(); err != nil {
 		return nil, fmt.Errorf("failed to iterate files for repair notification: %w", err)
 	}
 
 	return files, nil
+}
+
+// GetFilesForImmediateRepair returns files with a pending immediate-repair
+// request (set by nzbfilesystem's padRecorder the moment a playback hole is
+// confirmed - see migration 035). The worker fires an ARR rescan for each
+// without a CheckFile pass or a status change; see
+// HealthWorker.triggerImmediateRepairOnly. Only file_path is needed here -
+// the worker re-fetches the full record per file (same pattern
+// GetFilesForRepairNotification's caller already uses) so a webhook-updated
+// library_path is never stale by the time the ARR trigger fires.
+func (r *HealthRepository) GetFilesForImmediateRepair(ctx context.Context, limit int) ([]*FileHealth, error) {
+	query := `
+		SELECT file_path
+		FROM file_health
+		WHERE immediate_repair_requested_at IS NOT NULL
+		ORDER BY immediate_repair_requested_at ASC
+		LIMIT ?
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query files for immediate repair: %w", err)
+	}
+	defer rows.Close()
+
+	var immediateFiles []*FileHealth
+	for rows.Next() {
+		var filePath string
+		if err := rows.Scan(&filePath); err != nil {
+			return nil, fmt.Errorf("failed to scan file path for immediate repair: %w", err)
+		}
+		immediateFiles = append(immediateFiles, &FileHealth{FilePath: filePath})
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate files for immediate repair: %w", err)
+	}
+
+	return immediateFiles, nil
+}
+
+// SetImmediateRepairRequested marks filePath as needing an immediate ARR
+// repair trigger on the health worker's next cycle. Idempotent: repeated
+// calls before the worker processes it just refresh the timestamp, which is
+// harmless since GetFilesForImmediateRepair only cares that it's non-NULL.
+// A no-op (not an error) if the health record doesn't exist yet.
+func (r *HealthRepository) SetImmediateRepairRequested(ctx context.Context, filePath string) error {
+	filePath = normalizeHealthPath(filePath)
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE file_health SET immediate_repair_requested_at = datetime('now') WHERE file_path = ?`,
+		filePath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set immediate repair requested: %w", err)
+	}
+	return nil
+}
+
+// ClearImmediateRepairRequested clears a pending immediate-repair request
+// without touching the repair-retry budget - used when the worker decides
+// not to fire (repair disabled, or the budget is already exhausted).
+func (r *HealthRepository) ClearImmediateRepairRequested(ctx context.Context, filePath string) error {
+	filePath = normalizeHealthPath(filePath)
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE file_health SET immediate_repair_requested_at = NULL WHERE file_path = ?`,
+		filePath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to clear immediate repair requested: %w", err)
+	}
+	return nil
+}
+
+// RecordImmediateRepairAttempt clears a file's pending immediate-repair
+// request and increments its repair-retry budget counter - called after the
+// worker actually fires (or attempts to fire) the ARR trigger, regardless of
+// whether ARR's response was success or failure: the counter's purpose is to
+// bound how many times this specific file is asked for, independent of
+// whether any individual ask "worked" (ARR accepting the request is not the
+// same as ARR ever delivering a good replacement).
+func (r *HealthRepository) RecordImmediateRepairAttempt(ctx context.Context, filePath string) error {
+	filePath = normalizeHealthPath(filePath)
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE file_health
+		 SET immediate_repair_requested_at = NULL,
+		     repair_retry_count = repair_retry_count + 1,
+		     updated_at = CURRENT_TIMESTAMP
+		 WHERE file_path = ?`,
+		filePath,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record immediate repair attempt: %w", err)
+	}
+	return nil
 }
 
 // IncrementRetryCount increments the retry count and schedules next check

--- a/internal/database/migrations/sqlite/035_add_immediate_repair_requested.sql
+++ b/internal/database/migrations/sqlite/035_add_immediate_repair_requested.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Marks a file as needing an immediate ARR repair trigger, set by the FUSE
+-- layer's pad recorder the moment a playback hole is confirmed (see
+-- nzbfilesystem.padRecorder). Non-NULL = a trigger is pending; the health
+-- worker picks these up in a dedicated lane that fires the ARR rescan only
+-- (no CheckFile, no safety-folder move, no status change) so the file stays
+-- degraded and streamable while a live stream may still be reading it. A
+-- plain nullable column rather than a new health_status value: status is
+-- CHECK-constrained (see migration 033), so a new enum value would need a
+-- full table rebuild; this needs none.
+ALTER TABLE file_health ADD COLUMN immediate_repair_requested_at DATETIME DEFAULT NULL;
+
+CREATE INDEX idx_file_health_immediate_repair
+    ON file_health(immediate_repair_requested_at)
+    WHERE immediate_repair_requested_at IS NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP INDEX IF EXISTS idx_file_health_immediate_repair;
+-- SQLite cannot drop a column without a full table rebuild; left in place on
+-- down migration, matching migration 034's own documented precedent for the
+-- same situation (download_id).
+
+-- +goose StatementEnd

--- a/internal/database/models.go
+++ b/internal/database/models.go
@@ -121,6 +121,11 @@ type FileHealth struct {
 	IsMasked              bool    `db:"is_masked"`
 	Indexer               *string `db:"indexer"`
 	DownloadID            *string `db:"download_id"`
+	// ImmediateRepairRequestedAt is non-nil when the FUSE layer's pad recorder
+	// has asked the health worker to fire an ARR repair rescan for this file
+	// on its next cycle, bypassing the normal scheduled check. See migration
+	// 035 and health.HealthWorker.triggerImmediateRepairOnly.
+	ImmediateRepairRequestedAt *time.Time `db:"immediate_repair_requested_at"`
 }
 
 // IsImported reports whether library_path points to a real, ARR-relinked library

--- a/internal/health/repair_e2e_test.go
+++ b/internal/health/repair_e2e_test.go
@@ -128,7 +128,8 @@ func newRepairTestEnv(t *testing.T, tempDir string, arrsErr error, configure ...
 			streaming_failure_count INTEGER DEFAULT 0,
 			is_masked BOOLEAN DEFAULT FALSE,
 			indexer TEXT DEFAULT NULL,
-			download_id TEXT DEFAULT NULL
+			download_id TEXT DEFAULT NULL,
+			immediate_repair_requested_at DATETIME DEFAULT NULL
 		);
 
 		CREATE TABLE IF NOT EXISTS system_state (

--- a/internal/health/worker.go
+++ b/internal/health/worker.go
@@ -822,7 +822,17 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 		}
 	}
 
-	totalFiles := len(unhealthyFiles) + len(repairFiles)
+	// Files with a pending immediate-repair request (playback holes - see
+	// triggerImmediateRepairOnly's doc comment). Fetched regardless of
+	// cfg.GetRepairEnabled(): triggerImmediateRepairOnly checks that itself
+	// per file and clears the request either way, so a disabled repair
+	// setting doesn't leave requests stuck forever.
+	immediateRepairFiles, err := hw.healthRepo.GetFilesForImmediateRepair(ctx, maxJobs)
+	if err != nil {
+		return fmt.Errorf("failed to get files for immediate repair: %w", err)
+	}
+
+	totalFiles := len(unhealthyFiles) + len(repairFiles) + len(immediateRepairFiles)
 	if totalFiles == 0 {
 		hw.updateStats(func(s *WorkerStats) {
 			s.CurrentRunStartTime = nil
@@ -838,6 +848,7 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 	slog.InfoContext(ctx, "Found files to process",
 		"health_check_files", len(unhealthyFiles),
 		"repair_notification_files", len(repairFiles),
+		"immediate_repair_files", len(immediateRepairFiles),
 		"total", totalFiles,
 		"max_concurrent_jobs", maxJobs)
 
@@ -955,6 +966,37 @@ func (hw *HealthWorker) runHealthCheckCycle(ctx context.Context) error {
 			resultsMu.Unlock()
 
 			// Update cycle progress stats
+			hw.updateStats(func(s *WorkerStats) {
+				s.CurrentRunFilesChecked++
+				s.TotalFilesChecked++
+			})
+		})
+	}
+
+	for _, fileHealth := range immediateRepairFiles {
+		fh := fileHealth // Capture for closure
+		p.Go(func() {
+			// Re-fetch the full record: the listing query only returned
+			// file_path (see GetFilesForImmediateRepair), and this also picks
+			// up any library_path a concurrent webhook relinked in the
+			// meantime, same reasoning as the repairFiles loop above.
+			latest, err := hw.healthRepo.GetFileHealth(ctx, fh.FilePath)
+			if err != nil || latest == nil {
+				slog.WarnContext(ctx, "Skipping immediate repair — could not re-fetch health record",
+					"file_path", fh.FilePath, "error", err)
+				if clearErr := hw.healthRepo.ClearImmediateRepairRequested(ctx, fh.FilePath); clearErr != nil {
+					slog.WarnContext(ctx, "Failed to clear immediate repair request", "file_path", fh.FilePath, "error", clearErr)
+				}
+				return
+			}
+
+			// triggerImmediateRepairOnly does its own direct repository writes
+			// (clear/record) rather than going through the results/
+			// UpdateHealthStatusBulk path below: unlike every other update in
+			// this cycle it deliberately makes no status transition at all, so
+			// there is no HealthStatusUpdate/UpdateType that fits it.
+			hw.triggerImmediateRepairOnly(ctx, latest)
+
 			hw.updateStats(func(s *WorkerStats) {
 				s.CurrentRunFilesChecked++
 				s.TotalFilesChecked++
@@ -1272,6 +1314,68 @@ func (hw *HealthWorker) retriggerFileRepair(ctx context.Context, item *database.
 
 	slog.InfoContext(ctx, "Successfully re-triggered ARR rescan", "file_path", filePath)
 	return repairOutcomeTriggered, nil
+}
+
+// triggerImmediateRepairOnly fires an ARR rescan for a file with a pending
+// immediate-repair request (set by nzbfilesystem's padRecorder the moment a
+// playback hole is confirmed during live streaming - see migration 035 and
+// database.HealthRepository.SetImmediateRepairRequested), skipping every
+// other side effect the normal repair path has: no CheckFile (playback
+// already confirmed the hole; re-verifying it is redundant), no safety-folder
+// move, and no change to item.Status. The file must stay degraded and
+// streamable throughout, since the stream that triggered this may still be
+// reading it.
+//
+// Unlike the direct call this replaces, it inherits the same safeguards the
+// worker already enforces around every other ARR trigger: skipped entirely
+// when repair is disabled, and bounded by the same repair-retry budget
+// (RepairRetryCount vs MaxRepairRetries) so a permanently-broken release
+// cannot be re-downloaded on every debounce window forever. item is expected
+// to have been freshly re-fetched via GetFileHealth (see the call site in
+// runHealthCheckCycle) so LibraryPath/Indexer/Metadata are current, not a
+// stale snapshot from the initial GetFilesForImmediateRepair listing query.
+func (hw *HealthWorker) triggerImmediateRepairOnly(ctx context.Context, item *database.FileHealth) {
+	filePath := item.FilePath
+
+	if !hw.configGetter().GetRepairEnabled() {
+		slog.DebugContext(ctx, "Immediate repair request skipped: repair is disabled", "file_path", filePath)
+		if err := hw.healthRepo.ClearImmediateRepairRequested(ctx, filePath); err != nil {
+			slog.WarnContext(ctx, "Failed to clear immediate repair request", "file_path", filePath, "error", err)
+		}
+		return
+	}
+
+	if item.RepairRetryCount >= hw.configGetter().GetMaxRepairRetries() {
+		slog.WarnContext(ctx, "Immediate repair request skipped: repair budget already exhausted for this file",
+			"file_path", filePath, "repair_retry_count", item.RepairRetryCount)
+		if err := hw.healthRepo.ClearImmediateRepairRequested(ctx, filePath); err != nil {
+			slog.WarnContext(ctx, "Failed to clear immediate repair request", "file_path", filePath, "error", err)
+		}
+		return
+	}
+
+	pathForRescan := hw.resolvePathForRescan(item)
+	metadataStr := hw.ensureMetadata(ctx, item)
+
+	slog.InfoContext(ctx, "Playback hole confirmed, triggering immediate ARR repair search",
+		"file_path", filePath, "path_for_rescan", pathForRescan, "repair_retry_count", item.RepairRetryCount)
+
+	if err := hw.arrsService.TriggerFileRescan(ctx, pathForRescan, filePath, metadataStr); err != nil {
+		if item.Indexer != nil && *item.Indexer != "" && *item.Indexer != database.IndexerUnknown {
+			_ = hw.healthRepo.LogIndexerImport(ctx, *item.Indexer, "failed",
+				fmt.Sprintf("Immediate repair search failed: %s", err), "")
+		}
+		slog.WarnContext(ctx, "Immediate repair search failed (file remains degraded; will retry on the next playback hole or scheduled check)",
+			"file_path", filePath, "error", err)
+	}
+
+	// Increment the retry budget regardless of the outcome above: the counter
+	// bounds how many times this file is asked for, independent of whether
+	// any individual ask "worked" (ARR accepting the request is not the same
+	// as ARR ever delivering a good replacement).
+	if err := hw.healthRepo.RecordImmediateRepairAttempt(ctx, filePath); err != nil {
+		slog.WarnContext(ctx, "Failed to record immediate repair attempt", "file_path", filePath, "error", err)
+	}
 }
 
 func (hw *HealthWorker) ensureMetadata(ctx context.Context, item *database.FileHealth) *string {

--- a/internal/health/worker_test.go
+++ b/internal/health/worker_test.go
@@ -45,7 +45,8 @@ func setupWorkerTestDB(t *testing.T) (*database.HealthRepository, *sql.DB) {
 			streaming_failure_count INTEGER DEFAULT 0,
 			is_masked BOOLEAN DEFAULT FALSE,
 			indexer TEXT DEFAULT NULL,
-			download_id TEXT DEFAULT NULL
+			download_id TEXT DEFAULT NULL,
+			immediate_repair_requested_at DATETIME DEFAULT NULL
 		);
 	`)
 	require.NoError(t, err)

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -90,7 +90,7 @@ func NewMetadataRemoteFile(
 		streamTracker:    streamTracker,
 		cacheSource:      cacheSource,
 		repairCoalescer:  repairCoalescer,
-		padRecorder:      newPadRecorder(metadataService, healthRepository, repairCoalescer),
+		padRecorder:      newPadRecorder(metadataService, healthRepository, repairCoalescer, arrsService, configGetter),
 	}
 }
 

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -90,7 +90,7 @@ func NewMetadataRemoteFile(
 		streamTracker:    streamTracker,
 		cacheSource:      cacheSource,
 		repairCoalescer:  repairCoalescer,
-		padRecorder:      newPadRecorder(metadataService, healthRepository, repairCoalescer, arrsService, configGetter),
+		padRecorder:      newPadRecorder(metadataService, healthRepository, repairCoalescer),
 	}
 }
 

--- a/internal/nzbfilesystem/pad_recorder.go
+++ b/internal/nzbfilesystem/pad_recorder.go
@@ -6,11 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
-	"github.com/javi11/altmount/internal/utils"
 )
 
 // padMetadataStore is the slice of metadata.MetadataService the pad recorder
@@ -24,18 +22,15 @@ type padMetadataStore interface {
 // needs; narrowed to an interface so tests can fake it.
 type padHealthStore interface {
 	UpdateFileHealthScheduled(ctx context.Context, filePath string, status database.HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error
-	GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error)
-}
-
-// padArrsTrigger is the slice of ARRsRepairService the pad recorder needs;
-// narrowed to an interface (same shape as ARRsRepairService, declared
-// separately so tests can fake it without importing that type) so a
-// degraded-pad event can independently ask the owning ARR instance to
-// blocklist+redownload the title without going through the corrupted-file
-// repair lifecycle (no safety-folder move, no FILE_STATUS_CORRUPTED - the
-// file stays visible and streamable throughout).
-type padArrsTrigger interface {
-	TriggerFileRescan(ctx context.Context, pathForRescan string, relativePath string, metadataStr *string) error
+	// SetImmediateRepairRequested asks the health worker to fire an ARR
+	// repair rescan for this file on its next cycle, without moving it into
+	// the corrupted-file repair lifecycle - see
+	// database.HealthRepository.SetImmediateRepairRequested and
+	// health.HealthWorker.triggerImmediateRepairOnly for the full picture.
+	// The worker owns every safeguard around firing it (repair-enabled gate,
+	// retry budget, back-off, indexer logging, path resolution): the pad
+	// recorder's only job is to ask.
+	SetImmediateRepairRequested(ctx context.Context, filePath string) error
 }
 
 // padEvent carries everything a degraded-pad record needs as plain values.
@@ -68,31 +63,24 @@ const padRecorderQueueSize = 128
 // file handles that produced them and Close()'ing a handle never races the
 // recording. Compare RepairCoalescer, which owns the repair side the same way.
 type padRecorder struct {
-	ch           chan padEvent
-	metadata     padMetadataStore
-	health       padHealthStore
-	coalescer    *RepairCoalescer
-	arrs         padArrsTrigger
-	configGetter config.ConfigGetter
+	ch        chan padEvent
+	metadata  padMetadataStore
+	health    padHealthStore
+	coalescer *RepairCoalescer
 
 	stopCh chan struct{}
 	stopWg sync.WaitGroup
 }
 
 // newPadRecorder constructs a recorder and starts its worker. The worker runs
-// for the lifetime of the process; call Close to stop it in tests. arrs and
-// configGetter may be nil (e.g. test harnesses building a bare recorder) -
-// the immediate-repair-search trigger degrades to a no-op when either is nil,
-// same tolerance every other optional collaborator in this file already has.
-func newPadRecorder(metadata padMetadataStore, health padHealthStore, coalescer *RepairCoalescer, arrs padArrsTrigger, configGetter config.ConfigGetter) *padRecorder {
+// for the lifetime of the process; call Close to stop it in tests.
+func newPadRecorder(metadata padMetadataStore, health padHealthStore, coalescer *RepairCoalescer) *padRecorder {
 	r := &padRecorder{
-		ch:           make(chan padEvent, padRecorderQueueSize),
-		metadata:     metadata,
-		health:       health,
-		coalescer:    coalescer,
-		arrs:         arrs,
-		configGetter: configGetter,
-		stopCh:       make(chan struct{}),
+		ch:        make(chan padEvent, padRecorderQueueSize),
+		metadata:  metadata,
+		health:    health,
+		coalescer: coalescer,
+		stopCh:    make(chan struct{}),
 	}
 	r.stopWg.Add(1)
 	go r.run()
@@ -203,69 +191,19 @@ func (r *padRecorder) record(ev padEvent) {
 		slog.WarnContext(ctx, "Failed to record degraded status for padded file", "file", ev.name, "error", err)
 	}
 
-	r.triggerImmediateRepairSearch(ev)
-}
-
-// triggerImmediateRepairSearch asks the owning ARR instance to search for a
-// replacement the moment a playback hole is confirmed, instead of waiting for
-// the file's next scheduled health check (up to 90 days out for files older
-// than 30 days - see health.normalCheckInterval). Deliberately does NOT move
-// the file to the corrupted-safety folder or change its FILE_STATUS: the
-// current stream must keep reading the degraded-but-playable file undisturbed
-// (see the padRecorder doc comment). ARR's own delete+search path only acts
-// when the resolved movie/episode file actually matches this virtual file's
-// library path (see radarrFileMatchesTarget / its Sonarr equivalent), so
-// BearMount's own copy is never touched here - only the ARR-side record.
-//
-// Runs on its own goroutine so a slow ARR round-trip never stalls this
-// recorder's single serialized worker loop (see padRecorder's doc comment);
-// bounded by the same "\x00degraded-pad" debounce key already checked above,
-// so at most one of these fires per file per debounce window regardless of
-// how many holes it accumulates in that window.
-func (r *padRecorder) triggerImmediateRepairSearch(ev padEvent) {
-	if r.arrs == nil || r.configGetter == nil {
-		return
+	// Ask the health worker to fire an immediate ARR repair rescan on its next
+	// cycle, instead of waiting for this file's next scheduled health check
+	// (up to 90 days out for files older than 30 days - see
+	// health.normalCheckInterval). The worker (health.HealthWorker.
+	// triggerImmediateRepairOnly) owns everything about how that happens -
+	// the repair-enabled gate, the repair-retry budget, path resolution,
+	// back-off, indexer failure logging - the same way it already owns every
+	// other ARR trigger; the pad recorder's job stops at asking. This also
+	// keeps the invariant from the doc comment above intact automatically:
+	// the worker's immediate-repair lane never moves metadata to the
+	// corrupted-safety folder or changes FILE_STATUS, so the current stream
+	// keeps reading the degraded-but-playable file undisturbed.
+	if err := r.health.SetImmediateRepairRequested(ctx, ev.name); err != nil {
+		slog.WarnContext(ctx, "Failed to request immediate repair", "file", ev.name, "error", err)
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		fh, err := r.health.GetFileHealth(ctx, ev.name)
-		if err != nil {
-			slog.WarnContext(ctx, "Immediate repair-search: could not read health record, skipping",
-				"file", ev.name, "error", err)
-			return
-		}
-
-		var pathForRescan string
-		if fh != nil {
-			if p, ok := fh.EffectiveLibraryPath(); ok {
-				pathForRescan = p
-			}
-		}
-		if pathForRescan == "" {
-			cfg := r.configGetter()
-			switch {
-			case cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "":
-				pathForRescan = utils.JoinAbsPath(*cfg.Health.LibraryDir, ev.name)
-			case cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "":
-				pathForRescan = utils.JoinAbsPath(*cfg.Import.ImportDir, ev.name)
-			default:
-				pathForRescan = utils.JoinAbsPath(cfg.MountPath, ev.name)
-			}
-		}
-
-		var metadataStr *string
-		if fh != nil {
-			metadataStr = fh.Metadata
-		}
-
-		slog.InfoContext(ctx, "Playback hole confirmed, triggering immediate ARR repair search",
-			"file", ev.name, "path_for_rescan", pathForRescan, "total_missing", ev.total)
-
-		if err := r.arrs.TriggerFileRescan(ctx, pathForRescan, ev.name, metadataStr); err != nil {
-			slog.WarnContext(ctx, "Immediate repair search failed (file remains degraded, next scheduled check will retry)",
-				"file", ev.name, "error", err)
-		}
-	}()
 }

--- a/internal/nzbfilesystem/pad_recorder.go
+++ b/internal/nzbfilesystem/pad_recorder.go
@@ -6,9 +6,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/utils"
 )
 
 // padMetadataStore is the slice of metadata.MetadataService the pad recorder
@@ -22,6 +24,18 @@ type padMetadataStore interface {
 // needs; narrowed to an interface so tests can fake it.
 type padHealthStore interface {
 	UpdateFileHealthScheduled(ctx context.Context, filePath string, status database.HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error
+	GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error)
+}
+
+// padArrsTrigger is the slice of ARRsRepairService the pad recorder needs;
+// narrowed to an interface (same shape as ARRsRepairService, declared
+// separately so tests can fake it without importing that type) so a
+// degraded-pad event can independently ask the owning ARR instance to
+// blocklist+redownload the title without going through the corrupted-file
+// repair lifecycle (no safety-folder move, no FILE_STATUS_CORRUPTED - the
+// file stays visible and streamable throughout).
+type padArrsTrigger interface {
+	TriggerFileRescan(ctx context.Context, pathForRescan string, relativePath string, metadataStr *string) error
 }
 
 // padEvent carries everything a degraded-pad record needs as plain values.
@@ -54,24 +68,31 @@ const padRecorderQueueSize = 128
 // file handles that produced them and Close()'ing a handle never races the
 // recording. Compare RepairCoalescer, which owns the repair side the same way.
 type padRecorder struct {
-	ch        chan padEvent
-	metadata  padMetadataStore
-	health    padHealthStore
-	coalescer *RepairCoalescer
+	ch           chan padEvent
+	metadata     padMetadataStore
+	health       padHealthStore
+	coalescer    *RepairCoalescer
+	arrs         padArrsTrigger
+	configGetter config.ConfigGetter
 
 	stopCh chan struct{}
 	stopWg sync.WaitGroup
 }
 
 // newPadRecorder constructs a recorder and starts its worker. The worker runs
-// for the lifetime of the process; call Close to stop it in tests.
-func newPadRecorder(metadata padMetadataStore, health padHealthStore, coalescer *RepairCoalescer) *padRecorder {
+// for the lifetime of the process; call Close to stop it in tests. arrs and
+// configGetter may be nil (e.g. test harnesses building a bare recorder) -
+// the immediate-repair-search trigger degrades to a no-op when either is nil,
+// same tolerance every other optional collaborator in this file already has.
+func newPadRecorder(metadata padMetadataStore, health padHealthStore, coalescer *RepairCoalescer, arrs padArrsTrigger, configGetter config.ConfigGetter) *padRecorder {
 	r := &padRecorder{
-		ch:        make(chan padEvent, padRecorderQueueSize),
-		metadata:  metadata,
-		health:    health,
-		coalescer: coalescer,
-		stopCh:    make(chan struct{}),
+		ch:           make(chan padEvent, padRecorderQueueSize),
+		metadata:     metadata,
+		health:       health,
+		coalescer:    coalescer,
+		arrs:         arrs,
+		configGetter: configGetter,
+		stopCh:       make(chan struct{}),
 	}
 	r.stopWg.Add(1)
 	go r.run()
@@ -181,4 +202,70 @@ func (r *padRecorder) record(ev padEvent) {
 	); err != nil {
 		slog.WarnContext(ctx, "Failed to record degraded status for padded file", "file", ev.name, "error", err)
 	}
+
+	r.triggerImmediateRepairSearch(ev)
+}
+
+// triggerImmediateRepairSearch asks the owning ARR instance to search for a
+// replacement the moment a playback hole is confirmed, instead of waiting for
+// the file's next scheduled health check (up to 90 days out for files older
+// than 30 days - see health.normalCheckInterval). Deliberately does NOT move
+// the file to the corrupted-safety folder or change its FILE_STATUS: the
+// current stream must keep reading the degraded-but-playable file undisturbed
+// (see the padRecorder doc comment). ARR's own delete+search path only acts
+// when the resolved movie/episode file actually matches this virtual file's
+// library path (see radarrFileMatchesTarget / its Sonarr equivalent), so
+// BearMount's own copy is never touched here - only the ARR-side record.
+//
+// Runs on its own goroutine so a slow ARR round-trip never stalls this
+// recorder's single serialized worker loop (see padRecorder's doc comment);
+// bounded by the same "\x00degraded-pad" debounce key already checked above,
+// so at most one of these fires per file per debounce window regardless of
+// how many holes it accumulates in that window.
+func (r *padRecorder) triggerImmediateRepairSearch(ev padEvent) {
+	if r.arrs == nil || r.configGetter == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		fh, err := r.health.GetFileHealth(ctx, ev.name)
+		if err != nil {
+			slog.WarnContext(ctx, "Immediate repair-search: could not read health record, skipping",
+				"file", ev.name, "error", err)
+			return
+		}
+
+		var pathForRescan string
+		if fh != nil {
+			if p, ok := fh.EffectiveLibraryPath(); ok {
+				pathForRescan = p
+			}
+		}
+		if pathForRescan == "" {
+			cfg := r.configGetter()
+			switch {
+			case cfg.Health.LibraryDir != nil && *cfg.Health.LibraryDir != "":
+				pathForRescan = utils.JoinAbsPath(*cfg.Health.LibraryDir, ev.name)
+			case cfg.Import.ImportDir != nil && *cfg.Import.ImportDir != "":
+				pathForRescan = utils.JoinAbsPath(*cfg.Import.ImportDir, ev.name)
+			default:
+				pathForRescan = utils.JoinAbsPath(cfg.MountPath, ev.name)
+			}
+		}
+
+		var metadataStr *string
+		if fh != nil {
+			metadataStr = fh.Metadata
+		}
+
+		slog.InfoContext(ctx, "Playback hole confirmed, triggering immediate ARR repair search",
+			"file", ev.name, "path_for_rescan", pathForRescan, "total_missing", ev.total)
+
+		if err := r.arrs.TriggerFileRescan(ctx, pathForRescan, ev.name, metadataStr); err != nil {
+			slog.WarnContext(ctx, "Immediate repair search failed (file remains degraded, next scheduled check will retry)",
+				"file", ev.name, "error", err)
+		}
+	}()
 }

--- a/internal/nzbfilesystem/pad_recorder_test.go
+++ b/internal/nzbfilesystem/pad_recorder_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
@@ -46,9 +45,14 @@ func (f *fakePadMetadataStore) UpdateFileStatus(virtualPath string, status metap
 	return nil
 }
 
+// fakePadHealthStore records both the ordinary status-update writes and the
+// immediate-repair requests, so tests can assert on either independently.
 type fakePadHealthStore struct {
-	mu      sync.Mutex
-	updates []string
+	mu                        sync.Mutex
+	updates                   []string
+	immediateRepairRequests   []string
+	immediateRepairRequested  chan struct{}
+	setImmediateRepairErr     error
 }
 
 func (f *fakePadHealthStore) UpdateFileHealthScheduled(ctx context.Context, filePath string, status database.HealthStatus, errorMessage *string, sourceNzbPath *string, errorDetails *string, noRetry bool, scheduledAt time.Time) error {
@@ -58,47 +62,14 @@ func (f *fakePadHealthStore) UpdateFileHealthScheduled(ctx context.Context, file
 	return nil
 }
 
-func (f *fakePadHealthStore) GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error) {
-	return nil, nil
-}
-
-// fakePadHealthStoreWithLibraryPath returns a FileHealth carrying a library
-// path, exercising the EffectiveLibraryPath branch of triggerImmediateRepairSearch.
-type fakePadHealthStoreWithLibraryPath struct {
-	fakePadHealthStore
-	libraryPath string
-}
-
-func (f *fakePadHealthStoreWithLibraryPath) GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error) {
-	lp := f.libraryPath
-	return &database.FileHealth{FilePath: filePath, LibraryPath: &lp}, nil
-}
-
-// fakePadArrsTrigger records every TriggerFileRescan call it receives.
-type fakePadArrsTrigger struct {
-	mu       sync.Mutex
-	calls    []string
-	fired    chan struct{}
-	returnFn func() error
-}
-
-func (f *fakePadArrsTrigger) TriggerFileRescan(ctx context.Context, pathForRescan string, relativePath string, metadataStr *string) error {
+func (f *fakePadHealthStore) SetImmediateRepairRequested(ctx context.Context, filePath string) error {
 	f.mu.Lock()
-	f.calls = append(f.calls, pathForRescan)
+	f.immediateRepairRequests = append(f.immediateRepairRequests, filePath)
 	f.mu.Unlock()
-	if f.fired != nil {
-		f.fired <- struct{}{}
+	if f.immediateRepairRequested != nil {
+		f.immediateRepairRequested <- struct{}{}
 	}
-	if f.returnFn != nil {
-		return f.returnFn()
-	}
-	return nil
-}
-
-func testConfigGetter() config.ConfigGetter {
-	return func() *config.Config {
-		return &config.Config{MountPath: "/mnt/bearmount"}
-	}
+	return f.setImmediateRepairErr
 }
 
 func testPadEvent(name string) padEvent {
@@ -117,7 +88,7 @@ func testPadEvent(name string) padEvent {
 func TestPadRecorderPersistsEvent(t *testing.T) {
 	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
 	health := &fakePadHealthStore{}
-	r := newPadRecorder(meta, health, nil, nil, nil)
+	r := newPadRecorder(meta, health, nil)
 
 	r.enqueue(testPadEvent("movie.mkv"))
 
@@ -143,68 +114,53 @@ func TestPadRecorderPersistsEvent(t *testing.T) {
 	}
 }
 
-func TestPadRecorderTriggersImmediateRepairSearch(t *testing.T) {
+// TestPadRecorderRequestsImmediateRepair covers the replacement for the old
+// direct-ARR-trigger path: the pad recorder now just asks the health worker
+// (via SetImmediateRepairRequested) to handle the ARR rescan on its own next
+// cycle - every safeguard (repair-enabled gate, retry budget, path
+// resolution, back-off, indexer logging) now lives entirely in
+// health.HealthWorker.triggerImmediateRepairOnly, not here.
+func TestPadRecorderRequestsImmediateRepair(t *testing.T) {
 	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
-	health := &fakePadHealthStoreWithLibraryPath{libraryPath: "/data/movies/Movie (2020)/Movie.mkv"}
-	arrs := &fakePadArrsTrigger{fired: make(chan struct{}, 1)}
-	r := newPadRecorder(meta, health, nil, arrs, testConfigGetter())
+	health := &fakePadHealthStore{immediateRepairRequested: make(chan struct{}, 1)}
+	r := newPadRecorder(meta, health, nil)
 
 	r.enqueue(testPadEvent("movie.mkv"))
 
 	select {
-	case <-arrs.fired:
+	case <-health.immediateRepairRequested:
 	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for immediate repair-search trigger")
+		t.Fatal("timed out waiting for immediate repair request")
 	}
 	r.Close()
 
-	arrs.mu.Lock()
-	defer arrs.mu.Unlock()
-	if len(arrs.calls) != 1 || arrs.calls[0] != "/data/movies/Movie (2020)/Movie.mkv" {
-		t.Fatalf("TriggerFileRescan calls = %v, want one call for the library path", arrs.calls)
+	health.mu.Lock()
+	defer health.mu.Unlock()
+	if len(health.immediateRepairRequests) != 1 || health.immediateRepairRequests[0] != "movie.mkv" {
+		t.Fatalf("immediate repair requests = %v, want one request for movie.mkv", health.immediateRepairRequests)
 	}
 }
 
-// TestPadRecorderRepairSearchFallsBackToMountPath covers a file with no
-// library path yet (not relinked by an ARR) - triggerImmediateRepairSearch
-// must still fire, resolving the fallback path the same way
-// health.HealthWorker.resolvePathForRescan does (MountPath + virtual path).
-func TestPadRecorderRepairSearchFallsBackToMountPath(t *testing.T) {
-	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
-	health := &fakePadHealthStore{} // GetFileHealth returns (nil, nil): no library path
-	arrs := &fakePadArrsTrigger{fired: make(chan struct{}, 1)}
-	r := newPadRecorder(meta, health, nil, arrs, testConfigGetter())
-
-	r.enqueue(testPadEvent("movie.mkv"))
-
-	select {
-	case <-arrs.fired:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for immediate repair-search trigger")
+// TestPadRecorderSurvivesImmediateRepairRequestError covers the tolerance for
+// SetImmediateRepairRequested failing (e.g. the health record doesn't exist
+// yet): must log and move on, never block or crash the worker.
+func TestPadRecorderSurvivesImmediateRepairRequestError(t *testing.T) {
+	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 2)}
+	health := &fakePadHealthStore{
+		immediateRepairRequested: make(chan struct{}, 2),
+		setImmediateRepairErr:    context.DeadlineExceeded,
 	}
-	r.Close()
+	r := newPadRecorder(meta, health, nil)
 
-	arrs.mu.Lock()
-	defer arrs.mu.Unlock()
-	if len(arrs.calls) != 1 || arrs.calls[0] != "/mnt/bearmount/movie.mkv" {
-		t.Fatalf("TriggerFileRescan calls = %v, want one call for the mount-path fallback", arrs.calls)
-	}
-}
+	r.enqueue(testPadEvent("first.mkv"))
+	r.enqueue(testPadEvent("second.mkv"))
 
-// TestPadRecorderRepairSearchNilArrsIsNoop covers the padArrsTrigger==nil
-// tolerance (test harnesses / any deployment where health monitoring is off
-// but padding still applies): must not panic, must not block enqueue.
-func TestPadRecorderRepairSearchNilArrsIsNoop(t *testing.T) {
-	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
-	health := &fakePadHealthStore{}
-	r := newPadRecorder(meta, health, nil, nil, nil)
-
-	r.enqueue(testPadEvent("movie.mkv"))
-
-	select {
-	case <-meta.holesRecorded:
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for hole persistence")
+	for i := 0; i < 2; i++ {
+		select {
+		case <-meta.holesRecorded:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("worker died: only %d of 2 events processed", i)
+		}
 	}
 	r.Close()
 }
@@ -214,7 +170,7 @@ func TestPadRecorderSurvivesPanic(t *testing.T) {
 		panicOnHoles:  true,
 		holesRecorded: make(chan struct{}, 2),
 	}
-	r := newPadRecorder(meta, &fakePadHealthStore{}, nil, nil, nil)
+	r := newPadRecorder(meta, &fakePadHealthStore{}, nil)
 
 	r.enqueue(testPadEvent("first.mkv")) // panics after recording the hole
 	r.enqueue(testPadEvent("second.mkv"))

--- a/internal/nzbfilesystem/pad_recorder_test.go
+++ b/internal/nzbfilesystem/pad_recorder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/javi11/altmount/internal/config"
 	"github.com/javi11/altmount/internal/database"
 	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
@@ -57,6 +58,49 @@ func (f *fakePadHealthStore) UpdateFileHealthScheduled(ctx context.Context, file
 	return nil
 }
 
+func (f *fakePadHealthStore) GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error) {
+	return nil, nil
+}
+
+// fakePadHealthStoreWithLibraryPath returns a FileHealth carrying a library
+// path, exercising the EffectiveLibraryPath branch of triggerImmediateRepairSearch.
+type fakePadHealthStoreWithLibraryPath struct {
+	fakePadHealthStore
+	libraryPath string
+}
+
+func (f *fakePadHealthStoreWithLibraryPath) GetFileHealth(ctx context.Context, filePath string) (*database.FileHealth, error) {
+	lp := f.libraryPath
+	return &database.FileHealth{FilePath: filePath, LibraryPath: &lp}, nil
+}
+
+// fakePadArrsTrigger records every TriggerFileRescan call it receives.
+type fakePadArrsTrigger struct {
+	mu       sync.Mutex
+	calls    []string
+	fired    chan struct{}
+	returnFn func() error
+}
+
+func (f *fakePadArrsTrigger) TriggerFileRescan(ctx context.Context, pathForRescan string, relativePath string, metadataStr *string) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, pathForRescan)
+	f.mu.Unlock()
+	if f.fired != nil {
+		f.fired <- struct{}{}
+	}
+	if f.returnFn != nil {
+		return f.returnFn()
+	}
+	return nil
+}
+
+func testConfigGetter() config.ConfigGetter {
+	return func() *config.Config {
+		return &config.Config{MountPath: "/mnt/bearmount"}
+	}
+}
+
 func testPadEvent(name string) padEvent {
 	return padEvent{
 		name:          name,
@@ -73,7 +117,7 @@ func testPadEvent(name string) padEvent {
 func TestPadRecorderPersistsEvent(t *testing.T) {
 	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
 	health := &fakePadHealthStore{}
-	r := newPadRecorder(meta, health, nil)
+	r := newPadRecorder(meta, health, nil, nil, nil)
 
 	r.enqueue(testPadEvent("movie.mkv"))
 
@@ -99,12 +143,78 @@ func TestPadRecorderPersistsEvent(t *testing.T) {
 	}
 }
 
+func TestPadRecorderTriggersImmediateRepairSearch(t *testing.T) {
+	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
+	health := &fakePadHealthStoreWithLibraryPath{libraryPath: "/data/movies/Movie (2020)/Movie.mkv"}
+	arrs := &fakePadArrsTrigger{fired: make(chan struct{}, 1)}
+	r := newPadRecorder(meta, health, nil, arrs, testConfigGetter())
+
+	r.enqueue(testPadEvent("movie.mkv"))
+
+	select {
+	case <-arrs.fired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for immediate repair-search trigger")
+	}
+	r.Close()
+
+	arrs.mu.Lock()
+	defer arrs.mu.Unlock()
+	if len(arrs.calls) != 1 || arrs.calls[0] != "/data/movies/Movie (2020)/Movie.mkv" {
+		t.Fatalf("TriggerFileRescan calls = %v, want one call for the library path", arrs.calls)
+	}
+}
+
+// TestPadRecorderRepairSearchFallsBackToMountPath covers a file with no
+// library path yet (not relinked by an ARR) - triggerImmediateRepairSearch
+// must still fire, resolving the fallback path the same way
+// health.HealthWorker.resolvePathForRescan does (MountPath + virtual path).
+func TestPadRecorderRepairSearchFallsBackToMountPath(t *testing.T) {
+	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
+	health := &fakePadHealthStore{} // GetFileHealth returns (nil, nil): no library path
+	arrs := &fakePadArrsTrigger{fired: make(chan struct{}, 1)}
+	r := newPadRecorder(meta, health, nil, arrs, testConfigGetter())
+
+	r.enqueue(testPadEvent("movie.mkv"))
+
+	select {
+	case <-arrs.fired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for immediate repair-search trigger")
+	}
+	r.Close()
+
+	arrs.mu.Lock()
+	defer arrs.mu.Unlock()
+	if len(arrs.calls) != 1 || arrs.calls[0] != "/mnt/bearmount/movie.mkv" {
+		t.Fatalf("TriggerFileRescan calls = %v, want one call for the mount-path fallback", arrs.calls)
+	}
+}
+
+// TestPadRecorderRepairSearchNilArrsIsNoop covers the padArrsTrigger==nil
+// tolerance (test harnesses / any deployment where health monitoring is off
+// but padding still applies): must not panic, must not block enqueue.
+func TestPadRecorderRepairSearchNilArrsIsNoop(t *testing.T) {
+	meta := &fakePadMetadataStore{holesRecorded: make(chan struct{}, 1)}
+	health := &fakePadHealthStore{}
+	r := newPadRecorder(meta, health, nil, nil, nil)
+
+	r.enqueue(testPadEvent("movie.mkv"))
+
+	select {
+	case <-meta.holesRecorded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for hole persistence")
+	}
+	r.Close()
+}
+
 func TestPadRecorderSurvivesPanic(t *testing.T) {
 	meta := &fakePadMetadataStore{
 		panicOnHoles:  true,
 		holesRecorded: make(chan struct{}, 2),
 	}
-	r := newPadRecorder(meta, &fakePadHealthStore{}, nil)
+	r := newPadRecorder(meta, &fakePadHealthStore{}, nil, nil, nil)
 
 	r.enqueue(testPadEvent("first.mkv")) // panics after recording the hole
 	r.enqueue(testPadEvent("second.mkv"))


### PR DESCRIPTION
## Summary

Closes #798.

A missing article confirmed during live playback (`holes.DecisionPad`) was previously only
recorded as `FILE_STATUS_DEGRADED`, with **no repair action at all** — the file's next
scheduled health check could be up to 90 days away for files older than 30 days
(`health.normalCheckInterval`), so the only real recovery path was a human noticing and
manually re-searching.

`padRecorder` now independently asks the owning ARR instance to blocklist+redownload the
title the moment a hole is confirmed, without touching the corrupted-file repair lifecycle:
no safety-folder move, no `FILE_STATUS_CORRUPTED`, no change to the existing DB status
semantics (stays `degraded`, still visible and streamable). The current stream is never
disturbed — ARR's own delete+search path only acts once it resolves a matching movie/episode
file via its existing path-matching guards (`radarrFileMatchesTarget` / its Sonarr
equivalent), which is independent of anything in AltMount's own mount.

Runs on its own goroutine off the recorder's single serialized worker loop, gated by the same
`"\x00degraded-pad"` debounce key already used for the DB status write, bounded to at most one
trigger per file per 30s debounce window regardless of how many holes accumulate in it.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/nzbfilesystem/...` clean
- [x] `go test ./internal/nzbfilesystem/... -race` — full package suite passes, including 3
      new tests covering: library-path resolution, mount-path fallback resolution (file not
      yet relinked by an ARR), and nil-`arrs`/nil-`configGetter` no-op tolerance