### PR TITLE
fix(utils): detect Windows cross-drive rename failures in MoveFile (#810)

### DIFF
--- a/internal/utils/file.go
+++ b/internal/utils/file.go
@@ -70,15 +70,13 @@ func isCrossDeviceError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var lerr *os.LinkError
-	if errors.As(err, &lerr) {
-		return errors.Is(lerr.Err, syscall.EXDEV)
+	// os.LinkError and os.PathError both unwrap to the underlying syscall error.
+	if errors.Is(err, syscall.EXDEV) || isPlatformCrossDeviceError(err) {
+		return true
 	}
-	var perr *os.PathError
-	if errors.As(err, &perr) {
-		return errors.Is(perr.Err, syscall.EXDEV)
-	}
-	// Fallback to string check
+	// Fallback to string check. Windows never reports EXDEV (see isPlatformCrossDeviceError),
+	// so its ERROR_NOT_SAME_DEVICE message is matched here as well.
 	errStr := err.Error()
-	return strings.Contains(errStr, "cross-device") || strings.Contains(errStr, "invalid cross-device link") || strings.Contains(errStr, "EXDEV")
+	return strings.Contains(errStr, "cross-device") || strings.Contains(errStr, "invalid cross-device link") ||
+		strings.Contains(errStr, "EXDEV") || strings.Contains(errStr, "different disk drive")
 }

--- a/internal/utils/file_test.go
+++ b/internal/utils/file_test.go
@@ -54,6 +54,15 @@ func TestIsCrossDeviceError(t *testing.T) {
 		{errors.New("EXDEV: invalid cross-device link"), true},
 		{&os.LinkError{Op: "rename", Old: "a", New: "b", Err: syscall.EXDEV}, true},
 		{&os.PathError{Op: "rename", Path: "a", Err: syscall.EXDEV}, true},
+		// Windows reports ERROR_NOT_SAME_DEVICE, whose message never mentions
+		// "cross-device". Match it so the copy-and-delete fallback kicks in there too.
+		{errors.New("The system cannot move the file to a different disk drive."), true},
+		{&os.LinkError{
+			Op:  "rename",
+			Old: "a",
+			New: "b",
+			Err: errors.New("The system cannot move the file to a different disk drive."),
+		}, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/utils/file_unix.go
+++ b/internal/utils/file_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package utils
+
+// isPlatformCrossDeviceError has no extra cases outside Windows: os.Rename reports EXDEV directly,
+// which isCrossDeviceError already checks.
+func isPlatformCrossDeviceError(_ error) bool {
+	return false
+}

--- a/internal/utils/file_windows.go
+++ b/internal/utils/file_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package utils
+
+import (
+	"errors"
+	"syscall"
+)
+
+// errorNotSameDevice is the Win32 ERROR_NOT_SAME_DEVICE code that os.Rename returns when source
+// and destination live on different drives. Windows has no real EXDEV: syscall.EXDEV there is an
+// invented errno from the APPLICATION_ERROR block, so it never matches this, and the Windows
+// message ("The system cannot move the file to a different disk drive.") never says "cross-device".
+const errorNotSameDevice = syscall.Errno(17)
+
+func isPlatformCrossDeviceError(err error) bool {
+	return errors.Is(err, errorNotSameDevice)
+}

--- a/internal/utils/file_windows_test.go
+++ b/internal/utils/file_windows_test.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package utils
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// os.Rename on Windows fails a cross-drive move with ERROR_NOT_SAME_DEVICE, which is a raw
+// Win32 code and not syscall.EXDEV (an invented errno on Windows), so it needs its own check.
+func TestIsCrossDeviceError_WindowsNotSameDevice(t *testing.T) {
+	err := &os.LinkError{Op: "rename", Old: "a", New: "b", Err: errorNotSameDevice}
+
+	if !isCrossDeviceError(err) {
+		t.Errorf("isCrossDeviceError(%v) = false; want true", err)
+	}
+
+	if errorNotSameDevice != syscall.Errno(17) {
+		t.Errorf("errorNotSameDevice = %d; want 17 (ERROR_NOT_SAME_DEVICE)", errorNotSameDevice)
+	}
+}


### PR DESCRIPTION
Fixes #810

## What

`utils.MoveFile` does an `os.Rename` and falls back to copy-and-delete when the rename fails across devices. That fallback could never fire on Windows, so moving a failed NZB from `%TEMP%\.altmount-queue` to `.nzbs\failed` on a different drive failed outright:

```
Failed to move NZB to failed folder: rename C:\...\.altmount-queue\X.nzb .nzbs\failed\TV\X.nzb:
The system cannot move the file to a different disk drive.
```

## Why it broke

Three independent reasons, all in `isCrossDeviceError`:

1. `os.Rename` on Windows returns `ERROR_NOT_SAME_DEVICE` (`syscall.Errno(17)`), but Go's `syscall.EXDEV` on Windows is an *invented* errno from the `APPLICATION_ERROR + iota` block (`zerrors_windows.go`), so `errors.Is(err, syscall.EXDEV)` never matched.
2. The Windows message contains none of `cross-device` / `invalid cross-device link` / `EXDEV`, so the text fallback didn't match either.
3. The `os.LinkError` branch early-returned `false`, so the text fallback was unreachable for exactly the error users hit.

Unix/macOS were unaffected — `os.Rename` reports real `EXDEV` there.

## Changes

- `internal/utils/file.go` — collapse the duplicated `LinkError`/`PathError` branches into one `errors.Is(err, syscall.EXDEV)` (both types unwrap), delegate to a platform hook, and extend the text fallback with the Windows wording.
- `internal/utils/file_windows.go` (new) — matches `ERROR_NOT_SAME_DEVICE`.
- `internal/utils/file_unix.go` (new) — no-op hook; EXDEV is reported directly elsewhere.

## Tests

Written first and watched fail before the fix (TDD):

- `file_test.go` — two cross-platform cases for the Windows message, bare and wrapped in a `LinkError`. Both failed `= false; want true` pre-fix.
- `file_windows_test.go` (new, build-tagged) — asserts the errno path. Failed to compile pre-fix (`undefined: errorNotSameDevice`).

`go build ./...`, `go test ./internal/utils/ ./internal/importer/`, and `GOOS=windows go vet ./internal/utils/` all pass.

## Reviewer notes

- The Windows-only test is **compile-verified only** — it was checked with `GOOS=windows go vet`, but not executed, since CI/dev here is not Windows. Worth a look if there's a Windows runner available.
- Two things from #810 are deliberately **not** addressed here:
  - **No configurable temp dir.** `os.TempDir()` is hardcoded across ~15 call sites in `internal/importer` and `internal/api`. That's a feature with a much wider diff. Workaround today: set `TMP`/`TEMP` for the AltMount process.
  - **The underlying import failure** (`Skipping RAR archive group with missing volume(s)` on an obfuscated `.partNN.rar` set) is a separate bug; the move error was only its fallout.