### PR TITLE
fix(validation): honor segment sample percentage on large releases (#812)

### DIFF
--- a/internal/importer/processor.go
+++ b/internal/importer/processor.go
@@ -211,9 +211,9 @@ func (proc *Processor) preParseFastFail(ctx context.Context, n *nzbparser.Nzb, c
 	concurrency := fastFailConcurrency(cfg)
 
 	// Phase 1: cheap release-level probe. Sample the whole release once
-	// (≤55 Stats) and fail fast. Healthy releases — the common case — pay only
-	// this and skip the per-file sweep entirely, keeping the "Checking segment
-	// availability" stage short.
+	// (segment_sample_percentage of it) and fail fast. Healthy releases — the
+	// common case — pay only this and skip the per-file sweep entirely, keeping
+	// the "Checking segment availability" stage short.
 	probeStart := time.Now()
 	missing, err := validation.FastFailReleaseProbe(
 		ctx,

--- a/internal/importer/validation/fast_fail.go
+++ b/internal/importer/validation/fast_fail.go
@@ -15,21 +15,23 @@ import (
 
 // selectFastFailSegments picks a lightweight per-file sample for the fast-fail
 // reachability gate: always the first and last segment (DMCA/truncation
-// detection) plus samplePercentage% of the middle, capped at 55 to bound very
-// large files. It is intentionally lighter than usenet.SelectSegmentsForValidation
-// (which health checks use and which floors at 5 per file): fast-fail Stats run
-// across every file in the NZB, so a min-5 floor multiplies badly on multi-part
-// releases.
+// detection) plus samplePercentage% of the middle. It is intentionally lighter
+// than usenet.SelectSegmentsForValidation (which health checks use and which
+// floors at 5 per file): fast-fail Stats run across every file in the NZB, so a
+// min-5 floor multiplies badly on multi-part releases. The configured
+// percentage is honored exactly — a fixed upper cap used to make every setting
+// behave identically on large files (issue #812).
 func selectFastFailSegments(segments []*metapb.SegmentData, samplePercentage int) []*metapb.SegmentData {
 	n := len(segments)
 	if n <= 2 {
 		return segments
 	}
 
-	const maxSamples = 55
+	middleRange := n - 2 // sampleable indices are [1, n-2]
+	middleCount := min((n*samplePercentage)/100, middleRange)
 
-	chosen := make(map[int]struct{}, maxSamples)
-	out := make([]*metapb.SegmentData, 0, maxSamples)
+	chosen := make(map[int]struct{}, middleCount+2)
+	out := make([]*metapb.SegmentData, 0, middleCount+2)
 	add := func(i int) {
 		if _, ok := chosen[i]; ok {
 			return
@@ -41,12 +43,7 @@ func selectFastFailSegments(segments []*metapb.SegmentData, samplePercentage int
 	add(0)     // first — catches whole-article DMCA takedowns / missing files
 	add(n - 1) // last — catches truncated/incomplete uploads
 
-	middleCount := (n * samplePercentage) / 100
-	if len(out)+middleCount > maxSamples {
-		middleCount = maxSamples - len(out)
-	}
 	if middleCount > 0 {
-		middleRange := n - 2 // sample from indices [1, n-2]
 		perm := rand.Perm(middleRange)
 		for i := 0; i < middleCount && i < len(perm); i++ {
 			add(1 + perm[i])
@@ -71,7 +68,7 @@ type FastFailFile struct {
 // FastFailReleaseProbe is the cheap phase-1 reachability gate for an NZB import.
 // It flattens all candidate segments across the release and Stats a single
 // sample (usenet.SelectSegmentsForValidation: first 3 + last 2 + random middle,
-// min 5 / max 55 for the whole release), cancelling the remaining Stats on the
+// min 5 for the whole release), cancelling the remaining Stats on the
 // first miss.
 //
 // Returns (missing, err):

--- a/internal/importer/validation/fast_fail_test.go
+++ b/internal/importer/validation/fast_fail_test.go
@@ -187,13 +187,23 @@ func TestSelectFastFailSegments(t *testing.T) {
 		t.Errorf("pct=10: duplicates present (%d unique of %d)", len(ids), len(got))
 	}
 
-	// Total is capped at 55 even at 100% sampling, with no dups.
+	// Regression for #812: large files honor the configured percentage instead
+	// of collapsing onto a fixed sample cap, and stay duplicate-free.
 	big := selectFastFailSegments(makeTestSegments("b", 10000), 100)
-	if len(big) != 55 {
-		t.Fatalf("cap: got %d, want 55", len(big))
+	if len(big) != 10000 {
+		t.Fatalf("pct=100: got %d, want 10000", len(big))
 	}
-	if len(idOf(big)) != 55 {
-		t.Error("cap: duplicates present in capped result")
+	if len(idOf(big)) != len(big) {
+		t.Error("pct=100: duplicates present")
+	}
+
+	// 10% of 10000 middle segments + first + last.
+	sampled := selectFastFailSegments(makeTestSegments("b", 10000), 10)
+	if len(sampled) != 1002 {
+		t.Fatalf("pct=10: got %d, want 1002", len(sampled))
+	}
+	if len(idOf(sampled)) != len(sampled) {
+		t.Error("pct=10: duplicates present")
 	}
 }
 

--- a/internal/usenet/validation.go
+++ b/internal/usenet/validation.go
@@ -262,8 +262,10 @@ func selectSegmentsForValidation(segments []*metapb.SegmentData, samplePercentag
 
 	totalSegments := len(segments)
 
-	// Min 5 for statistical validity, max 55 to cap network I/O on large files.
-	targetSamples := min(max((totalSegments*samplePercentage)/100, 5), 55)
+	// Min 5 for statistical validity. The configured percentage is otherwise
+	// honored exactly: a hard upper cap used to collapse every sub-100% setting
+	// onto the same handful of segments on large releases (issue #812).
+	targetSamples := max((totalSegments*samplePercentage)/100, 5)
 
 	if targetSamples >= totalSegments {
 		return segments

--- a/internal/usenet/validation_test.go
+++ b/internal/usenet/validation_test.go
@@ -73,15 +73,21 @@ func TestSelectSegmentsForValidation(t *testing.T) {
 		assert.Equal(t, 5, len(selected))
 	})
 
-	t.Run("cap 55", func(t *testing.T) {
-		// Create 20,000 segments (10% = 2000)
+	t.Run("large files honor the configured percentage", func(t *testing.T) {
+		// Regression for #812: a hard 55-sample cap made every sub-100%
+		// setting sample the same handful of segments on large releases.
 		largeSegments := make([]*metapb.SegmentData, 20000)
 		for i := range 20000 {
 			largeSegments[i] = &metapb.SegmentData{Id: fmt.Sprintf("seg%d", i)}
 		}
 
-		selected := selectSegmentsForValidation(largeSegments, 10)
-		assert.Equal(t, 55, len(selected), "Should be capped at 55")
+		assert.Equal(t, 2000, len(selectSegmentsForValidation(largeSegments, 10)))
+		assert.Equal(t, 10000, len(selectSegmentsForValidation(largeSegments, 50)))
+		// Higher percentages must sample strictly more than lower ones.
+		assert.Greater(t,
+			len(selectSegmentsForValidation(largeSegments, 25)),
+			len(selectSegmentsForValidation(largeSegments, 10)),
+		)
 	})
 }
 


### PR DESCRIPTION
Fixes #812.

## Problem

The segment scan percentage setting had no effect below 100%. Sampling applied a hard 55-sample ceiling *after* the percentage math, so on any release with more than ~1,100 segments every setting from 1% to 99% collapsed onto the same 55 STATs. Only 100% behaved as configured, because it takes an early-return path that skips sampling entirely — which is exactly the asymmetry the reporter observed.

The UI presents this as a plain percentage slider ("1% (FAST)" → "100% (SLOW)") with no mention of a cap, so the ceiling was silently overriding an explicit user choice.

## Changes

- `internal/usenet/validation.go` — `selectSegmentsForValidation` (health checks; the path the settings slider drives) drops `min(..., 55)` and honors the configured percentage exactly. The min-5 floor for statistical validity is kept.
- `internal/importer/validation/fast_fail.go` — `selectFastFailSegments` (import fast-fail, per file) had the same `maxSamples = 55` ceiling, which capped even 100% sampling. It now takes first + last + exactly `pct%` of the middle; the redundant clamp is removed and slice capacity is sized from the real sample count.
- Stale `≤55` comments in `processor.go` and the `FastFailReleaseProbe` doc updated.

## Reviewer notes

**This raises default sampling cost.** The 55 cap was doing real work to keep out-of-box checks cheap. At the 5% health default, a ~7,000-segment release moves from 55 STATs to ~350 per check; the 1% import default is milder. That is the intended meaning of the setting, but if it proves too aggressive in practice, lowering the shipped default in `manager.go:1663` is a one-line follow-up. The alternative considered was making the cap a new config knob — rejected as extra surface for a setting that should already mean what it says.

## Testing

The two tests that asserted the 55 cap are rewritten as `#812` regressions, and were confirmed red against the old code (`got 55, want 2000`) before the fix:

- health sampling: 20,000 segments → 2,000 at 10%, 10,000 at 50%, strictly monotonic across percentages.
- fast-fail sampling: 10,000 at 100%, 1,002 at 10%, no duplicates.

`go build ./...`, `go vet ./internal/...` and the full `go test ./...` pass; `internal/usenet`, `internal/importer`, `internal/importer/validation` and `internal/health` re-verified with `-race`.