### PR TITLE
fix(arrs): restrict ARR auto-registration to internal URLs (SSRF, #796)

### DIFF
--- a/internal/arrs/instances/manager.go
+++ b/internal/arrs/instances/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"strings"
 
@@ -148,9 +149,81 @@ func (m *Manager) GetInstance(instanceType, instanceName string) *model.ConfigIn
 
 // RegisterInstance attempts to automatically register an ARR instance
 // It returns true if a new instance was registered, false if it already existed
+// isInternalIP reports whether ip is on loopback or a private network (RFC1918 / IPv6 ULA).
+// Link-local addresses (including the 169.254.169.254 cloud-metadata endpoint) and global
+// addresses are treated as non-internal.
+func isInternalIP(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate()
+}
+
+// validateInternalARRURL rejects ARR auto-registration targets that are not on an internal
+// network. Auto-registration is reachable via the unauthenticated SABnzbd ARR-credential
+// path, so an external URL here would let a caller drive AltMount into issuing outbound
+// requests to — and persisting — an attacker-chosen destination (SSRF). Legitimate
+// Radarr/Sonarr instances always live on loopback or a private network; a genuinely external
+// ARR can still be added manually through the UI.
+func validateInternalARRURL(arrURL string, lookupIP func(host string) ([]net.IP, error)) error {
+	if strings.TrimSpace(arrURL) == "" {
+		return fmt.Errorf("ARR URL is empty")
+	}
+
+	parsed, err := url.Parse(arrURL)
+	if err != nil {
+		return fmt.Errorf("invalid ARR URL %q: %w", arrURL, err)
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("ARR URL %q has no host", arrURL)
+	}
+
+	// IP literal: classify directly, no DNS lookup required.
+	if ip := net.ParseIP(host); ip != nil {
+		if !isInternalIP(ip) {
+			return fmt.Errorf("ARR URL %q points to non-internal address %s; add external ARR instances manually", arrURL, ip)
+		}
+		return nil
+	}
+
+	// Hostname: resolve and require every returned address to be internal so a mixed
+	// public/private DNS record cannot slip an external target through.
+	ips, err := lookupIP(host)
+	if err != nil {
+		return fmt.Errorf("failed to resolve ARR host %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("ARR host %q did not resolve to any address", host)
+	}
+	for _, ip := range ips {
+		if !isInternalIP(ip) {
+			return fmt.Errorf("ARR host %q resolves to non-internal address %s; add external ARR instances manually", host, ip)
+		}
+	}
+	return nil
+}
+
 func (m *Manager) RegisterInstance(ctx context.Context, arrURL, apiKey string) (bool, error) {
 	if m.configManager == nil {
 		return false, fmt.Errorf("config manager not available")
+	}
+
+	// Reject non-internal targets before dialing out. Auto-registration is reachable via the
+	// unauthenticated SABnzbd ARR-credential path; an external URL here would be SSRF.
+	if err := validateInternalARRURL(arrURL, func(host string) ([]net.IP, error) {
+		addrs, lErr := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if lErr != nil {
+			return nil, lErr
+		}
+		ips := make([]net.IP, len(addrs))
+		for i, a := range addrs {
+			ips[i] = a.IP
+		}
+		return ips, nil
+	}); err != nil {
+		return false, fmt.Errorf("ARR URL not allowed for auto-registration: %w", err)
 	}
 
 	slog.InfoContext(ctx, "Attempting to register ARR instance", "url", arrURL)

--- a/internal/arrs/instances/register_validate_test.go
+++ b/internal/arrs/instances/register_validate_test.go
@@ -1,0 +1,86 @@
+package instances
+
+import (
+	"errors"
+	"net"
+	"testing"
+)
+
+func fakeResolver(hosts map[string][]net.IP) func(string) ([]net.IP, error) {
+	return func(host string) ([]net.IP, error) {
+		if ips, ok := hosts[host]; ok {
+			return ips, nil
+		}
+		return nil, errors.New("no such host")
+	}
+}
+
+func TestValidateInternalARRURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		hosts   map[string][]net.IP
+		wantErr bool
+	}{
+		// Allowed: internal targets
+		{name: "private 192.168 literal", url: "http://192.168.1.10:8989", wantErr: false},
+		{name: "private 10.x literal", url: "http://10.0.0.5:7878", wantErr: false},
+		{name: "private 172.16 literal", url: "http://172.16.0.3:8989", wantErr: false},
+		{name: "loopback literal", url: "http://127.0.0.1:8989", wantErr: false},
+		{name: "ipv6 ULA literal", url: "http://[fd00::1]:8989", wantErr: false},
+		{name: "ipv6 loopback literal", url: "http://[::1]:8989", wantErr: false},
+		{name: "docker hostname resolves private", url: "http://sonarr:8989",
+			hosts: map[string][]net.IP{"sonarr": {net.ParseIP("172.18.0.4")}}, wantErr: false},
+		{name: "localhost resolves loopback", url: "http://localhost:8989",
+			hosts: map[string][]net.IP{"localhost": {net.ParseIP("127.0.0.1")}}, wantErr: false},
+
+		// Rejected: external / dangerous targets
+		{name: "public ip literal", url: "http://8.8.8.8", wantErr: true},
+		{name: "cloud metadata link-local", url: "http://169.254.169.254", wantErr: true},
+		{name: "public hostname", url: "http://evil.example.com",
+			hosts: map[string][]net.IP{"evil.example.com": {net.ParseIP("93.184.216.34")}}, wantErr: true},
+		{name: "dns rebinding mixed public+private", url: "http://rebind.test",
+			hosts: map[string][]net.IP{"rebind.test": {net.ParseIP("192.168.1.5"), net.ParseIP("93.184.216.34")}}, wantErr: true},
+		{name: "unresolvable hostname", url: "http://nope.invalid", wantErr: true},
+		{name: "empty url", url: "", wantErr: true},
+		{name: "no host", url: "http://", wantErr: true},
+		{name: "invalid url", url: "://bad", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInternalARRURL(tt.url, fakeResolver(tt.hosts))
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.url)
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tt.url, err)
+			}
+		})
+	}
+}
+
+func TestIsInternalIP(t *testing.T) {
+	tests := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"10.1.2.3", true},
+		{"172.16.5.5", true},
+		{"192.168.0.1", true},
+		{"fd00::1", true},
+		{"::1", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"169.254.169.254", false}, // cloud metadata
+		{"172.32.0.1", false},      // just outside 172.16/12
+	}
+	for _, tt := range tests {
+		t.Run(tt.ip, func(t *testing.T) {
+			if got := isInternalIP(net.ParseIP(tt.ip)); got != tt.want {
+				t.Fatalf("isInternalIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #796.

## What

Restricts the ARR auto-registration path (`Manager.RegisterInstance`) to **internal network targets only**, closing the unauthenticated SSRF reported in #796.

## Why

The `/sabnzbd` endpoint (mounted on the root app, ahead of the authenticated route group) accepts `ma_username`/`ma_password` — an ARR URL + API key — as an alternate auth method meant to let Radarr/Sonarr self-register. When no valid AltMount API key is supplied, that path reaches `validateARRCredentials` → `RegisterInstance` → `detectARRType`, which builds a `starr.Config{URL: <caller-supplied>}` and issues **real outbound HTTP probes** to the attacker-chosen URL — before any credential is validated and with no host allow-list. A successful-looking response gets **persisted to config** as a new ARR instance.

Net effect: an unauthenticated caller could drive AltMount into issuing outbound requests to, and storing, an attacker-controlled destination (classic SSRF with a stateful side effect).

## Fix

Guard `RegisterInstance` before it dials out:

- Parse the URL, resolve the host, and require **every** resolved address to be loopback or private (RFC1918 / IPv6 ULA).
- Reject public and link-local addresses — including the `169.254.169.254` cloud-metadata endpoint.
- For hostnames, all resolved IPs must be internal, so a mixed public/private DNS record can't slip an external target through.

This blocks both the outbound probe and the config write in a single chokepoint, covering both SABnzbd call sites (`validateARRCredentials` and `tryAutoRegisterARR`).

## Scope / compatibility

- `RegisterInstance` is called **only** from the two SABnzbd auto-register spots. The normal UI "add ARR" flow does **not** go through it, so a user who genuinely runs a public ARR can still add it manually.
- Legitimate Radarr/Sonarr instances live on internal addresses, so existing auto-registration setups are unaffected.
- The `ma_username`/`ma_password` self-registration feature is intentionally **kept working** — only the target URL is constrained.

## Notes for reviewers

- The `ma_*`-only path is still reachable without an AltMount API key; this PR neutralizes the impactful part (external SSRF + external config write) rather than removing the auth path. Happy to additionally require a valid API key on that path if that's the preferred direction.
- Chosen a hard internal-only rule over a configurable allow-list to keep it simple; the escape hatch for external ARRs is the manual UI add.

## Tests (TDD)

New `internal/arrs/instances/register_validate_test.go`:
- `TestValidateInternalARRURL` — 16 cases: private/loopback/ULA literals, Docker & localhost hostname resolution, public IPs, cloud-metadata link-local, DNS-rebinding mixed records, unresolvable hosts, malformed URLs.
- `TestIsInternalIP` — boundary cases incl. `169.254.169.254` and `172.32.0.1` (just outside `172.16/12`).

`go test -race`, `go build ./...`, and `go vet ./internal/arrs/...` all pass.