### PR TITLE
fix(stremio): persist NzbTTLHours of 0 across API round-trip

### DIFF
--- a/internal/api/stremio_ttl_test.go
+++ b/internal/api/stremio_ttl_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/javi11/altmount/internal/config"
+)
+
+// TestStremioNzbTTLHoursZeroRoundTrip verifies that an explicit NzbTTLHours of 0
+// ("cache forever / disable expiry") survives serialization to the API response.
+// A dropped 0 causes the frontend to fall back to its default of 24, silently
+// overwriting the user's choice on the next save.
+func TestStremioNzbTTLHoursZeroRoundTrip(t *testing.T) {
+	enabled := true
+	cfg := &config.Config{
+		Stremio: config.StremioConfig{
+			Enabled:     &enabled,
+			NzbTTLHours: 0,
+		},
+	}
+
+	resp := ToConfigAPIResponse(cfg, "")
+
+	data, err := json.Marshal(resp.Stremio)
+	if err != nil {
+		t.Fatalf("marshal stremio response: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"nzb_ttl_hours":0`) {
+		t.Errorf("expected nzb_ttl_hours:0 to be present in response JSON, got: %s", data)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -204,7 +204,7 @@ type ArrsInstanceAPIResponse struct {
 // StremioAPIResponse sanitizes Stremio config for API responses
 type StremioAPIResponse struct {
 	Enabled     bool                `json:"enabled"`
-	NzbTTLHours int                 `json:"nzb_ttl_hours,omitempty"`
+	NzbTTLHours int                 `json:"nzb_ttl_hours"`
 	BaseURL     string              `json:"base_url,omitempty"`
 	Prowlarr    ProwlarrAPIResponse `json:"prowlarr"`
 }

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -173,7 +173,7 @@ type StremioConfig struct {
 	// NzbTTLHours controls how long a completed NZB result is cached before
 	// the same NZB is re-processed on the next request.
 	// Set to 0 to disable expiry (cache forever). Defaults to 24 hours.
-	NzbTTLHours int `yaml:"nzb_ttl_hours" mapstructure:"nzb_ttl_hours" json:"nzb_ttl_hours,omitempty"`
+	NzbTTLHours int `yaml:"nzb_ttl_hours" mapstructure:"nzb_ttl_hours" json:"nzb_ttl_hours"`
 	// BaseURL is the public base URL used when building Stremio stream links
 	// (e.g. "https://altmount.example.com"). Falls back to the auto-detected
 	// request origin when not set.


### PR DESCRIPTION
## Summary

Setting the Stremio NZB cleanup TTL to `0` ("cache forever / never expire") reverted to `24` after a page reload.

The value **was** persisted to disk correctly — the bug was on read-back. `StremioAPIResponse.NzbTTLHours` carried `json:"nzb_ttl_hours,omitempty"`, so Go's `omitempty` dropped the field from `GET /api/config` whenever the TTL was `0`. The frontend then applied `config.stremio?.nzb_ttl_hours ?? 24`, displaying `24` — and re-sent `24` on the next save, permanently overwriting the user's `0`. Display bug → silent data loss.

## Fix

Since `0` is a meaningful value ("disable expiry"), removed `omitempty` from:
- `StremioAPIResponse.NzbTTLHours` (`internal/api/types.go`) — the actual bug.
- The `StremioConfig.NzbTTLHours` struct field (`internal/config/manager.go`) — same latent bug on any future JSON marshal of `Config`.

This mirrors the segment-cache expiry fix in #800 (0 = cache forever).

## Test

Added `internal/api/stremio_ttl_test.go` asserting `nzb_ttl_hours:0` survives the response round-trip.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/api/ ./internal/config/`
- [ ] Manual: set Stremio NZB TTL to 0, save, reload — value stays 0