### PR TITLE
fix(frontend): stop mount config from showing cache limits it never sends (#811)

### DIFF
--- a/frontend/src/components/config/MountConfigSection.tsx
+++ b/frontend/src/components/config/MountConfigSection.tsx
@@ -3,6 +3,7 @@ import {
 	Eye,
 	EyeOff,
 	HardDrive,
+	Info,
 	Play,
 	Save,
 	Square,
@@ -608,6 +609,11 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 		setMountFormData(buildRCloneMountFormData(config));
 	}, [config.rclone, config]);
 
+	// rclone applies no cache size cap unless one is passed, so an empty value
+	// while caching is enabled lets the cache directory fill the disk.
+	const cacheLimitsUnbounded =
+		mountFormData.vfs_cache_mode !== "off" && mountFormData.vfs_cache_max_size.trim() === "";
+
 	const handleMountInputChange = (
 		field: keyof RCloneMountFormData,
 		value: string | boolean | number | Record<string, string>,
@@ -621,6 +627,16 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 
 	return (
 		<div className="space-y-8">
+			{/* Mount options are passed to rclone when the mount is created, so saving
+			    alone does not change a mount that is already running. */}
+			<div className="alert alert-info rounded-2xl border border-info/20 bg-info/5 py-3">
+				<Info className="h-4 w-4 shrink-0" aria-hidden="true" />
+				<span className="text-xs">
+					These options are applied when the mount is created. After saving, stop and start the
+					mount (or restart AltMount) for the changes to take effect.
+				</span>
+			</div>
+
 			{/* Basic Mount Settings */}
 			<div className="space-y-4">
 				<h5 className="font-bold text-base-content/60 text-xs uppercase tracking-widest">
@@ -795,6 +811,15 @@ function RCloneMountSubSection({ config, onFormDataChange }: RCloneSubSectionPro
 								onChange={(e) => handleMountInputChange("vfs_cache_max_size", e.target.value)}
 								placeholder="50G"
 							/>
+							{cacheLimitsUnbounded && (
+								<p className="label flex items-start gap-1.5 text-warning text-xs">
+									<AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+									<span>
+										Empty: no size limit is sent to rclone, so the cache directory grows until the
+										disk is full. Set a value such as 50G.
+									</span>
+								</p>
+							)}
 						</fieldset>
 						<fieldset className="fieldset">
 							<legend className="fieldset-legend">Cache Poll Interval</legend>
@@ -1388,9 +1413,12 @@ function buildRCloneMountFormData(config: ConfigResponse): RCloneMountFormData {
 		transfers: config.rclone.transfers || 4,
 		cache_dir: config.rclone.cache_dir || "",
 		vfs_cache_mode: config.rclone.vfs_cache_mode || "full",
-		vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval || "1m",
-		vfs_cache_max_size: config.rclone.vfs_cache_max_size || "50G",
-		vfs_cache_max_age: config.rclone.vfs_cache_max_age || "504h",
+		// Cache limits are shown verbatim: an empty value means AltMount sends no
+		// limit to rclone (rclone then caches without bound), so substituting a
+		// placeholder default here would misreport the mount's real behaviour.
+		vfs_cache_poll_interval: config.rclone.vfs_cache_poll_interval ?? "",
+		vfs_cache_max_size: config.rclone.vfs_cache_max_size ?? "",
+		vfs_cache_max_age: config.rclone.vfs_cache_max_age ?? "",
 		vfs_read_chunk_size: config.rclone.vfs_read_chunk_size || "32M",
 		vfs_read_chunk_size_limit: config.rclone.vfs_read_chunk_size_limit || "2G",
 		vfs_read_ahead: config.rclone.vfs_read_ahead || "128M",


### PR DESCRIPTION
## Summary

Follow-up to triage of #811 ("Internal Rclone mount not correctly purging used storage"). Two UI-side defects that make the rclone VFS cache limits look configured when they are not.

**1. The form fabricated limits that were never sent to rclone.**
`buildRCloneMountFormData` used `config.rclone.vfs_cache_max_size || "50G"` (and the same for `vfs_cache_max_age` / `vfs_cache_poll_interval`). If the stored value was empty, the UI displayed `50G` while the backend's `if != ""` guard in `pkg/rclonecli/client.go` sent no `CacheMaxSize` at all — and rclone's default is no cap, so the cache directory grows until the disk fills. That is exactly the reported symptom. Now the stored value is shown verbatim, the defaults remain as `placeholder` hints, and an inline warning appears when cache mode is on with an empty max size.

**2. No indication that a remount is required.**
`vfsOpt` is only built in `performMount`, and no `OnConfigChange` handler remounts, so edits to the cache limits do nothing to a running mount until stop/start or an app restart. The section now says so.

## Not included

Verified during triage and left for separate changes:

- The option plumbing itself is correct — tested the exact `mount/mount` payload against rclone 1.72.1, and `vfs/stats` reported `CacheMaxSize: 53687091200`, `CacheMaxAge: 1814400000000000`, `CachePollInterval: 60000000000`. When a mount is created, the limits do reach rclone.
- Auto-remount on config change is not implemented here — an automatic remount drops in-flight streams and deserves its own discussion.
- Several options the UI exposes are never passed to the mount: `vfs_cache_min_free_space`, `vfs_disk_space_total`, `dir_cache_time`, `async_read`, `use_mmap`, `vfs_fast_fingerprint`, `vfs_read_chunk_streams`, `read_only`, `umask`, `transfers`, `timeout`, `syslog`. `vfs_cache_min_free_space` is the notable one since it reads as a cache limit.

## Test plan

- [x] `bun run check` (biome) clean
- [x] `bun run build` (`tsc -b` + vite) green
- [ ] Config with `vfs_cache_max_size: ""` → field renders empty with the warning, not a phantom `50G`
- [ ] Config with `vfs_cache_max_size: 50G` → field renders `50G`, no warning
- [ ] Saving an untouched form does not rewrite the stored cache limits

Refs #811