### PR TITLE
fix(metadata): preserve ModifiedAt across status and holes updates

### DIFF
--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -640,7 +640,9 @@ func (ms *MetadataService) CreateFileMetadata(
 	}
 }
 
-// UpdateFileMetadata updates the modified timestamp of metadata
+// UpdateFileMetadata applies updateFunc to existing metadata and writes it back.
+// ModifiedAt is preserved unless the callback sets it — status/holes updates are
+// not content changes and must not rewrite WebDAV Last-Modified / FUSE mtime.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)
@@ -653,9 +655,6 @@ func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc fun
 
 	// Apply update function
 	updateFunc(metadata)
-
-	// Update modified timestamp
-	metadata.ModifiedAt = time.Now().Unix()
 
 	// Write back to disk
 	return ms.WriteFileMetadata(virtualPath, metadata)

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -257,4 +258,40 @@ func TestReadFileMetadataLite_FallsBackOnLongHeader(t *testing.T) {
 	require.NotNil(t, lite)
 	assert.Equal(t, int64(1234), lite.FileSize)
 	assert.Equal(t, metapb.FileStatus_FILE_STATUS_HEALTHY, lite.Status)
+}
+
+// TestUpdateFileMetadata_PreservesModifiedAt ensures status and known-holes
+// RMW paths do not rewrite ModifiedAt (WebDAV Last-Modified / FUSE mtime).
+func TestUpdateFileMetadata_PreservesModifiedAt(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := filepath.Join("movies", "stable_mtime.mkv")
+	const fixedModifiedAt int64 = 1_700_000_000
+
+	meta := ms.CreateFileMetadata(
+		2048, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "mtime-id",
+	)
+	meta.ModifiedAt = fixedModifiedAt
+	meta.CreatedAt = fixedModifiedAt - 60
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	require.NoError(t, ms.UpdateFileStatus(virtualPath, metapb.FileStatus_FILE_STATUS_DEGRADED))
+
+	afterStatus, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, afterStatus)
+	assert.Equal(t, fixedModifiedAt, afterStatus.ModifiedAt)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterStatus.Status)
+	assert.Equal(t, fixedModifiedAt-60, afterStatus.CreatedAt)
+
+	require.NoError(t, ms.AddKnownHoles(virtualPath, []holes.Run{{Start: 10, Count: 2}}))
+
+	afterHoles, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, afterHoles)
+	assert.Equal(t, fixedModifiedAt, afterHoles.ModifiedAt)
+	require.NotEmpty(t, afterHoles.KnownHoles)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterHoles.Status)
 }


### PR DESCRIPTION
## Problem

Health checks call `UpdateFileStatus` → `UpdateFileMetadata`, which previously always set `ModifiedAt = time.Now()`. That value is exposed as WebDAV `Last-Modified` (and thus to external rclone mounts). Media servers that detect changes via mtime (e.g. Jellyfin 10.11) then mass-reprobe files whose content and size never changed.

FUSE `no_mod_time` (#642) only covers Altmount's native hanwen mount. WebDAV / external rclone were unaffected.

## Solution

Stop auto-bumping `ModifiedAt` inside `UpdateFileMetadata`. Import/create still set `CreatedAt` and `ModifiedAt` together. Callers may still set `ModifiedAt` explicitly in the update callback or before `WriteFileMetadata`. Status and known-holes RMW preserve the existing timestamp.

### Changes

- **`internal/metadata/service.go`**: `UpdateFileMetadata` no longer rewrites `ModifiedAt`
- **`internal/metadata/service_test.go`**: `TestUpdateFileMetadata_PreservesModifiedAt` covers `UpdateFileStatus` and `AddKnownHoles`

### Notes

- No config flag — NZB virtual file bytes do not change on health/holes updates
- Existing libraries keep their current `ModifiedAt` (no mass reset to `CreatedAt`)
- External rclone benefits with zero sidecar changes once this is deployed