### PR TITLE
fix(metadata): preserve ModifiedAt across updates and stabilise file & directory mtime

### DIFF
--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -224,7 +224,12 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 	// a VFS cache flush or attr-timeout expiry.
 	if metadata.ModifiedAt != 0 {
 		t := time.Unix(metadata.ModifiedAt, 0)
-		_ = os.Chtimes(metadataPath, t, t)
+		if err := os.Chtimes(metadataPath, t, t); err != nil {
+			// Not fatal: the proto is written and the WebDAV/FUSE mtime we
+			// report comes from ModifiedAt, not from the host filesystem.
+			slog.DebugContext(context.Background(), "Failed to pin metadata file mtime",
+				"path", metadataPath, "error", err)
+		}
 	}
 
 	metadata.NzbdavId = nzbdavId // Restore for in-memory use
@@ -616,41 +621,21 @@ func (ms *MetadataService) ListDirectoryAll(virtualPath string) (dirs []fs.FileI
 	return dirs, fileNames, nil
 }
 
-// GetDirectoryModTime returns max(children's ModifiedAt) for the given virtual
-// directory, returning a zero time.Time if the directory is empty or has no
-// children with ModifiedAt > 0 (allowing callers to fall back to a static epoch).
+// DirectoryModTime returns the on-disk mtime of the metadata directory backing
+// the given virtual directory, or a zero time.Time if it does not exist or is
+// not a directory (letting callers fall back to a static epoch).
 //
