### PR TITLE
fix(streaming): bound reads and surface failures on the FUSE read path

### DIFF
--- a/docs/docs/3. Configuration/streaming.md
+++ b/docs/docs/3. Configuration/streaming.md
@@ -17,19 +17,42 @@ _Streaming settings in the system configuration_
 
 ### Parameters
 
-| Parameter      | Description                                           | Default |
-| -------------- | ----------------------------------------------------- | ------- |
-| `max_prefetch` | Number of segments to prefetch ahead during streaming | `30`    |
+| Parameter              | Description                                           | Default |
+| ---------------------- | ----------------------------------------------------- | ------- |
+| `max_prefetch`         | Number of segments to prefetch ahead during streaming | `30`    |
+| `read_timeout_seconds` | Maximum duration of a single read before it fails     | `120`   |
 
 ```yaml
 streaming:
   max_prefetch: 30 # Number of segments prefetched ahead (default: 30)
+  read_timeout_seconds: 120 # Fail a read that stalls this long (0 = default, -1 = disabled)
   failure_masking:
     enabled: true # Automatically hide files from mounts after repeated failures
     threshold: 3 # Number of streaming failures before masking a file
 ```
 
-Higher values improve playback smoothness for high-bitrate content but increase memory usage. Lower values are better for resource-constrained environments.
+Higher `max_prefetch` values improve playback smoothness for high-bitrate content but increase memory usage. Lower values are better for resource-constrained environments.
+
+## Read Timeout
+
+`read_timeout_seconds` bounds how long any single read may take. It applies to both
+FUSE and WebDAV reads.
+
+Without it, a segment fetch that stalls without ever returning an error parks the read
+forever. On a FUSE mount that means the reading process — Sonarr's `ffprobe`, a media
+player, a scanner — enters uninterruptible sleep (D-state) and cannot be killed; only
+restarting AltMount clears it.
+
+When the timeout expires, AltMount interrupts the in-flight reader and the read fails
+with an I/O error, which the calling process can handle normally. The failure is also
+reported to [Failure Masking](#failure-masking) and the health system, so a file that
+repeatedly stalls is eventually masked.
+
+- `0` — use the built-in default of 120 seconds
+- `-1` — disable the timeout entirely (not recommended; restores the hang behavior)
+
+Note this is unrelated to `health.read_timeout_seconds`, which governs only the
+background health-check sweep and has no effect on playback reads.
 
 ## Failure Masking
 

--- a/frontend/src/components/config/StreamingConfigSection.tsx
+++ b/frontend/src/components/config/StreamingConfigSection.tsx
@@ -111,6 +111,44 @@ export function StreamingConfigSection({
 					</div>
 				</div>
 
+				{/* Read Timeout */}
+				<div className="space-y-6 rounded-2xl border-2 border-base-300/80 bg-base-200/60 p-6">
+					<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+						<div className="min-w-0">
+							<h4 className="font-bold text-base-content text-sm">Read Timeout</h4>
+							<p className="mt-1 break-words text-[11px] text-base-content/50 leading-relaxed">
+								Maximum time a single read may take before it fails. Without this, a stalled
+								download can hang the reading process indefinitely.
+							</p>
+						</div>
+						<div className="flex shrink-0 items-center gap-3">
+							<fieldset className="fieldset">
+								<legend className="sr-only">Read timeout in seconds</legend>
+								<input
+									type="number"
+									min="-1"
+									max="3600"
+									step="1"
+									className="input w-28"
+									value={streamingData.read_timeout_seconds}
+									disabled={isReadOnly}
+									onChange={(e) =>
+										handleStreamingChange(
+											"read_timeout_seconds",
+											Number.parseInt(e.target.value, 10) || 0,
+										)
+									}
+								/>
+							</fieldset>
+							<span className="font-bold text-base-content/60 text-xs uppercase">seconds</span>
+						</div>
+					</div>
+					<p className="text-[11px] text-base-content/50 leading-relaxed">
+						Use <span className="font-bold font-mono">0</span> for the default (120s) or{" "}
+						<span className="font-bold font-mono">-1</span> to disable the timeout entirely.
+					</p>
+				</div>
+
 				{/* Guidance */}
 				<div className="alert items-start rounded-2xl border border-info/20 bg-info/5 p-4 shadow-sm">
 					<Info className="mt-0.5 h-5 w-5 shrink-0 text-info" />

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -89,6 +89,7 @@ export interface FailureMaskingConfig {
 // Streaming configuration
 export interface StreamingConfig {
 	max_prefetch: number;
+	read_timeout_seconds: number;
 	failure_masking: FailureMaskingConfig;
 }
 
@@ -381,6 +382,7 @@ export interface MetadataUpdateRequest {
 // Streaming update request
 export interface StreamingUpdateRequest {
 	max_prefetch?: number;
+	read_timeout_seconds?: number;
 	failure_masking?: Partial<FailureMaskingConfig>;
 }
 

--- a/internal/config/accessors.go
+++ b/internal/config/accessors.go
@@ -91,6 +91,25 @@ func (c *Config) GetHealthReadTimeout() time.Duration {
 	return time.Duration(c.Health.ReadTimeoutSeconds) * time.Second
 }
 
+// DefaultStreamReadTimeout bounds a single streaming read when
+// streaming.read_timeout_seconds is unset. A healthy read finishes in seconds;
+// even a pathological one is bounded by the per-segment fetch budget (15s per
+// attempt, 2 attempts). Anything past this is a stall, not slowness.
+const DefaultStreamReadTimeout = 120 * time.Second
+
+// GetStreamReadTimeout returns the per-read timeout for streaming reads.
+// Zero configures the default; a negative value disables the timeout entirely
+// and is returned as 0.
+func (c *Config) GetStreamReadTimeout() time.Duration {
+	if c.Streaming.ReadTimeoutSeconds < 0 {
+		return 0 // Explicitly disabled
+	}
+	if c.Streaming.ReadTimeoutSeconds == 0 {
+		return DefaultStreamReadTimeout
+	}
+	return time.Duration(c.Streaming.ReadTimeoutSeconds) * time.Second
+}
+
 // GetMaxRetries returns the maximum number of health check retries.
 func (c *Config) GetMaxRetries() int {
 	if c.Health.MaxRetries <= 0 {

--- a/internal/config/manager.go
+++ b/internal/config/manager.go
@@ -250,8 +250,16 @@ type FailureMaskingConfig struct {
 
 // StreamingConfig represents streaming and chunking configuration
 type StreamingConfig struct {
-	MaxPrefetch    int                  `yaml:"max_prefetch" mapstructure:"max_prefetch" json:"max_prefetch"`
-	FailureMasking FailureMaskingConfig `yaml:"failure_masking" mapstructure:"failure_masking" json:"failure_masking"`
+	MaxPrefetch int `yaml:"max_prefetch" mapstructure:"max_prefetch" json:"max_prefetch"`
+	// ReadTimeoutSeconds bounds a single streaming read (WebDAV Read and FUSE
+	// ReadAt alike). Nothing below this layer carries a deadline the caller can
+	// observe: a segment fetch that stalls without erroring parks the read
+	// indefinitely, and on FUSE that means an uninterruptible D-state for the
+	// reading process. On expiry the in-flight reader is interrupted and the
+	// read fails, so the caller gets an EIO it can act on. 0 uses the built-in
+	// default; a negative value disables the timeout.
+	ReadTimeoutSeconds int                  `yaml:"read_timeout_seconds" mapstructure:"read_timeout_seconds" json:"read_timeout_seconds"`
+	FailureMasking     FailureMaskingConfig `yaml:"failure_masking" mapstructure:"failure_masking" json:"failure_masking"`
 }
 
 // RCloneConfig represents rclone configuration
@@ -1575,7 +1583,8 @@ func DefaultConfig(configDir ...string) *Config {
 			},
 		},
 		Streaming: StreamingConfig{
-			MaxPrefetch: 60, // Default: 60 segments prefetched ahead
+			MaxPrefetch:        60,  // Default: 60 segments prefetched ahead
+			ReadTimeoutSeconds: 120, // Default: bound a single read at 2 minutes
 			FailureMasking: FailureMaskingConfig{
 				Enabled:   &failureMaskingEnabled,
 				Threshold: 3,

--- a/internal/nzbfilesystem/constants.go
+++ b/internal/nzbfilesystem/constants.go
@@ -3,6 +3,8 @@ package nzbfilesystem
 import (
 	"errors"
 	"fmt"
+
+	"github.com/javi11/altmount/internal/config"
 )
 
 // File system constants
@@ -63,6 +65,11 @@ var (
 	ErrNoEncryptionParams  = errors.New("no NZB data available for encryption parameters")
 	ErrFileIsCorrupted     = errors.New("file is corrupted, there are some missing segments")
 	ErrFileClosed          = errors.New("file closed")
+	// ErrReadTimeout is returned when a single read exceeds
+	// streaming.read_timeout_seconds. Deliberately not a context error: the
+	// FUSE handles map context errors to EINTR (a retryable interruption),
+	// whereas a timed-out read is a genuine failure and must surface as EIO.
+	ErrReadTimeout = errors.New("read timed out")
 )
 
 // Database operation error message templates
@@ -70,3 +77,7 @@ const (
 	ErrMsgFailedCreateDecryptReader = "failed to create decrypt reader: %w"
 	ErrMsgFailedWrapEncryption      = "failed to wrap reader with encryption: %w"
 )
+
+// defaultStreamReadTimeout mirrors config.DefaultStreamReadTimeout so this
+// package can reason about the fallback without importing it at every call.
+const defaultStreamReadTimeout = config.DefaultStreamReadTimeout

--- a/internal/nzbfilesystem/metadata_remote_file.go
+++ b/internal/nzbfilesystem/metadata_remote_file.go
@@ -914,6 +914,92 @@ func (mvf *MetadataVirtualFile) interruptCurrentReader() {
 	}
 }
 
+// armReadTimeout bounds a single read, returning a context carrying the
+// deadline, a predicate reporting whether that deadline was hit, and a stop
+// function the caller must defer.
+//
+// Two mechanisms are needed because the read path has two shapes:
+//
+//   - The shared reader ignores the caller's context entirely —
+//     UsenetReader.Read waits on the reader's own context (see
+//     usenet.segment.GetReaderContext), so a derived deadline is invisible to
+//     it. A timer fires the reader's Interrupt hook instead, which cancels its
+//     internal context and releases its segments, unblocking the read.
+//   - Ephemeral (seek-driven) readers are short-lived locals that are never
+//     registered for interruption, but their reads run through
+//     readFullContext, which force-closes the reader when the context expires.
+//     Those need the deadline on the context.
+//
+// Both are no-ops when the timeout is disabled; the parent context is returned
+// unchanged.
+//
+// Safe to call without holding mvf.mu: interruptCurrentReader reads an
+// atomic.Value, so the watchdog can break a jam even while another read holds
+// the mutex.
+func (mvf *MetadataVirtualFile) armReadTimeout(parent context.Context) (ctx context.Context, timedOut func() bool, stop func()) {
+	never := func() bool { return false }
+	if mvf.configGetter == nil {
+		return parent, never, func() {}
+	}
+	cfg := mvf.configGetter()
+	if cfg == nil {
+		return parent, never, func() {}
+	}
+	timeout := cfg.GetStreamReadTimeout()
+	if timeout <= 0 {
+		return parent, never, func() {}
+	}
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+
+	var interrupted atomic.Bool
+	timer := time.AfterFunc(timeout, func() {
+		interrupted.Store(true)
+		slog.WarnContext(mvf.ctx, "Read exceeded the streaming read timeout, interrupting reader",
+			"path", mvf.name,
+			"timeout", timeout)
+		mvf.interruptCurrentReader()
+	})
+
+	// Checking ctx.Err() rather than only the timer flag keeps this
+	// deterministic: the context package sets DeadlineExceeded before it
+	// releases any waiter, so a read that returns because of the deadline
+	// always observes it, with no race against the timer goroutine.
+	timedOut = func() bool {
+		return interrupted.Load() || errors.Is(ctx.Err(), context.DeadlineExceeded)
+	}
+
+	return ctx, timedOut, func() {
+		timer.Stop()
+		cancel()
+	}
+}
+
+// readContext returns the handle's context, falling back to Background for
+// handles built without one (tests, bridges).
+func (mvf *MetadataVirtualFile) readContext() context.Context {
+	if mvf.ctx != nil {
+		return mvf.ctx
+	}
+	return context.Background()
+}
+
+// classifyReadError maps a reader error to the error a read should return,
+// reporting data corruption to the health pipeline on the way. This is what
+// feeds streaming failure masking — without it a DMCA'd file never accumulates
+// failures and is never masked. Callers must hold mvf.mu.
+func (mvf *MetadataVirtualFile) classifyReadError(readErr error) error {
+	var dataCorruptionErr *usenet.DataCorruptionError
+	if errors.As(readErr, &dataCorruptionErr) {
+		mvf.updateFileHealthOnError(dataCorruptionErr, dataCorruptionErr.NoRetry)
+		return &CorruptedFileError{
+			TotalExpected: mvf.meta.FileSize,
+			UnderlyingErr: dataCorruptionErr,
+		}
+	}
+	return readErr
+}
+
 // segmentOffsetIndex provides O(1) lookup for offset→segment mapping using binary search
 type segmentOffsetIndex struct {
 	offsets []int64 // Cumulative start offset of each segment in file coordinates
@@ -998,6 +1084,17 @@ func (mvf *MetadataVirtualFile) Read(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
+	// Same watchdog as ReadAtContext — a stalled fetch parks a WebDAV/rclone
+	// read just as indefinitely as a FUSE one. Read has no context to thread
+	// through, so only the interrupt half applies here.
+	_, timedOut, stopTimeout := mvf.armReadTimeout(mvf.readContext())
+	defer func() {
+		stopTimeout()
+		if timedOut() && err != nil && !errors.Is(err, ErrReadTimeout) {
+			err = fmt.Errorf("%w: %w", ErrReadTimeout, err)
+		}
+	}()
+
 	mvf.mu.Lock()
 	defer mvf.mu.Unlock()
 
@@ -1072,6 +1169,18 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 		return 0, ErrNegativeOffset
 	}
 
+	// Armed before taking mvf.mu so the budget covers queueing behind another
+	// read on the same handle. A single stuck read otherwise blocks every
+	// subsequent read on this file; interrupting the in-flight reader from here
+	// breaks that jam.
+	readCtx, timedOut, stopTimeout := mvf.armReadTimeout(readCtx)
+	defer func() {
+		stopTimeout()
+		if timedOut() && err != nil && !errors.Is(err, ErrReadTimeout) {
+			err = fmt.Errorf("%w: %w", ErrReadTimeout, err)
+		}
+	}()
+
 	mvf.mu.Lock()
 	defer mvf.mu.Unlock()
 
@@ -1127,6 +1236,7 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 			want = mvf.meta.FileSize - off
 		}
 		buf := p[:want]
+		var sharedErr error
 		for n < int(want) {
 			rn, readErr := mvf.reader.Read(buf[n:])
 			n += rn
@@ -1142,11 +1252,13 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 			if readErr != nil {
 				if errors.Is(readErr, io.EOF) && mvf.hasMoreDataToRead() {
 					mvf.closeCurrentReader()
-					if err := mvf.ensureReader(); err != nil {
+					if rotateErr := mvf.ensureReader(); rotateErr != nil {
+						sharedErr = rotateErr
 						break
 					}
 					continue
 				}
+				sharedErr = readErr
 				break
 			}
 		}
@@ -1154,6 +1266,19 @@ func (mvf *MetadataVirtualFile) ReadAtContext(readCtx context.Context, p []byte,
 		// Advance the shared cursor so the next sequential call hits this path again.
 		mvf.readAtSharedNext = off + int64(n)
 		mvf.ephemeralStreak = 0 // sequential read — reset scrub counter
+
+		// A real failure (missing segment, interrupted reader, pool error) must
+		// reach the caller. Returning a silent short read here was what kept
+		// streaming failure masking from ever seeing a FUSE-path failure.
+		// io.EOF stays non-fatal: hasMoreDataToRead() already said there is
+		// nothing left to rotate to, so it is a genuine end of data.
+		if sharedErr != nil && !errors.Is(sharedErr, io.EOF) {
+			// The shared reader is in an indeterminate state — drop it so the
+			// next read rebuilds cleanly rather than inheriting the failure.
+			mvf.closeCurrentReader()
+			mvf.readAtSharedNext = -1
+			return n, mvf.classifyReadError(sharedErr)
+		}
 		return n, nil
 	}
 
@@ -1219,7 +1344,14 @@ ephemeral:
 		mvf.readAtSharedNext = off + int64(n)
 	}
 
-	return n, err
+	if err != nil {
+		// Same reporting as the shared path — scrub-driven reads must feed
+		// failure masking too, otherwise a player that seeks never marks a
+		// DMCA'd file as failing.
+		return n, mvf.classifyReadError(err)
+	}
+
+	return n, nil
 }
 
 // tryServeFromRandomReadCache attempts to satisfy a single-segment
@@ -1632,10 +1764,14 @@ const closerWorkerCount = 4
 // mvf.mu (so the lazy init is safe).
 func (mvf *MetadataVirtualFile) enqueueCloser(r io.Closer) {
 	if mvf.closerCh == nil {
-		mvf.closerCh = make(chan io.Closer, closerWorkerCount)
-		for i := 0; i < closerWorkerCount; i++ {
+		// Workers range over this local, not mvf.closerCh: Close() nils the
+		// field under mvf.mu, which the workers do not hold, so reading the
+		// field from inside the goroutine is a data race.
+		ch := make(chan io.Closer, closerWorkerCount)
+		mvf.closerCh = ch
+		for range closerWorkerCount {
 			mvf.closeWg.Go(func() {
-				for c := range mvf.closerCh {
+				for c := range ch {
 					_ = c.Close()
 				}
 			})
@@ -2088,6 +2224,14 @@ func (mvf *MetadataVirtualFile) wrapWithEncryption(start, end int64) (io.ReadClo
 // of corrupt files) cannot fan out into one DB write + one rclone VFS refresh
 // per call. See issue #539 for the failure mode this guards against.
 func (mvf *MetadataVirtualFile) updateFileHealthOnError(dataCorruptionErr *usenet.DataCorruptionError, noRetry bool) {
+	// Health reporting needs both persistence layers. Handles built without
+	// them (nzbdav bridge, tests) have nothing to record — bail rather than
+	// nil-deref. This runs on the read path, where a panic would take the whole
+	// mount down.
+	if mvf.healthRepository == nil || mvf.metadataService == nil || mvf.configGetter == nil {
+		return
+	}
+
 	// Per-path debounce: short-circuit if this file already triggered a repair
 	// inside the debounce window. ShouldTrigger handles a nil coalescer
 	// (test harness) by returning true.

--- a/internal/nzbfilesystem/readat_failure_test.go
+++ b/internal/nzbfilesystem/readat_failure_test.go
@@ -1,0 +1,218 @@
+package nzbfilesystem
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/javi11/altmount/internal/config"
+	"github.com/javi11/altmount/internal/database"
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/javi11/altmount/internal/testsupport/fakepool"
+	"github.com/javi11/altmount/internal/testsupport/segments"
+	"github.com/javi11/nntppool/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readat_failure_test.go pins the two safety nets that must hold on the FUSE
+// read path (ReadAtContext), as opposed to the WebDAV path (Read):
+//
+//  1. Read errors must propagate. The sequential branch used to `return n, nil`
+//     after breaking out of its read loop, so a permanently missing segment
+//     surfaced as a silent short read — the caller saw truncated data and no
+//     error, and streaming failure masking never saw a failure to count.
+//
+//  2. A read must not block forever. Nothing on this path carried a deadline,
+//     so a stalled fetch parked the FUSE request indefinitely and left the
+//     calling process (e.g. Sonarr's ffprobe) in uninterruptible D-state.
+
+// withConfig attaches a config getter to a test file handle. newTestMVF leaves
+// configGetter nil; every path touched here reads config.
+func withConfig(mvf *MetadataVirtualFile, cfg *config.Config) *MetadataVirtualFile {
+	mvf.configGetter = func() *config.Config { return cfg }
+	return mvf
+}
+
+// TestReadAtContext_MissingSegment_ReturnsError verifies that a sequential
+// ReadAtContext spanning a permanently missing (DMCA'd) segment reports an
+// error rather than silently returning a short read.
+func TestReadAtContext_MissingSegment_ReturnsError(t *testing.T) {
+	const (
+		segCount = 4
+		segSize  = 1024
+	)
+
+	ctx := context.Background()
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	// Segment 2 is gone from every provider — a permanent 430.
+	fp.SetBehavior(segments.MessageID(2), fakepool.SegmentBehavior{
+		Err: nntppool.ErrArticleNotFound,
+	})
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), config.DefaultConfig())
+
+	buf := make([]byte, segCount*segSize)
+	n, err := mvf.ReadAtContext(ctx, buf, 0)
+
+	require.Error(t, err, "read spanning a permanently missing segment must surface an error")
+	assert.Less(t, n, len(buf), "read must be short — segment 2 is unavailable")
+}
+
+// TestReadAtContext_MissingSegment_CountsStreamingFailure verifies that the
+// FUSE read path feeds streaming failure masking. Previously only Read() (the
+// WebDAV path) called updateFileHealthOnError, so `streaming.failure_masking`
+// was inert for FUSE mounts and a DMCA'd file was never masked.
+func TestReadAtContext_MissingSegment_CountsStreamingFailure(t *testing.T) {
+	const (
+		segCount = 4
+		segSize  = 1024
+	)
+
+	repo, db, ms := setupStreamHealthEnv(t)
+	ctx := context.Background()
+
+	filePath := "series/masked.s01e06.mkv"
+	_, err := db.Exec(
+		`INSERT INTO file_health (file_path, library_path, status, scheduled_check_at, streaming_failure_count)
+		 VALUES (?, ?, 'healthy', datetime('now'), 0)`,
+		filePath, "/media/library/masked.s01e06.mkv",
+	)
+	require.NoError(t, err)
+
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	fp.SetBehavior(segments.MessageID(2), fakepool.SegmentBehavior{
+		Err: nntppool.ErrArticleNotFound,
+	})
+
+	healthEnabled := true
+	maskingEnabled := true
+	cfg := config.DefaultConfig()
+	cfg.Health.Enabled = &healthEnabled
+	cfg.Streaming.FailureMasking.Enabled = &maskingEnabled
+	cfg.Streaming.FailureMasking.Threshold = 3
+	cfg.MountPath = ""
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), cfg)
+	// Route health updates at the real repository. The file is named .mkv so
+	// hole padding would normally apply; clip boundaries keep it ineligible so
+	// the miss surfaces as an error instead of being zero-filled.
+	mvf.name = filePath
+	mvf.healthRepository = repo
+	mvf.metadataService = ms
+	mvf.meta.ClipBoundaries = []*metapb.ClipBoundary{{}}
+
+	buf := make([]byte, segCount*segSize)
+	_, readErr := mvf.ReadAtContext(ctx, buf, 0)
+	require.Error(t, readErr)
+
+	fh, err := repo.GetFileHealth(ctx, filePath)
+	require.NoError(t, err)
+	require.NotNil(t, fh)
+	assert.Equal(t, 1, fh.StreamingFailureCount,
+		"a failed FUSE read must increment the streaming failure counter")
+	assert.Equal(t, database.HealthStatusPending, fh.Status,
+		"below the masking threshold the file stays pending, not repair_triggered")
+}
+
+// TestReadAtContext_StalledFetch_TimesOut verifies that a fetch which never
+// completes and ignores context cancellation still lets ReadAtContext return.
+// The fake pool's gate blocks without consulting ctx, reproducing the stall
+// that left ffprobe in D-state for over half an hour.
+func TestReadAtContext_StalledFetch_TimesOut(t *testing.T) {
+	const (
+		segCount = 4
+		segSize  = 1024
+	)
+
+	ctx := context.Background()
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	fp.BlockUntil(make(chan struct{})) // never released, never cancelled
+
+	cfg := config.DefaultConfig()
+	cfg.Streaming.ReadTimeoutSeconds = 1
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), cfg)
+
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		buf := make([]byte, segSize)
+		n, err := mvf.ReadAtContext(ctx, buf, 0)
+		done <- result{n, err}
+	}()
+
+	select {
+	case got := <-done:
+		require.Error(t, got.err, "a stalled fetch must fail the read, not return success")
+		assert.ErrorIs(t, got.err, ErrReadTimeout)
+	case <-time.After(20 * time.Second):
+		t.Fatal("ReadAtContext hung well past the configured 1s read timeout")
+	}
+}
+
+// TestReadAtContext_StalledEphemeralFetch_TimesOut covers the seek path. It
+// builds a short-lived reader that is never registered for interruption, so it
+// relies on the read context carrying the deadline instead. A player scrubbing
+// into a stalled region must not hang either.
+func TestReadAtContext_StalledEphemeralFetch_TimesOut(t *testing.T) {
+	const (
+		segCount = 8
+		segSize  = 1024
+	)
+
+	ctx := context.Background()
+	fp := fakepool.New()
+	configurePoolForFile(fp, segCount, segSize, fakepool.SegmentBehavior{})
+	fp.BlockUntil(make(chan struct{})) // never released, never cancelled
+
+	cfg := config.DefaultConfig()
+	cfg.Streaming.ReadTimeoutSeconds = 1
+
+	mvf := withConfig(newTestMVF(t, ctx, fp, segCount, segSize, 2), cfg)
+
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, segSize)
+		// Offset 4*segSize is not the shared reader's next position, so this
+		// takes the ephemeral branch.
+		_, err := mvf.ReadAtContext(ctx, buf, 4*segSize)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a stalled seek-driven fetch must fail the read")
+		assert.ErrorIs(t, err, ErrReadTimeout)
+	case <-time.After(20 * time.Second):
+		t.Fatal("ephemeral ReadAtContext hung past the configured 1s read timeout")
+	}
+}
+
+// TestReadTimeout_Defaults pins the configured/default resolution so a zero
+// value cannot silently disable the safety net.
+func TestReadTimeout_Defaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{"explicit value wins", 30, 30 * time.Second},
+		{"zero falls back to the default", 0, defaultStreamReadTimeout},
+		{"negative disables the timeout", -1, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.DefaultConfig()
+			cfg.Streaming.ReadTimeoutSeconds = tt.seconds
+			assert.Equal(t, tt.want, cfg.GetStreamReadTimeout())
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A file with permanently missing segments (DMCA'd articles) could hang a reader indefinitely. Sonarr's `ffprobe` was observed stuck in uninterruptible D-state for 34 minutes, unkillable until AltMount was restarted.

Both safeguards that should have caught this miss it:

**Read errors never reached the caller.** `ReadAtContext` — the FUSE read path — returned `n, nil` after breaking out of its sequential read loop, so a permanently missing segment surfaced as a silent short read. It also never called `updateFileHealthOnError`; only `Read()` (the WebDAV path) did. So `streaming.failure_masking` was effectively dead config for FUSE mounts — not just for hangs, but for clean fast errors too.

**Reads had no deadline.** Nothing on the path carried one, and the caller's context cannot help: the shared reader waits on the reader's *own* context (`usenet.segment.GetReaderContext`), so cancelling the FUSE request context does not unblock an in-flight fetch. A stall parks the request forever.

Worth noting for anyone who hit this: `health.read_timeout_seconds` governs only the background health-check sweep and has never applied to playback reads. The `fuse:` section has no read timeout at all.

## Changes

**Errors propagate and feed masking** — both the sequential and ephemeral branches of `ReadAtContext` now return real failures and route them through a new `classifyReadError`, which reports data corruption to the health pipeline exactly as `Read()` always did. The failing shared reader is torn down so the next read rebuilds cleanly. `io.EOF` stays non-fatal, since `hasMoreDataToRead()` has already confirmed there is nothing left to rotate to.

**New `streaming.read_timeout_seconds`** (default `120`, `0` = default, `-1` = disabled), applied to both FUSE and WebDAV reads. It needs two mechanisms because the read path has two shapes:

- The **shared reader** ignores the caller's context entirely, so a derived deadline is invisible to it — a timer fires the existing `Interrupt()` hook instead, which cancels the reader's internal context and releases its segments.
- **Ephemeral (seek-driven) readers** are short-lived locals never registered for interruption, so `Interrupt` cannot reach them — but their reads run through `readFullContext`, which already force-closes the reader on context expiry. Those need the deadline on the context.

Armed *before* taking `mvf.mu`, so a single stuck read cannot wedge every subsequent read on the same handle. Returns `ErrReadTimeout` rather than a context error: the FUSE handles map context errors to `EINTR`, whereas a timed-out read is a genuine failure and should surface as `EIO`.

**Two bugs found while testing:**

- **Data race** in `enqueueCloser` — the closer workers ranged over the `mvf.closerCh` *field* unsynchronized while `Close()` nils it under `mvf.mu`. Pre-existing; `-race` surfaced it once the read path started closing readers on failure.
- **Nil deref** in `updateFileHealthOnError` when `metadataService`/`healthRepository` are nil. Previously unreachable, now guarded — a panic on the read path takes the whole mount down.

## Reviewer notes

- **Behavior change:** existing configs without `read_timeout_seconds` unmarshal to `0`, which resolves to the 120s default. Reads that previously hung forever now fail with EIO after 2 minutes. Set `-1` to restore the old behavior.
- **Deliberate non-change:** a short read ending in `io.EOF` still returns `nil`. That is arguably also a silent-truncation vector, but changing it risks breaking playback of files with benign trailing mismatch — worth a separate look against real files.
- The tests reproduce both hangs using the fake pool's gate, which blocks *without consulting the context* — matching the real uninterruptible stall rather than simulating it with a plain error.

## Test plan

Five new tests in `internal/nzbfilesystem/readat_failure_test.go`, each observed failing for the right reason before the fix:

```
--- FAIL: TestReadAtContext_MissingSegment_ReturnsError           (error was nil)
--- FAIL: TestReadAtContext_MissingSegment_CountsStreamingFailure (counter never incremented)
--- FAIL: TestReadAtContext_StalledFetch_TimesOut                 (hung the full 20s budget)
--- FAIL: TestReadAtContext_StalledEphemeralFetch_TimesOut        (hung the full 60s budget)
```

The ephemeral test is what caught an incomplete first attempt that only implemented the interrupt half of the timeout.

- [x] `go test ./... -race` — full suite, 0 failures
- [x] New tests `-count=5 -race` — no flakes, no races
- [x] `golangci-lint` on changed packages — 0 issues (6 pre-existing staticcheck hits in `internal/importer/archive/iso/bluray_test.go` are unrelated; confirmed by stashing)
- [x] `bun run check` and `bun run build` — pass
- [ ] Manual: confirm a DMCA'd file now fails ffprobe with EIO instead of hanging, and gets masked after 3 attempts

Docs updated in `docs/docs/3. Configuration/streaming.md`, including a note clarifying that `health.read_timeout_seconds` does not affect playback reads.
