### PR TITLE
feat(stremio): mark already-imported releases as cached in stream list

### DIFF
--- a/docs/superpowers/specs/2026-07-25-stremio-cached-indicator-design.md
+++ b/docs/superpowers/specs/2026-07-25-stremio-cached-indicator-design.md
@@ -1,0 +1,114 @@
+# Stremio "Cached/Imported" Stream Indicator
+
+**Date:** 2026-07-25
+**Status:** Approved (design)
+
+## Problem
+
+The Stremio addon's stream handler (`handleStremioAddonStream`) returns one stream
+option per Prowlarr result. Every option points at the `/play` endpoint, which
+downloads and queues the NZB when clicked. Some of those releases are **already
+imported** into AltMount and still fresh — clicking them plays instantly — but the
+user has no way to tell which ones. This mirrors a gap that debrid addons like
+AIOStreams/Torrentio solve by tagging instantly-available results as "cached".
+
+## Goal
+
+Mark each Prowlarr result that is already imported and still fresh with a
+`⚡ Cached` badge, and sort those results to the top of the stream list. Uncached
+results remain listed and playable. The feature is best-effort: it must never
+break stream listing.
+
+## Definition of "cached"
+
+A result is cached if a queue item exists that satisfies **all** of:
+
+- `status = completed`
+- `download_id LIKE 'stremio:%'` (originated from the Stremio addon)
+- non-empty `storage_path`
+- `nzb_path` contains `sanitizeFilename(result.Title) + ".nzb"`
+- when `Stremio.NzbTTLHours > 0`: `completed_at` is within the TTL window
+
+This is exactly the short-circuit condition already used by
+`handleStremioAddonPlay`. Reusing it guarantees the badge is truthful: a badged
+result is one that `/play` will resolve to an instant 302 redirect without a
+download.
+
+## Architecture & data flow
+
+1. **Batch lookup (new repo method).** Add
+   `Repository.GetCachedStremioQueueItems(ctx) ([]*ImportQueueItem, error)`,
+   modeled on `GetExpiredStremioQueueItems`. It selects completed
+   `download_id LIKE 'stremio:%'` items with a non-empty `storage_path`, ordered
+   by `completed_at DESC`, with a sane cap (`LIMIT 500`). Called **once** per
+   stream request — no per-result DB scan.
+
+2. **Handler wiring.** After the existing language/quality filtering in
+   `handleStremioAddonStream`, the handler:
+   - calls `GetCachedStremioQueueItems`; on error, logs a warning and continues
+     with the current behavior (no badges, original order),
+   - passes the filtered results + cached items + `NzbTTLHours` to a pure helper,
+   - emits the helper's ordered streams.
+
+3. **Pure helper (testable).** Extract a pure function, e.g.
+
+   ```go
+   func buildStremioStreamOptions(
+       results []prowlarr.NZBResult,
+       cached []*database.ImportQueueItem,
+       ttlHours int,
+       now time.Time,
+       ... presentation deps ...,
+   ) []streamOption
+   ```
+
+   It builds the in-memory set of cached `nzb_path`s (applying the TTL filter in
+   Go against `now`), marks each result cached via `strings.Contains`, constructs
+   the stream `name`/`title`/`url` exactly as today, and performs a **stable**
+   sort placing cached results first while preserving Prowlarr's relative order
+   within each group. Taking `now` as a parameter keeps the TTL logic
+   deterministically testable.
+
+## Presentation
+
+- Cached results get `⚡ Cached` prepended to the existing badge, e.g.
+  `⚡ Cached · AltMount 🇪🇸 4K - La película (2024) [2160p][Esp]`.
+- Uncached results are rendered exactly as today.
+- Stable sort: cached group first, original order preserved within each group.
+- The `url` continues to point at `/play` (unchanged). `/play` already
+  short-circuits cached items to a fast redirect, so this avoids duplicating the
+  episode-selection and multi-episode-ambiguity logic in `buildStremioStreams`.
+
+## Error handling / degradation
+
+- Repo lookup failure → warn + fall back to current behavior. Never fatal.
+- No cached items → helper returns streams in original order with no badges.
+
+## Testing
+
+Table-driven tests for the pure helper:
+
+- cached within TTL → badged and sorted first
+- cached but expired (`completed_at` older than TTL) → not badged
+- `TTLHours <= 0` → cached regardless of `completed_at` age
+- completed item with empty `storage_path` → not treated as cached
+- non-Stremio item present in input → ignored (defense-in-depth; repo already
+  filters)
+- sort stability: two cached + two uncached preserve intra-group order
+- empty cache slice → all uncached, original order
+
+Repo method covered by a package-style integration test if the database package
+has an existing harness for it.
+
+## Files touched
+
+- `internal/database/repository.go` — new `GetCachedStremioQueueItems` method.
+- `internal/api/stremio_addon_handlers.go` — handler wiring + extracted pure
+  helper.
+- `internal/api/stremio_addon_handlers_test.go` (new or existing) — helper tests.
+
+## Out of scope (YAGNI)
+
+- Linking cached results directly to the media stream URL (bypassing `/play`).
+- Any change to `/play`, `buildStremioStreams`, or episode-selection logic.
+- Indexing `nzb_path` for the LIKE lookup (batch fetch avoids the need).

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -221,12 +222,93 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 	}
 	results = filtered
 
