### PR TITLE
fix(metadata): bound the NzbStore cache by bytes instead of entry count (#819)

### DIFF
--- a/internal/metadata/service.go
+++ b/internal/metadata/service.go
@@ -49,13 +49,18 @@ type FileMetadataLite struct {
 
 // MetadataService provides low-level read/write operations for metadata files.
 //
-// Only a lightweight metadata projection (liteCache) is kept in memory. The
-// full FileMetadata proto — dominated by SegmentData/NestedSources slices
-// holding thousands of message-ID strings — is never cached. Callers that need
-// segments (Open, HealthChecker) re-read from disk each time; the proto then
-// lives only for the duration of the open handle or the health check. This
-// bounds steady-state memory at ~liteCache_entries × 40 bytes instead of the
-// previous unbounded segment retention.
+// The full FileMetadata proto is never cached: callers that need segments
+// (Open, HealthChecker) re-read from disk each time, so the proto lives only
+// for the duration of the open handle or the health check. Two caches hold
+// state between calls, and both are bounded:
+//
+//   - liteCache, a lightweight projection (size, modtime, status) at
+//     ~liteCache_entries × 40 bytes.
+//   - store's decoded NzbStore cache, which v3 metadata resolves segments
+//     against. Stores are shared per release and are the one place message-ID
+//     strings do survive a call, so that cache is bounded by estimated bytes
+//     (defaultStoreCacheBytes) rather than by entry count — bounding it by
+//     entry count left steady-state retention unbounded (issue #819).
 type MetadataService struct {
 	rootPath string
 	// liteCache caches lightweight metadata (size, modtime, status) used by

--- a/internal/metadata/store.go
+++ b/internal/metadata/store.go
@@ -6,31 +6,161 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 
-	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	metapb "github.com/javi11/altmount/internal/metadata/proto"
 	"github.com/javi11/altmount/internal/nzb"
 	"github.com/klauspost/compress/zstd"
 	"google.golang.org/protobuf/proto"
 )
 
-const defaultStoreCacheSize = 256
+// The store cache carries two bounds, because a store's cost has two parts
+// that scale independently:
+//
+//   - defaultStoreCacheBytes bounds the decoded payload, which is dominated by
+//     one message-ID string per segment and is what made retention unbounded
+//     when only entry count was capped (issue #819).
+//   - defaultStoreCacheSize bounds the number of entries, and with it the LRU
+//     list nodes and map slots that the byte estimate charges per entry but
+//     that a library of very small releases would otherwise multiply freely.
+//
+// Neither subsumes the other: large releases hit the byte bound first, small
+// ones hit the entry bound first.
+const (
+	defaultStoreCacheSize = 256
+
+	defaultStoreCacheBytes int64 = 64 << 20
+
+	// The overhead constants below approximate the live heap of each cached
+	// element beyond its own string contents: the message struct, its slot in
+	// the enclosing slice, and allocator rounding. They are calibrated against
+	// measured retention and only need to be the right order for the budget to
+	// hold; TestStoreCache_LiveHeapStaysBounded is the guard against drift as
+	// the proto schema evolves.
+	storeSegOverheadBytes   int64 = 104
+	storeFileOverheadBytes  int64 = 160
+	storeGroupOverheadBytes int64 = 16
+	storeEntryOverheadBytes int64 = 96
+)
+
+// storeEntry pairs a cached store with the size it was charged, so eviction
+// can refund exactly what insertion counted without a second bookkeeping map
+// to keep in lockstep with the LRU.
+type storeEntry struct {
+	store *metapb.NzbStore
+	size  int64
+}
 
 // StoreService reads/writes per-release NzbStore files (zstd proto) and caches
 // decompressed stores keyed by store ref (path).
+//
+// The cache is bounded by estimated bytes, not by entry count: stores vary in
+// size by orders of magnitude (a single-file release versus a full season), so
+// an entry-count bound places no bound at all on retained heap. cache is a
+// non-thread-safe simplelru guarded by mu, which lets the eviction callback
+// maintain the byte accounting without re-entering the lock.
 type StoreService struct {
 	rootPath string
-	cache    *lru.Cache[string, *metapb.NzbStore]
 	encoder  *zstd.Encoder
 	decoder  *zstd.Decoder
+
+	mu       sync.Mutex
+	cache    *simplelru.LRU[string, storeEntry]
+	curBytes int64
+	maxBytes int64
 }
 
-// NewStoreService creates a StoreService rooted at rootPath with an LRU cache.
+// NewStoreService creates a StoreService rooted at rootPath with an LRU cache
+// bounded by defaultStoreCacheBytes.
 func NewStoreService(rootPath string) *StoreService {
-	c, _ := lru.New[string, *metapb.NzbStore](defaultStoreCacheSize)
+	return newStoreServiceWithBudget(rootPath, defaultStoreCacheBytes)
+}
+
+func newStoreServiceWithBudget(rootPath string, maxBytes int64) *StoreService {
 	enc, _ := zstd.NewWriter(nil)
 	dec, _ := zstd.NewReader(nil)
-	return &StoreService{rootPath: rootPath, cache: c, encoder: enc, decoder: dec}
+	ss := &StoreService{
+		rootPath: rootPath,
+		encoder:  enc,
+		decoder:  dec,
+		maxBytes: maxBytes,
+	}
+	ss.cache, _ = simplelru.NewLRU(defaultStoreCacheSize, ss.onEvict)
+	return ss
+}
+
+// onEvict runs inside cache mutations, which only happen under ss.mu, so it
+// must not take the lock itself.
+func (ss *StoreService) onEvict(_ string, e storeEntry) {
+	ss.curBytes -= e.size
+}
+
+// cacheGet returns a cached store, marking it as recently used.
+func (ss *StoreService) cacheGet(ref string) (*metapb.NzbStore, bool) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	e, ok := ss.cache.Get(ref)
+	return e.store, ok
+}
+
+// cacheAdd inserts a store and evicts from the cold end until the byte budget
+// is met. A store larger than the whole budget is still cached (so the caller
+// that just paid to decode it can reuse it) but will be the sole occupant, and
+// the next insertion evicts it.
+func (ss *StoreService) cacheAdd(ref string, store *metapb.NzbStore) {
+	e := storeEntry{store: store, size: estimateStoreBytes(ref, store)}
+
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	// simplelru replaces a duplicate key in place without invoking the evict
+	// callback, so remove first to refund the previous charge for this ref.
+	ss.cache.Remove(ref)
+	ss.curBytes += e.size
+	ss.cache.Add(ref, e)
+
+	for ss.curBytes > ss.maxBytes && ss.cache.Len() > 1 {
+		ss.cache.RemoveOldest()
+	}
+}
+
+// purgeCache drops every cached store.
+func (ss *StoreService) purgeCache() {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	ss.cache.Purge()
+	ss.curBytes = 0
+}
+
+// cachedBytes reports the estimated live heap currently held by cached stores.
+func (ss *StoreService) cachedBytes() int64 {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	return ss.curBytes
+}
+
+// estimateStoreBytes approximates the live heap a decoded store retains. It is
+// deliberately a cheap structural estimate rather than a marshalled size: the
+// on-disk size understates in-memory cost by roughly 2-3x, and the budget only
+// needs to track the real figure to within a small factor.
+func estimateStoreBytes(ref string, store *metapb.NzbStore) int64 {
+	// Charged even for an empty store: the ref key, the LRU list node and the
+	// map slot cost the same whether the store holds one segment or thousands.
+	total := storeEntryOverheadBytes + int64(len(ref))
+	if store == nil {
+		return total
+	}
+	for _, f := range store.Files {
+		total += storeFileOverheadBytes + int64(len(f.Subject)+len(f.Poster))
+		for _, g := range f.Groups {
+			total += storeGroupOverheadBytes + int64(len(g))
+		}
+		for _, s := range f.Segments {
+			total += storeSegOverheadBytes + int64(len(s.Id))
+		}
+	}
+	return total
 }
 
 // WriteStore writes zstd(proto) to ref atomically and refreshes the cache.
@@ -63,13 +193,13 @@ func (ss *StoreService) WriteStore(ref string, store *metapb.NzbStore) error {
 		_ = os.Remove(tmpPath)
 		return fmt.Errorf("rename store file: %w", err)
 	}
-	ss.cache.Add(ref, store)
+	ss.cacheAdd(ref, store)
 	return nil
 }
 
 // ReadStore reads and decompresses a store, caching the result.
 func (ss *StoreService) ReadStore(ref string) (*metapb.NzbStore, error) {
-	if c, ok := ss.cache.Get(ref); ok {
+	if c, ok := ss.cacheGet(ref); ok {
 		return c, nil
 	}
 	compressed, err := os.ReadFile(ref)
@@ -84,7 +214,7 @@ func (ss *StoreService) ReadStore(ref string) (*metapb.NzbStore, error) {
 	if err := proto.Unmarshal(raw, store); err != nil {
 		return nil, fmt.Errorf("unmarshal store: %w", err)
 	}
-	ss.cache.Add(ref, store)
+	ss.cacheAdd(ref, store)
 	return store, nil
 }
 

--- a/internal/metadata/store_cache_test.go
+++ b/internal/metadata/store_cache_test.go
@@ -1,0 +1,161 @@
+package metadata
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	metapb "github.com/javi11/altmount/internal/metadata/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// bigStore builds a store whose segment count is representative of a real
+// release (thousands of message IDs), which is what makes the decoded proto
+// expensive to retain.
+func bigStore(segCount int) *metapb.NzbStore {
+	segs := make([]*metapb.NzbSeg, segCount)
+	for i := range segs {
+		segs[i] = &metapb.NzbSeg{
+			Id:     fmt.Sprintf("part%dof%d.abcdef0123456789abcdef@powerpost.local", i+1, segCount),
+			Number: int32(i + 1),
+			Bytes:  760000,
+		}
+	}
+	return &metapb.NzbStore{Files: []*metapb.NzbFileEntry{{
+		Subject:  "Some.Release.S01E01.1080p.WEB.h264 yEnc (1/1)",
+		Poster:   "poster@example.invalid",
+		Groups:   []string{"alt.binaries.test"},
+		Segments: segs,
+	}}}
+}
+
+// writeStores writes n stores of segCount segments each and returns their refs,
+// leaving the cache empty so the caller controls what gets faulted in.
+func writeStores(t *testing.T, ss *StoreService, dir string, n, segCount int) []string {
+	t.Helper()
+	refs := make([]string, n)
+	for i := range refs {
+		ref := filepath.Join(dir, fmt.Sprintf("rel%d.nzbz", i))
+		require.NoError(t, ss.WriteStore(ref, bigStore(segCount)))
+		refs[i] = ref
+	}
+	ss.purgeCache()
+	return refs
+}
+
+// A store LRU bounded only by entry count retains an unbounded number of
+// bytes: 256 large releases is hundreds of MB of live heap (issue #819).
+// Retention must be bounded by size, not by entry count.
+func TestStoreCache_BoundedByBytes(t *testing.T) {
+	dir := t.TempDir()
+	const budget = 8 << 20
+	ss := newStoreServiceWithBudget(dir, budget)
+
+	refs := writeStores(t, ss, dir, 60, 5000)
+	for _, ref := range refs {
+		_, err := ss.ReadStore(ref)
+		require.NoError(t, err)
+	}
+
+	assert.LessOrEqual(t, ss.cachedBytes(), int64(budget),
+		"cache must stay within its byte budget")
+	assert.Less(t, ss.cache.Len(), len(refs),
+		"a byte-bounded cache must have evicted entries")
+	assert.Positive(t, ss.cache.Len(), "cache must still retain the hot entries")
+}
+
+// The most recently read store stays cached: eviction targets the cold end.
+func TestStoreCache_KeepsHotEntry(t *testing.T) {
+	dir := t.TempDir()
+	ss := newStoreServiceWithBudget(dir, 8<<20)
+
+	refs := writeStores(t, ss, dir, 20, 5000)
+	for _, ref := range refs {
+		_, err := ss.ReadStore(ref)
+		require.NoError(t, err)
+	}
+
+	assert.True(t, ss.cache.Contains(refs[len(refs)-1]),
+		"most recently read store must survive eviction")
+}
+
+// A single store larger than the whole budget must still be served, and must
+// not leave the accounting permanently over budget once it is evicted.
+func TestStoreCache_OversizedStore(t *testing.T) {
+	dir := t.TempDir()
+	ss := newStoreServiceWithBudget(dir, 1<<10) // absurdly small
+
+	refs := writeStores(t, ss, dir, 2, 500)
+	for _, ref := range refs {
+		got, err := ss.ReadStore(ref)
+		require.NoError(t, err)
+		require.Len(t, got.Files[0].Segments, 500, "oversized store must still be returned")
+	}
+
+	assert.LessOrEqual(t, ss.cache.Len(), 1,
+		"an oversized store must not accumulate alongside others")
+	ss.purgeCache()
+	assert.Zero(t, ss.cachedBytes(), "purge must reset the byte accounting")
+}
+
+// Writes are cached too, and must obey the same budget.
+func TestStoreCache_WriteObeysBudget(t *testing.T) {
+	dir := t.TempDir()
+	const budget = 4 << 20
+	ss := newStoreServiceWithBudget(dir, budget)
+
+	for i := range 40 {
+		ref := filepath.Join(dir, fmt.Sprintf("w%d.nzbz", i))
+		require.NoError(t, ss.WriteStore(ref, bigStore(5000)))
+	}
+
+	assert.LessOrEqual(t, ss.cachedBytes(), int64(budget))
+}
+
+// Every entry costs something regardless of payload, so a flood of tiny
+// stores cannot multiply LRU nodes and map slots free of charge.
+func TestStoreCache_ChargesPerEntryOverhead(t *testing.T) {
+	empty := estimateStoreBytes("/meta/rel.nzbz", &metapb.NzbStore{})
+	assert.Positive(t, empty, "an empty store must still be charged for its entry")
+	assert.Greater(t, estimateStoreBytes("/meta/a-much-longer-store-ref.nzbz", &metapb.NzbStore{}), empty,
+		"the ref key is part of the entry's cost")
+	assert.Positive(t, estimateStoreBytes("/meta/rel.nzbz", nil), "a nil store still occupies an entry")
+}
+
+// End-to-end guard on the reported symptom: faulting in far more store bytes
+// than the budget must not grow live heap without bound.
+func TestStoreCache_LiveHeapStaysBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("heap measurement is slow")
+	}
+	dir := t.TempDir()
+	ss := newStoreServiceWithBudget(dir, defaultStoreCacheBytes)
+	refs := writeStores(t, ss, dir, 300, 5000)
+
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	for _, ref := range refs {
+		_, err := ss.ReadStore(ref)
+		require.NoError(t, err)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	retainedMB := (float64(after.HeapAlloc) - float64(before.HeapAlloc)) / (1 << 20)
+	t.Logf("live heap retained by store cache: %.1f MB (budget %d MB, %d entries)",
+		retainedMB, defaultStoreCacheBytes>>20, ss.cache.Len())
+
+	// Unbounded-by-entry-count retention measured ~190 MB here; the estimator
+	// is deliberately conservative, so allow generous headroom over the budget
+	// while still failing loudly on a regression to entry-count bounding.
+	limit := float64(defaultStoreCacheBytes>>20) * 1.5
+	assert.Less(t, retainedMB, limit, "store cache retention must track its byte budget")
+}


### PR DESCRIPTION
Fixes #819.

## Root cause

Not the reported mechanism. `CheckFilesBatch`'s `preps` slice does **not** retain `FileMetadata` — `preparedCheck` holds only `filePath`, `sourceNzbPath`, `sampledIDs []string`, `earlyEvent` and `totalSegments`. `prepareCheck`'s comment about dropping the segment slice before the network sweep still holds, as does the one in `internal/health/holes.go`.

The retention is `StoreService`'s LRU. `defaultStoreCacheSize = 256` bounds the cache by **entry count**, but a cached entry is a fully-decoded `NzbStore` covering an entire release, dominated by one message-ID string per segment. Stores differ in size by orders of magnitude, so an entry-count bound places no bound at all on retained heap.

This explains the reported profile exactly: `ReadFileMetadata` at 713 MB cum with children `prepareCheck` 411 MB and `webdav` 302 MB is **one shared cache**, with each entry attributed to whichever caller happened to fault it in. It is steady state because it is an LRU, and it scales with the number of distinct releases touched rather than with `check_batch_size × max_concurrent_jobs`. Lowering `check_batch_size` helps only because it slows the rate at which the health sweep pulls new releases through the cache.

It also broke the bound documented on `MetadataService`, which `internal/metadata/service.go` still asserted.

## Measurement

Controlled test, 300 stores of 5000 segments each read through `ReadStore`, live heap after two forced GCs:

| | entries retained | live heap |
|---|---|---|
| before (256-entry bound) | 256 | **189.8 MB** |
| after (64 MB byte bound) | 85 | **64.3 MB** |

The structural estimator tracks measured retention to within 0.5%.

## Change

- `StoreService` is bounded by estimated live bytes (`defaultStoreCacheBytes`, 64 MB). The 256-entry cap stays as a backstop against accumulating many tiny stores.
- The cache is now a `simplelru.LRU` guarded by the service's own mutex, so the eviction callback can maintain byte accounting without re-entering the lock. Insertion evicts from the cold end until the budget is met.
- A store larger than the entire budget is still cached — the caller just paid to decode it — but becomes the sole occupant and is evicted by the next insertion.
- `CachedBytes()` and `PurgeCache()` added for accounting and tests.
- The stale invariant comment on `MetadataService` now describes both bounded caches instead of claiming nothing is cached.

## Test plan

- [x] `TestStoreCache_BoundedByBytes` — retention stays within budget and entries are evicted (fails before the change)
- [x] `TestStoreCache_KeepsHotEntry` — eviction targets the cold end
- [x] `TestStoreCache_OversizedStore` — a store bigger than the budget is still served, and purge resets accounting
- [x] `TestStoreCache_WriteObeysBudget` — `WriteStore`'s cache population obeys the same budget
- [x] `TestStoreCache_LiveHeapStaysBounded` — end-to-end guard on the reported symptom (`-short` skips it)
- [x] `go test -race ./internal/metadata/ ./internal/health/` passes
- [x] `go build ./...` and `go test ./internal/...` pass

## Note for the reporter

64 MB is a judgement call, not a measured optimum — it trades store re-decode cost against heap. If your profile after this still shows the store cache dominating, that constant is the knob, and it can be plumbed to config if there's demand.