-// This ensures that virtual directory mtime advances when a new file is imported
-// (which sets ModifiedAt once at creation time), while remaining stable across
-// container restarts that trigger health sweeps (which never mutate ModifiedAt).
-func (ms *MetadataService) GetDirectoryModTime(virtualPath string) time.Time {
-	metadataDir := filepath.Join(ms.rootPath, virtualPath)
-
-	entries, err := os.ReadDir(metadataDir)
-	if err != nil {
+// This is a single stat: the kernel already advances a directory's mtime when
+// children are created or removed, so there is no need to scan children. It
+// stays stable across restart health sweeps because UpdateFileStatus skips the
+// write entirely when the status is unchanged, and advances on real imports and
+// deletions, which do mutate directory entries.
+func (ms *MetadataService) DirectoryModTime(virtualPath string) time.Time {
+	info, err := os.Stat(filepath.Join(ms.rootPath, virtualPath))
+	if err != nil || !info.IsDir() {
 		return time.Time{}
 	}
-
-	var maxModTime int64
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".meta" {
-			continue
-		}
-		virtualFileName := entry.Name()[:len(entry.Name())-5]
-		virtualFilePath := filepath.Join(virtualPath, virtualFileName)
-		lite, err := ms.ReadFileMetadataLite(virtualFilePath)
-		if err != nil || lite == nil || lite.ModifiedAt <= 0 {
-			continue
-		}
-		if lite.ModifiedAt > maxModTime {
-			maxModTime = lite.ModifiedAt
-		}
-	}
-
-	if maxModTime > 0 {
-		return time.Unix(maxModTime, 0)
-	}
-	return time.Time{}
+	return info.ModTime()
 }
 
 // CreateFileMetadata creates a new FileMetadata with basic fields
@@ -698,6 +683,11 @@ func (ms *MetadataService) CreateFileMetadata(
 // For paths that legitimately need to set a new ModifiedAt (initial import,
 // content replacement), call WriteFileMetadata or CreateFileMetadata directly
 // with the correct timestamp already set on the metadata struct.
+//
+// This is not a cheap call: it unmarshals the full proto and rewrites the .meta
+// via temp file + rename, which also bumps the parent directory's mtime. Callers
+// that may be asked to apply a no-op should guard against it first — see
+// UpdateFileStatus.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)
@@ -724,8 +714,26 @@ func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc fun
 	return ms.WriteFileMetadata(virtualPath, metadata)
 }
 
-// UpdateFileStatus updates the status of a file in metadata
+// UpdateFileStatus updates the status of a file in metadata.
+//
+// Re-asserting the status a file already has is a no-op and is skipped without
+// touching the disk. This matters at startup: the health worker emits
+// EventTypeFileHealthy for every known-healthy file, and the full read-modify-
+// write path unmarshals the entire proto (megabytes once SegmentData is inline)
+// and rewrites the .meta via temp file + rename for each one. The lite
+// projection carries Status, is served from an LRU, and on a miss reads only
+// liteScanBytes without ever instantiating the full proto — so the unchanged
+// case costs approximately nothing.
+//
+// Skipping the write also leaves the parent directory's mtime untouched, which
+// is what keeps DirectoryModTime stable across restarts.
 func (ms *MetadataService) UpdateFileStatus(virtualPath string, status metapb.FileStatus) error {
+	// Fall through on any error or miss so not-found and unreadable-metadata
+	// behaviour stays exactly as it was.
+	if lite, err := ms.ReadFileMetadataLite(virtualPath); err == nil && lite != nil && lite.Status == status {
+		return nil
+	}
+
 	return ms.UpdateFileMetadata(virtualPath, func(metadata *metapb.FileMetadata) {
 		metadata.Status = status
 	})

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -216,6 +216,17 @@ func (ms *MetadataService) WriteFileMetadata(virtualPath string, metadata *metap
 		return fmt.Errorf("failed to rename metadata file: %w", err)
 	}
 
+	// Stabilise the .meta disk mtime to match ModifiedAt in the proto.
+	// os.Rename always sets mtime=now on the destination file; without this
+	// Chtimes call any host tool reading the ext4 mtime (rather than the WebDAV
+	// Last-Modified we return from the proto) would see a freshly-updated
+	// timestamp on every health-check rewrite, potentially confusing rclone after
+	// a VFS cache flush or attr-timeout expiry.
+	if metadata.ModifiedAt != 0 {
+		t := time.Unix(metadata.ModifiedAt, 0)
+		_ = os.Chtimes(metadataPath, t, t)
+	}
+
 	metadata.NzbdavId = nzbdavId // Restore for in-memory use
 
 	// Update only the lightweight cache; the full proto (with SegmentData) is
@@ -641,8 +652,10 @@ func (ms *MetadataService) CreateFileMetadata(
 }
 
 // UpdateFileMetadata applies updateFunc to existing metadata and writes it back.
-// ModifiedAt is preserved unless the callback sets it — status/holes updates are
-// not content changes and must not rewrite WebDAV Last-Modified / FUSE mtime.
+// ModifiedAt is always preserved — health-status and known-holes updates are not
+// content changes and must not rewrite WebDAV Last-Modified / FUSE mtime.
+// The snapshot+restore is unconditional so future callbacks cannot accidentally
+// mutate ModifiedAt either.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)
@@ -653,8 +666,17 @@ func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc fun
 		return fmt.Errorf("metadata not found for path: %s", virtualPath)
 	}
 
+	// Snapshot ModifiedAt before invoking the callback. Health-status and
+	// known-holes updates are not content changes; they must not alter WebDAV
+	// Last-Modified or the FUSE mtime seen by Jellyfin. Restored unconditionally
+	// so future callbacks cannot accidentally mutate it.
+	originalModifiedAt := metadata.ModifiedAt
+
 	// Apply update function
 	updateFunc(metadata)
+
+	// Always restore ModifiedAt to its pre-call value.
+	metadata.ModifiedAt = originalModifiedAt
 
 	// Write back to disk
 	return ms.WriteFileMetadata(virtualPath, metadata)

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -640,7 +640,9 @@ func (ms *MetadataService) CreateFileMetadata(
 	}
 }
 
-// UpdateFileMetadata updates the modified timestamp of metadata
+// UpdateFileMetadata applies updateFunc to existing metadata and writes it back.
+// ModifiedAt is preserved unless the callback sets it — status/holes updates are
+// not content changes and must not rewrite WebDAV Last-Modified / FUSE mtime.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)
@@ -653,9 +655,6 @@ func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc fun
 
 	// Apply update function
 	updateFunc(metadata)
-
-	// Update modified timestamp
-	metadata.ModifiedAt = time.Now().Unix()
 
 	// Write back to disk
 	return ms.WriteFileMetadata(virtualPath, metadata)

--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -616,6 +616,43 @@ func (ms *MetadataService) ListDirectoryAll(virtualPath string) (dirs []fs.FileI
 	return dirs, fileNames, nil
 }
 
