### PR TITLE
fix(stremio): exclude failed releases and fall back to next candidate

### DIFF
--- a/frontend/src/components/config/StremioConfigSection.tsx
+++ b/frontend/src/components/config/StremioConfigSection.tsx
@@ -111,6 +111,8 @@ export function StremioConfigSection({
 	const [formData, setFormData] = useState<StremioConfig>({
 		enabled: config.stremio?.enabled ?? false,
 		nzb_ttl_hours: config.stremio?.nzb_ttl_hours ?? 24,
+		failed_release_ttl_hours: config.stremio?.failed_release_ttl_hours ?? 24,
+		max_fallback_releases: config.stremio?.max_fallback_releases ?? 2,
 		base_url: config.stremio?.base_url ?? "",
 		prowlarr: resolveProwlarr(config.stremio?.prowlarr),
 	});
@@ -124,6 +126,8 @@ export function StremioConfigSection({
 		setFormData({
 			enabled: config.stremio?.enabled ?? false,
 			nzb_ttl_hours: config.stremio?.nzb_ttl_hours ?? 24,
+			failed_release_ttl_hours: config.stremio?.failed_release_ttl_hours ?? 24,
+			max_fallback_releases: config.stremio?.max_fallback_releases ?? 2,
 			base_url: config.stremio?.base_url ?? "",
 			prowlarr: resolveProwlarr(config.stremio?.prowlarr),
 		});
@@ -135,6 +139,8 @@ export function StremioConfigSection({
 		const changed =
 			updated.enabled !== (orig?.enabled ?? false) ||
 			updated.nzb_ttl_hours !== (orig?.nzb_ttl_hours ?? 24) ||
+			updated.failed_release_ttl_hours !== (orig?.failed_release_ttl_hours ?? 24) ||
+			updated.max_fallback_releases !== (orig?.max_fallback_releases ?? 2) ||
 			updated.base_url !== (orig?.base_url ?? "") ||
 			JSON.stringify(updated.prowlarr) !== JSON.stringify(orig?.prowlarr ?? DEFAULT_PROWLARR);
 		setHasChanges(changed);
@@ -270,6 +276,45 @@ export function StremioConfigSection({
 							/>
 							<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
 								How long cached NZB files stay on disk. Use <strong>0</strong> to keep forever.
+							</p>
+						</fieldset>
+
+						<fieldset className="fieldset min-w-0">
+							<legend className="fieldset-legend">Failed Release TTL (hours)</legend>
+							<input
+								type="number"
+								className="input w-full min-w-0 max-w-full"
+								min={0}
+								value={formData.failed_release_ttl_hours}
+								disabled={isReadOnly}
+								onChange={(e) =>
+									update({ failed_release_ttl_hours: Math.max(0, Number(e.target.value)) })
+								}
+							/>
+							<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+								How long a release that failed to import stays hidden from stream results. Use{" "}
+								<strong>0</strong> to hide it for as long as the failure record survives.
+							</p>
+						</fieldset>
+
+						<fieldset className="fieldset min-w-0">
+							<legend className="fieldset-legend">Fallback Releases</legend>
+							<input
+								type="number"
+								className="input w-full min-w-0 max-w-full"
+								min={0}
+								max={4}
+								value={formData.max_fallback_releases}
+								disabled={isReadOnly}
+								onChange={(e) =>
+									update({
+										max_fallback_releases: Math.min(4, Math.max(0, Number(e.target.value))),
+									})
+								}
+							/>
+							<p className="label min-w-0 max-w-full whitespace-normal break-words text-base-content/50 text-xs">
+								How many extra releases to try automatically when playback fails. Use{" "}
+								<strong>0</strong> to disable fallback.
 							</p>
 						</fieldset>
 					</div>

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -683,6 +683,8 @@ export interface ProwlarrIndexer {
 export interface StremioConfig {
 	enabled: boolean;
 	nzb_ttl_hours: number;
+	failed_release_ttl_hours: number;
+	max_fallback_releases: number;
 	base_url?: string;
 	prowlarr: ProwlarrConfig;
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -73,6 +73,9 @@ type Server struct {
 
 	// stremioPlayGroup coalesces concurrent Stremio plays of the same title (download once).
 	stremioPlayGroup singleflight.Group
+	// stremioFailures records releases that failed without leaving a 'failed' queue row,
+	// so they stop being offered in the stream list.
+	stremioFailures *stremioFailureCache
 }
 
 // NewServer creates a new API server that can optionally register routes on the provided mux (for backwards compatibility)
@@ -100,6 +103,7 @@ func NewServer(
 
 	server := &Server{
 		config:              config,
+		stremioFailures:     newStremioFailureCache(),
 		queueRepo:           queueRepo,
 		healthRepo:          healthRepo,
 		authService:         authService,

--- a/internal/api/stremio_addon_handlers.go
+++ b/internal/api/stremio_addon_handlers.go
@@ -161,14 +161,207 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		"type", streamType, "id", rawID, "imdb_id", imdbID)
 
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
-	prowlarrCfg := cfg.Stremio.Prowlarr
 
-	// Search Prowlarr -- return play-URL options immediately, no download yet
+	results, cachedItems, err := s.searchStremioReleases(ctx, cfg, streamType, prowlarrType, imdbID, season, episode)
+	if err != nil || len(results) == 0 {
+		return emptyStreamsResponse(c)
+	}
+
+	entries := buildStremioStreamEntries(results, cachedItems, cfg.Stremio.NzbTTLHours, time.Now(),
+		baseURL, key, streamType, season, episode, imdbID)
+
+	streams := make([]fiber.Map, 0, len(entries))
+	for _, e := range entries {
+		streams = append(streams, fiber.Map{
+			"name":  e.Name,
+			"title": e.Title,
+			"url":   e.URL,
+		})
+	}
+
+	return c.JSON(fiber.Map{"streams": streams})
+}
+
+// stremioPlayCandidate is one release a /play request may attempt. Candidates are
+// produced in the same order the stream list presented, so the fallback chain and the
+// list agree on what "the next release" means.
+type stremioPlayCandidate struct {
+	Title       string // raw Prowlarr title
+	SafeTitle   string // sanitizeFilename(Title) -- the release key
+	DownloadURL string
+	Indexer     string
+}
+
+// stremioNzbPathMatches reports whether a queue item's nzb path belongs to the release
+// identified by safeTitle. The play handler stages every NZB as "<safeTitle>.nzb", and
+// the importer preserves that base name, so a substring test is the join between a
+// Prowlarr result and its queue rows.
+func stremioNzbPathMatches(nzbPath, safeTitle string) bool {
+	return strings.Contains(filepath.ToSlash(nzbPath), safeTitle+".nzb")
+}
+
+// stremioCachedPredicate returns a test for "already imported and still usable":
+// the item must have a storage path and, when a TTL is configured, have completed
+// within it. Mirrors the reuse condition in handleStremioAddonPlay so the "⚡ Cached"
+// badge is truthful.
+func stremioCachedPredicate(cached []*database.ImportQueueItem, ttlHours int, now time.Time) func(safeTitle string) bool {
+	paths := make([]string, 0, len(cached))
+	for _, item := range cached {
+		if item == nil || item.StoragePath == nil || *item.StoragePath == "" {
+			continue
+		}
+		if ttlHours > 0 {
+			if item.CompletedAt == nil || now.Sub(*item.CompletedAt) >= time.Duration(ttlHours)*time.Hour {
+				continue
+			}
+		}
+		paths = append(paths, item.NzbPath)
+	}
+
+	return func(safeTitle string) bool {
+		for _, p := range paths {
+			if stremioNzbPathMatches(p, safeTitle) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// stremioFailedPredicate returns a test for "known not to work", combining the durable
+// half (failed import_queue rows) with the process-local half (failures that leave no
+// failed row -- see stremioFailureCache).
+//
+// Unlike the cached predicate this keys off UpdatedAt, because UpdateQueueItemStatus
+// does not set completed_at on failure, and it does not require a storage path.
+func stremioFailedPredicate(
+	failed []*database.ImportQueueItem,
+	memKeys map[string]struct{},
+	ttlHours int,
+	now time.Time,
+) func(safeTitle string) bool {
+	paths := make([]string, 0, len(failed))
+	for _, item := range failed {
+		if item == nil {
+			continue
+		}
+		if ttlHours > 0 && now.Sub(item.UpdatedAt) >= time.Duration(ttlHours)*time.Hour {
+			continue
+		}
+		paths = append(paths, item.NzbPath)
+	}
+
+	return func(safeTitle string) bool {
+		if _, ok := memKeys[safeTitle]; ok {
+			return true
+		}
+		for _, p := range paths {
+			if stremioNzbPathMatches(p, safeTitle) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// filterStremioResults drops releases failing the configured language/quality filters,
+// and those already known to have failed. Excluding failed releases here -- rather than
+// demoting them -- is what stops a bad release being offered, and re-picked, forever.
+func filterStremioResults(
+	results []prowlarr.NZBResult,
+	languages, qualities []string,
+	isFailed func(safeTitle string) bool,
+) []prowlarr.NZBResult {
+	filtered := make([]prowlarr.NZBResult, 0, len(results))
+	for _, r := range results {
+		if !prowlarr.MatchesLanguage(r.Title, languages) {
+			continue
+		}
+		if !prowlarr.MatchesQuality(r.Title, qualities) {
+			continue
+		}
+		if isFailed != nil && isFailed(sanitizeFilename(r.Title)) {
+			continue
+		}
+		filtered = append(filtered, r)
+	}
+	return filtered
+}
+
+// orderStremioResults stably reorders results so cached releases come first,
+// preserving Prowlarr's relative order (publish date, newest first) within each group.
+func orderStremioResults(results []prowlarr.NZBResult, isCached func(safeTitle string) bool) []prowlarr.NZBResult {
+	ordered := make([]prowlarr.NZBResult, len(results))
+	copy(ordered, results)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return isCached(sanitizeFilename(ordered[i].Title)) && !isCached(sanitizeFilename(ordered[j].Title))
+	})
+	return ordered
+}
+
+// stremioCandidates converts ordered Prowlarr results into play candidates.
+func stremioCandidates(results []prowlarr.NZBResult, fallbackID string) []stremioPlayCandidate {
+	cands := make([]stremioPlayCandidate, 0, len(results))
+	for _, r := range results {
+		safeTitle := sanitizeFilename(r.Title)
+		if safeTitle == "" {
+			safeTitle = fallbackID
+		}
+		cands = append(cands, stremioPlayCandidate{
+			Title:       r.Title,
+			SafeTitle:   safeTitle,
+			DownloadURL: r.DownloadURL,
+			Indexer:     r.Indexer,
+		})
+	}
+	return cands
+}
+
+// nextStremioCandidate returns the index of the release to try after currentSafeTitle.
+// When the current release is absent -- the Prowlarr list can change between /stream and
+// /play -- it starts from the top rather than giving up. Reports false when exhausted.
+func nextStremioCandidate(cands []stremioPlayCandidate, currentSafeTitle string, startAfter int) (int, bool) {
+	if len(cands) == 0 {
+		return 0, false
+	}
+
+	if startAfter < 0 {
+		startAfter = -1
+		for i, c := range cands {
+			if c.SafeTitle == currentSafeTitle {
+				startAfter = i
+				break
+			}
+		}
+		if startAfter < 0 {
+			return 0, true
+		}
+	}
+
+	next := startAfter + 1
+	if next >= len(cands) {
+		return 0, false
+	}
+	return next, true
+}
+
+// searchStremioReleases runs the Prowlarr search for a Stremio content id, applies the
+// language/quality filters, drops releases known to have failed, and orders the result
+// cached-first. It is the single source of truth for candidate ordering, shared by the
+// stream list and the play fallback chain, so both agree on what "next" means.
+func (s *Server) searchStremioReleases(
+	ctx context.Context,
+	cfg *config.Config,
+	streamType, prowlarrType, imdbID string,
+	season, episode int,
+) ([]prowlarr.NZBResult, []*database.ImportQueueItem, error) {
+	prowlarrCfg := cfg.Stremio.Prowlarr
 	client := prowlarr.NewClient(
 		prowlarrCfg.Host,
 		prowlarrCfg.APIKey,
 		httpclient.NewForExternal(cfg.Network, 30*time.Second),
 	)
+
 	var (
 		results []prowlarr.NZBResult
 		err     error
@@ -200,53 +393,58 @@ func (s *Server) handleStremioAddonStream(c *fiber.Ctx) error {
 		results, err = client.Search(ctx, imdbID, prowlarrType, prowlarrCfg.Categories, prowlarrCfg.Indexers, season, episode)
 		if err != nil {
 			slog.WarnContext(ctx, "Prowlarr search failed", "error", err, "imdb_id", imdbID, "tvdb_id", tvdbID)
-			return emptyStreamsResponse(c)
+			return nil, nil, err
 		}
 	}
 
 	if len(results) == 0 {
 		slog.InfoContext(ctx, "No Prowlarr results found", "imdb_id", imdbID, "tvdb_id", tvdbID)
-		return emptyStreamsResponse(c)
+		return nil, nil, nil
 	}
 
-	// Apply language and quality filters
-	filtered := results[:0]
-	for _, r := range results {
-		if !prowlarr.MatchesLanguage(r.Title, prowlarrCfg.Languages) {
-			continue
-		}
-		if !prowlarr.MatchesQuality(r.Title, prowlarrCfg.Qualities) {
-			continue
-		}
-		filtered = append(filtered, r)
-	}
-	results = filtered
+	now := time.Now()
+	cachedItems, failedItems := s.loadStremioQueueState(ctx)
 
-	// Mark already-imported releases as cached so instantly-playable options
-	// surface first. Best-effort: on lookup failure, fall back to no badges.
-	var cachedItems []*database.ImportQueueItem
-	if s.queueRepo != nil {
-		if items, cacheErr := s.queueRepo.GetCachedStremioQueueItems(ctx); cacheErr != nil {
-			slog.WarnContext(ctx, "Failed to load cached Stremio items; continuing without cache badges",
-				"error", cacheErr)
-		} else {
-			cachedItems = items
-		}
+	total := len(results)
+	results = filterStremioResults(results, prowlarrCfg.Languages, prowlarrCfg.Qualities,
+		stremioFailedPredicate(failedItems, s.stremioFailures.Keys(stremioFailedTTL(cfg)),
+			cfg.Stremio.FailedReleaseTTLHours, now))
+	if len(results) < total {
+		slog.InfoContext(ctx, "Filtered Prowlarr results",
+			"imdb_id", imdbID, "total", total, "kept", len(results))
 	}
 
-	entries := buildStremioStreamEntries(results, cachedItems, cfg.Stremio.NzbTTLHours, time.Now(),
-		baseURL, key, streamType, season, episode, imdbID)
+	ordered := orderStremioResults(results, stremioCachedPredicate(cachedItems, cfg.Stremio.NzbTTLHours, now))
+	return ordered, cachedItems, nil
+}
 
-	streams := make([]fiber.Map, 0, len(entries))
-	for _, e := range entries {
-		streams = append(streams, fiber.Map{
-			"name":  e.Name,
-			"title": e.Title,
-			"url":   e.URL,
-		})
+// stremioFailedTTL is the age after which a recorded failure stops excluding a release.
+func stremioFailedTTL(cfg *config.Config) time.Duration {
+	return time.Duration(cfg.Stremio.FailedReleaseTTLHours) * time.Hour
+}
+
+// loadStremioQueueState fetches the cached and failed Stremio queue items. Both lookups
+// are best-effort: a DB hiccup degrades badges and exclusion rather than failing search.
+func (s *Server) loadStremioQueueState(ctx context.Context) (cached, failed []*database.ImportQueueItem) {
+	if s.queueRepo == nil {
+		return nil, nil
 	}
 
-	return c.JSON(fiber.Map{"streams": streams})
+	if items, err := s.queueRepo.GetCachedStremioQueueItems(ctx); err != nil {
+		slog.WarnContext(ctx, "Failed to load cached Stremio items; continuing without cache badges",
+			"error", err)
+	} else {
+		cached = items
+	}
+
+	if items, err := s.queueRepo.GetFailedStremioQueueItems(ctx); err != nil {
+		slog.WarnContext(ctx, "Failed to load failed Stremio items; continuing without exclusion",
+			"error", err)
+	} else {
+		failed = items
+	}
+
+	return cached, failed
 }
 
 // stremioStreamEntry is a single Stremio stream option produced from a Prowlarr
@@ -276,30 +474,10 @@ func buildStremioStreamEntries(
 	season, episode int,
 	fallbackID string,
 ) []stremioStreamEntry {
-	// Collect the nzb paths of cached items that are still usable: they must have
-	// a storage path and, when a TTL is configured, have completed within it.
-	// Mirrors the reuse condition in handleStremioAddonPlay.
-	validCachedPaths := make([]string, 0, len(cached))
-	for _, item := range cached {
-		if item == nil || item.StoragePath == nil || *item.StoragePath == "" {
-			continue
-		}
-		if ttlHours > 0 {
-			if item.CompletedAt == nil || now.Sub(*item.CompletedAt) >= time.Duration(ttlHours)*time.Hour {
-				continue
-			}
-		}
-		validCachedPaths = append(validCachedPaths, filepath.ToSlash(item.NzbPath))
-	}
+	isCached := stremioCachedPredicate(cached, ttlHours, now)
 
-	isCached := func(safeFilename string) bool {
-		for _, p := range validCachedPaths {
-			if strings.Contains(p, safeFilename) {
-				return true
-			}
-		}
-		return false
-	}
+	// Order first, then build, so entries come out in final order without a second sort.
+	results = orderStremioResults(results, isCached)
 
 	entries := make([]stremioStreamEntry, 0, len(results))
 	for _, r := range results {
@@ -307,7 +485,7 @@ func buildStremioStreamEntries(
 		if safeTitle == "" {
 			safeTitle = fallbackID
 		}
-		cachedHit := isCached(safeTitle + ".nzb")
+		cachedHit := isCached(safeTitle)
 
 		playURL := baseURL + "/stremio/" + key + "/play" +
 			"?url=" + url.QueryEscape(r.DownloadURL) +
@@ -315,6 +493,10 @@ func buildStremioStreamEntries(
 			"&type=" + url.QueryEscape(streamType)
 		if r.Indexer != "" {
 			playURL += "&indexer=" + url.QueryEscape(r.Indexer)
+		}
+		if fallbackID != "" {
+			// The content id lets /play re-derive the candidate list to fall back on.
+			playURL += "&id=" + url.QueryEscape(fallbackID)
 		}
 		if streamType == "series" && season > 0 && episode > 0 {
 			playURL += "&season=" + url.QueryEscape(strconv.Itoa(season)) +
@@ -371,12 +553,6 @@ func buildStremioStreamEntries(
 		})
 	}
 
-	// Stably sort cached entries first, preserving Prowlarr's relative order
-	// within each group.
-	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].Cached && !entries[j].Cached
-	})
-
 	return entries
 }
 
@@ -425,36 +601,233 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 	if safeTitle == "" {
 		safeTitle = "unknown"
 	}
-	var indexerPtr *string
-	if indexer := c.Query("indexer"); indexer != "" {
-		indexerPtr = &indexer
-	}
+	imdbID := c.Query("id")
+	streamType := c.Query("type")
 
 	baseURL := resolveBaseURL(c, cfg.Stremio.BaseURL)
 	selector := stremioEpisodeSelectorFromRequest(c)
 
-	safeFilename := safeTitle + ".nzb"
-	nzbName := safeTitle
+	cand := stremioPlayCandidate{
+		Title:       safeTitle,
+		SafeTitle:   safeTitle,
+		DownloadURL: downloadURL,
+		Indexer:     c.Query("indexer"),
+	}
 
-	// Short-circuit: return cached stream if already processed within TTL
+	// Short-circuit: return cached stream if already processed within TTL. This runs
+	// before the failed-release check so a genuinely playable file always wins over a
+	// stale failure record.
 	ttlHours := cfg.Stremio.NzbTTLHours
 	completedStatus := database.QueueStatusCompleted
-	if existing, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, safeFilename, "", 1, 0, "updated_at", "desc"); err == nil && len(existing) > 0 {
+	if existing, err := s.queueRepo.ListQueueItems(ctx, &completedStatus, cand.SafeTitle+".nzb", "", 1, 0, "updated_at", "desc"); err == nil && len(existing) > 0 {
 		prev := existing[0]
 		cacheValid := prev.StoragePath != nil && *prev.StoragePath != ""
 		if cacheValid && ttlHours > 0 && prev.CompletedAt != nil {
 			cacheValid = time.Since(*prev.CompletedAt) < time.Duration(ttlHours)*time.Hour
 		}
 		if cacheValid {
-			if streams, err := s.buildStremioStreams(ctx, prev, baseURL, key, nzbName, selector); err == nil && len(streams) > 0 {
+			if streams, err := s.buildStremioStreams(ctx, prev, baseURL, key, cand.SafeTitle, selector); err == nil && len(streams) > 0 {
 				slog.InfoContext(ctx, "Returning cached Stremio stream for Prowlarr NZB",
-					"nzb_name", nzbName)
+					"nzb_name", cand.SafeTitle)
 				return c.Redirect(streams[0].URL, fiber.StatusFound)
 			}
 		}
 	}
 
-	// Coalesce concurrent plays of the same title so the release is downloaded/queued once.
+	return s.playStremioWithFallback(c, cfg, cand, playRequest{
+		baseURL:    baseURL,
+		key:        key,
+		streamType: streamType,
+		imdbID:     imdbID,
+		selector:   selector,
+	})
+}
+
+// playRequest carries the per-request context the fallback loop needs, keeping the
+// loop signature readable.
+type playRequest struct {
+	baseURL    string
+	key        string
+	streamType string
+	imdbID     string
+	selector   *stremioEpisodeSelector
+}
+
+const (
+	// stremioPlayBudget is the total wall clock a /play request may spend across all
+	// attempts. Unchanged from the original single-attempt timeout, so client
+	// behaviour is unaffected.
+	stremioPlayBudget = 300 * time.Second
+	// stremioMinAttemptBudget is the minimum time left worth starting another attempt.
+	stremioMinAttemptBudget = 20 * time.Second
+)
+
+// playStremioWithFallback queues the requested release and waits for it, advancing to
+// the next candidate release when one fails. Without this, a release that fails is
+// simply re-downloaded and re-queued on every play, forever.
+func (s *Server) playStremioWithFallback(
+	c *fiber.Ctx,
+	cfg *config.Config,
+	cand stremioPlayCandidate,
+	req playRequest,
+) error {
+	ctx := c.Context()
+
+	// Candidates are resolved lazily: the happy path must not pay for a second
+	// Prowlarr search.
+	var (
+		cands       []stremioPlayCandidate
+		candsLoaded bool
+		curIdx      = -1
+	)
+	loadCandidates := func() {
+		if candsLoaded {
+			return
+		}
+		candsLoaded = true
+		if req.imdbID == "" {
+			return
+		}
+		prowlarrType := "search"
+		switch req.streamType {
+		case "movie":
+			prowlarrType = "movie"
+		case "series":
+			prowlarrType = "tvsearch"
+		}
+		season, episode := 0, 0
+		if req.selector != nil {
+			season, episode = req.selector.Season, req.selector.Episode
+		}
+		results, _, err := s.searchStremioReleases(ctx, cfg, req.streamType, prowlarrType, req.imdbID, season, episode)
+		if err != nil {
+			slog.WarnContext(ctx, "Stremio fallback search failed", "error", err, "imdb_id", req.imdbID)
+			return
+		}
+		cands = stremioCandidates(results, req.imdbID)
+	}
+
+	// advance moves to the next candidate, returning false when fallback is disabled,
+	// unavailable, or exhausted.
+	advance := func() bool {
+		if cfg.Stremio.EffectiveMaxFallbackReleases() == 0 || req.imdbID == "" {
+			return false
+		}
+		loadCandidates()
+		next, ok := nextStremioCandidate(cands, cand.SafeTitle, curIdx)
+		if !ok {
+			return false
+		}
+		curIdx = next
+		cand = cands[next]
+		slog.InfoContext(ctx, "Falling back to next Stremio release",
+			"imdb_id", req.imdbID, "title", cand.SafeTitle)
+		return true
+	}
+
+	deadline := time.Now().Add(stremioPlayBudget)
+	maxAttempts := 1 + cfg.Stremio.EffectiveMaxFallbackReleases()
+	attempts := 0
+
+	// A stale client-cached stream list can point straight at a release we already know
+	// is bad. Skip the download entirely and start from the next candidate.
+	if s.stremioIsFailed(ctx, cfg, cand.SafeTitle) {
+		slog.InfoContext(ctx, "Skipping known-failed Stremio release", "title", cand.SafeTitle)
+		if !advance() {
+			return RespondServiceUnavailable(c, "No playable release found", "release previously failed")
+		}
+	}
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		remaining := time.Until(deadline)
+		if attempt > 1 && remaining < stremioMinAttemptBudget {
+			break
+		}
+		attempts++
+
+		itemID, err := s.enqueueStremioRelease(ctx, cfg, cand, req.streamType)
+		if err != nil {
+			// Pre-queue failure (dead Prowlarr URL, malformed NZB): no queue row will
+			// ever exist, so the in-memory cache is the only place this can be recorded.
+			slog.WarnContext(ctx, "Failed to prepare Stremio NZB stream",
+				"error", err, "title", cand.SafeTitle)
+			s.stremioFailures.Record(cand.SafeTitle)
+			if !advance() {
+				return RespondServiceUnavailable(c, "Failed to prepare NZB stream", err.Error())
+			}
+			continue
+		}
+
+		out := s.waitForStream(ctx, itemID, req.baseURL, req.key, cand.SafeTitle, req.selector, remaining)
+		switch out.Kind {
+		case streamOutcomeReady:
+			// Self-healing: a release that plays is no longer excluded.
+			s.stremioFailures.Forget(cand.SafeTitle)
+			return c.Redirect(out.StreamURL, fiber.StatusFound)
+
+		case streamOutcomeNoStreams:
+			// The row is 'completed', so GetFailedStremioQueueItems will never see it
+			// and it would otherwise keep its "⚡ Cached" badge.
+			s.stremioFailures.Record(cand.SafeTitle)
+			if !advance() {
+				return respondStreamOutcome(c, out)
+			}
+
+		case streamOutcomeFailed:
+			// The failed import_queue row already records this durably.
+			if !advance() {
+				return respondStreamOutcome(c, out)
+			}
+
+		default:
+			// Ambiguous, timeout and unavailable are not evidence the release is bad.
+			return respondStreamOutcome(c, out)
+		}
+	}
+
+	slog.WarnContext(ctx, "No playable Stremio release found",
+		"imdb_id", req.imdbID, "attempts", attempts, "candidates", len(cands))
+	return RespondServiceUnavailable(c, "No playable release found",
+		fmt.Sprintf("tried %d release(s), none playable", attempts))
+}
+
+// stremioIsFailed reports whether a release is currently excluded, consulting both the
+// durable (import_queue) and process-local halves of the exclusion set.
+func (s *Server) stremioIsFailed(ctx context.Context, cfg *config.Config, safeTitle string) bool {
+	if s.stremioFailures.Has(safeTitle, stremioFailedTTL(cfg)) {
+		return true
+	}
+	if s.queueRepo == nil {
+		return false
+	}
+	failed, err := s.queueRepo.GetFailedStremioQueueItems(ctx)
+	if err != nil {
+		return false
+	}
+	return stremioFailedPredicate(failed, nil, cfg.Stremio.FailedReleaseTTLHours, time.Now())(safeTitle)
+}
+
+// enqueueStremioRelease downloads the NZB and adds it to the import queue, coalescing
+// concurrent callers for the same release so it is downloaded once.
+//
+// It returns as soon as the queue item exists. The wait deliberately stays outside the
+// singleflight group: holding the group for the whole import would serialize every
+// concurrent viewer of the release behind one request.
+func (s *Server) enqueueStremioRelease(
+	ctx context.Context,
+	cfg *config.Config,
+	cand stremioPlayCandidate,
+	streamType string,
+) (int64, error) {
+	safeFilename := cand.SafeTitle + ".nzb"
+	ttlHours := cfg.Stremio.NzbTTLHours
+
+	var indexerPtr *string
+	if cand.Indexer != "" {
+		indexer := cand.Indexer
+		indexerPtr = &indexer
+	}
+
 	v, err, _ := s.stremioPlayGroup.Do(safeFilename, func() (interface{}, error) {
 		// Serialized per title: reuse an in-flight or TTL-fresh import instead of re-downloading.
 		if items, e := s.queueRepo.ListQueueItems(ctx, nil, safeFilename, "", 1, 0, "updated_at", "desc"); e == nil && len(items) > 0 {
@@ -500,7 +873,7 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 			prowlarrCfg.APIKey,
 			httpclient.NewForExternal(cfg.Network, httpclient.LongTimeout),
 		)
-		nzbData, err := client.DownloadNZB(workCtx, downloadURL)
+		nzbData, err := client.DownloadNZB(workCtx, cand.DownloadURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download NZB from Prowlarr: %w", err)
 		}
@@ -517,7 +890,7 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 		// Map Stremio stream type to Newznab category name so downloads land in the
 		// correct folder (matches default SABnzbd category config).
 		category := "Movies"
-		if c.Query("type") == "series" {
+		if streamType == "series" {
 			category = "TV"
 		}
 		stremioDownloadID := stremioDownloadIDPrefix + uuid.NewString()
@@ -527,100 +900,162 @@ func (s *Server) handleStremioAddonPlay(c *fiber.Ctx) error {
 		}
 
 		slog.InfoContext(ctx, "Prowlarr NZB queued for Stremio play",
-			"queue_id", item.ID, "title", safeTitle)
+			"queue_id", item.ID, "title", cand.SafeTitle)
 		return item.ID, nil
 	})
 	if err != nil {
-		slog.WarnContext(ctx, "Failed to prepare Stremio NZB stream", "error", err, "title", safeTitle)
-		return RespondServiceUnavailable(c, "Failed to prepare NZB stream", err.Error())
+		return 0, err
 	}
 
 	itemID, ok := v.(int64)
 	if !ok {
-		return RespondInternalError(c, "Unexpected play result", "")
+		return 0, fmt.Errorf("unexpected play result type %T", v)
 	}
-
-	return s.waitAndRedirectToStream(c, itemID, baseURL, key, nzbName, selector, 300)
+	return itemID, nil
 }
 
-// waitAndRedirectToStream waits for a queue item to complete and 302-redirects to the first stream URL.
-func (s *Server) waitAndRedirectToStream(c *fiber.Ctx, itemID int64, baseURL, downloadKey, nzbName string, selector *stremioEpisodeSelector, timeoutSecs int) error {
-	ctx := c.Context()
+// streamOutcomeKind classifies how a wait for a queue item ended. The distinction
+// drives fallback: only definitive, release-specific failures justify trying another
+// release.
+type streamOutcomeKind int
 
+const (
+	// streamOutcomeReady: a playable stream URL is available.
+	streamOutcomeReady streamOutcomeKind = iota
+	// streamOutcomeFailed: the import failed. A 'failed' row now exists in
+	// import_queue, so exclusion is already durably recorded.
+	streamOutcomeFailed
+	// streamOutcomeNoStreams: the import completed but produced nothing playable.
+	// The row is 'completed', so this must be recorded in the in-memory cache.
+	streamOutcomeNoStreams
+	// streamOutcomeAmbiguous: a multi-episode pack with no episode selector. A client
+	// problem, not a bad release -- never falls back, never recorded.
+	streamOutcomeAmbiguous
+	// streamOutcomeTimeout: still importing. Never falls back (the item is still
+	// running and a second high-priority import would contend for the same connection
+	// pool) and never recorded.
+	streamOutcomeTimeout
+	// streamOutcomeUnavailable: the wait could not be performed at all.
+	streamOutcomeUnavailable
+)
+
+// streamOutcome is the result of waiting on a queue item.
+type streamOutcome struct {
+	Kind      streamOutcomeKind
+	StreamURL string
+	Detail    string
+}
+
+// waitForStream waits for a queue item to become streamable and classifies the result.
+// Unlike waitAndRedirectToStream it never writes to the HTTP response, so the caller
+// can decide between redirecting and falling back to another release.
+func (s *Server) waitForStream(
+	ctx context.Context,
+	itemID int64,
+	baseURL, downloadKey, nzbName string,
+	selector *stremioEpisodeSelector,
+	timeout time.Duration,
+) streamOutcome {
+	// Subscribe before reading status so an event fired between the two is not missed.
 	subID, ch := s.progressBroadcaster.Subscribe()
 	defer s.progressBroadcaster.Unsubscribe(subID)
 
 	current, err := s.queueRepo.GetQueueItem(ctx, itemID)
 	if err != nil || current == nil {
-		return RespondServiceUnavailable(c, "Queue item not found", "")
+		return streamOutcome{Kind: streamOutcomeUnavailable, Detail: "queue item not found"}
 	}
 
-	redirectToFirst := func(item *database.ImportQueueItem) error {
+	firstStream := func(item *database.ImportQueueItem) streamOutcome {
 		streams, err := s.buildStremioStreams(ctx, item, baseURL, downloadKey, nzbName, selector)
 		if err != nil {
 			if errors.Is(err, errStremioEpisodeAmbiguous) {
-				return respondEpisodeAmbiguous(c)
+				return streamOutcome{Kind: streamOutcomeAmbiguous}
 			}
-			return RespondServiceUnavailable(c, "No streams available", "")
+			return streamOutcome{Kind: streamOutcomeNoStreams, Detail: err.Error()}
 		}
 		if len(streams) == 0 {
-			return RespondServiceUnavailable(c, "No streams available", "")
+			return streamOutcome{Kind: streamOutcomeNoStreams, Detail: "no media files in release"}
 		}
-		return c.Redirect(streams[0].URL, fiber.StatusFound)
+		return streamOutcome{Kind: streamOutcomeReady, StreamURL: streams[0].URL}
 	}
 
 	switch current.Status {
 	case database.QueueStatusCompleted:
-		return redirectToFirst(current)
+		return firstStream(current)
 	case database.QueueStatusFailed:
-		return RespondServiceUnavailable(c, "NZB processing failed", "")
+		detail := ""
+		if current.ErrorMessage != nil {
+			detail = *current.ErrorMessage
+		}
+		return streamOutcome{Kind: streamOutcomeFailed, Detail: detail}
 	default:
 		// If the item is already processing and has a storage path, the streamable
-		// event fired before we subscribed — redirect immediately.
+		// event fired before we subscribed — use it immediately.
 		if current.StoragePath != nil && *current.StoragePath != "" {
-			if streams, err := s.buildStremioStreams(ctx, current, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
-				return c.Redirect(streams[0].URL, fiber.StatusFound)
+			if out := firstStream(current); out.Kind == streamOutcomeReady {
+				return out
 			}
 		}
 	}
 
-	timer := time.NewTimer(time.Duration(timeoutSecs) * time.Second)
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
 	for {
 		select {
 		case update, ok := <-ch:
 			if !ok {
-				return RespondServiceUnavailable(c, "Progress channel closed", "")
+				return streamOutcome{Kind: streamOutcomeUnavailable, Detail: "progress channel closed"}
 			}
 			if update.QueueID != int(itemID) {
 				continue
 			}
 			switch update.Status {
 			case "streamable":
-				// Redirect as soon as the file is accessible in the VFS — before post-processing.
+				// Serve as soon as the file is accessible in the VFS — before post-processing.
 				if update.StoragePath != "" {
 					fakeItem := &database.ImportQueueItem{ID: itemID, StoragePath: &update.StoragePath}
-					if streams, err := s.buildStremioStreams(ctx, fakeItem, baseURL, downloadKey, nzbName, selector); err == nil && len(streams) > 0 {
-						return c.Redirect(streams[0].URL, fiber.StatusFound)
+					if out := firstStream(fakeItem); out.Kind == streamOutcomeReady {
+						return out
 					}
 				}
 				// No media files yet — fall through to wait for completed.
 			case "completed":
 				item, err := s.queueRepo.GetQueueItem(ctx, itemID)
 				if err != nil {
-					return RespondServiceUnavailable(c, "Failed to fetch queue item", "")
+					return streamOutcome{Kind: streamOutcomeUnavailable, Detail: "failed to fetch queue item"}
 				}
-				return redirectToFirst(item)
+				return firstStream(item)
 			case "failed":
-				return RespondServiceUnavailable(c, "NZB processing failed", "")
+				return streamOutcome{Kind: streamOutcomeFailed}
 			}
 		case <-timer.C:
-			return RespondServiceUnavailable(c, "Processing timed out",
-				fmt.Sprintf("did not complete within %d seconds", timeoutSecs))
+			return streamOutcome{
+				Kind:   streamOutcomeTimeout,
+				Detail: fmt.Sprintf("did not complete within %s", timeout),
+			}
 		}
 	}
 }
+
+// respondStreamOutcome writes the HTTP response for a non-ready outcome.
+func respondStreamOutcome(c *fiber.Ctx, out streamOutcome) error {
+	switch out.Kind {
+	case streamOutcomeReady:
+		return c.Redirect(out.StreamURL, fiber.StatusFound)
+	case streamOutcomeAmbiguous:
+		return respondEpisodeAmbiguous(c)
+	case streamOutcomeFailed:
+		return RespondServiceUnavailable(c, "NZB processing failed", out.Detail)
+	case streamOutcomeNoStreams:
+		return RespondServiceUnavailable(c, "No streams available", out.Detail)
+	case streamOutcomeTimeout:
+		return RespondServiceUnavailable(c, "Processing timed out", out.Detail)
+	default:
+		return RespondServiceUnavailable(c, "Failed to prepare NZB stream", out.Detail)
+	}
+}
+
 
 // validateDownloadKey returns true if key matches any user's hashed API key.
 func (s *Server) validateDownloadKey(ctx context.Context, key string) bool {

--- a/internal/api/stremio_failures.go
+++ b/internal/api/stremio_failures.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"sync"
+	"time"
+)
+
+// stremioFailureCacheMaxEntries bounds the cache so a long-running server cannot
+// accumulate failure keys without limit. On overflow the oldest entry is dropped.
+const stremioFailureCacheMaxEntries = 1000
+
+// stremioFailureCache remembers Stremio releases that failed in ways which leave no
+// 'failed' row in import_queue, and which therefore cannot be recovered by
+// Repository.GetFailedStremioQueueItems:
+//
+//   - pre-queue failures, where Prowlarr's download URL is dead or the NZB is
+//     malformed, so no queue item is ever created;
+//   - imports that complete but yield no playable media, which leave a 'completed'
+//     row and would otherwise be badged as instantly-playable.
+//
+// It is deliberately process-local and not persisted: the durable half of the
+// exclusion set comes from import_queue, so losing this on restart costs at most one
+// retry of an affected release.
+//
+// Expiry is applied by the reader rather than stored, so a live change to
+// Stremio.FailedReleaseTTLHours takes effect without recreating the cache — matching
+// how the import_queue half applies the same TTL at its call site.
+type stremioFailureCache struct {
+	mu    sync.RWMutex
+	items map[string]time.Time // release key -> when the failure was recorded
+}
+
+func newStremioFailureCache() *stremioFailureCache {
+	return &stremioFailureCache{items: make(map[string]time.Time)}
+}
+
+// stremioFailureExpired reports whether a failure recorded at recordedAt has aged out.
+// A non-positive ttl means failures never expire on age alone.
+func stremioFailureExpired(recordedAt, now time.Time, ttl time.Duration) bool {
+	return ttl > 0 && now.Sub(recordedAt) >= ttl
+}
+
+// Record marks a release key as failed, refreshing the timestamp if already present.
+func (c *stremioFailureCache) Record(releaseKey string) {
+	if releaseKey == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Evict the oldest entry rather than growing without bound. Only needed when
+	// adding a genuinely new key.
+	if _, exists := c.items[releaseKey]; !exists && len(c.items) >= stremioFailureCacheMaxEntries {
+		var oldestKey string
+		var oldestAt time.Time
+		for k, at := range c.items {
+			if oldestKey == "" || at.Before(oldestAt) {
+				oldestKey, oldestAt = k, at
+			}
+		}
+		delete(c.items, oldestKey)
+	}
+
+	c.items[releaseKey] = time.Now()
+}
+
+// Has reports whether a release key is recorded as failed and not yet aged out.
+func (c *stremioFailureCache) Has(releaseKey string, ttl time.Duration) bool {
+	if releaseKey == "" {
+		return false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	recordedAt, ok := c.items[releaseKey]
+	return ok && !stremioFailureExpired(recordedAt, time.Now(), ttl)
+}
+
+// Forget drops a release key, so a release that later imports successfully stops
+// being excluded.
+func (c *stremioFailureCache) Forget(releaseKey string) {
+	if releaseKey == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.items, releaseKey)
+}
+
+// Keys returns the set of release keys still considered failed under ttl, purging
+// aged-out entries as a side effect. This lazy sweep is why the cache needs no
+// background goroutine.
+func (c *stremioFailureCache) Keys(ttl time.Duration) map[string]struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	keys := make(map[string]struct{}, len(c.items))
+	for k, recordedAt := range c.items {
+		if stremioFailureExpired(recordedAt, now, ttl) {
+			delete(c.items, k)
+			continue
+		}
+		keys[k] = struct{}{}
+	}
+
+	return keys
+}

--- a/internal/api/stremio_failures_test.go
+++ b/internal/api/stremio_failures_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStremioFailureCache_RecordHasForget(t *testing.T) {
+	c := newStremioFailureCache()
+	const ttl = time.Hour
+
+	if c.Has("nothing", ttl) {
+		t.Error("empty cache reported a hit")
+	}
+
+	c.Record("Some.Release.1080p")
+	if !c.Has("Some.Release.1080p", ttl) {
+		t.Error("recorded key not reported as failed")
+	}
+	if c.Has("Other.Release", ttl) {
+		t.Error("unrelated key reported as failed")
+	}
+
+	// A release that later plays must stop being excluded.
+	c.Forget("Some.Release.1080p")
+	if c.Has("Some.Release.1080p", ttl) {
+		t.Error("forgotten key still reported as failed")
+	}
+
+	// Empty keys are ignored rather than poisoning the cache.
+	c.Record("")
+	if c.Has("", ttl) {
+		t.Error("empty key reported as failed")
+	}
+}
+
+func TestStremioFailureCache_TTL(t *testing.T) {
+	c := newStremioFailureCache()
+	c.Record("Aged.Release")
+
+	// Backdate the entry so it is two hours old.
+	c.mu.Lock()
+	c.items["Aged.Release"] = time.Now().Add(-2 * time.Hour)
+	c.mu.Unlock()
+
+	tests := []struct {
+		name string
+		ttl  time.Duration
+		want bool
+	}{
+		{name: "within ttl", ttl: 3 * time.Hour, want: true},
+		{name: "past ttl", ttl: time.Hour, want: false},
+		{name: "zero ttl never expires", ttl: 0, want: true},
+		{name: "negative ttl never expires", ttl: -1, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.Has("Aged.Release", tt.ttl); got != tt.want {
+				t.Errorf("Has = %v; want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStremioFailureCache_KeysPurgesExpired(t *testing.T) {
+	c := newStremioFailureCache()
+	c.Record("Fresh")
+	c.Record("Stale")
+
+	c.mu.Lock()
+	c.items["Stale"] = time.Now().Add(-48 * time.Hour)
+	c.mu.Unlock()
+
+	keys := c.Keys(24 * time.Hour)
+	if _, ok := keys["Fresh"]; !ok {
+		t.Error("fresh key missing from Keys")
+	}
+	if _, ok := keys["Stale"]; ok {
+		t.Error("stale key returned by Keys")
+	}
+
+	// Keys purges lazily, which is why the cache needs no background goroutine.
+	c.mu.RLock()
+	_, stillStored := c.items["Stale"]
+	c.mu.RUnlock()
+	if stillStored {
+		t.Error("expired entry was not purged from the backing map")
+	}
+}
+
+func TestStremioFailureCache_EvictsOldestWhenFull(t *testing.T) {
+	c := newStremioFailureCache()
+
+	base := time.Now()
+	for i := range stremioFailureCacheMaxEntries {
+		key := "release-" + string(rune('a'+i%26)) + "-" + time.Duration(i).String()
+		c.Record(key)
+		// Force a strictly increasing age ordering so "oldest" is deterministic.
+		c.mu.Lock()
+		c.items[key] = base.Add(time.Duration(i) * time.Millisecond)
+		c.mu.Unlock()
+	}
+
+	c.mu.RLock()
+	size := len(c.items)
+	c.mu.RUnlock()
+	if size != stremioFailureCacheMaxEntries {
+		t.Fatalf("expected %d entries, got %d", stremioFailureCacheMaxEntries, size)
+	}
+
+	// The oldest entry is the one stamped at base.
+	oldest := "release-a-0s"
+	c.Record("brand-new")
+
+	c.mu.RLock()
+	size = len(c.items)
+	_, oldestPresent := c.items[oldest]
+	_, newPresent := c.items["brand-new"]
+	c.mu.RUnlock()
+
+	if size != stremioFailureCacheMaxEntries {
+		t.Errorf("cache grew past cap: %d entries", size)
+	}
+	if oldestPresent {
+		t.Error("oldest entry was not evicted")
+	}
+	if !newPresent {
+		t.Error("new entry was not stored")
+	}
+}
+
+func TestStremioFailureCache_ConcurrentAccess(t *testing.T) {
+	c := newStremioFailureCache()
+	const ttl = time.Hour
+
+	var wg sync.WaitGroup
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := "release-" + time.Duration(i).String()
+			c.Record(key)
+			c.Has(key, ttl)
+			c.Keys(ttl)
+			if i%3 == 0 {
+				c.Forget(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/internal/api/stremio_play_fallback_test.go
+++ b/internal/api/stremio_play_fallback_test.go
@@ -1,0 +1,322 @@
+package api
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/database"
+	"github.com/javi11/altmount/internal/prowlarr"
+)
+
+func contains(haystack, needle string) bool { return strings.Contains(haystack, needle) }
+
+func urlEscape(s string) string { return url.QueryEscape(s) }
+
+// failedItem builds a failed Stremio queue item for exclusion tests.
+func failedItem(nzbPath string, updatedAt time.Time) *database.ImportQueueItem {
+	return &database.ImportQueueItem{NzbPath: nzbPath, UpdatedAt: updatedAt}
+}
+
+func resultsFromTitles(titles ...string) []prowlarr.NZBResult {
+	results := make([]prowlarr.NZBResult, len(titles))
+	for i, ti := range titles {
+		results[i] = prowlarr.NZBResult{Title: ti, DownloadURL: "https://prowlarr/dl", Size: 1e9}
+	}
+	return results
+}
+
+func titlesOf(results []prowlarr.NZBResult) []string {
+	out := make([]string, len(results))
+	for i, r := range results {
+		out[i] = r.Title
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestFilterStremioResults_ExcludesFailed(t *testing.T) {
+	tests := []struct {
+		name      string
+		titles    []string
+		failedKey string
+		languages []string
+		qualities []string
+		want      []string
+	}{
+		{
+			name:   "no failures keeps everything",
+			titles: []string{"Alpha 2024 1080p", "Bravo 2024 1080p"},
+			want:   []string{"Alpha 2024 1080p", "Bravo 2024 1080p"},
+		},
+		{
+			name:      "failed release is dropped",
+			titles:    []string{"Alpha 2024 1080p", "Bravo 2024 1080p"},
+			failedKey: sanitizeFilename("Alpha 2024 1080p"),
+			want:      []string{"Bravo 2024 1080p"},
+		},
+		{
+			name:      "all failed yields empty",
+			titles:    []string{"Alpha 2024 1080p"},
+			failedKey: sanitizeFilename("Alpha 2024 1080p"),
+			want:      nil,
+		},
+		{
+			name:      "title needing sanitization still matches",
+			titles:    []string{"Movie: The Sequel 2024 1080p"},
+			failedKey: sanitizeFilename("Movie: The Sequel 2024 1080p"),
+			want:      nil,
+		},
+		{
+			name:      "release already dropped by quality filter does not double-drop",
+			titles:    []string{"Alpha 2024 720p", "Bravo 2024 1080p"},
+			failedKey: sanitizeFilename("Alpha 2024 720p"),
+			qualities: []string{"1080p"},
+			want:      []string{"Bravo 2024 1080p"},
+		},
+		{
+			name:      "language filter still applies alongside exclusion",
+			titles:    []string{"Alpha 2024 1080p Spanish", "Bravo 2024 1080p"},
+			languages: []string{"Spanish"},
+			want:      []string{"Alpha 2024 1080p Spanish"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isFailed := func(safeTitle string) bool {
+				return tt.failedKey != "" && safeTitle == tt.failedKey
+			}
+
+			got := filterStremioResults(resultsFromTitles(tt.titles...), tt.languages, tt.qualities, isFailed)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v; want %v", titlesOf(got), tt.want)
+			}
+			if !equalStrings(titlesOf(got), tt.want) {
+				t.Errorf("got %v; want %v", titlesOf(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterStremioResults_NilPredicate(t *testing.T) {
+	got := filterStremioResults(resultsFromTitles("Alpha 2024 1080p"), nil, nil, nil)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 result with nil predicate, got %d", len(got))
+	}
+}
+
+func TestStremioFailedPredicate(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	title := "Some Movie 2024 1080p WEB-DL"
+	key := sanitizeFilename(title)
+	path := "/config/.nzbs/Movies/7/" + key + ".nzb"
+
+	tests := []struct {
+		name     string
+		failed   []*database.ImportQueueItem
+		memKeys  map[string]struct{}
+		ttlHours int
+		want     bool
+	}{
+		{
+			name:     "failed within ttl is excluded",
+			failed:   []*database.ImportQueueItem{failedItem(path, now.Add(-1 * time.Hour))},
+			ttlHours: 24,
+			want:     true,
+		},
+		{
+			name:     "failed past ttl is not excluded",
+			failed:   []*database.ImportQueueItem{failedItem(path, now.Add(-48 * time.Hour))},
+			ttlHours: 24,
+			want:     false,
+		},
+		{
+			name:     "ttl zero excludes regardless of age",
+			failed:   []*database.ImportQueueItem{failedItem(path, now.Add(-1000 * time.Hour))},
+			ttlHours: 0,
+			want:     true,
+		},
+		{
+			name:     "unrelated failed path does not match",
+			failed:   []*database.ImportQueueItem{failedItem("/config/.nzbs/Movies/9/Other Release.nzb", now)},
+			ttlHours: 24,
+			want:     false,
+		},
+		{
+			name:     "in-memory key excludes without a queue row",
+			memKeys:  map[string]struct{}{key: {}},
+			ttlHours: 24,
+			want:     true,
+		},
+		{
+			name:     "empty everything does not exclude",
+			ttlHours: 24,
+			want:     false,
+		},
+		{
+			name:     "windows-style backslash path still matches",
+			failed:   []*database.ImportQueueItem{failedItem(`C:\config\.nzbs\Movies\7\`+key+".nzb", now)},
+			ttlHours: 24,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isFailed := stremioFailedPredicate(tt.failed, tt.memKeys, tt.ttlHours, now)
+			if got := isFailed(key); got != tt.want {
+				t.Errorf("isFailed(%q) = %v; want %v", key, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrderStremioResults_CachedFirstStable(t *testing.T) {
+	results := resultsFromTitles("Alpha 2024", "Bravo 2024", "Charlie 2024", "Delta 2024")
+	cachedKeys := map[string]struct{}{
+		sanitizeFilename("Bravo 2024"): {},
+		sanitizeFilename("Delta 2024"): {},
+	}
+	isCached := func(safeTitle string) bool {
+		_, ok := cachedKeys[safeTitle]
+		return ok
+	}
+
+	got := titlesOf(orderStremioResults(results, isCached))
+	want := []string{"Bravo 2024", "Delta 2024", "Alpha 2024", "Charlie 2024"}
+	if !equalStrings(got, want) {
+		t.Errorf("got %v; want %v", got, want)
+	}
+
+	// Ordering must not mutate the caller's slice: the stream list and the fallback
+	// chain both order the same search results.
+	if titlesOf(results)[0] != "Alpha 2024" {
+		t.Errorf("input slice was mutated: %v", titlesOf(results))
+	}
+}
+
+func TestNextStremioCandidate(t *testing.T) {
+	cands := stremioCandidates(resultsFromTitles("Alpha", "Bravo", "Charlie"), "tt1")
+
+	tests := []struct {
+		name       string
+		cands      []stremioPlayCandidate
+		current    string
+		startAfter int
+		wantIdx    int
+		wantOK     bool
+	}{
+		{
+			name:       "advances from explicit index",
+			cands:      cands,
+			startAfter: 0,
+			wantIdx:    1,
+			wantOK:     true,
+		},
+		{
+			name:       "exhausted at last index",
+			cands:      cands,
+			startAfter: 2,
+			wantOK:     false,
+		},
+		{
+			name:       "finds current by title on first advance",
+			cands:      cands,
+			current:    sanitizeFilename("Alpha"),
+			startAfter: -1,
+			wantIdx:    1,
+			wantOK:     true,
+		},
+		{
+			name:       "current is last known release",
+			cands:      cands,
+			current:    sanitizeFilename("Charlie"),
+			startAfter: -1,
+			wantOK:     false,
+		},
+		{
+			name:       "current absent starts from the top",
+			cands:      cands,
+			current:    "Release That Was Filtered Out",
+			startAfter: -1,
+			wantIdx:    0,
+			wantOK:     true,
+		},
+		{
+			name:       "empty candidate list is exhausted",
+			cands:      nil,
+			startAfter: -1,
+			wantOK:     false,
+		},
+		{
+			name:       "single-element list matching current is exhausted",
+			cands:      stremioCandidates(resultsFromTitles("Solo"), "tt1"),
+			current:    sanitizeFilename("Solo"),
+			startAfter: -1,
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := nextStremioCandidate(tt.cands, tt.current, tt.startAfter)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v; want %v", ok, tt.wantOK)
+			}
+			if ok && idx != tt.wantIdx {
+				t.Errorf("idx = %d; want %d", idx, tt.wantIdx)
+			}
+		})
+	}
+}
+
+// TestStremioCandidatesMatchStreamEntries pins the invariant that makes fallback
+// correct: the candidate list and the stream list must agree on both ordering and
+// release keys. If they drift, /play advances to a release the user never saw, or
+// re-tries the one that just failed.
+func TestStremioCandidatesMatchStreamEntries(t *testing.T) {
+	now := time.Date(2026, 8, 2, 12, 0, 0, 0, time.UTC)
+	results := resultsFromTitles("Alpha 2024 1080p", "Bravo: The Sequel 2024 1080p", "Charlie 2024 1080p")
+
+	// Bravo is cached, so both paths must float it to the front.
+	cached := []*database.ImportQueueItem{
+		cachedItem("/nzbs/"+sanitizeFilename("Bravo: The Sequel 2024 1080p")+".nzb", "/s/b",
+			timePtr(now.Add(-time.Hour))),
+	}
+
+	isCached := stremioCachedPredicate(cached, 24, now)
+	ordered := orderStremioResults(results, isCached)
+	cands := stremioCandidates(ordered, "tt1")
+
+	entries := buildStremioStreamEntries(results, cached, 24, now,
+		"https://host", "k", "movie", 0, 0, "tt1")
+
+	if len(cands) != len(entries) {
+		t.Fatalf("candidates (%d) and entries (%d) differ in length", len(cands), len(entries))
+	}
+	if !entries[0].Cached {
+		t.Error("expected the cached release to sort first")
+	}
+
+	for i := range cands {
+		// The play URL embeds the release key as its title param, so a matching
+		// title= proves both paths derived the same key for the same position.
+		if !contains(entries[i].URL, "title="+urlEscape(cands[i].SafeTitle)) {
+			t.Errorf("position %d: entry URL %q does not carry candidate key %q",
+				i, entries[i].URL, cands[i].SafeTitle)
+		}
+	}
+}

--- a/internal/api/stremio_ttl_test.go
+++ b/internal/api/stremio_ttl_test.go
@@ -32,3 +32,62 @@ func TestStremioNzbTTLHoursZeroRoundTrip(t *testing.T) {
 		t.Errorf("expected nzb_ttl_hours:0 to be present in response JSON, got: %s", data)
 	}
 }
+
+// TestStremioFallbackFieldsZeroRoundTrip guards the same class of bug for the
+// failed-release settings. A dropped max_fallback_releases:0 would silently
+// re-enable fallback for a user who deliberately turned it off.
+func TestStremioFallbackFieldsZeroRoundTrip(t *testing.T) {
+	enabled := true
+	cfg := &config.Config{
+		Stremio: config.StremioConfig{
+			Enabled:               &enabled,
+			FailedReleaseTTLHours: 0,
+			MaxFallbackReleases:   0,
+		},
+	}
+
+	data, err := json.Marshal(ToConfigAPIResponse(cfg, "").Stremio)
+	if err != nil {
+		t.Fatalf("marshal stremio response: %v", err)
+	}
+
+	for _, want := range []string{`"failed_release_ttl_hours":0`, `"max_fallback_releases":0`} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("expected %s in response JSON, got: %s", want, data)
+		}
+	}
+}
+
+func TestStremioDefaults(t *testing.T) {
+	cfg := config.DefaultConfig(t.TempDir())
+
+	if cfg.Stremio.FailedReleaseTTLHours != 24 {
+		t.Errorf("FailedReleaseTTLHours = %d; want 24", cfg.Stremio.FailedReleaseTTLHours)
+	}
+	if cfg.Stremio.MaxFallbackReleases != 2 {
+		t.Errorf("MaxFallbackReleases = %d; want 2", cfg.Stremio.MaxFallbackReleases)
+	}
+}
+
+func TestEffectiveMaxFallbackReleases(t *testing.T) {
+	tests := []struct {
+		name string
+		set  int
+		want int
+	}{
+		{name: "zero disables fallback", set: 0, want: 0},
+		{name: "default passes through", set: 2, want: 2},
+		{name: "at the cap", set: 4, want: 4},
+		{name: "above the cap is clamped", set: 99, want: 4},
+		{name: "negative is treated as disabled", set: -1, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := config.StremioConfig{MaxFallbackReleases: tt.set}
+			if got := c.EffectiveMaxFallbackReleases(); got != tt.want {
+				t.Errorf("EffectiveMaxFallbackReleases() = %d; want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -203,10 +203,14 @@ type ArrsInstanceAPIResponse struct {
 
 // StremioAPIResponse sanitizes Stremio config for API responses
 type StremioAPIResponse struct {
-	Enabled     bool                `json:"enabled"`
-	NzbTTLHours int                 `json:"nzb_ttl_hours"`
-	BaseURL     string              `json:"base_url,omitempty"`
-	Prowlarr    ProwlarrAPIResponse `json:"prowlarr"`
+	Enabled bool `json:"enabled"`
+	NzbTTLHours int `json:"nzb_ttl_hours"`
+	// No omitempty: an explicit 0 must survive the round-trip, otherwise saving the
+	// config would silently restore the defaults.
+	FailedReleaseTTLHours int                 `json:"failed_release_ttl_hours"`
+	MaxFallbackReleases   int                 `json:"max_fallback_releases"`
+	BaseURL               string              `json:"base_url,omitempty"`
+	Prowlarr              ProwlarrAPIResponse `json:"prowlarr"`
 }
 
 // ProwlarrAPIResponse sanitizes Prowlarr config for API responses
@@ -380,9 +384,11 @@ func ToConfigAPIResponse(cfg *config.Config, apiKey string) *ConfigAPIResponse {
 	}
 
 	stremioResp := StremioAPIResponse{
-		Enabled:     cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled,
-		NzbTTLHours: cfg.Stremio.NzbTTLHours,
-		BaseURL:     cfg.Stremio.BaseURL,
+		Enabled:               cfg.Stremio.Enabled != nil && *cfg.Stremio.Enabled,
+		NzbTTLHours:           cfg.Stremio.NzbTTLHours,
+		FailedReleaseTTLHours: cfg.Stremio.FailedReleaseTTLHours,
+		MaxFallbackReleases:   cfg.Stremio.MaxFallbackReleases,
+		BaseURL:               cfg.Stremio.BaseURL,
 		Prowlarr: ProwlarrAPIResponse{
 			Enabled:    cfg.Stremio.Prowlarr.Enabled != nil && *cfg.Stremio.Prowlarr.Enabled,
 			Host:       cfg.Stremio.Prowlarr.Host,

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -174,12 +174,36 @@ type StremioConfig struct {
 	// the same NZB is re-processed on the next request.
 	// Set to 0 to disable expiry (cache forever). Defaults to 24 hours.
 	NzbTTLHours int `yaml:"nzb_ttl_hours" mapstructure:"nzb_ttl_hours" json:"nzb_ttl_hours"`
+	// FailedReleaseTTLHours controls how long a release that failed to import stays
+	// excluded from the Stremio stream list. Mirrors NzbTTLHours semantics: it filters
+	// failure records by age rather than deleting them, so it is bounded above by
+	// Import.FailedItemRetentionHours. Set to 0 to exclude for as long as the record
+	// survives. Defaults to 24 hours.
+	FailedReleaseTTLHours int `yaml:"failed_release_ttl_hours" mapstructure:"failed_release_ttl_hours" json:"failed_release_ttl_hours"`
+	// MaxFallbackReleases caps how many *extra* releases a single play request may try
+	// after the first one fails. Set to 0 to disable fallback. Defaults to 2.
+	MaxFallbackReleases int `yaml:"max_fallback_releases" mapstructure:"max_fallback_releases" json:"max_fallback_releases"`
 	// BaseURL is the public base URL used when building Stremio stream links
 	// (e.g. "https://altmount.example.com"). Falls back to the auto-detected
 	// request origin when not set.
 	BaseURL string `yaml:"base_url" mapstructure:"base_url" json:"base_url,omitempty"`
 	// Prowlarr configures the Prowlarr indexer used by the Stremio addon to search for NZBs.
 	Prowlarr ProwlarrConfig `yaml:"prowlarr" mapstructure:"prowlarr" json:"prowlarr"`
+}
+
+// maxStremioFallbackReleases bounds MaxFallbackReleases so a run of failures cannot
+// fire an unbounded number of Prowlarr searches for a single play request.
+const maxStremioFallbackReleases = 4
+
+// EffectiveMaxFallbackReleases returns MaxFallbackReleases clamped to [0, 4].
+func (s StremioConfig) EffectiveMaxFallbackReleases() int {
+	if s.MaxFallbackReleases < 0 {
+		return 0
+	}
+	if s.MaxFallbackReleases > maxStremioFallbackReleases {
+		return maxStremioFallbackReleases
+	}
+	return s.MaxFallbackReleases
 }
 
 // AuthConfig represents authentication configuration
@@ -1523,8 +1547,10 @@ func DefaultConfig(configDir ...string) *Config {
 			Prefix: "/api",
 		},
 		Stremio: StremioConfig{
-			Enabled:     &stremioEnabled,
-			NzbTTLHours: 24,
+			Enabled:               &stremioEnabled,
+			NzbTTLHours:           24,
+			FailedReleaseTTLHours: 24,
+			MaxFallbackReleases:   2,
 			Prowlarr: ProwlarrConfig{
 				Enabled:    &prowlarrEnabled,
 				Host:       "http://localhost:9696",

--- a/internal/database/repository.go
+++ b/internal/database/repository.go
@@ -2128,6 +2128,47 @@ func (r *Repository) GetExpiredStremioQueueItems(ctx context.Context, ttlHours i
 	return items, rows.Err()
 }
 
+// GetFailedStremioQueueItems returns Stremio-originated queue items whose import
+// failed. Used by the Stremio stream handler to exclude releases that are known not
+// to work, so they stop being offered (and re-picked) on every search.
+//
+// Ordered by updated_at because UpdateQueueItemStatus does not set completed_at on
+// failure. Age filtering (Stremio.FailedReleaseTTLHours) is applied by the caller,
+// mirroring GetCachedStremioQueueItems.
+func (r *Repository) GetFailedStremioQueueItems(ctx context.Context) ([]*ImportQueueItem, error) {
+	query := `
+		SELECT id, download_id, nzb_path, relative_path, category, priority, status, created_at, updated_at,
+		       started_at, completed_at, retry_count, max_retries, error_message, batch_id, metadata, file_size, storage_path, target_path
+		FROM import_queue
+		WHERE status = 'failed'
+		  AND download_id LIKE 'stremio:%'
+		ORDER BY updated_at DESC
+		LIMIT 500
+	`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query failed stremio queue items: %w", err)
+	}
+	defer rows.Close()
+
+	var items []*ImportQueueItem
+	for rows.Next() {
+		var item ImportQueueItem
+		err := rows.Scan(
+			&item.ID, &item.DownloadID, &item.NzbPath, &item.RelativePath, &item.Category, &item.Priority, &item.Status,
+			&item.CreatedAt, &item.UpdatedAt, &item.StartedAt, &item.CompletedAt,
+			&item.RetryCount, &item.MaxRetries, &item.ErrorMessage, &item.BatchID, &item.Metadata, &item.FileSize, &item.StoragePath, &item.TargetPath,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan failed stremio queue item: %w", err)
+		}
+		items = append(items, &item)
+	}
+
+	return items, rows.Err()
+}
+
 // GetCachedStremioQueueItems returns completed Stremio-originated queue items that
 // have a storage path (i.e. are streamable). Used by the Stremio stream handler to
 // mark already-imported releases as cached. TTL freshness is applied by the caller.

--- a/internal/database/stremio_failed_queue_test.go
+++ b/internal/database/stremio_failed_queue_test.go
@@ -1,0 +1,75 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// insertStremioQueueItem inserts a queue item with an explicit download_id and
+// updated_at, which is what GetFailedStremioQueueItems filters and orders on.
+func insertStremioQueueItem(t *testing.T, db *sql.DB, nzbPath, status, downloadID, updatedAt string) {
+	t.Helper()
+
+	var dl any
+	if downloadID != "" {
+		dl = downloadID
+	}
+
+	_, err := db.Exec(
+		`INSERT INTO import_queue (nzb_path, status, download_id, updated_at) VALUES (?, ?, ?, ?)`,
+		nzbPath, status, dl, updatedAt,
+	)
+	require.NoError(t, err, "insert queue item %q", nzbPath)
+}
+
+func TestGetFailedStremioQueueItems(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:test_failed_stremio?mode=memory&cache=shared")
+	require.NoError(t, err)
+	defer db.Close()
+
+	setupQueueSchema(t, db)
+
+	// Two failed Stremio releases, plus rows that must NOT be returned.
+	insertStremioQueueItem(t, db, "/nzbs/Older.Failed.nzb", "failed", "stremio:aaa", "2026-08-01 10:00:00")
+	insertStremioQueueItem(t, db, "/nzbs/Newer.Failed.nzb", "failed", "stremio:bbb", "2026-08-02 10:00:00")
+	insertStremioQueueItem(t, db, "/nzbs/Completed.nzb", "completed", "stremio:ccc", "2026-08-02 11:00:00")
+	insertStremioQueueItem(t, db, "/nzbs/Pending.nzb", "pending", "stremio:ddd", "2026-08-02 11:00:00")
+	insertStremioQueueItem(t, db, "/nzbs/Sab.Failed.nzb", "failed", "sab:eee", "2026-08-02 11:00:00")
+	insertStremioQueueItem(t, db, "/nzbs/NoDownloadID.Failed.nzb", "failed", "", "2026-08-02 11:00:00")
+
+	repo := NewRepository(db, DialectSQLite)
+
+	items, err := repo.GetFailedStremioQueueItems(context.Background())
+	require.NoError(t, err)
+	require.Len(t, items, 2, "only failed stremio: items should be returned")
+
+	// Newest first: the query orders by updated_at DESC because
+	// UpdateQueueItemStatus does not set completed_at on failure.
+	assert.Equal(t, "/nzbs/Newer.Failed.nzb", items[0].NzbPath)
+	assert.Equal(t, "/nzbs/Older.Failed.nzb", items[1].NzbPath)
+
+	for _, item := range items {
+		require.NotNil(t, item.DownloadID)
+		assert.Contains(t, *item.DownloadID, "stremio:")
+	}
+}
+
+func TestGetFailedStremioQueueItems_Empty(t *testing.T) {
+	db, err := sql.Open("sqlite3", "file:test_failed_stremio_empty?mode=memory&cache=shared")
+	require.NoError(t, err)
+	defer db.Close()
+
+	setupQueueSchema(t, db)
+	insertStremioQueueItem(t, db, "/nzbs/Completed.nzb", "completed", "stremio:aaa", "2026-08-02 11:00:00")
+
+	repo := NewRepository(db, DialectSQLite)
+
+	items, err := repo.GetFailedStremioQueueItems(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, items, "no failed stremio items should yield an empty result, not an error")
+}


### PR DESCRIPTION
## Problem

In the Stremio addon, a release that failed to import kept getting picked again on every play.

**Root cause:** failed releases were structurally invisible to the Stremio stream list.

- `handleStremioAddonStream` rebuilds the list from Prowlarr on every request and orders it publish-date desc, with one adjustment — cached-first.
- Its only DB signal was `GetCachedStremioQueueItems`, which hard-filters `status = 'completed'`. A failed release therefore looked identical to an untried one and kept its exact rank, so whatever picked it before picked it again.
- `/play` compounded this: the singleflight lookup switched on the most-recent item's status and handled only `pending/processing/paused/completed`. A `failed` most-recent row **fell through**, re-downloading and re-queueing the identical NZB every time.
- Nothing else recorded release→failure identity. `indexer_import_stats` stores only an indexer name plus a per-play random `stremio:<uuid>`, and `prowlarr.NZBResult` carries no guid or hash.

## Approach

**Exclusion — no new table.** The importer already writes `status='failed'` to `import_queue`, and Stremio items carry `download_id LIKE 'stremio:%'`. That *is* the durable failure record, so this adds `GetFailedStremioQueueItems` mirroring the existing cached query rather than duplicating it in a new table. Notably this means **no migration and no changes to `internal/importer`**.

Ordered by `updated_at`, not `completed_at` — `UpdateQueueItemStatus` does not set `completed_at` on failure.

A small process-local cache (`stremio_failures.go`) covers the two failure modes that leave no `failed` row:
- **pre-queue failures** — a dead Prowlarr download URL or malformed NZB, where no queue item is ever created;
- **imported but no playable media** — this leaves a **`completed`** row, so without it the release would wrongly earn a `⚡ Cached` badge and then fail to play.

It's deliberately not persisted: the durable half comes from `import_queue`, so a restart costs at most one retry.

**Fallback.** `searchStremioReleases` becomes the single source of truth for search → filter → exclude → order, shared by the stream list and the fallback chain — otherwise fallback would advance to a release the user never saw. `waitForStream` returns a typed outcome instead of writing the HTTP response, and `playStremioWithFallback` loops over candidates within one 300s budget (unchanged from the previous single-attempt timeout, so client behaviour is unaffected).

## Reviewer notes

- **`enqueueStremioRelease` un-nests the singleflight.** Nested `Do` on the same key self-deadlocks; on a different key it would hold the first key in flight for the whole fallback chain and return the wrong item ID. The wait deliberately stays *outside* the group — moving it in would serialize every concurrent viewer of a release behind one 300s request.
- **Timeouts do not trigger fallback.** The import is still running; a second high-priority import would contend for the same NNTP pool and make both slower. The abandoned item still completes, so the user's re-click hits the cached short-circuit.
- **Ordering matters.** In `/play` the cached-completed short-circuit runs *before* the failed-release check, so a genuinely playable file always beats a stale failure record.
- **Existing tests were preserved.** `buildStremioStreamEntries` keeps its exact signature and behaviour; the reusable pieces were extracted from inside it rather than stripped out, so both existing table tests stay green untouched.
- Failure memory is bounded by `Import.FailedItemRetentionHours` (24h default) and cleared by the admin "clear failed items" action, since that's where the durable record lives.
- Pre-existing dead code carried over for symmetry: the `if safeTitle == "" { safeTitle = fallbackID }` guard never fires, because `sanitizeFilename` returns `"download"`, never `""`. Left alone rather than diverging the two call sites.

## Config

| Key | Default | Meaning |
| --- | --- | --- |
| `failed_release_ttl_hours` | 24 | How long a failed release stays hidden. `0` = as long as the record survives. |
| `max_fallback_releases` | 2 | Extra releases tried after the first fails. `0` disables fallback. Clamped to `[0,4]`. |

Both are surfaced in the config UI, with an explicit `0` preserved across the API round-trip — the same bug class as #803.

## Testing

- `go test -race ./internal/...` — passes
- `go build ./...` and the frontend build — clean
- `golangci-lint` — 0 issues on the three changed packages