-	var streams []fiber.Map
+	// Mark already-imported releases as cached so instantly-playable options
+	// surface first. Best-effort: on lookup failure, fall back to no badges.
+	var cachedItems []*database.ImportQueueItem
+	if s.queueRepo != nil {
+		if items, cacheErr := s.queueRepo.GetCachedStremioQueueItems(ctx); cacheErr != nil {
+			slog.WarnContext(ctx, "Failed to load cached Stremio items; continuing without cache badges",
+				"error", cacheErr)
+		} else {
+			cachedItems = items
+		}
+	}
+
+	entries := buildStremioStreamEntries(results, cachedItems, cfg.Stremio.NzbTTLHours, time.Now(),
+		baseURL, key, streamType, season, episode, imdbID)
+
+	streams := make([]fiber.Map, 0, len(entries))
+	for _, e := range entries {
+		streams = append(streams, fiber.Map{
+			"name":  e.Name,
+			"title": e.Title,
+			"url":   e.URL,
+		})
+	}
+
+	return c.JSON(fiber.Map{"streams": streams})
+}
+
+// stremioStreamEntry is a single Stremio stream option produced from a Prowlarr
+// result, together with whether the underlying release is already cached/imported
+// in AltMount.
+type stremioStreamEntry struct {
+	Name   string
+	Title  string
+	URL    string
+	Cached bool
+}
+
+// buildStremioStreamEntries converts filtered Prowlarr results into ordered
+// Stremio stream entries. Results whose release is already imported and still
+// fresh (per the cached queue items and TTL) are badged "⚡ Cached" and stably
+// sorted ahead of the rest, mirroring the aiostreams/Torrentio UX.
+//
+// The match/TTL logic mirrors the short-circuit in handleStremioAddonPlay so the
+// badge is truthful: a cached entry is one /play resolves to an instant redirect.
+// now is injected for deterministic TTL testing.
+func buildStremioStreamEntries(
+	results []prowlarr.NZBResult,
+	cached []*database.ImportQueueItem,
+	ttlHours int,
+	now time.Time,
+	baseURL, key, streamType string,
+	season, episode int,
+	fallbackID string,
+) []stremioStreamEntry {
+	// Collect the nzb paths of cached items that are still usable: they must have
+	// a storage path and, when a TTL is configured, have completed within it.
+	// Mirrors the reuse condition in handleStremioAddonPlay.
+	validCachedPaths := make([]string, 0, len(cached))
+	for _, item := range cached {
+		if item == nil || item.StoragePath == nil || *item.StoragePath == "" {
+			continue
+		}
+		if ttlHours > 0 {
+			if item.CompletedAt == nil || now.Sub(*item.CompletedAt) >= time.Duration(ttlHours)*time.Hour {
+				continue
+			}
+		}
+		validCachedPaths = append(validCachedPaths, filepath.ToSlash(item.NzbPath))
+	}
+
+	isCached := func(safeFilename string) bool {
+		for _, p := range validCachedPaths {
+			if strings.Contains(p, safeFilename) {
+				return true
+			}
+		}
+		return false
+	}
+
+	entries := make([]stremioStreamEntry, 0, len(results))
 	for _, r := range results {
 		safeTitle := sanitizeFilename(r.Title)
 		if safeTitle == "" {
-			safeTitle = imdbID
+			safeTitle = fallbackID
 		}
+		cachedHit := isCached(safeTitle + ".nzb")
+
 		playURL := baseURL + "/stremio/" + key + "/play" +
 			"?url=" + url.QueryEscape(r.DownloadURL) +
 			"&title=" + url.QueryEscape(safeTitle) +
@@ -275,16 +357,27 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		if contentTitle != "" {
 			streamName += " - " + contentTitle
 		}
+		if cachedHit {
+			// Prefix marks instantly-playable releases, aiostreams-style.
+			streamName = "⚡ Cached · " + streamName
+		}
 
 		metaLine := fmt.Sprintf("💾 %.2f GB 🌐 %s", sizeGB, indexerLabel)
-		streams = append(streams, fiber.Map{
-			"name":  streamName,
-			"title": fmt.Sprintf("%s\n%s", r.Title, metaLine),
-			"url":   playURL,
+		entries = append(entries, stremioStreamEntry{
+			Name:   streamName,
+			Title:  fmt.Sprintf("%s\n%s", r.Title, metaLine),
+			URL:    playURL,
+			Cached: cachedHit,
 		})
 	}
 
-	return c.JSON(fiber.Map{"streams": streams})
+	// Stably sort cached entries first, preserving Prowlarr's relative order
+	// within each group.
+	sort.SliceStable(entries, func(i, j int) bool {
+		return entries[i].Cached && !entries[j].Cached
+	})
+
+	return entries
 }
 
 // handleStremioAddonPlay handles GET /stremio/:key/play

--- a/internal/api/stremio_addon_handlers_test.go
+++ b/internal/api/stremio_addon_handlers_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/prowlarr"
+)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+// cachedItem builds a completed Stremio queue item for cache-lookup tests.
+func cachedItem(nzbPath, storagePath string, completedAt *time.Time) *database.ImportQueueItem {
+	item := &database.ImportQueueItem{
+		NzbPath:     nzbPath,
+		CompletedAt: completedAt,
+	}
+	if storagePath != "" {
+		item.StoragePath = strPtr(storagePath)
+	}
+	return item
+}
+
+func TestBuildStremioStreamEntries_CacheDetection(t *testing.T) {
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	title := "Some Movie 2024 1080p WEB-DL"
+	// safeFilename the play handler would use for this title.
+	safeFilename := sanitizeFilename(title) + ".nzb"
+	matchingPath := "/config/.nzbs/Movies/7/" + safeFilename
+
+	tests := []struct {
+		name       string
+		cached     []*database.ImportQueueItem
+		ttlHours   int
+		wantCached bool
+	}{
+		{
+			name:       "cached within TTL",
+			cached:     []*database.ImportQueueItem{cachedItem(matchingPath, "/storage/movie", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:   24,
+			wantCached: true,
+		},
+		{
+			name:       "cached but expired",
+			cached:     []*database.ImportQueueItem{cachedItem(matchingPath, "/storage/movie", timePtr(now.Add(-48*time.Hour)))},
+			ttlHours:   24,
+			wantCached: false,
+		},
+		{
+			name:       "ttl disabled caches regardless of age",
+			cached:     []*database.ImportQueueItem{cachedItem(matchingPath, "/storage/movie", timePtr(now.Add(-1000*time.Hour)))},
+			ttlHours:   0,
+			wantCached: true,
+		},
+		{
+			name:       "completed item without storage path is not cached",
+			cached:     []*database.ImportQueueItem{cachedItem(matchingPath, "", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:   24,
+			wantCached: false,
+		},
+		{
+			name:       "non-matching path is not cached",
+			cached:     []*database.ImportQueueItem{cachedItem("/config/.nzbs/Movies/9/Different Release.nzb", "/storage/other", timePtr(now.Add(-1*time.Hour)))},
+			ttlHours:   24,
+			wantCached: false,
+		},
+		{
+			name:       "empty cache is not cached",
+			cached:     nil,
+			ttlHours:   24,
+			wantCached: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := []prowlarr.NZBResult{{Title: title, DownloadURL: "https://prowlarr/dl/1", Size: 1_500_000_000, Indexer: "IdxA"}}
+
+			entries := buildStremioStreamEntries(results, tt.cached, tt.ttlHours, now,
+				"https://host", "thekey", "movie", 0, 0, "tt123")
+
+			if len(entries) != 1 {
+				t.Fatalf("expected 1 entry, got %d", len(entries))
+			}
+			got := entries[0]
+
+			if got.Cached != tt.wantCached {
+				t.Errorf("Cached = %v; want %v", got.Cached, tt.wantCached)
+			}
+			hasBadge := strings.Contains(got.Name, "⚡ Cached")
+			if hasBadge != tt.wantCached {
+				t.Errorf("badge present = %v; want %v (name=%q)", hasBadge, tt.wantCached, got.Name)
+			}
+			// URL always routes through /play regardless of cache status.
+			if !strings.Contains(got.URL, "/stremio/thekey/play") {
+				t.Errorf("URL does not route through /play: %q", got.URL)
+			}
+			if !strings.Contains(got.URL, "type=movie") {
+				t.Errorf("URL missing type param: %q", got.URL)
+			}
+		})
+	}
+}
+
+func TestBuildStremioStreamEntries_CachedSortedFirstStable(t *testing.T) {
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+
+	titles := []string{"Alpha 2024 1080p", "Bravo 2024 1080p", "Charlie 2024 1080p", "Delta 2024 1080p"}
+	results := make([]prowlarr.NZBResult, len(titles))
+	for i, ti := range titles {
+		results[i] = prowlarr.NZBResult{Title: ti, DownloadURL: "https://prowlarr/dl", Size: 1e9}
+	}
+
+	// Bravo and Delta are cached; Alpha and Charlie are not.
+	cached := []*database.ImportQueueItem{
+		cachedItem("/nzbs/"+sanitizeFilename("Bravo 2024 1080p")+".nzb", "/s/b", timePtr(now.Add(-time.Hour))),
+		cachedItem("/nzbs/"+sanitizeFilename("Delta 2024 1080p")+".nzb", "/s/d", timePtr(now.Add(-time.Hour))),
+	}
+
+	entries := buildStremioStreamEntries(results, cached, 24, now,
+		"https://host", "k", "movie", 0, 0, "tt1")
+
+	if len(entries) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(entries))
+	}
+
+	// Expected order: cached group first in original order (Bravo, Delta),
+	// then uncached in original order (Alpha, Charlie).
+	wantTitles := []string{"Bravo", "Delta", "Alpha", "Charlie"}
+	for i, want := range wantTitles {
+		if !strings.Contains(entries[i].Name, want) {
+			t.Errorf("position %d: name %q does not contain %q", i, entries[i].Name, want)
+		}
+	}
+	if !entries[0].Cached || !entries[1].Cached {
+		t.Errorf("first two entries should be cached")
+	}
+	if entries[2].Cached || entries[3].Cached {
+		t.Errorf("last two entries should not be cached")
+	}
+}

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -1513,7 +1513,7 @@ func (r *Repository) GetProviderHistoricalStats(ctx context.Context, days int, i
 		if err := rows.Scan(&tsRaw, &stat.ProviderID, &stat.BytesDownloaded); err != nil {
 			return nil, fmt.Errorf("failed to scan provider historical stat: %w", err)
 		}
-		
+
 		switch v := tsRaw.(type) {
 		case time.Time:
 			stat.Timestamp = v
@@ -2121,6 +2121,45 @@ func (r *Repository) GetExpiredStremioQueueItems(ctx context.Context, ttlHours i
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan expired stremio queue item: %w", err)
+		}
+		items = append(items, &item)
+	}
+
+	return items, rows.Err()
+}
+
+// GetCachedStremioQueueItems returns completed Stremio-originated queue items that
+// have a storage path (i.e. are streamable). Used by the Stremio stream handler to
+// mark already-imported releases as cached. TTL freshness is applied by the caller.
+func (r *Repository) GetCachedStremioQueueItems(ctx context.Context) ([]*ImportQueueItem, error) {
+	query := `
+		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
+		FROM import_queue
+		WHERE status = 'completed'
+		  AND download_id LIKE 'stremio:%'
+		  AND storage_path IS NOT NULL
+		  AND storage_path != ''
+		ORDER BY completed_at DESC
+		LIMIT 500
+	`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query cached stremio queue items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*ImportQueueItem
+	for rows.Next() {
+		var item ImportQueueItem
+		err := rows.Scan(
+			&item.ID, &item.DownloadID, &item.NzbPath, &item.RelativePath, &item.Category, &item.Priority, &item.Status,
+			&item.CreatedAt, &item.UpdatedAt, &item.StartedAt, &item.CompletedAt,
+			&item.RetryCount, &item.MaxRetries, &item.ErrorMessage, &item.BatchID, &item.Metadata, &item.FileSize, &item.StoragePath, &item.TargetPath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan cached stremio queue item: %w", err)
 		}
 		items = append(items, &item)
 	}


### PR DESCRIPTION
## What

Adds an aiostreams/Torrentio-style **cached indicator** to the Stremio addon's stream list. Prowlarr results whose release is already imported into AltMount and still fresh are prefixed with a `⚡ Cached` badge and stably sorted above uncached results, so instantly-playable options surface first.

## Why

Previously every stream option looked identical and pointed at `/play`, which downloads + queues the NZB on click. Some of those releases were already imported (clicking plays instantly), but the user had no way to tell which. This closes that gap without changing playback behavior.

## How

- **`Repository.GetCachedStremioQueueItems`** (new): a single query for completed `stremio:`-originated queue items with a non-empty `storage_path` (`LIMIT 500`, newest first). Called once per stream request — avoids N non-indexed `LIKE` scans.
- **`buildStremioStreamEntries`** (new, pure/testable): builds the stream entries, flags each result cached using the **same** condition `handleStremioAddonPlay` already uses for its short-circuit (storage path present + within `NzbTTLHours`, where `ttl <= 0` means cache-forever), prepends `⚡ Cached · `, and stably sorts cached first while preserving Prowlarr's intra-group order. `now` is injected for deterministic TTL tests.
- The handler wires the cache fetch in as **best-effort**: on lookup error it logs a warning and falls back to the original unbadged listing.

## Reviewer notes

- **Badge is truthful by construction:** it reuses `/play`'s reuse condition, so a badged entry is one `/play` resolves to an instant 302.
- **`url` is unchanged** — cached options still route through `/play` (already a fast redirect for cached items). This deliberately avoids duplicating the episode-selection / multi-episode-ambiguity logic in `buildStremioStreams`.
- The match is `strings.Contains(nzb_path, sanitizeFilename(title)+".nzb")`, mirroring the existing `ListQueueItems` search semantics used by `/play`.

## Testing

- Table-driven tests (TDD, written first) for `buildStremioStreamEntries`: cached-within-TTL, expired, TTL-disabled, missing storage path, non-matching path, empty cache, and sort stability.
- `go build ./...`, `go vet`, `go test -race ./internal/api/`, `go test ./internal/database/`, `gofmt -l` — all clean.

Design spec: `docs/superpowers/specs/2026-07-25-stremio-cached-indicator-design.md`