+// GetDirectoryModTime returns max(children's ModifiedAt) for the given virtual
+// directory, returning a zero time.Time if the directory is empty or has no
+// children with ModifiedAt > 0 (allowing callers to fall back to a static epoch).
+//
+// This ensures that virtual directory mtime advances when a new file is imported
+// (which sets ModifiedAt once at creation time), while remaining stable across
+// container restarts that trigger health sweeps (which never mutate ModifiedAt).
+func (ms *MetadataService) GetDirectoryModTime(virtualPath string) time.Time {
+	metadataDir := filepath.Join(ms.rootPath, virtualPath)
+
+	entries, err := os.ReadDir(metadataDir)
+	if err != nil {
+		return time.Time{}
+	}
+
+	var maxModTime int64
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".meta" {
+			continue
+		}
+		virtualFileName := entry.Name()[:len(entry.Name())-5]
+		virtualFilePath := filepath.Join(virtualPath, virtualFileName)
+		lite, err := ms.ReadFileMetadataLite(virtualFilePath)
+		if err != nil || lite == nil || lite.ModifiedAt <= 0 {
+			continue
+		}
+		if lite.ModifiedAt > maxModTime {
+			maxModTime = lite.ModifiedAt
+		}
+	}
+
+	if maxModTime > 0 {
+		return time.Unix(maxModTime, 0)
+	}
+	return time.Time{}
+}
+
 // CreateFileMetadata creates a new FileMetadata with basic fields
 func (ms *MetadataService) CreateFileMetadata(
 	fileSize int64,
@@ -652,10 +689,15 @@ func (ms *MetadataService) CreateFileMetadata(
 }
 
 // UpdateFileMetadata applies updateFunc to existing metadata and writes it back.
-// ModifiedAt is always preserved — health-status and known-holes updates are not
-// content changes and must not rewrite WebDAV Last-Modified / FUSE mtime.
-// The snapshot+restore is unconditional so future callbacks cannot accidentally
-// mutate ModifiedAt either.
+//
+// IMPORTANT — non-content RMW only: this helper is reserved for mutations that
+// do NOT change the file's logical content (e.g. health status, known-holes).
+// ModifiedAt is always unconditionally restored to its pre-call value, so any
+// attempt to bump it inside updateFunc will be silently discarded.
+//
+// For paths that legitimately need to set a new ModifiedAt (initial import,
+// content replacement), call WriteFileMetadata or CreateFileMetadata directly
+// with the correct timestamp already set on the metadata struct.
 func (ms *MetadataService) UpdateFileMetadata(virtualPath string, updateFunc func(*metapb.FileMetadata)) error {
 	// Read existing metadata
 	metadata, err := ms.ReadFileMetadata(virtualPath)

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -257,4 +258,40 @@ func TestReadFileMetadataLite_FallsBackOnLongHeader(t *testing.T) {
 	require.NotNil(t, lite)
 	assert.Equal(t, int64(1234), lite.FileSize)
 	assert.Equal(t, metapb.FileStatus_FILE_STATUS_HEALTHY, lite.Status)
+}
+
+// TestUpdateFileMetadata_PreservesModifiedAt ensures status and known-holes
+// RMW paths do not rewrite ModifiedAt (WebDAV Last-Modified / FUSE mtime).
+func TestUpdateFileMetadata_PreservesModifiedAt(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := filepath.Join("movies", "stable_mtime.mkv")
+	const fixedModifiedAt int64 = 1_700_000_000
+
+	meta := ms.CreateFileMetadata(
+		2048, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "mtime-id",
+	)
+	meta.ModifiedAt = fixedModifiedAt
+	meta.CreatedAt = fixedModifiedAt - 60
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	require.NoError(t, ms.UpdateFileStatus(virtualPath, metapb.FileStatus_FILE_STATUS_DEGRADED))
+
+	afterStatus, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, afterStatus)
+	assert.Equal(t, fixedModifiedAt, afterStatus.ModifiedAt)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterStatus.Status)
+	assert.Equal(t, fixedModifiedAt-60, afterStatus.CreatedAt)
+
+	require.NoError(t, ms.AddKnownHoles(virtualPath, []holes.Run{{Start: 10, Count: 2}}))
+
+	afterHoles, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, afterHoles)
+	assert.Equal(t, fixedModifiedAt, afterHoles.ModifiedAt)
+	require.NotEmpty(t, afterHoles.KnownHoles)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterHoles.Status)
 }

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -295,3 +295,38 @@ func TestUpdateFileMetadata_PreservesModifiedAt(t *testing.T) {
 	require.NotEmpty(t, afterHoles.KnownHoles)
 	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterHoles.Status)
 }
