### PR TITLE
fix(nzbfs): bind file context to HTTP request context and cancel on close

### DIFF
--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -521,7 +521,7 @@ func createHTTPServer(apiServer *api.Server, app *fiber.App, webdavHandler *webd
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      mainHandler,
 		IdleTimeout:  time.Minute * 5,
-		WriteTimeout: time.Minute * 3,
+		WriteTimeout: time.Minute * 30,
 		ReadTimeout:  time.Minute * 5,
 	}
 }

--- a/cmd/altmount/cmd/setup.go
+++ b/cmd/altmount/cmd/setup.go
@@ -521,7 +521,7 @@ func createHTTPServer(apiServer *api.Server, app *fiber.App, webdavHandler *webd
 		Addr:         fmt.Sprintf(":%d", port),
 		Handler:      mainHandler,
 		IdleTimeout:  time.Minute * 5,
-		WriteTimeout: time.Minute * 30,
+		WriteTimeout: time.Minute * 3,
 		ReadTimeout:  time.Minute * 5,
 	}
 }

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -1493,6 +1493,9 @@ func (mvf *MetadataVirtualFile) Seek(offset int64, whence int) (int64, error) {
 
 // Close implements afero.File.Close
 func (mvf *MetadataVirtualFile) Close() error {
+	if mvf.cancelCtx != nil {
+		mvf.cancelCtx()
+	}
 	// Cancel the in-flight reader before taking mvf.mu — a concurrent
 	// Read can hold the lock for the full segment-download latency.
 	mvf.interruptCurrentReader()

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -267,6 +267,7 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		KnownHoles:     fileMeta.KnownHoles,
 	}
 
+	fileCtx, cancel := context.WithCancel(ctx)
 	// Create a metadata-based virtual file handle
 	virtualFile := &MetadataVirtualFile{
 		name:             name,
@@ -279,7 +280,8 @@ func (mrf *MetadataRemoteFile) OpenFile(ctx context.Context, name string) (bool,
 		padRecorder:      mrf.padRecorder,
 		configGetter:     mrf.configGetter,
 		poolManager:      mrf.poolManager,
-		ctx:              ctx,
+		ctx:              fileCtx,
+		cancelCtx:        cancel,
 		maxPrefetch:      maxPrefetch,
 		rcloneCipher:     mrf.rcloneCipher,
 		aesCipher:        mrf.aesCipher,
@@ -799,6 +801,7 @@ type MetadataVirtualFile struct {
 	configGetter     config.ConfigGetter
 	poolManager      pool.Manager // Pool manager for dynamic pool access
 	ctx              context.Context
+	cancelCtx        context.CancelFunc
 	maxPrefetch      int // Maximum segments prefetched ahead of current read position
 	rcloneCipher     *rclone.RcloneCrypt
 	aesCipher        *aes.AesCipher


### PR DESCRIPTION
### Description

This PR ensures that virtual file handles opened via WebDAV/HTTP bind their execution context to the caller's request context and cancel in-flight reader downloads when closed or disconnected.

### Changes

- **Request-bound File Context**: Wrapped `OpenFile` context in a child context derived from the HTTP request context (`fileCtx, cancel := context.WithCancel(ctx)`), and explicitly invoke `mvf.cancelCtx()` in `MetadataVirtualFile.Close()`. This ensures client disconnects or handle closures immediately cancel in-flight Usenet reader downloads.