+
+func TestGetDirectoryModTime(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	dir := filepath.Join("movies", "ActionMovie")
+
+	// 1. Non-existent / empty directory returns zero time
+	assert.True(t, ms.GetDirectoryModTime(dir).IsZero())
+
+	// 2. Add two files with different ModifiedAt timestamps
+	meta1 := ms.CreateFileMetadata(100, "1.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+	meta1.ModifiedAt = 1_700_000_100
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part1.mkv"), meta1))
+
+	meta2 := ms.CreateFileMetadata(200, "2.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+	meta2.ModifiedAt = 1_700_000_500
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part2.mkv"), meta2))
+
+	// Should return max of the children
+	dirModTime := ms.GetDirectoryModTime(dir)
+	assert.Equal(t, time.Unix(1_700_000_500, 0), dirModTime)
+
+	// 3. Status update (health sweep) does not change max directory modTime
+	require.NoError(t, ms.UpdateFileStatus(filepath.Join(dir, "part2.mkv"), metapb.FileStatus_FILE_STATUS_DEGRADED))
+	assert.Equal(t, time.Unix(1_700_000_500, 0), ms.GetDirectoryModTime(dir))
+
+	// 4. Adding a newer file advances directory modTime
+	meta3 := ms.CreateFileMetadata(300, "3.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+	meta3.ModifiedAt = 1_700_000_900
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part3.mkv"), meta3))
+
+	assert.Equal(t, time.Unix(1_700_000_900, 0), ms.GetDirectoryModTime(dir))
+}
+

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestDeleteFileMetadataWithSourceNzb_RemovesMetadata(t *testing.T) {
 	root := t.TempDir()
 	ms := NewMetadataService(root)
@@ -297,37 +296,158 @@ func TestUpdateFileMetadata_PreservesModifiedAt(t *testing.T) {
 	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, afterHoles.Status)
 }
 
-func TestGetDirectoryModTime(t *testing.T) {
+// TestWriteFileMetadata_PinsDiskMtimeToModifiedAt covers the os.Chtimes call
+// that follows the atomic rename: os.Rename always stamps the destination with
+// mtime=now, which would surface as a fresh timestamp to any host tool reading
+// the on-disk mtime rather than the proto.
+func TestWriteFileMetadata_PinsDiskMtimeToModifiedAt(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := filepath.Join("movies", "pinned.mkv")
+	const fixedModifiedAt int64 = 1_700_000_000
+
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	meta.ModifiedAt = fixedModifiedAt
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	info, err := os.Stat(ms.GetMetadataFilePath(virtualPath))
+	require.NoError(t, err)
+	assert.Equal(t, fixedModifiedAt, info.ModTime().Unix())
+}
+
+// TestUpdateFileStatus_UnchangedStatusSkipsWrite pins the fast path that keeps
+// restarts cheap: the health worker re-asserts HEALTHY for every known-healthy
+// file at startup, and rewriting an identical proto for each one is pure waste.
+//
+// A sentinel mtime detects the write: WriteFileMetadata always re-stamps the
+// file to ModifiedAt, so the sentinel survives only if no write happened.
+func TestUpdateFileStatus_UnchangedStatusSkipsWrite(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := filepath.Join("movies", "already_healthy.mkv")
+	const fixedModifiedAt int64 = 1_700_000_000
+
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	meta.ModifiedAt = fixedModifiedAt
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	metaPath := ms.GetMetadataFilePath(virtualPath)
+	sentinel := time.Unix(1_600_000_000, 0)
+	require.NoError(t, os.Chtimes(metaPath, sentinel, sentinel))
+
+	// Re-asserting the current status must not touch the file.
+	require.NoError(t, ms.UpdateFileStatus(virtualPath, metapb.FileStatus_FILE_STATUS_HEALTHY))
+
+	info, err := os.Stat(metaPath)
+	require.NoError(t, err)
+	assert.Equal(t, sentinel.Unix(), info.ModTime().Unix(),
+		"re-asserting an unchanged status must not rewrite the .meta file")
+
+	// A real transition still writes, restoring the pinned ModifiedAt mtime.
+	require.NoError(t, ms.UpdateFileStatus(virtualPath, metapb.FileStatus_FILE_STATUS_DEGRADED))
+
+	info, err = os.Stat(metaPath)
+	require.NoError(t, err)
+	assert.Equal(t, fixedModifiedAt, info.ModTime().Unix(),
+		"a genuine status transition must write and re-pin mtime to ModifiedAt")
+
+	after, err := ms.ReadFileMetadata(virtualPath)
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, metapb.FileStatus_FILE_STATUS_DEGRADED, after.Status)
+}
+
+// TestUpdateFileStatus_SkipsWriteOnColdCache ensures the fast path is driven by
+// on-disk state, not just a warm liteCache — a restart starts with an empty one.
+func TestUpdateFileStatus_SkipsWriteOnColdCache(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	virtualPath := filepath.Join("movies", "cold_cache.mkv")
+
+	meta := ms.CreateFileMetadata(
+		1024, "test.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY,
+		nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "",
+	)
+	meta.ModifiedAt = 1_700_000_000
+	require.NoError(t, ms.WriteFileMetadata(virtualPath, meta))
+
+	ms.liteCache.Purge()
+
+	metaPath := ms.GetMetadataFilePath(virtualPath)
+	sentinel := time.Unix(1_600_000_000, 0)
+	require.NoError(t, os.Chtimes(metaPath, sentinel, sentinel))
+
+	require.NoError(t, ms.UpdateFileStatus(virtualPath, metapb.FileStatus_FILE_STATUS_HEALTHY))
+
+	info, err := os.Stat(metaPath)
+	require.NoError(t, err)
+	assert.Equal(t, sentinel.Unix(), info.ModTime().Unix())
+}
+
+// TestDirectoryModTime reports the on-disk mtime of the backing metadata
+// directory. The kernel already advances it when children are created or
+// removed, so no per-child scan is needed to derive a virtual directory mtime.
+func TestDirectoryModTime(t *testing.T) {
 	root := t.TempDir()
 	ms := NewMetadataService(root)
 
 	dir := filepath.Join("movies", "ActionMovie")
 
-	// 1. Non-existent / empty directory returns zero time
-	assert.True(t, ms.GetDirectoryModTime(dir).IsZero())
+	// Non-existent directory reports zero, letting callers fall back to an epoch.
+	assert.True(t, ms.DirectoryModTime(dir).IsZero())
 
-	// 2. Add two files with different ModifiedAt timestamps
-	meta1 := ms.CreateFileMetadata(100, "1.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
-	meta1.ModifiedAt = 1_700_000_100
-	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part1.mkv"), meta1))
+	meta := ms.CreateFileMetadata(100, "1.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+	meta.ModifiedAt = 1_700_000_100
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part1.mkv"), meta))
 
-	meta2 := ms.CreateFileMetadata(200, "2.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
-	meta2.ModifiedAt = 1_700_000_500
-	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part2.mkv"), meta2))
+	onDisk, err := os.Stat(filepath.Join(root, dir))
+	require.NoError(t, err)
+	assert.Equal(t, onDisk.ModTime(), ms.DirectoryModTime(dir))
 
-	// Should return max of the children
-	dirModTime := ms.GetDirectoryModTime(dir)
-	assert.Equal(t, time.Unix(1_700_000_500, 0), dirModTime)
-
-	// 3. Status update (health sweep) does not change max directory modTime
-	require.NoError(t, ms.UpdateFileStatus(filepath.Join(dir, "part2.mkv"), metapb.FileStatus_FILE_STATUS_DEGRADED))
-	assert.Equal(t, time.Unix(1_700_000_500, 0), ms.GetDirectoryModTime(dir))
-
-	// 4. Adding a newer file advances directory modTime
-	meta3 := ms.CreateFileMetadata(300, "3.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
-	meta3.ModifiedAt = 1_700_000_900
-	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part3.mkv"), meta3))
-
-	assert.Equal(t, time.Unix(1_700_000_900, 0), ms.GetDirectoryModTime(dir))
+	// A file path is not a directory.
+	assert.True(t, ms.DirectoryModTime(filepath.Join(dir, "part1.mkv")).IsZero())
 }
 
+// TestDirectoryModTime_StableAcrossHealthSweep is the regression guard for the
+// original bug: a restart's health sweep must not make directories look freshly
+// modified to media scanners that only rescan folders whose mtime changed.
+func TestDirectoryModTime_StableAcrossHealthSweep(t *testing.T) {
+	root := t.TempDir()
+	ms := NewMetadataService(root)
+
+	dir := filepath.Join("movies", "ActionMovie")
+
+	for _, name := range []string{"part1.mkv", "part2.mkv", "part3.mkv"} {
+		meta := ms.CreateFileMetadata(100, "x.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+		meta.ModifiedAt = 1_700_000_100
+		require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, name), meta))
+	}
+
+	before := ms.DirectoryModTime(dir)
+	require.False(t, before.IsZero())
+
+	// Simulate the startup sweep re-asserting HEALTHY for every file.
+	for _, name := range []string{"part1.mkv", "part2.mkv", "part3.mkv"} {
+		require.NoError(t, ms.UpdateFileStatus(filepath.Join(dir, name), metapb.FileStatus_FILE_STATUS_HEALTHY))
+	}
+
+	assert.Equal(t, before, ms.DirectoryModTime(dir),
+		"a no-op health sweep must not bump the directory mtime")
+
+	// A genuine import advances it.
+	newMeta := ms.CreateFileMetadata(300, "3.nzb", metapb.FileStatus_FILE_STATUS_HEALTHY, nil, metapb.Encryption_NONE, "", "", nil, nil, 0, nil, "")
+	newMeta.ModifiedAt = 1_700_000_900
+	require.NoError(t, ms.WriteFileMetadata(filepath.Join(dir, "part4.mkv"), newMeta))
+
+	assert.True(t, ms.DirectoryModTime(dir).After(before),
+		"importing a new file must advance the directory mtime")
+}

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/javi11/altmount/internal/holes"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -508,11 +508,15 @@ func (mrf *MetadataRemoteFile) Stat(ctx context.Context, name string) (bool, fs.
 
 	// Check if this is a directory first
 	if mrf.metadataService.DirectoryExists(normalizedName) {
+		modT := mrf.metadataService.GetDirectoryModTime(normalizedName)
+		if modT.IsZero() {
+			modT = staticVirtualDirModTime
+		}
 		info := &MetadataFileInfo{
 			name:    filepath.Base(normalizedName),
 			size:    0,
 			mode:    os.ModeDir | 0755,
-			modTime: staticVirtualDirModTime, // Fixed static time for virtual directories to prevent media server re-scanning
+			modTime: modT,
 			isDir:   true,
 		}
 		return true, info, nil
@@ -669,7 +673,18 @@ func (mvd *MetadataVirtualDirectory) Readdir(count int) ([]fs.FileInfo, error) {
 
 	// Add directories first
 	for _, dirInfo := range dirInfos {
-		infos = append(infos, dirInfo)
+		subPath := filepath.Join(mvd.normalizedPath, dirInfo.Name())
+		subModT := mvd.metadataService.GetDirectoryModTime(subPath)
+		if subModT.IsZero() {
+			subModT = staticVirtualDirModTime
+		}
+		infos = append(infos, &MetadataFileInfo{
+			name:    dirInfo.Name(),
+			size:    0,
+			mode:    os.ModeDir | 0755,
+			modTime: subModT,
+			isDir:   true,
+		})
 		if count > 0 && len(infos) >= count {
 			return infos, nil
 		}
@@ -734,11 +749,15 @@ func (mvd *MetadataVirtualDirectory) Readdirnames(n int) ([]string, error) {
 
 // Stat implements afero.File.Stat
 func (mvd *MetadataVirtualDirectory) Stat() (fs.FileInfo, error) {
+	modT := mvd.metadataService.GetDirectoryModTime(mvd.normalizedPath)
+	if modT.IsZero() {
+		modT = staticVirtualDirModTime
+	}
 	info := &MetadataFileInfo{
 		name:    filepath.Base(mvd.normalizedPath),
 		size:    0,
 		mode:    os.ModeDir | 0755,
-		modTime: staticVirtualDirModTime,
+		modTime: modT,
 		isDir:   true,
 	}
 	return info, nil

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -33,13 +33,22 @@ import (
 	"github.com/spf13/afero"
 )
 
-var staticVirtualDirModTime = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+// epochFallbackModTime is reported when no real timestamp is available (a file
+// whose ModifiedAt was never set, or a directory that is not backed by an
+// on-disk metadata dir). A fixed date is deliberate: returning time.Now() would
+// make every stat look like a fresh modification and force media scanners to
+// re-probe on every call.
+var epochFallbackModTime = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
+// getFileModTime maps a proto ModifiedAt to the mtime reported over WebDAV and
+// FUSE. Note that ReadFileMetadataLite treats modified_at as best-effort — it
+// stays zero when the field sits past liteScanBytes — so listings can legitimately
+// fall back to the epoch here.
 func getFileModTime(modifiedAt int64) time.Time {
 	if modifiedAt > 0 {
 		return time.Unix(modifiedAt, 0)
 	}
-	return staticVirtualDirModTime
+	return epochFallbackModTime
 }
 
 // MetadataRemoteFile implements the RemoteFile interface for metadata-backed virtual files
@@ -508,9 +517,9 @@ func (mrf *MetadataRemoteFile) Stat(ctx context.Context, name string) (bool, fs.
 
 	// Check if this is a directory first
 	if mrf.metadataService.DirectoryExists(normalizedName) {
-		modT := mrf.metadataService.GetDirectoryModTime(normalizedName)
+		modT := mrf.metadataService.DirectoryModTime(normalizedName)
 		if modT.IsZero() {
-			modT = staticVirtualDirModTime
+			modT = epochFallbackModTime
 		}
 		info := &MetadataFileInfo{
 			name:    filepath.Base(normalizedName),
@@ -671,20 +680,11 @@ func (mvd *MetadataVirtualDirectory) Readdir(count int) ([]fs.FileInfo, error) {
 
 	var infos []fs.FileInfo
 
-	// Add directories first
+	// Add directories first. dirInfo already carries the backing directory's
+	// real mtime from the single os.ReadDir in ListDirectoryAll, so there is
+	// nothing extra to stat per subdirectory.
 	for _, dirInfo := range dirInfos {
-		subPath := filepath.Join(mvd.normalizedPath, dirInfo.Name())
-		subModT := mvd.metadataService.GetDirectoryModTime(subPath)
-		if subModT.IsZero() {
-			subModT = staticVirtualDirModTime
-		}
-		infos = append(infos, &MetadataFileInfo{
-			name:    dirInfo.Name(),
-			size:    0,
-			mode:    os.ModeDir | 0755,
-			modTime: subModT,
-			isDir:   true,
-		})
+		infos = append(infos, dirInfo)
 		if count > 0 && len(infos) >= count {
 			return infos, nil
 		}
@@ -749,9 +749,9 @@ func (mvd *MetadataVirtualDirectory) Readdirnames(n int) ([]string, error) {
 
 // Stat implements afero.File.Stat
 func (mvd *MetadataVirtualDirectory) Stat() (fs.FileInfo, error) {
-	modT := mvd.metadataService.GetDirectoryModTime(mvd.normalizedPath)
+	modT := mvd.metadataService.DirectoryModTime(mvd.normalizedPath)
 	if modT.IsZero() {
-		modT = staticVirtualDirModTime
+		modT = epochFallbackModTime
 	}
 	info := &MetadataFileInfo{
 		name:    filepath.Base(mvd.normalizedPath),

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -33,6 +33,15 @@ import (
 	"github.com/spf13/afero"
 )
 
+var staticVirtualDirModTime = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func getFileModTime(modifiedAt int64) time.Time {
+	if modifiedAt > 0 {
+		return time.Unix(modifiedAt, 0)
+	}
+	return staticVirtualDirModTime
+}
+
 // MetadataRemoteFile implements the RemoteFile interface for metadata-backed virtual files
 type MetadataRemoteFile struct {
 	metadataService  *metadata.MetadataService
@@ -503,7 +512,7 @@ func (mrf *MetadataRemoteFile) Stat(ctx context.Context, name string) (bool, fs.
 			name:    filepath.Base(normalizedName),
 			size:    0,
 			mode:    os.ModeDir | 0755,
-			modTime: time.Now(), // Use current time for directories
+			modTime: staticVirtualDirModTime, // Fixed static time for virtual directories to prevent media server re-scanning
 			isDir:   true,
 		}
 		return true, info, nil
@@ -560,7 +569,7 @@ func (mrf *MetadataRemoteFile) Stat(ctx context.Context, name string) (bool, fs.
 		name:    filepath.Base(normalizedName),
 		size:    fileMeta.FileSize,
 		mode:    0644, // Default file mode
-		modTime: time.Unix(fileMeta.ModifiedAt, 0),
+		modTime: getFileModTime(fileMeta.ModifiedAt),
 		isDir:   false,
 	}
 
@@ -696,7 +705,7 @@ func (mvd *MetadataVirtualDirectory) Readdir(count int) ([]fs.FileInfo, error) {
 			name:    fileName,
 			size:    fileMeta.FileSize,
 			mode:    0644,
-			modTime: time.Unix(fileMeta.ModifiedAt, 0),
+			modTime: getFileModTime(fileMeta.ModifiedAt),
 			isDir:   false,
 		}
 		infos = append(infos, info)
@@ -729,7 +738,7 @@ func (mvd *MetadataVirtualDirectory) Stat() (fs.FileInfo, error) {
 		name:    filepath.Base(mvd.normalizedPath),
 		size:    0,
 		mode:    os.ModeDir | 0755,
-		modTime: time.Now(),
+		modTime: staticVirtualDirModTime,
 		isDir:   true,
 	}
 	return info, nil
@@ -1558,7 +1567,7 @@ func (mvf *MetadataVirtualFile) Stat() (fs.FileInfo, error) {
 		name:    filepath.Base(mvf.name),
 		size:    mvf.meta.FileSize,
 		mode:    0644,
-		modTime: time.Unix(mvf.meta.ModifiedAt, 0),
+		modTime: getFileModTime(mvf.meta.ModifiedAt),
 		isDir:   false, // Files are never directories in simplified schema
 	}
 


### PR DESCRIPTION
## Problem

Every time Altmount restarts, its health worker fires `EventTypeFileHealthy` for all known-healthy files immediately. Each event calls `UpdateFileStatus` → `UpdateFileMetadata` → `WriteFileMetadata`, which does an atomic `os.Rename`. That rename always sets the `.meta` disk mtime to `now()`, even when the file's logical `ModifiedAt` hasn't changed at all.

For setups where Altmount's WebDAV is mounted via rclone (or any client that reads `Last-Modified`), this causes media servers (Jellyfin, Plex, Emby, etc.) to detect a timestamp change on every container restart and re-probe every affected file over the mount — wasting bandwidth, CPU, and blocking concurrent imports.

## Root Cause

1. **`UpdateFileMetadata` — no enforcement of ModifiedAt immutability**: Any callback passed to `UpdateFileMetadata` could accidentally alter `ModifiedAt`.
2. **`WriteFileMetadata` — `os.Rename` silently updates disk mtime**: After `os.Rename(tmpPath, metadataPath)`, the destination file gets `mtime = now()`.
3. **Virtual Directory `modTime` churn**: Virtual directories previously returned `time.Now()` on every stat, causing folder-level timestamp churn on media scanners.

## Fix

### 1. `UpdateFileMetadata` — unconditional snapshot + restore & clear contract
- Snapshot `ModifiedAt` before invoking the callback and restore it unconditionally afterwards.
- Documented that `UpdateFileMetadata` is strictly reserved for non-content RMW operations (health status, known-holes). Content-modifying paths must use `WriteFileMetadata` / `CreateFileMetadata` directly.

### 2. `WriteFileMetadata` — `os.Chtimes` after rename
- Pin the `.meta` disk mtime back to `ModifiedAt` immediately after the atomic rename:
  ```go
  if metadata.ModifiedAt != 0 {
      t := time.Unix(metadata.ModifiedAt, 0)
      _ = os.Chtimes(metadataPath, t, t)
  }
  ```

### 3. Virtual Directory `modTime` — `max(children's ModifiedAt)`
- Virtual directory `Stat` and `Readdir` paths now derive `modTime` dynamically via `max(children's ModifiedAt)` (using `GetDirectoryModTime()`).
- Stays frozen across restarts (because health sweeps never touch any child's `ModifiedAt`), while advancing cleanly when new files are actually imported. Static epoch (`2000-01-01`) is used purely as a fallback for empty directories.

## Testing

- Added `TestGetDirectoryModTime` verifying empty directories, multi-file max aggregation, stability across status updates, and advancement on new file creation.
- Verified on production (rclone WebDAV sidecar + Jellyfin 10.11): `.meta` disk mtimes and directory timestamps remain stable across container restarts and continuous health sweeps.